### PR TITLE
improve secrets cli: add validation, provide secret value through input

### DIFF
--- a/src/flyte/cli/_create.py
+++ b/src/flyte/cli/_create.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, get_args
 import rich_click as click
 
 import flyte.cli._common as common
+from flyte.cli._option import MutuallyExclusiveOption
 from flyte.remote import SecretTypes
 
 
@@ -16,8 +17,21 @@ def create():
 
 @create.command(cls=common.CommandBase)
 @click.argument("name", type=str, required=True)
-@click.argument("value", type=str, required=False)
-@click.option("--from-file", type=click.Path(exists=True), help="Path to the file with the binary secret.")
+@click.option(
+    "--value",
+    help="Secret value",
+    prompt="Enter secret value",
+    hide_input=True,
+    cls=MutuallyExclusiveOption,
+    mutually_exclusive=["from_file"],
+)
+@click.option(
+    "--from-file",
+    type=click.Path(exists=True),
+    help="Path to the file with the binary secret.",
+    cls=MutuallyExclusiveOption,
+    mutually_exclusive=["value"],
+)
 @click.option(
     "--type", type=click.Choice(get_args(SecretTypes)), default="regular", help="Type of the secret.", show_default=True
 )
@@ -36,6 +50,14 @@ def secret(
 
     ```bash
     $ flyte create secret my_secret --value my_value
+    ```
+
+    If you don't provide a `--value` flag, you will be prompted to enter the
+    secret value in the terminal.
+
+    ```bash
+    $ flyte create secret my_secret
+    Enter secret value:
     ```
 
     If `--from-file` is specified, the value will be read from the file instead of being provided directly:

--- a/src/flyte/cli/_option.py
+++ b/src/flyte/cli/_option.py
@@ -1,0 +1,31 @@
+from click import Argument, Option, UsageError
+
+
+class MutuallyExclusiveMixin:
+    def __init__(self, *args, **kwargs):
+        self.mutually_exclusive = set(kwargs.pop("mutually_exclusive", []))
+        self.error_format = kwargs.pop("error_msg", "Illegal usage: options '{name}' and '{invalid}' are mutually exclusive")
+        super().__init__(*args, **kwargs)
+
+    def handle_parse_result(self, ctx, opts, args):
+        self_present = self.name in opts and opts[self.name] is not None
+        others_intersect = self.mutually_exclusive.intersection(opts)
+        others_present = others_intersect and any(opts[value] is not None for value in others_intersect)
+
+        if others_present:
+            if self_present:
+                raise UsageError(self.error_format.format(name=self.name, invalid=", ".join(self.mutually_exclusive)))
+            else:
+                self.prompt = None
+
+        return super().handle_parse_result(ctx, opts, args)
+
+
+# See https://stackoverflow.com/a/37491504/499285 and https://stackoverflow.com/a/44349292/499285
+class MutuallyExclusiveOption(MutuallyExclusiveMixin, Option):
+    def __init__(self, *args, **kwargs):
+        mutually_exclusive = kwargs.get("mutually_exclusive", [])
+        help = kwargs.get("help", "")
+        if mutually_exclusive:
+            kwargs["help"] = help + f" Mutually exclusive with {', '.join(mutually_exclusive)}."
+        super().__init__(*args, **kwargs)

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -1,0 +1,50 @@
+import pytest
+import click
+from io import BytesIO
+from click.testing import CliRunner
+from unittest.mock import patch, Mock
+from flyte.cli.main import main
+
+
+@pytest.fixture(scope="function")
+def runner():
+    return CliRunner()
+
+
+def test_create_secret_no_value(runner: CliRunner):
+    result = runner.invoke(main, ["create", "secret", "my_secret"])
+    assert result.exit_code == 1
+    assert result.stdout.startswith("Enter secret value: ")
+
+
+@patch("flyte.remote.Secret.create")
+@patch("flyte.cli._common.CLIConfig", return_value=Mock())
+def test_create_secret_value(mock_cli_config, mock_secret_create, runner: CliRunner):
+    mock_secret_create.return_value = None    
+
+    secret_value = "my_value"
+
+    result = runner.invoke(main, ["create", "secret", "my_secret", "--value", secret_value])
+    assert result.exit_code == 0, result.stderr
+    mock_secret_create.assert_called_once_with(name="my_secret", value="my_value", type="regular")
+
+
+@patch("flyte.remote.Secret.create")
+@patch("flyte.cli._common.CLIConfig", return_value=Mock())
+def test_create_secret_from_file(mock_cli_config, mock_secret_create, runner: CliRunner, tmp_path):
+    mock_secret_create.return_value = None
+
+    secret_value = "my_value"
+    with open(tmp_path / "secret.txt", "w") as f:
+        f.write(secret_value)
+
+    result = runner.invoke(main, ["create", "secret", "my_secret", "--from-file", str(tmp_path / "secret.txt")])
+    assert result.exit_code == 0, result.stderr
+    mock_secret_create.assert_called_once_with(name="my_secret", value=b"my_value", type="regular")
+
+
+def test_create_secret_invalid_combination(runner: CliRunner):
+    result = runner.invoke(main, ["create", "secret", "my_secret", "--value", "my_value", "--from-file", "my_file"])
+    assert result.exit_code == 2
+    error_msg = "Illegal usage: options 'value' and 'from_file' are mutually exclusive"
+    assert error_msg in result.stderr


### PR DESCRIPTION
This PR aligns the actual implementation of `flyte create secret` with the docstring. Users need to supply a secret `--value` flag, and if not provided, an input prompt that hides the password value is shown to the user.