### PR TITLE
Remove cache behavior "enabled", adjust remote cache return accordingly

### DIFF
--- a/src/flyte/_cache/cache.py
+++ b/src/flyte/_cache/cache.py
@@ -21,7 +21,7 @@ from flyte.models import CodeBundle
 P = ParamSpec("P")
 FuncOut = TypeVar("FuncOut")
 
-CacheBehavior = Literal["auto", "override", "disable", "enabled"]
+CacheBehavior = Literal["auto", "override", "disable"]
 
 
 @dataclass

--- a/src/flyte/remote/_task.py
+++ b/src/flyte/remote/_task.py
@@ -203,11 +203,19 @@ class TaskDetails(ToJSONMixin):
         """
         The cache policy of the task.
         """
+        metadata = self.pb2.spec.task_template.metadata
+        if not metadata.discoverable:
+            behavior = "disable"
+        elif metadata.discovery_version:
+            behavior = "override"
+        else:
+            behavior = "auto"
+
         return flyte.Cache(
-            behavior="enabled" if self.pb2.spec.task_template.metadata.discoverable else "disable",
-            version_override=self.pb2.spec.task_template.metadata.discovery_version,
-            serialize=self.pb2.spec.task_template.metadata.cache_serializable,
-            ignored_inputs=tuple(self.pb2.spec.task_template.metadata.cache_ignore_input_vars),
+            behavior=behavior,
+            version_override=metadata.discovery_version if metadata.discovery_version else None,
+            serialize=metadata.cache_serializable,
+            ignored_inputs=tuple(metadata.cache_ignore_input_vars),
         )
 
     @property


### PR DESCRIPTION
The cache behavior "enabled" is not implemented. 

I have removed it from the `CacheBehavior` type. 

I have also adjusted the only place where it was referenced, which was when returning the cache policy from TaskDetails. 

The new logic correctly determines the `behavior` and `version_override` values based on the information in the `task_template.metadata`