### PR TITLE
Tweak wheel layer

### DIFF
--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -134,6 +134,7 @@ class PipPackages(PipOption, Layer):
 @dataclass(kw_only=True, frozen=True, repr=True)
 class PythonWheels(PipOption, Layer):
     wheel_dir: Path
+    package_name: str
 
     def update_hash(self, hasher: hashlib._Hash):
         super().update_hash(hasher)
@@ -899,7 +900,7 @@ class Image:
         dist_folder = Path(__file__).parent.parent.parent / "dist"
         # Manually declare the PythonWheel so we can set the hashing
         # used to compute the identifier. Can remove if we ever decide to expose the lambda in with_ commands
-        with_dist = self.clone(addl_layer=PythonWheels(wheel_dir=dist_folder, _compute_identifier=lambda x: "/dist"))
+        with_dist = self.clone(addl_layer=PythonWheels(wheel_dir=dist_folder, package_name="flyte", _compute_identifier=lambda x: "/dist"))
 
         return with_dist
 

--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -162,7 +162,7 @@ class PythonWheelHandler:
     async def handle(layer: PythonWheels, context_path: Path, dockerfile: str) -> str:
         shutil.copytree(layer.wheel_dir, context_path / "dist", dirs_exist_ok=True)
         pip_install_args = layer.get_pip_install_args()
-        pip_install_args.extend(["/dist/*.whl"])
+        pip_install_args.extend(["--find-links", "/dist", layer.package_name])
         secret_mounts = _get_secret_mounts_layer(layer.secret_mounts)
         delta = UV_WHEEL_INSTALL_COMMAND_TEMPLATE.substitute(
             PIP_INSTALL_ARGS=" ".join(pip_install_args), SECRET_MOUNT=secret_mounts


### PR DESCRIPTION
Change how python wheels are handled... currently we're just installing *whl, but this doesn't work for multi-arch wheels.  pip knows how to find the correct architecture with the --find-links arg, but we need to tweak the command.

Will need to update the remote builder as well.
