### PR TITLE
[WIP] Recursively deploying Environments.

### DIFF
--- a/examples/advanced/fractal.py
+++ b/examples/advanced/fractal.py
@@ -12,9 +12,7 @@ import flyte
 
 env = flyte.TaskEnvironment(
     name="recursion",
-    image=flyte.Image.from_uv_script(
-        __file__, registry="ghcr.io/flyteorg", name="flyte", arch=("linux/amd64", "linux/arm64")
-    ),
+    image=flyte.Image.from_uv_script(__file__, registry="ghcr.io/flyteorg", name="flyte"),
 )
 
 

--- a/examples/basics/container_images.py
+++ b/examples/basics/container_images.py
@@ -16,8 +16,7 @@ env = flyte.TaskEnvironment(
     image=flyte.Image.from_uv_script(
         __file__,
         name="flyte",
-        registry="ghcr.io/<your-username>",
-        arch=("linux/amd64", "linux/arm64"),
+        registry="ghcr.io/flyteorg",
     ).with_apt_packages("ca-certificates"),
 )
 

--- a/examples/basics/dataframe.py
+++ b/examples/basics/dataframe.py
@@ -10,9 +10,7 @@ import flyte
 
 env = flyte.TaskEnvironment(
     name="hello_world",
-    image=flyte.Image.from_uv_script(
-        __file__, name="flyte", registry="ghcr.io/flyteorg", arch=("linux/amd64", "linux/arm64")
-    ),
+    image=flyte.Image.from_uv_script(__file__, name="flyte", registry="ghcr.io/flyteorg"),
 )
 
 

--- a/examples/basics/exception_handling.py
+++ b/examples/basics/exception_handling.py
@@ -3,7 +3,7 @@ import asyncio
 import flyte
 import flyte.errors
 
-env = flyte.TaskEnvironment(name="hello_world", resources=flyte.Resources(cpu=1, memory="250Mi"))
+env = flyte.TaskEnvironment(name="exc_handler", resources=flyte.Resources(cpu=1, memory="250Mi"))
 
 
 @env.task

--- a/examples/basics/using_dockerfiles.py
+++ b/examples/basics/using_dockerfiles.py
@@ -10,7 +10,7 @@ env = flyte.TaskEnvironment(
         name="flyte-temp-dockerfile-example",
         registry="ghcr.io/flyteorg",
         platform=("linux/amd64", "linux/arm64"),
-    ).with_apt_packages("ca-certificates"),
+    ),
 )
 
 

--- a/src/flyte/_environment.py
+++ b/src/flyte/_environment.py
@@ -6,13 +6,23 @@ from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
 
 import rich.repr
 
-from flyte._secret import SecretRequest
-
 from ._image import Image
 from ._resources import Resources
+from ._secret import SecretRequest
 
 if TYPE_CHECKING:
     from kubernetes.client import V1PodTemplate
+
+# Global registry to track all Environment instances in load order
+_ENVIRONMENT_REGISTRY: List[Environment] = []
+
+
+def list_loaded_environments() -> List[Environment]:
+    """
+    Return a list of all Environment objects in the order they were loaded.
+    This is useful for deploying environments in the order they were defined.
+    """
+    return _ENVIRONMENT_REGISTRY
 
 
 def is_snake_or_kebab_with_numbers(s: str) -> bool:
@@ -20,7 +30,7 @@ def is_snake_or_kebab_with_numbers(s: str) -> bool:
 
 
 @rich.repr.auto
-@dataclass(init=True, repr=True)
+@dataclass(init=True, repr=True, unsafe_hash=True)
 class Environment:
     """
     :param name: Name of the environment
@@ -44,6 +54,8 @@ class Environment:
     def __post_init__(self):
         if not is_snake_or_kebab_with_numbers(self.name):
             raise ValueError(f"Environment name '{self.name}' must be in snake_case or kebab-case format.")
+        # Automatically register this environment instance in load order
+        _ENVIRONMENT_REGISTRY.append(self)
 
     def add_dependency(self, *env: Environment):
         """

