### PR TITLE
Add support override in LazyEntity

### DIFF
--- a/examples/advanced/container_task.py
+++ b/examples/advanced/container_task.py
@@ -1,5 +1,4 @@
 import flyte
-from flyte import remote
 from flyte.extras import ContainerTask
 
 env = flyte.TaskEnvironment(name="hello_world")
@@ -30,12 +29,5 @@ if __name__ == "__main__":
     import flyte.storage
 
     flyte.init_from_config("../../config.yaml")
-    entity = remote.Task.get(
-        name="echo_and_return_greeting",
-        project="flytesnacks",
-        domain="development",
-        auto_version="latest",
-    ).override(secrets=[flyte.Secret(key="secret-project-domain", as_env_var="OPENAI_API_KEY")])
-
-    run = flyte.with_runcontext(mode="remote").run(entity, "Union")
+    run = flyte.with_runcontext(mode="remote").run(say_hello, "Union")
     print(run.url)

--- a/examples/advanced/container_task.py
+++ b/examples/advanced/container_task.py
@@ -1,4 +1,5 @@
 import flyte
+from flyte import remote
 from flyte.extras import ContainerTask
 
 env = flyte.TaskEnvironment(name="hello_world")
@@ -29,4 +30,12 @@ if __name__ == "__main__":
     import flyte.storage
 
     flyte.init_from_config("../../config.yaml")
-    flyte.with_runcontext(mode="local").run(say_hello, "Union")
+    entity = remote.Task.get(
+        name="echo_and_return_greeting",
+        project="flytesnacks",
+        domain="development",
+        auto_version="latest",
+    ).override(secrets=[flyte.Secret(key="secret-project-domain", as_env_var="OPENAI_API_KEY")])
+
+    run = flyte.with_runcontext(mode="remote").run(entity, "Union")
+    print(run.url)

