### PR TITLE
Add support for running reference tasks

### DIFF
--- a/examples/basics/hello_v2.py
+++ b/examples/basics/hello_v2.py
@@ -5,6 +5,7 @@ import flyte
 
 env = flyte.TaskEnvironment(
     name="hello_v2",
+    image=flyte.Image.from_debian_base().with_pip_packages("flyte", pre=True),
 )
 
 

--- a/examples/basics/hello_v2.py
+++ b/examples/basics/hello_v2.py
@@ -5,7 +5,6 @@ import flyte
 
 env = flyte.TaskEnvironment(
     name="hello_v2",
-    image=flyte.Image.from_debian_base().with_pip_packages("flyte", pre=True),
 )
 
 

--- a/src/flyte/cli/_common.py
+++ b/src/flyte/cli/_common.py
@@ -320,17 +320,18 @@ class FileGroup(GroupBase):
             _files = [os.fspath(p) for p in directory.glob("*.py") if p.name != "__init__.py"]
 
             # add directories
-            _files.extend([
-                os.fspath(directory / p.name) for p in directory.iterdir() if not p.name.startswith(("_", ".")) and p.is_dir()
-            ])
+            _files.extend(
+                [
+                    os.fspath(directory / p.name)
+                    for p in directory.iterdir()
+                    if not p.name.startswith(("_", ".")) and p.is_dir()
+                ]
+            )
 
             # files that are in the current directory or subdirectories of the
             # current directory should be displayed as relative paths
             self._files = [
-                str(Path(f).relative_to(Path.cwd()))
-                if Path(f).is_relative_to(Path.cwd())
-                else f
-                for f in _files
+                str(Path(f).relative_to(Path.cwd())) if Path(f).is_relative_to(Path.cwd()) else f for f in _files
             ]
         return self._files
 

--- a/src/flyte/cli/_common.py
+++ b/src/flyte/cli/_common.py
@@ -326,7 +326,10 @@ class FileGroup(GroupBase):
         return self._files
 
     def list_commands(self, ctx):
-        return self.files
+        return [
+            "reference-task",
+            *self.files,
+        ]
 
     def get_command(self, ctx, filename):
         raise NotImplementedError

--- a/src/flyte/cli/_common.py
+++ b/src/flyte/cli/_common.py
@@ -320,22 +320,24 @@ class FileGroup(GroupBase):
             _files = [os.fspath(p) for p in directory.glob("*.py") if p.name != "__init__.py"]
 
             # add directories
