### PR TITLE
implement json output format for flyte get commands

### DIFF
--- a/src/flyte/remote/_action.py
+++ b/src/flyte/remote/_action.py
@@ -20,6 +20,7 @@ from typing import (
 import grpc
 import rich.pretty
 import rich.repr
+from google.protobuf.json_format import MessageToDict
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 
@@ -127,6 +128,12 @@ class Action:
 
     pb2: run_definition_pb2.Action
     _details: ActionDetails | None = None
+
+    def to_json_dict(self) -> dict:
+        """
+        Convert the action to a JSON dictionary.
+        """
+        return MessageToDict(self.pb2)
 
     @syncify
     @classmethod

--- a/src/flyte/remote/_secret.py
+++ b/src/flyte/remote/_secret.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import AsyncIterator, Literal, Union
 
 import rich.repr
+from google.protobuf.json_format import MessageToDict
 
 from flyte._initialize import ensure_client, get_client, get_common_config
 from flyte._protos.secret import definition_pb2, payload_pb2
@@ -15,6 +16,12 @@ SecretTypes = Literal["regular", "image_pull"]
 @dataclass
 class Secret:
     pb2: definition_pb2.Secret
+
+    def to_json_dict(self) -> dict:
+        """
+        Convert the secret to a JSON dictionary.
+        """
+        return MessageToDict(self.pb2)
 
     @syncify
     @classmethod

--- a/src/flyte/remote/_task.py
+++ b/src/flyte/remote/_task.py
@@ -7,6 +7,7 @@ from typing import Any, AsyncIterator, Callable, Coroutine, Dict, Iterator, Lite
 
 import rich.repr
 from google.protobuf import timestamp
+from google.protobuf.json_format import MessageToDict
 
 import flyte
 import flyte.errors
@@ -82,6 +83,12 @@ AutoVersioning = Literal["latest", "current"]
 class TaskDetails:
     pb2: task_definition_pb2.TaskDetails
     max_inline_io_bytes: int = 10 * 1024 * 1024  # 10 MB
+
+    def to_json_dict(self) -> dict:
+        """
+        Convert the task details to a JSON dictionary.
+        """
+        return MessageToDict(self.pb2)
 
     @classmethod
     def get(
@@ -299,6 +306,12 @@ class Task:
 
     def __init__(self, pb2: task_definition_pb2.Task):
         self.pb2 = pb2
+
+    def to_json_dict(self) -> dict:
+        """
+        Convert the task to a JSON dictionary.
+        """
+        return MessageToDict(self.pb2)
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
With these changes, you could do something like:

```bash
flyte get run --output-format json --limit 3 | jq '.[].action.id.run.name' | xargs -I {} flyte abort run {}
```

Which will abort the last three runs.

This adds the `--output-format` flag to the following commands:
- `flyte get run`
- `flyte get task`
- `flyte get action`
- `flyte get secret`