### PR TITLE
Making every command output json (In the future yaml too)

### DIFF
--- a/examples/genai/langgraph_agent.py
+++ b/examples/genai/langgraph_agent.py
@@ -8,20 +8,20 @@
 # ]
 # ///
 
+
+from langchain_core.messages import BaseMessage
+from langgraph.prebuilt import create_react_agent
+
 import flyte
 
-from langgraph.prebuilt import create_react_agent
-from langchain_core.messages import BaseMessage
-import json
-
 agent_env = flyte.TaskEnvironment(
-    name="agent", 
+    name="agent",
     secrets=[
         flyte.Secret(key="ANTHROPIC_API_KEY", as_env_var="ANTHROPIC_API_KEY"),
     ],
     image=flyte.Image.from_uv_script(script=__file__, name="langgraph-agent", pre=True),
     resources=flyte.Resources(cpu=1),
-    )
+)
 
 
 def get_weather_tool(city: str) -> str:
@@ -38,22 +38,17 @@ def get_weather(city: str) -> str:
 def main(in_str: str) -> list[BaseMessage]:
     # Create a React agent with the weather tool
     agent = create_react_agent(
-        model="anthropic:claude-3-7-sonnet-latest",
-        tools=[get_weather_tool],
-        prompt="You are a helpful assistant"
+        model="anthropic:claude-3-7-sonnet-latest", tools=[get_weather_tool], prompt="You are a helpful assistant"
     )
 
     # Run the agent
     print("Running agent...")
-    output = agent.invoke(
-        {"messages": [{"role": "user", "content": in_str}]}
-    )
+    output = agent.invoke({"messages": [{"role": "user", "content": in_str}]})
 
     return output["messages"]
 
 
 if __name__ == "__main__":
-
     flyte.init_from_config("../../config.yaml")
     r = flyte.run(main, in_str="what is the weather in sf")
     print(r.url)

--- a/src/flyte/cli/_build.py
+++ b/src/flyte/cli/_build.py
@@ -54,7 +54,7 @@ class BuildEnvCommand(click.Command):
         with console.status("Building...", spinner="dots"):
             image_cache = flyte.build_images(self.obj)
 
-        console.print(common.get_table("Images", image_cache.repr(), simple=obj.simple))
+        console.print(common.format("Images", image_cache.repr(), obj.output_format))
 
 
 class EnvPerFileGroup(common.ObjectsPerFileGroup):

--- a/src/flyte/cli/_deploy.py
+++ b/src/flyte/cli/_deploy.py
@@ -109,8 +109,8 @@ class DeployEnvCommand(click.Command):
                 version=self.deploy_args.version,
             )
 
-        console.print(common.get_table("Environments", deployment[0].env_repr(), simple=obj.simple))
-        console.print(common.get_table("Tasks", deployment[0].task_repr(), simple=obj.simple))
+        console.print(common.format("Environments", deployment[0].env_repr(), obj.output_format))
+        console.print(common.format("Tasks", deployment[0].task_repr(), obj.output_format))
 
 
 class DeployEnvRecursiveCommand(click.Command):
@@ -139,7 +139,7 @@ class DeployEnvRecursiveCommand(click.Command):
         if failed_paths:
             console.print(f"Loaded {len(loaded_modules)} modules with, but failed to load {len(failed_paths)} paths:")
             console.print(
-                common.get_table("Modules", [[("Path", p), ("Err", e)] for p, e in failed_paths], simple=obj.simple)
+                common.format("Modules", [[("Path", p), ("Err", e)] for p, e in failed_paths], obj.output_format)
             )
         else:
             console.print(f"Loaded {len(loaded_modules)} modules")
@@ -149,9 +149,7 @@ class DeployEnvRecursiveCommand(click.Command):
         if not all_envs:
             console.print("No environments found to deploy")
             return
-        console.print(
-            common.get_table("Loaded Environments", [[("name", e.name)] for e in all_envs], simple=obj.simple)
-        )
+        console.print(common.format("Loaded Environments", [[("name", e.name)] for e in all_envs], obj.output_format))
 
         if not self.deploy_args.ignore_load_errors and len(failed_paths) > 0:
             raise click.ClickException(
@@ -168,11 +166,9 @@ class DeployEnvRecursiveCommand(click.Command):
             )
 
         console.print(
-            common.get_table("Environments", [env for d in deployments for env in d.env_repr()], simple=obj.simple)
+            common.format("Environments", [env for d in deployments for env in d.env_repr()], obj.output_format)
         )
-        console.print(
-            common.get_table("Tasks", [task for d in deployments for task in d.task_repr()], simple=obj.simple)
-        )
+        console.print(common.format("Tasks", [task for d in deployments for task in d.task_repr()], obj.output_format))
 
 
 class EnvPerFileGroup(common.ObjectsPerFileGroup):