--- a/examples/plugins/ray_example.py
+++ b/examples/plugins/ray_example.py
@@ -25,8 +25,7 @@ ray_config = RayJobConfig(
 image = (
     flyte.Image.from_debian_base(name="ray")
     .with_apt_packages("wget")
-    .with_pip_packages("ray[default]==2.46.0", "flyteplugins-ray", "pip", "mypy")
-    .with_env_vars({"hello": "test3"})
+    .with_pip_packages("ray[default]==2.46.0", "flyteplugins-ray", "pip")
 )
 
 task_env = flyte.TaskEnvironment(

--- a/examples/plugins/ray_example.py
+++ b/examples/plugins/ray_example.py
@@ -23,9 +23,10 @@ ray_config = RayJobConfig(
 )
 
 image = (
-    flyte.Image.from_debian_base()
+    flyte.Image.from_debian_base(name="ray")
     .with_apt_packages("wget")
-    .with_pip_packages("ray[default]==2.46.0", "flyteplugins-ray", "pip")
+    .with_pip_packages("ray[default]==2.46.0", "flyteplugins-ray", "pip", "mypy")
+    .with_env_vars({"hello": "test3"})
 )
 
 task_env = flyte.TaskEnvironment(

--- a/examples/plugins/spark_example.py
+++ b/examples/plugins/spark_example.py
@@ -9,9 +9,10 @@ from flyte._context import internal_ctx
 
 image = (
     flyte.Image.from_base("apache/spark-py:v3.4.0")
-    .clone(name="spark", python_version="3.10")
-    .with_pip_packages("flyteplugins-spark")
+    .clone(name="spark", python_version=(3, 10))
+    .with_pip_packages("flyteplugins-spark", pre=True)
 )
+image = "us-docker.pkg.dev/dogfood-gcp-dataplane/orgs/dogfood-gcp/spark:91feb34fb2fe8f14415eb667121e2e94-opt"
 
 task_env = flyte.TaskEnvironment(
     name="get_pi", resources=flyte.Resources(cpu=(1, 2), memory=("400Mi", "1000Mi")), image=image

--- a/examples/plugins/spark_example.py
+++ b/examples/plugins/spark_example.py
@@ -12,7 +12,6 @@ image = (
     .clone(name="spark", python_version=(3, 10))
     .with_pip_packages("flyteplugins-spark", pre=True)
 )
-image = "us-docker.pkg.dev/dogfood-gcp-dataplane/orgs/dogfood-gcp/spark:91feb34fb2fe8f14415eb667121e2e94-opt"
 
 task_env = flyte.TaskEnvironment(
     name="get_pi", resources=flyte.Resources(cpu=(1, 2), memory=("400Mi", "1000Mi")), image=image

--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -548,7 +548,7 @@ class Image:
             platform=platform,
         )
 
-        if registry and name:
+        if registry or name:
             return base_image.clone(registry=registry, name=name)
 
         # # Set this to auto for all auto images because the meaning of "auto" can change (based on logic inside

--- a/src/flyte/_internal/imagebuild/remote_builder.py
+++ b/src/flyte/_internal/imagebuild/remote_builder.py
@@ -94,12 +94,12 @@ class RemoteImageBuilder(ImageBuilder):
         spec, context = await _validate_configuration(image)
 
         start = datetime.now(timezone.utc)
-        entity = remote.Task.get(
+        entity = await remote.Task.get(
             name=IMAGE_TASK_NAME,
             project=IMAGE_TASK_PROJECT,
             domain=IMAGE_TASK_DOMAIN,
             auto_version="latest",
-        )
+        ).override(resources=flyte.Resources(cpu=(2, 3), memory="400Mi"))
         run = cast(
             Run,
             await flyte.with_runcontext(project=IMAGE_TASK_PROJECT, domain=IMAGE_TASK_DOMAIN).run.aio(

--- a/src/flyte/_internal/imagebuild/remote_builder.py
+++ b/src/flyte/_internal/imagebuild/remote_builder.py
@@ -94,12 +94,12 @@ class RemoteImageBuilder(ImageBuilder):
         spec, context = await _validate_configuration(image)
 
         start = datetime.now(timezone.utc)
-        entity = await remote.Task.get(
+        entity = remote.Task.get(
             name=IMAGE_TASK_NAME,
             project=IMAGE_TASK_PROJECT,
             domain=IMAGE_TASK_DOMAIN,
             auto_version="latest",
-        ).override(resources=flyte.Resources(cpu=(2, 3), memory="400Mi"))
+        )
         run = cast(
             Run,
             await flyte.with_runcontext(project=IMAGE_TASK_PROJECT, domain=IMAGE_TASK_DOMAIN).run.aio(

--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -512,7 +512,7 @@ class _Runner:
             raise ValueError("Remote task can only be run in remote mode.")
 
         if not isinstance(task, TaskTemplate) and not isinstance(task, LazyEntity):
-            raise TypeError("On Flyte tasks can be run, not generic functions or methods.")
+            raise TypeError(f"On Flyte tasks can be run, not generic functions or methods '{type(task)}'.")
 
         if self._mode == "remote":
             return await self._run_remote(task, *args, **kwargs)

--- a/src/flyte/remote/_task.py
+++ b/src/flyte/remote/_task.py
@@ -295,9 +295,8 @@ class TaskDetails(ToJSONMixin):
             template.security_context.CopyFrom(get_security_context(secrets))
         if template.HasField("container"):
             if env:
-                template.container.env = (
-                    [literals_pb2.KeyValuePair(key=k, value=v) for k, v in env.items()] if env else None
-                )
+                template.container.env.clear()
+                template.container.env.extend([literals_pb2.KeyValuePair(key=k, value=v) for k, v in env.items()])
             if resources:
                 template.container.resources.CopyFrom(get_proto_resources(resources))
         if retries:

--- a/src/flyte/remote/_task.py
+++ b/src/flyte/remote/_task.py
@@ -271,7 +271,7 @@ class TaskDetails:
         max_inline_io_bytes: int | None = None,
         **kwargs: Any,
     ) -> TaskDetails:
-        raise NotImplementedError
+        self.pb2.spec
 
     def __rich_repr__(self) -> rich.repr.Result:
         """

--- a/src/flyte/remote/_task.py
+++ b/src/flyte/remote/_task.py
@@ -71,7 +71,7 @@ class LazyEntity:
     async def override(
         self,
         **kwargs: Any,
-    ) -> TaskDetails:
+    ) -> LazyEntity:
         task_details = cast(TaskDetails, await self.fetch.aio())
         task_details.override(**kwargs)
         return self

--- a/src/flyte/remote/_task.py
+++ b/src/flyte/remote/_task.py
@@ -290,6 +290,11 @@ class TaskDetails(ToJSONMixin):
         secrets: Optional[flyte.SecretRequest] = None,
         **kwargs: Any,
     ) -> TaskDetails:
+        if len(kwargs) > 0:
+            raise ValueError(
+                f"ReferenceTasks [{self.name}] do not support overriding with kwargs: {kwargs}, "
+                f"Check the parameters for override method."
+            )
         template = self.pb2.spec.task_template
         if secrets:
             template.security_context.CopyFrom(get_security_context(secrets))


### PR DESCRIPTION
```python
import flyte
from flyte import remote
from flyte.extras import ContainerTask

env = flyte.TaskEnvironment(name="hello_world")


greeting_task = ContainerTask(
    name="echo_and_return_greeting",
    image="alpine:latest",
    input_data_dir="/var/inputs",
    output_data_dir="/var/outputs",
    inputs={"name": str},
    outputs={"greeting": str},
    command=["/bin/sh", "-c", "echo 'Hello, my name is {{.inputs.name}}.' | tee -a /var/outputs/greeting"],
)

# Add it to the environment if you want to deploy it.
env.add_task(greeting_task)


@env.task
async def say_hello(name: str = "flyte") -> str:
    print("Hello container task")
    return await greeting_task(name=name)


if __name__ == "__main__":
    # asyncio.run(say_hello("Union"))
    import flyte.storage

    flyte.init_from_config("../../config.yaml")
    entity = remote.Task.get(
        name="echo_and_return_greeting",
        project="flytesnacks",
        domain="development",
        auto_version="latest",
    ).override(secrets=[flyte.Secret(key="secret-project-domain", as_env_var="OPENAI_API_KEY")])

    run = flyte.with_runcontext(mode="remote").run(entity, "Union")
    print(run.url)
```