--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -394,8 +394,8 @@ class Image:
         )
         labels_and_user = _DockerLines(
             (
-                "LABEL org.opencontainers.image.authors='Union.AI <sales@union.ai>'",
-                "LABEL org.opencontainers.image.source=https://github.com/unionai/unionv2",
+                "LABEL org.opencontainers.image.authors='Union.AI <info@union.ai>'",
+                "LABEL org.opencontainers.image.source=https://github.com/flyteorg/flyte",
                 "RUN useradd --create-home --shell /bin/bash flytekit &&"
                 " chown -R flytekit /root && chown -R flytekit /home",
                 "WORKDIR /root",

--- a/src/flyte/_task.py
+++ b/src/flyte/_task.py
@@ -148,6 +148,10 @@ class TaskTemplate(Generic[P, R]):
         self.__dict__.update(state)
         self.parent_env = None
 
+    @property
+    def source_file(self) -> Optional[str]:
+        return None
+
     async def pre(self, *args, **kwargs) -> Dict[str, Any]:
         """
         This is the preexecute function that will be
@@ -388,6 +392,15 @@ class AsyncFunctionTaskTemplate(TaskTemplate[P, R]):
         super().__post_init__()
         if not iscoroutinefunction(self.func):
             self._call_as_synchronous = True
+
+    @property
+    def source_file(self) -> Optional[str]:
+        """
+        Returns the source file of the function, if available. This is useful for debugging and tracing.
+        """
+        if hasattr(self.func, "__code__") and self.func.__code__:
+            return self.func.__code__.co_filename
+        return None
 
     def forward(self, *args: P.args, **kwargs: P.kwargs) -> Coroutine[Any, Any, R] | R:
         # In local execution, we want to just call the function. Note we're not awaiting anything here.

--- a/src/flyte/_task_environment.py
+++ b/src/flyte/_task_environment.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 
 
 @rich.repr.auto
-@dataclass(init=True, repr=True)
+@dataclass(init=True, repr=True, unsafe_hash=True)
 class TaskEnvironment(Environment):
     """
     Environment class to define a new environment for a set of tasks.
@@ -94,8 +94,8 @@ class TaskEnvironment(Environment):
         :param resources: The resources to allocate for the environment.
         :param env: The environment variables to set for the environment.
         :param secrets: The secrets to inject into the environment.
-        :param depends_on: The environment dependencies to hint, so when you deploy the environment, the dependencies are
-            also deployed. This is useful when you have a set of environments that depend on each other.
+        :param depends_on: The environment dependencies to hint, so when you deploy the environment, the dependencies
+         are also deployed. This is useful when you have a set of environments that depend on each other.
         :param kwargs: Additional parameters to override the environment (e.g., cache, reusable, plugin_config).
         """
         cache = kwargs.pop("cache", None)

--- a/src/flyte/_utils/__init__.py
+++ b/src/flyte/_utils/__init__.py
@@ -9,6 +9,7 @@ from .coro_management import run_coros
 from .file_handling import filehash_update, update_hasher_for_source
 from .helpers import get_cwd_editable_install
 from .lazy_module import lazy_module
+from .module_loader import load_python_modules
 from .org_discovery import hostname_from_url, org_from_endpoint, sanitize_endpoint
 from .uv_script_parser import parse_uv_script_file
 
@@ -18,6 +19,7 @@ __all__ = [
     "get_cwd_editable_install",
     "hostname_from_url",
     "lazy_module",
+    "load_python_modules",
     "org_from_endpoint",
     "parse_uv_script_file",
     "run_coros",

--- a/src/flyte/_utils/module_loader.py
+++ b/src/flyte/_utils/module_loader.py
@@ -1,0 +1,84 @@
+import glob
+import importlib.util
+from pathlib import Path
+from typing import List, Tuple
+
+from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn, TimeRemainingColumn
+
+import flyte.errors
+
+
+def load_python_modules(path: Path, recursive: bool = False) -> Tuple[List[str], List[Tuple[Path, str]]]:
+    """
+    Load all Python modules from a path and return list of loaded module names.
+
+    :param path: File or directory path
+    :param recursive: If True, load modules recursively from subdirectories
+    :return: List of loaded module names, and list of file paths that failed to load
+    """
+    loaded_modules = []
+    failed_paths = []
+
+    if path.is_file() and path.suffix == ".py":
+        # Single file case
+        module_name = _load_module_from_file(path)
+        if module_name:
+            loaded_modules.append(module_name)
+
+    elif path.is_dir():
+        # Directory case
+        pattern = "**/*.py" if recursive else "*.py"
+        python_files = glob.glob(str(path / pattern), recursive=recursive)
+
+        with Progress(
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            "[progress.percentage]{task.percentage:>3.0f}%",
+            TimeElapsedColumn(),
+            TimeRemainingColumn(),
+            TextColumn("• {task.fields[current_file]}"),
+        ) as progress:
+            task = progress.add_task(f"Loading {len(python_files)} files", total=len(python_files), current_file="")
+            for file_path in python_files:
+                p = Path(file_path)
+                progress.update(task, advance=1, current_file=p.name)
+                # Skip __init__.py files
+                if p.name == "__init__.py":
+                    continue
+
+                try:
+                    module_name = _load_module_from_file(p)
+                    if module_name:
+                        loaded_modules.append(module_name)
+                except flyte.errors.ModuleLoadError as e:
+                    failed_paths.append((p, str(e)))
+
+            progress.update(task, advance=1, current_file="[green]Done[/green]")
+
+    return loaded_modules, failed_paths
+
+
+def _load_module_from_file(file_path: Path) -> str | None:
+    """
+    Load a Python module from a file path.
+
+    :param file_path: Path to the Python file
+    :return: Module name if successfully loaded, None otherwise
+    """
+    try:
+        # Use the file stem as module name
+        module_name = file_path.stem
+
+        # Load the module specification
+        spec = importlib.util.spec_from_file_location(module_name, file_path)
+        if spec is None or spec.loader is None:
+            return None
+
+        # Create and execute the module
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        return module_name
+
+    except Exception as e:
+        raise flyte.errors.ModuleLoadError(f"Failed to load module from {file_path}: {e}") from e

--- a/src/flyte/cli/_common.py
+++ b/src/flyte/cli/_common.py
@@ -265,7 +265,7 @@ class ObjectsPerFileGroup(GroupBase):
 
         spec = importlib.util.spec_from_file_location(module_name, self.filename)
         if spec is None or spec.loader is None:
-            raise click.ClickException(f"Could not load module {module_name} from {self.filename}")
+            raise click.ClickException(f"Could not load module {module_name} from path [{self.filename}]")
 
         module = importlib.util.module_from_spec(spec)
         sys.modules[module_name] = module
@@ -314,6 +314,10 @@ class FileGroup(GroupBase):
         if self._files is None:
             directory = self._dir or Path(".").absolute()
             self._files = [os.fspath(p) for p in directory.glob("*.py") if p.name != "__init__.py"]
+            if not self._files:
+                self._files = [os.fspath(".")] + [
+                    os.fspath(p.name) for p in directory.iterdir() if not p.name.startswith(("_", ".")) and p.is_dir()
+                ]
         return self._files
 
     def list_commands(self, ctx):

--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -199,7 +199,7 @@ class TaskFiles(common.FileGroup):
         if fp.is_dir():
             return TaskFiles(directory=fp)
         return TaskPerFileGroup(
-            filename=Path(filename),
+            filename=fp,
             run_args=run_args,
             name=filename,
             help=f"Run, functions decorated with `env.task` in {filename}",

--- a/src/flyte/errors.py
+++ b/src/flyte/errors.py
@@ -179,3 +179,13 @@ class ImageBuildError(RuntimeUserError):
 
     def __init__(self, message: str):
         super().__init__("ImageBuildError", message, "user")
+
+
+class ModuleLoadError(RuntimeUserError):
+    """
+    This error is raised when the module cannot be loaded, either because it does not exist or because of a
+     syntax error.
+    """
+
+    def __init__(self, message: str):
+        super().__init__("ModuleLoadError", message, "user")


### PR DESCRIPTION
Currently fails, as it cannot determine the `module` for the recursively discovered enviroments.

Example usage:
```bash
flyte deploy --all --recursive examples/basics
```