--- a/src/flyte/cli/_get.py
+++ b/src/flyte/cli/_get.py
@@ -48,7 +48,7 @@ def project(cfg: common.CLIConfig, name: str | None = None):
     if name:
         console.print(pretty_repr(Project.get(name)))
     else:
-        console.print(common.get_table("Projects", Project.listall(), simple=cfg.simple))
+        console.print(common.format("Projects", Project.listall(), cfg.output_format))
 
 
 @get.command(cls=common.CommandBase)
@@ -71,7 +71,7 @@ def run(cfg: common.CLIConfig, name: str | None = None, project: str | None = No
         details = RunDetails.get(name=name)
         console.print(pretty_repr(details))
     else:
-        console.print(common.get_table("Runs", Run.listall(), simple=cfg.simple))
+        console.print(common.format("Runs", Run.listall(), cfg.output_format))
 
 
 @get.command(cls=common.CommandBase)
@@ -105,9 +105,9 @@ def task(
             t = v.fetch()
             console.print(pretty_repr(t))
         else:
-            console.print(common.get_table("Tasks", Task.listall(by_task_name=name, limit=limit), simple=cfg.simple))
+            console.print(common.format("Tasks", Task.listall(by_task_name=name, limit=limit), cfg.output_format))
     else:
-        console.print(common.get_table("Tasks", Task.listall(limit=limit), simple=cfg.simple))
+        console.print(common.format("Tasks", Task.listall(limit=limit), cfg.output_format))
 
 
 @get.command(cls=common.CommandBase)
@@ -133,8 +133,8 @@ def action(
     else:
         # List all actions for the run
         console.print(
-            common.get_table(
-                f"Actions for {run_name}", flyte.remote._action.Action.listall(for_run_name=run_name), simple=cfg.simple
+            common.format(
+                f"Actions for {run_name}", flyte.remote._action.Action.listall(for_run_name=run_name), cfg.output_format
             )
         )
 
@@ -230,7 +230,7 @@ def secret(
     if name:
         console.print(pretty_repr(remote.Secret.get(name)))
     else:
-        console.print(common.get_table("Secrets", remote.Secret.listall(), simple=cfg.simple))
+        console.print(common.format("Secrets", remote.Secret.listall(), cfg.output_format))
 
 
 @get.command(cls=common.CommandBase)
@@ -299,7 +299,7 @@ def io(
         common.get_panel(
             "Inputs & Outputs",
             f"[green bold]Inputs[/green bold]\n{inputs}\n\n[blue bold]Outputs[/blue bold]\n{outputs}",
-            simple=cfg.simple,
+            cfg.output_format,
         )
     )
 

--- a/src/flyte/cli/_get.py
+++ b/src/flyte/cli/_get.py
@@ -53,8 +53,15 @@ def project(cfg: common.CLIConfig, name: str | None = None):
 
 @get.command(cls=common.CommandBase)
 @click.argument("name", type=str, required=False)
+@click.option("--limit", type=int, default=100, help="Limit the number of runs to fetch when listing.")
 @click.pass_obj
-def run(cfg: common.CLIConfig, name: str | None = None, project: str | None = None, domain: str | None = None):
+def run(
+    cfg: common.CLIConfig,
+    name: str | None = None,
+    project: str | None = None,
+    domain: str | None = None,
+    limit: int = 100,
+):
     """
     Get a list of all runs, or details of a specific run by name.
 
@@ -71,13 +78,13 @@ def run(cfg: common.CLIConfig, name: str | None = None, project: str | None = No
         details = RunDetails.get(name=name)
         console.print(pretty_repr(details))
     else:
-        console.print(common.format("Runs", Run.listall(), cfg.output_format))
+        console.print(common.format("Runs", Run.listall(limit=limit), cfg.output_format))
 
 
 @get.command(cls=common.CommandBase)
 @click.argument("name", type=str, required=False)
 @click.argument("version", type=str, required=False)
-@click.option("--limit", type=int, default=100, help="Limit the number of tasks to show.")
+@click.option("--limit", type=int, default=100, help="Limit the number of tasks to fetch.")
 @click.pass_obj
 def task(
     cfg: common.CLIConfig,

--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -117,7 +117,7 @@ class RunTaskCommand(click.Command):
                         f"[green bold]Created Run: {r.name} [/green bold] "
                         f"(Project: {r.action.action_id.run.project}, Domain: {r.action.action_id.run.domain})\n"
                         f"➡️  [blue bold]{r.url}[/blue bold]",
-                        simple=obj.simple,
+                        obj.output_format,
                     )
                 )
                 if self.run_args.follow:

--- a/src/flyte/cli/main.py
+++ b/src/flyte/cli/main.py
@@ -1,4 +1,5 @@
 import rich_click as click
+from typing_extensions import get_args
 
 from flyte._logging import initialize_logger, logger
 
@@ -107,10 +108,13 @@ def _verbosity_to_loglevel(verbosity: int) -> int | None:
     help="Path to the configuration file to use. If not specified, the default configuration file is used.",
 )
 @click.option(
-    "--simple",
-    is_flag=True,
-    default=False,
-    help="Use a simple output format for commands that support it. This is useful for copying, pasting, and scripting.",
+    "--output-format",
+    "-of",
+    type=click.Choice(get_args(common.OutputFormat), case_sensitive=False),
+    default="table",
+    help="Output format for commands that support it. Defaults to 'table'.",
+    show_default=True,
+    required=False,
 )
 @click.rich_config(help_config=help_config)
 @click.pass_context
@@ -121,8 +125,8 @@ def main(
     verbose: int,
     org: str | None,
     config_file: str | None,
-    simple: bool = False,
     auth_type: str | None = None,
+    output_format: common.OutputFormat = "table",
 ):
     """
     The Flyte CLI is the command line interface for working with the Flyte SDK and backend.
@@ -176,8 +180,8 @@ def main(
         org=org,
         config=cfg,
         ctx=ctx,
-        simple=simple,
         auth_type=auth_type,
+        output_format=output_format,
     )
 
 

--- a/src/flyte/remote/_action.py
+++ b/src/flyte/remote/_action.py
@@ -28,6 +28,7 @@ from flyte._initialize import ensure_client, get_client, get_common_config
 from flyte._protos.common import identifier_pb2, list_pb2
 from flyte._protos.workflow import run_definition_pb2, run_service_pb2
 from flyte._protos.workflow.run_service_pb2 import WatchActionDetailsResponse
+from flyte.remote._common import ToJSONMixin
 from flyte.remote._logs import Logs
 from flyte.syncify import syncify
 
@@ -120,7 +121,7 @@ def _action_done_check(phase: run_definition_pb2.Phase) -> bool:
 
 
 @dataclass
-class Action:
+class Action(ToJSONMixin):
     """
     A class representing an action. It is used to manage the run of a task and its state on the remote Union API.
     """
@@ -411,7 +412,7 @@ class Action:
 
 
 @dataclass
-class ActionDetails:
+class ActionDetails(ToJSONMixin):
     """
     A class representing an action. It is used to manage the run of a task and its state on the remote Union API.
     """
@@ -692,7 +693,7 @@ class ActionDetails:
 
 
 @dataclass
-class ActionInputs(UserDict):
+class ActionInputs(UserDict, ToJSONMixin):
     """
     A class representing the inputs of an action. It is used to manage the inputs of a task and its state on the
     remote Union API.
@@ -709,7 +710,7 @@ class ActionInputs(UserDict):
         return rich.pretty.pretty_repr(types.literal_string_repr(self.pb2))
 
 
-class ActionOutputs(tuple):
+class ActionOutputs(tuple, ToJSONMixin):
     """
     A class representing the outputs of an action. It is used to manage the outputs of a task and its state on the
     remote Union API.

--- a/src/flyte/remote/_common.py
+++ b/src/flyte/remote/_common.py
@@ -1,0 +1,30 @@
+import json
+
+from google.protobuf.json_format import MessageToDict, MessageToJson
+
+
+class ToJSONMixin:
+    """
+    A mixin class that provides a method to convert an object to a JSON-serializable dictionary.
+    """
+
+    def to_dict(self) -> dict:
+        """
+        Convert the object to a JSON-serializable dictionary.
+
+        Returns:
+            dict: A dictionary representation of the object.
+        """
+        if hasattr(self, "pb2"):
+            return MessageToDict(self.pb2)
+        else:
+            return {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
+
+    def to_json(self) -> str:
+        """
+        Convert the object to a JSON string.
+
+        Returns:
+            str: A JSON string representation of the object.
+        """
+        return MessageToJson(self.pb2) if hasattr(self, "pb2") else json.dumps(self.to_dict())

--- a/src/flyte/remote/_project.py
+++ b/src/flyte/remote/_project.py
@@ -9,15 +9,17 @@ from flyteidl.admin import common_pb2, project_pb2
 from flyte._initialize import ensure_client, get_client
 from flyte.syncify import syncify
 
+from ._common import ToJSONMixin
+
 
 # TODO Add support for orgs again
 @dataclass
-class Project:
+class Project(ToJSONMixin):
     """
     A class representing a project in the Union API.
     """
 
-    _pb2: project_pb2.Project
+    pb2: project_pb2.Project
 
     @syncify
     @classmethod
@@ -76,11 +78,11 @@ class Project:
                 break
 
     def __rich_repr__(self) -> rich.repr.Result:
-        yield "name", self._pb2.name
-        yield "id", self._pb2.id
-        yield "description", self._pb2.description
-        yield "state", project_pb2.Project.ProjectState.Name(self._pb2.state)
+        yield "name", self.pb2.name
+        yield "id", self.pb2.id
+        yield "description", self.pb2.description
+        yield "state", project_pb2.Project.ProjectState.Name(self.pb2.state)
         yield (
             "labels",
-            ", ".join([f"{k}: {v}" for k, v in self._pb2.labels.values.items()]) if self._pb2.labels else None,
+            ", ".join([f"{k}: {v}" for k, v in self.pb2.labels.values.items()]) if self.pb2.labels else None,
         )

--- a/src/flyte/remote/_secret.py
+++ b/src/flyte/remote/_secret.py
@@ -7,13 +7,14 @@ import rich.repr
 
 from flyte._initialize import ensure_client, get_client, get_common_config
 from flyte._protos.secret import definition_pb2, payload_pb2
+from flyte.remote._common import ToJSONMixin
 from flyte.syncify import syncify
 
 SecretTypes = Literal["regular", "image_pull"]
 
 
 @dataclass
-class Secret:
+class Secret(ToJSONMixin):
     pb2: definition_pb2.Secret
 
     @syncify

--- a/src/flyte/remote/_task.py
+++ b/src/flyte/remote/_task.py
@@ -18,6 +18,8 @@ from flyte._protos.workflow import task_definition_pb2, task_service_pb2
 from flyte.models import NativeInterface
 from flyte.syncify import syncify
 
+from ._common import ToJSONMixin
+
 
 def _repr_task_metadata(metadata: task_definition_pb2.TaskMetadata) -> rich.repr.Result:
     """
@@ -79,7 +81,7 @@ AutoVersioning = Literal["latest", "current"]
 
 
 @dataclass
-class TaskDetails:
+class TaskDetails(ToJSONMixin):
     pb2: task_definition_pb2.TaskDetails
     max_inline_io_bytes: int = 10 * 1024 * 1024  # 10 MB
 
@@ -294,7 +296,7 @@ class TaskDetails:
 
 
 @dataclass
-class Task:
+class Task(ToJSONMixin):
     pb2: task_definition_pb2.Task
 
     def __init__(self, pb2: task_definition_pb2.Task):


### PR DESCRIPTION
### PR Description

#### Overview

This pull request introduces significant improvements to the Flyte CLI and SDK around output formatting and JSON serialization. The goal is to make CLI output more flexible, scriptable, and user-friendly, especially for automation and integration with other tools.

---

#### Key Changes

**1. Output Format Option for CLI**
- Replaces the boolean --simple flag with a new --output-format (or -of) option.
- Supports multiple formats: table (default), table-simple, and json.
- All CLI commands that previously used get_table now use the new format function, allowing consistent output formatting based on user preference.

**2. Common Formatting Utilities**
- Introduces a new format function in _common.py that handles table, simple table, and JSON output for iterable objects.
- get_panel is updated to respect output format for consistency.

**3. ToJSONMixin for Models**
- Adds a new ToJSONMixin class (in remote/_common.py) that provides to_dict and to_json methods.
- All major API model classes (Project, Run, Task, Secret, Action, ActionDetails, ActionInputs, ActionOutputs, RunDetails, TaskDetails) now inherit from ToJSONMixin.
- This enables easy and consistent JSON serialization for CLI output and programmatic use.

**4. Improved List Commands**
- All list commands (e.g., flyte get projects, flyte get runs, flyte get tasks, etc.) now respect the --output-format option.
- Limits for listing are more consistently handled (e.g., flyte get run/task now have a --limit option).

**5. Codebase Modernization**
- Refactors all usages of simple argument to output_format.
- Updates type annotations using Literal and typing_extensions.get_args for CLI option validation.

---

#### Motivation

- Provides a more scriptable CLI experience for users and automation by supporting JSON output.
- Makes the CLI more flexible for different use cases (human-friendly tables, simple for scripting, JSON for parsing).
- Unifies output formatting and serialization logic across the codebase for maintainability and consistency.

---

#### Backward Compatibility

- The --simple flag is removed and replaced by --output-format. The default remains a rich table, so most users will not notice a change unless they used --simple (who can now use --output-format table-simple).
- All API models are backward compatible, now with additional methods for JSON serialization.

---

#### How to Use

- Human-readable table (default):  
  `flyte get projects`
- Simple table (for copy-pasting):  
  `flyte get projects --output-format table-simple`
- JSON output (for scripting/automation):  
  `flyte get projects --output-format json`

---

#### Example

```sh
flyte get tasks --output-format json --limit 10
```

---

#### Additional Notes

- All new output format logic is centralized, making future extensions (e.g., YAML, CSV) easy to add.
- The ToJSONMixin is designed to work seamlessly with protobuf-based models as well as plain dataclasses.

