### PR TITLE
Update spark/ray example

### DIFF
--- a/examples/plugins/ray_example.py
+++ b/examples/plugins/ray_example.py
@@ -26,9 +26,7 @@ ray_config = RayJobConfig(
 image = (
     flyte.Image.from_debian_base()
     .with_apt_packages("wget")
-    .with_pip_packages("ray[default]==2.46.0", "pip")
-    .with_source_folder(Path(__file__).parent.parent.parent / "plugins/ray", "./ray")
-    .with_env_vars({"PYTHONPATH": "./ray/src:${PYTHONPATH}", "hello": "world"})
+    .with_pip_packages("ray[default]==2.46.0", "flyteplugins-ray", "pip")
 )
 
 task_env = flyte.TaskEnvironment(

--- a/examples/plugins/spark_example.py
+++ b/examples/plugins/spark_example.py
@@ -1,21 +1,16 @@
 # # Spark Example
 import random
 from operator import add
-from pathlib import Path
 
 from flyteplugins.spark.task import Spark
 
-import flyte
 import flyte.remote._action
 from flyte._context import internal_ctx
 
 image = (
     flyte.Image.from_base("apache/spark-py:v3.4.0")
     .clone(name="spark", python_version="3.10")
-    .with_pip_packages("pyspark")
-    .with_source_folder(Path(__file__).parent.parent.parent / "plugins/spark", "./spark")
-    .with_env_vars({"PYTHONPATH": "./spark/src:${PYTHONPATH}"})
-    .with_local_v2()
+    .with_pip_packages("flyteplugins-spark")
 )
 
 task_env = flyte.TaskEnvironment(
@@ -38,8 +33,8 @@ spark_env = flyte.TaskEnvironment(
             # For AWS environments, you can use the following jars:
             # "spark.jars": "https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.2.2/hadoop-aws-3.2.2.jar,https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar"
         },
-        executor_path="/opt/union/venv/bin/python",
-        applications_path="local:///opt/union/venv/bin/runtime.py",
+        executor_path="/opt/venv/bin/python",
+        applications_path="local:///opt/venv/bin/runtime.py",
     ),
     image=image,
 )

--- a/plugins/ray/pyproject.toml
+++ b/plugins/ray/pyproject.toml
@@ -7,6 +7,7 @@ authors = [{ name = "Kevin Su", email = "pingsutw@users.noreply.github.com" }]
 requires-python = ">=3.10"
 dependencies = [
     "ray[default]",
+    "flyte"
 ]
 
 [build-system]

--- a/plugins/spark/pyproject.toml
+++ b/plugins/spark/pyproject.toml
@@ -7,6 +7,7 @@ authors = [{ name = "Kevin Su", email = "pingsutw@users.noreply.github.com" }]
 requires-python = ">=3.10"
 dependencies = [
     "pyspark",
+    "flyte"
 ]
 
 [build-system]


### PR DESCRIPTION
This pull request updates the dependencies and configurations for the Flyte plugins used in the `ray` and `spark` examples. The main changes include adding new plugin dependencies, modifying environment variables, and updating paths for executors and applications.

### Updates to dependencies:

- **`examples/plugins/ray_example.py`**: Added `flyteplugins-ray` to the pip packages for the Ray plugin.
- **`examples/plugins/spark_example.py`**: Replaced `pyspark` with `flyteplugins-spark` in the pip packages for the Spark plugin.
- **`plugins/ray/pyproject.toml`**: Added `flyte` as a dependency for the Ray plugin.
- **`plugins/spark/pyproject.toml`**: Added `flyte` as a dependency for the Spark plugin.

### Configuration updates:

- **`examples/plugins/spark_example.py`**: Updated paths for the executor and application from `/opt/union/venv/bin` to `/opt/venv/bin`.