-            _files.extend([os.fspath(".")] + [
+            _files.extend([
                 os.fspath(directory / p.name) for p in directory.iterdir() if not p.name.startswith(("_", ".")) and p.is_dir()
             ])
-            self._files = _files
+
+            # files that are in the current directory or subdirectories of the
+            # current directory should be displayed as relative paths
+            self._files = [
+                str(Path(f).relative_to(Path.cwd()))
+                if Path(f).is_relative_to(Path.cwd())
+                else f
+                for f in _files
+            ]
         return self._files
 
     def list_commands(self, ctx):
-        file_commands = []
-        for f in self.files:
-            if Path(f).is_relative_to(Path.cwd()):
-                file_commands.append(str(Path(f).relative_to(Path.cwd())))
-            else:
-                file_commands.append(f)
         return [
             "reference-task",
-            *file_commands,
+            *self.files,
         ]
 
     def get_command(self, ctx, filename):

--- a/src/flyte/cli/_common.py
+++ b/src/flyte/cli/_common.py
@@ -316,11 +316,13 @@ class FileGroup(GroupBase):
     def files(self):
         if self._files is None:
             directory = self._dir or Path(".").absolute()
-            self._files = [os.fspath(p) for p in directory.glob("*.py") if p.name != "__init__.py"]
-            if not self._files:
-                self._files = [os.fspath(".")] + [
+            _files = [os.fspath(p) for p in directory.glob("*.py") if p.name != "__init__.py"]
+            if not _files:
+                _files = [os.fspath(".")] + [
                     os.fspath(p.name) for p in directory.iterdir() if not p.name.startswith(("_", ".")) and p.is_dir()
                 ]
+            _files = [str(Path(f).relative_to(Path.cwd())) for f in _files]
+            self._files = _files
         return self._files
 
     def list_commands(self, ctx):

--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 from dataclasses import dataclass, field, fields
+from functools import lru_cache
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Dict, List, cast
@@ -19,6 +20,30 @@ from . import _common as common
 from ._common import CLIConfig
 from ._params import to_click_option
 
+
+@lru_cache()
+def _initialize_config(ctx: Context, project: str, domain: str):
+    obj: CLIConfig | None = ctx.obj
+    if obj is None:
+        import flyte.config
+
+        obj = CLIConfig(flyte.config.auto(), ctx)
+
+    obj.init(project, domain)
+    return obj
+
+@lru_cache()
+def _list_tasks(
+    ctx: Context,
+    project: str,
+    domain: str,
+    by_task_name: str | None = None,
+    by_task_env: str | None = None,
+) -> list[str]:
+    import flyte.remote
+
+    _initialize_config(ctx, project, domain)
+    return [task.name for task in flyte.remote.Task.listall(by_task_name=by_task_name, by_task_env=by_task_env)]
 
 @dataclass
 class RunArguments:
@@ -60,7 +85,7 @@ class RunArguments:
         },
     )
     follow: bool = field(
-        default=True,
+        default=False,
         metadata={
             "click.option": click.Option(
                 ["--follow", "-f"],
@@ -93,22 +118,16 @@ class RunTaskCommand(click.Command):
         super().__init__(obj_name, *args, **kwargs)
 
     def invoke(self, ctx: Context):
-        obj: CLIConfig = ctx.obj
-        if obj is None:
-            import flyte.config
-
-            obj = CLIConfig(flyte.config.auto(), ctx)
-
-        obj.init(self.run_args.project, self.run_args.domain)
+        obj: CLIConfig = _initialize_config(ctx, self.run_args.project, self.run_args.domain)
 
         async def _run():
             import flyte
 
-            r = flyte.with_runcontext(
+            r = await flyte.with_runcontext(
                 copy_style=self.run_args.copy_style,
                 mode="local" if self.run_args.local else "remote",
                 name=self.run_args.name,
-            ).run(self.obj, **ctx.params)
+            ).run.aio(self.obj, **ctx.params)
             if isinstance(r, Run) and r.action is not None:
                 console = Console()
                 console.print(
@@ -174,25 +193,27 @@ class TaskPerFileGroup(common.ObjectsPerFileGroup):
         )
     
 class RunReferenceTaskCommand(click.Command):
-    def __init__(self, task_name: str, run_args: RunArguments, *args, **kwargs):
+    def __init__(self, task_name: str, run_args: RunArguments, version: str | None, *args, **kwargs):
         self.task_name = task_name
         self.run_args = run_args
+        self.version = version
+
         super().__init__(*args, **kwargs)
 
     def invoke(self, ctx: click.Context):
-        obj: CLIConfig = ctx.obj
+        obj: CLIConfig = _initialize_config(ctx, self.run_args.project, self.run_args.domain)
 
         async def _run():
             import flyte
             import flyte.remote
 
-            task = flyte.remote.Task.get(self.task_name, auto_version="latest")
+            task = flyte.remote.Task.get(self.task_name, version=self.version, auto_version="latest")
 
-            r = flyte.with_runcontext(
+            r = await flyte.with_runcontext(
                 copy_style=self.run_args.copy_style,
                 mode="local" if self.run_args.local else "remote",
                 name=self.run_args.name,
-            ).run(task, **ctx.params)
+            ).run.aio(task, **ctx.params)
             if isinstance(r, Run) and r.action is not None:
                 console = Console()
                 console.print(
@@ -218,13 +239,7 @@ class RunReferenceTaskCommand(click.Command):
         import flyte.remote
         from flyte._internal.runtime.types_serde import transform_native_to_typed_interface
 
-        obj: CLIConfig = ctx.obj
-        if obj is None:
-            import flyte.config
-
-            obj = CLIConfig(flyte.config.auto(), ctx)
-
-        obj.init(self.run_args.project, self.run_args.domain)
+        _initialize_config(ctx, self.run_args.project, self.run_args.domain)
 
         task = flyte.remote.Task.get(self.task_name, auto_version="latest")
         task_details = task.fetch()
@@ -243,6 +258,26 @@ class RunReferenceTaskCommand(click.Command):
 
         self.params = params
         return super().get_params(ctx)
+    
+
+class ReferenceEnvGroup(common.GroupBase):
+    def __init__(self, name: str, *args, run_args, env: str, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.name = name
+        self.env = env
+        self.run_args = run_args
+    
+    def list_commands(self, ctx):
+        return _list_tasks(ctx, self.run_args.project, self.run_args.domain, by_task_env=self.env)
+
+    def get_command(self, ctx, name):
+        return RunReferenceTaskCommand(
+            task_name=name,
+            run_args=self.run_args,
+            name=name,
+            version=None,
+            help=f"Run reference task '{name}' from the Flyte backend",
+        )
 
 
 class ReferenceTaskGroup(common.GroupBase):
@@ -250,19 +285,80 @@ class ReferenceTaskGroup(common.GroupBase):
     Group that creates a command for each reference task in the current directory that is not __init__.py.
     """
 
-    def __init__(self, name: str, *args, run_args, **kwargs):
+    def __init__(self, name: str, *args, run_args, tasks: list[str] | None = None, **kwargs):
         super().__init__(*args, **kwargs)
         self.name = name
         self.run_args = run_args
+
+    def list_commands(self, ctx):
+        # list envs of all reference tasks
+        envs = []
+        for task in _list_tasks(ctx, self.run_args.project, self.run_args.domain):
+            env = task.split(".")[0]
+            if env not in envs:
+                envs.append(env)
+        return envs
+
+    @staticmethod
+    def _parse_task_name(task_name: str) -> tuple[str, str | None, str | None]:
+        import re
+
+        pattern = r"^([^.:]+)(?:\.([^:]+))?(?::(.+))?$"
+        match = re.match(pattern, task_name)
+        if not match:
+            raise click.BadParameter(f"Invalid task name format: {task_name}")
+        return match.group(1), match.group(2), match.group(3)
     
-    def get_command(self, ctx, task_name):
-        return RunReferenceTaskCommand(
-            task_name=task_name,
-            run_args=RunArguments.from_dict(ctx.params),
-            name=task_name,
-            help=f"Run reference task '{task_name}' from the Flyte backend",
-        )
-        
+    def _env_is_task(self, ctx: click.Context, env: str) -> bool:
+        # check if the env name is the full task name, since sometimes task
+        # names don't have an environment prefix
+        tasks = [*_list_tasks(ctx, self.run_args.project, self.run_args.domain, by_task_name=env)]
+        return len(tasks) > 0
+
+    def get_command(self, ctx, name):
+        env, task, version = self._parse_task_name(name)
+
+        match env, task, version:
+            case env, None, None:
+                if self._env_is_task(ctx, env):
+                    # this handles cases where task names do not have a environment prefix
+                    task_name = env
+                    return RunReferenceTaskCommand(
+                        task_name=task_name,
+                        run_args=self.run_args,
+                        name=task_name,
+                        version=None,
+                        help=f"Run reference task `{task_name}` from the Flyte backend",
+                    )
+                else:
+                    return ReferenceEnvGroup(
+                        name=name,
+                        run_args=self.run_args,
+                        env=env,
+                        help=f"Run reference tasks in the `{env}` environment from the Flyte backend",
+                    )
+            case env, task, None:
+                task_name = f"{env}.{task}"
+                return RunReferenceTaskCommand(
+                    task_name=task_name,
+                    run_args=self.run_args,
+                    name=task_name,
+                    version=None,
+                    help=f"Run reference task '{task_name}' from the Flyte backend",
+                )
+            case env, task, version:
+                task_name = f"{env}.{task}"
+                import ipdb; ipdb.set_trace()
+                return RunReferenceTaskCommand(
+                    task_name=task_name,
+                    run_args=self.run_args,
+                    version=version,
+                    name=f"{task_name}:{version}",
+                    help=f"Run reference task '{task_name}' from the Flyte backend",
+                )
+            case _:
+                raise click.BadParameter(f"Invalid task name format: {task_name}")
+
 
 class TaskFiles(common.FileGroup):
     """
@@ -311,7 +407,9 @@ class TaskFiles(common.FileGroup):
 run = TaskFiles(
     name="run",
     help="""
-Run a task from a python file.
+Run a task from a python file or reference a remote task.
+
+To run a remote task that already exists in Flyte, use the reference-task command:
 
 Example usage:
 
@@ -327,6 +425,24 @@ Flyte environment:
 
 ```bash
 flyte run --local hello.py my_task --arg1 value1 --arg2 value2
+```
+
+To run tasks that you've already deployed to Flyte, use the reference-task command:
+
+```bash
+flyte run reference-task my_env.my_task --arg1 value1 --arg2 value2
+```
+
+You can specify the `--config` flag to point to a specific Flyte cluster:
+
+```bash
+flyte run --config my-config.yaml reference-task ...
+```
+
+You can discover what reference tasks are available by running:
+
+```bash
+flyte run reference-task
 ```
 
 Other arguments to the run command are listed below.

--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -289,14 +289,17 @@ class TaskFiles(common.FileGroup):
             return ReferenceTaskGroup(
                 name=cmd_name,
                 run_args=run_args,
-                help=f"Run reference task '{cmd_name}' from the Flyte backend",
+                help=f"Run reference task from the Flyte backend",
             )
 
         fp = Path(cmd_name)
         if not fp.exists():
             raise click.BadParameter(f"File {cmd_name} does not exist")
         if fp.is_dir():
-            return TaskFiles(directory=fp)
+            return TaskFiles(
+                directory=fp,
+                help=f"Run `*.py` file inside in the {fp} directory",
+            )
         return TaskPerFileGroup(
             filename=fp,
             run_args=run_args,

--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -156,8 +156,9 @@ class TaskPerFileGroup(common.ObjectsPerFileGroup):
     """
 
     def __init__(self, filename: Path, run_args: RunArguments, *args, **kwargs):
-        args = (filename, *args)
-        super().__init__(*args, **kwargs)
+        if filename.is_absolute():
+            filename = filename.relative_to(Path.cwd())
+        super().__init__(*(filename, *args), **kwargs)
         self.run_args = run_args
 
     def _filter_objects(self, module: ModuleType) -> Dict[str, Any]:
@@ -202,7 +203,7 @@ class TaskFiles(common.FileGroup):
             filename=fp,
             run_args=run_args,
             name=filename,
-            help=f"Run, functions decorated with `env.task` in {filename}",
+            help=f"Run functions decorated with `env.task` in {filename}",
         )
 
 

--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -435,6 +435,12 @@ To run tasks that you've already deployed to Flyte, use the reference-task comma
 flyte run reference-task my_env.my_task --arg1 value1 --arg2 value2
 ```
 
+To run a specific version of a reference task, use the `env.task:version` syntax:
+
+```bash
+flyte run reference-task my_env.my_task:xyz123 --arg1 value1 --arg2 value2
+```
+
 You can specify the `--config` flag to point to a specific Flyte cluster:
 
 ```bash

--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -32,6 +32,7 @@ def _initialize_config(ctx: Context, project: str, domain: str):
     obj.init(project, domain)
     return obj
 
+
 @lru_cache()
 def _list_tasks(
     ctx: Context,
@@ -44,6 +45,7 @@ def _list_tasks(
 
     _initialize_config(ctx, project, domain)
     return [task.name for task in flyte.remote.Task.listall(by_task_name=by_task_name, by_task_env=by_task_env)]
+
 
 @dataclass
 class RunArguments:
@@ -191,7 +193,8 @@ class TaskPerFileGroup(common.ObjectsPerFileGroup):
             help=obj.docs.__help__str__() if obj.docs else None,
             run_args=self.run_args,
         )
-    
+
+
 class RunReferenceTaskCommand(click.Command):
     def __init__(self, task_name: str, run_args: RunArguments, version: str | None, *args, **kwargs):
         self.task_name = task_name
@@ -258,7 +261,7 @@ class RunReferenceTaskCommand(click.Command):
 
         self.params = params
         return super().get_params(ctx)
-    
+
 
 class ReferenceEnvGroup(common.GroupBase):
     def __init__(self, name: str, *args, run_args, env: str, **kwargs):
@@ -266,7 +269,7 @@ class ReferenceEnvGroup(common.GroupBase):
         self.name = name
         self.env = env
         self.run_args = run_args
-    
+
     def list_commands(self, ctx):
         return _list_tasks(ctx, self.run_args.project, self.run_args.domain, by_task_env=self.env)
 
@@ -308,7 +311,7 @@ class ReferenceTaskGroup(common.GroupBase):
         if not match:
             raise click.BadParameter(f"Invalid task name format: {task_name}")
         return match.group(1), match.group(2), match.group(3)
-    
+
     def _env_is_task(self, ctx: click.Context, env: str) -> bool:
         # check if the env name is the full task name, since sometimes task
         # names don't have an environment prefix
@@ -348,7 +351,6 @@ class ReferenceTaskGroup(common.GroupBase):
                 )
             case env, task, version:
                 task_name = f"{env}.{task}"
-                import ipdb; ipdb.set_trace()
                 return RunReferenceTaskCommand(
                     task_name=task_name,
                     run_args=self.run_args,
@@ -385,7 +387,7 @@ class TaskFiles(common.FileGroup):
             return ReferenceTaskGroup(
                 name=cmd_name,
                 run_args=run_args,
-                help=f"Run reference task from the Flyte backend",
+                help="Run reference task from the Flyte backend",
             )
 
         fp = Path(cmd_name)

--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -396,7 +396,7 @@ class TaskFiles(common.FileGroup):
         if fp.is_dir():
             return TaskFiles(
                 directory=fp,
-                help=f"Run `*.py` file inside in the {fp} directory",
+                help=f"Run `*.py` file inside the {fp} directory",
             )
         return TaskPerFileGroup(
             filename=fp,

--- a/src/flyte/remote/_task.py
+++ b/src/flyte/remote/_task.py
@@ -382,6 +382,7 @@ class Task(ToJSONMixin):
     async def listall(
         cls,
         by_task_name: str | None = None,
+        by_task_env: str | None = None,
         project: str | None = None,
         domain: str | None = None,
         sort_by: Tuple[str, Literal["asc", "desc"]] | None = None,
@@ -391,6 +392,7 @@ class Task(ToJSONMixin):
         Get all runs for the current project and domain.
 
         :param by_task_name: If provided, only tasks with this name will be returned.
+        :param by_task_env: If provided, only tasks with this environment prefix will be returned.
         :param project: The project to filter tasks by. If None, the current project will be used.
         :param domain: The domain to filter tasks by. If None, the current domain will be used.
         :param sort_by: The sorting criteria for the project list, in the format (field, order).
@@ -411,6 +413,15 @@ class Task(ToJSONMixin):
                     function=list_pb2.Filter.Function.EQUAL,
                     field="name",
                     values=[by_task_name],
+                )
+            )
+        if by_task_env:
+            # ideally we should have a STARTS_WITH filter, but it is not supported yet
+            filters.append(
+                list_pb2.Filter(
+                    function=list_pb2.Filter.Function.CONTAINS,
+                    field="name",
+                    values=[f"{by_task_env}."],
                 )
             )
         original_limit = limit


### PR DESCRIPTION
This PR adds support for running reference tasks from the cli with:
```bash
flyte run reference-task <task-name> --arg1 foo --arg2 bar
```

This also modifies the `flyte run` file commands so that it's relative to the current working directory:

```
flyte run 

╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────────╮
│ reference-task         Run reference task 'reference-task' from the Flyte backend                    │
│ exception_handling.py  Run functions decorated with env.task in exception_handling.py                │
│ hello.py               Run functions decorated with env.task in hello.py                             │
│ report_example.py      Run functions decorated with env.task in report_example.py                    │
│ devbox_one.py          Run functions decorated with env.task in devbox_one.py                        │
│ union_type_simple.py   Run functions decorated with env.task in union_type_simple.py                 │
```

The current behavior showing the absolute path makes the help text less readable

## Test

From the `examples/basics` directory, config pointing to playground:

```
flyte --config ../../config.yaml run reference-task exc_handler.always_succeeds
╭──────────────────────────────────────────────── Run ─────────────────────────────────────────────────╮
│ Created Run: r96c2998f766fwr7cn8w  (Project: flytesnacks, Domain: development)                       │
│ ➡️                                                                                                    │
│ https://playground.canary.unionai.cloud/v2/runs/project/flytesnacks/domain/development/r96c2998f766f │
│ wr7cn8w                                                                                              │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────╯
Log streaming enabled, will wait for task to start running and log stream to be available
```