### PR TITLE
Remove editable

### DIFF
--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -451,11 +451,7 @@ class Image:
         # this default image definition may need to be updated once there is a released pypi version
         from flyte._version import __version__
 
-        dev_mode = (
-            (cls._is_editable_install() or (__version__ and "dev" in __version__))
-            and not flyte_version
-            and install_flyte
-        )
+        dev_mode = (__version__ and "dev" in __version__) and not flyte_version and install_flyte
         if install_flyte is False:
             preset_tag = f"py{python_version[0]}.{python_version[1]}"
         else:
@@ -506,13 +502,6 @@ class Image:
         object.__setattr__(image, "_identifier_override", "auto")
 
         return image
-
-    @staticmethod
-    def _is_editable_install():
-        """Internal hacky function to see if the current install is editable or not."""
-        curr = Path(__file__)
-        pyproject = curr.parent.parent.parent / "pyproject.toml"
-        return pyproject.exists()
 
     @classmethod
     def from_debian_base(

--- a/tests/flyte/test_int_image_builder.py
+++ b/tests/flyte/test_int_image_builder.py
@@ -20,14 +20,6 @@ async def test_real_build_copied():
     await ImageBuildEngine.build(default_image, force=True)
 
 
-# This may fail in CI so marking this special
-@pytest.mark.editable
-def test_editable():
-    from flyte._image import Image
-
-    assert Image._is_editable_install()
-
-
 def test_real_build_copiedfsaf():
     default_image = Image.from_debian_base(registry="ghcr.io/flyteorg", name="flyte-example")
     print(default_image)


### PR DESCRIPTION
This removes the pretty hacky editable install detection and now relies purely on detecting the 'dev' word in the version that should be placed there by setuptools_scm.

The recent change to again hash the built wheel when constructing local images broke image building for releases because the missing preset tag caused the image to be tagged with a hash instead of the release tag.
example: https://github.com/flyteorg/flyte-sdk/actions/runs/16977992633/job/48132152647

b9 images have been built and pushed locally.