### PR TITLE
Removes the grpc warning messages.

### DIFF
--- a/examples/basics/hello_polyglot.py
+++ b/examples/basics/hello_polyglot.py
@@ -1,12 +1,15 @@
 import sys
-import flyte
+
 import polyglot_hello
+
+import flyte
 
 env = flyte.TaskEnvironment(
     name="hello_polyglot",
     resources=flyte.Resources(memory="250Mi"),
     image=flyte.Image.from_debian_base().with_pip_packages("polyglot-hello"),
 )
+
 
 @env.task
 def hello_for_code(code: str) -> tuple[str, str, str]:
@@ -17,9 +20,7 @@ def hello_for_code(code: str) -> tuple[str, str, str]:
 @env.task
 def main(letter: str) -> dict[str, str]:
     if not isinstance(letter, str) or len(letter) != 1 or not letter.isalpha():
-        raise ValueError(
-            "letter must be a single alphabetic character, e.g., 'e' or 'S'"
-        )
+        raise ValueError("letter must be a single alphabetic character, e.g., 'e' or 'S'")
 
     letter_lower = letter.lower()
 

--- a/src/flyte/__init__.py
+++ b/src/flyte/__init__.py
@@ -2,6 +2,62 @@
 Flyte SDK for authoring compound AI applications, services and workflows.
 """
 
+from __future__ import annotations
+
+import sys
+
+from ._build import build
+from ._cache import Cache, CachePolicy, CacheRequest
+from ._context import ctx
+from ._deploy import build_images, deploy
+from ._environment import Environment
+from ._excepthook import custom_excepthook
+from ._group import group
+from ._image import Image
+from ._initialize import init, init_from_config
+from ._map import map
+from ._pod import PodTemplate
+from ._resources import GPU, TPU, Device, Resources
+from ._retry import RetryStrategy
+from ._reusable_environment import ReusePolicy
+from ._run import run, with_runcontext
+from ._secret import Secret, SecretRequest
+from ._task_environment import TaskEnvironment
+from ._timeout import Timeout, TimeoutType
+from ._trace import trace
+from ._version import __version__
+
+sys.excepthook = custom_excepthook
+
+
+def _silence_grpc_warnings():
+    """
+    Silences gRPC warnings that can clutter the output.
+    """
+    import os
+
+    # Set environment variables for gRPC, this reduces log spew and avoids unnecessary warnings
+    # before importing grpc
+    if "GRPC_VERBOSITY" not in os.environ:
+        os.environ["GRPC_VERBOSITY"] = "ERROR"
+        os.environ["GRPC_CPP_MIN_LOG_LEVEL"] = "ERROR"
+        # Disable fork support (stops "skipping fork() handlers")
+        os.environ["GRPC_ENABLE_FORK_SUPPORT"] = "0"
+        # Reduce absl/glog verbosity
+        os.environ["GLOG_minloglevel"] = "2"
+        os.environ["ABSL_LOG"] = "0"
+
+
+_silence_grpc_warnings()
+
+
+def version() -> str:
+    """
+    Returns the version of the Flyte SDK.
+    """
+    return __version__
+
+
 __all__ = [
     "GPU",
     "TPU",
@@ -33,35 +89,3 @@ __all__ = [
     "trace",
     "with_runcontext",
 ]
-
-import sys
-
-from ._build import build
-from ._cache import Cache, CachePolicy, CacheRequest
-from ._context import ctx
-from ._deploy import build_images, deploy
-from ._environment import Environment
-from ._excepthook import custom_excepthook
-from ._group import group
-from ._image import Image
-from ._initialize import init, init_from_config
-from ._map import map
-from ._pod import PodTemplate
-from ._resources import GPU, TPU, Device, Resources
-from ._retry import RetryStrategy
-from ._reusable_environment import ReusePolicy
-from ._run import run, with_runcontext
-from ._secret import Secret, SecretRequest
-from ._task_environment import TaskEnvironment
-from ._timeout import Timeout, TimeoutType
-from ._trace import trace
-from ._version import __version__
-
-sys.excepthook = custom_excepthook
-
-
-def version() -> str:
-    """
-    Returns the version of the Flyte SDK.
-    """
-    return __version__

--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -11,7 +11,6 @@ from flyte.errors import InitializationError
 from flyte.syncify import syncify
 
 from ._logging import initialize_logger, logger
-from ._tools import ipython_check
 
 if TYPE_CHECKING:
     from flyte._internal.imagebuild import ImageBuildEngine
@@ -173,6 +172,7 @@ async def init(
 
     :return: None
     """
+    from flyte._tools import ipython_check
     from flyte._utils import get_cwd_editable_install, org_from_endpoint, sanitize_endpoint
 
     interactive_mode = ipython_check()

--- a/src/flyte/_logging.py
+++ b/src/flyte/_logging.py
@@ -4,8 +4,6 @@ import logging
 import os
 from typing import Optional
 
-from ._tools import ipython_check, is_in_cluster
-
 DEFAULT_LOG_LEVEL = logging.WARNING
 
 
@@ -42,6 +40,8 @@ def get_rich_handler(log_level: int) -> Optional[logging.Handler]:
     """
     Upgrades the global loggers to use Rich logging.
     """
+    from flyte._tools import ipython_check, is_in_cluster
+
     if is_in_cluster():
         return None
     if not ipython_check() and is_rich_logging_disabled():

--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -19,8 +19,6 @@ from flyte._initialize import (
 )
 from flyte._logging import logger
 from flyte._task import P, R, TaskTemplate
-from flyte._tools import ipython_check
-from flyte.errors import InitializationError
 from flyte.models import (
     ActionID,
     Checkpoints,
@@ -96,6 +94,8 @@ class _Runner:
         log_level: int | None = None,
         disable_run_cache: bool = False,
     ):
+        from flyte._tools import ipython_check
+
         init_config = _get_init_config()
         client = init_config.client if init_config else None
         if not force_mode and client is not None:
@@ -207,7 +207,7 @@ class _Runner:
         if not self._dry_run:
             if get_client() is None:
                 # This can only happen, if the user forces flyte.run(mode="remote") without initializing the client
-                raise InitializationError(
+                raise flyte.errors.InitializationError(
                     "ClientNotInitializedError",
                     "user",
                     "flyte.run requires client to be initialized. "

--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -20,7 +20,6 @@ from . import _common as common
 from ._common import CLIConfig
 from ._params import to_click_option
 
-
 RUN_REMOTE_CMD = "deployed-task"
 
 

--- a/src/flyte/remote/_client/auth/_channel.py
+++ b/src/flyte/remote/_client/auth/_channel.py
@@ -1,4 +1,3 @@
-import os
 import ssl
 import typing
 
@@ -15,11 +14,6 @@ from ._authenticators.factory import (
     create_proxy_auth_interceptors,
     get_async_proxy_authenticator,
 )
-
-# Set environment variables for gRPC, this reduces log spew and avoids unnecessary warnings
-if "GRPC_VERBOSITY" not in os.environ:
-    os.environ["GRPC_VERBOSITY"] = "ERROR"
-    os.environ["GRPC_CPP_MIN_LOG_LEVEL"] = "ERROR"
 
 # Initialize gRPC AIO early enough so it can be used in the main thread
 init_grpc_aio()

--- a/src/flyte/remote/_client/controlplane.py
+++ b/src/flyte/remote/_client/controlplane.py
@@ -1,5 +1,19 @@
 from __future__ import annotations
 
+import os
+
+# Set environment variables for gRPC, this reduces log spew and avoids unnecessary warnings
+# before importing grpc
+if "GRPC_VERBOSITY" not in os.environ:
+    os.environ["GRPC_VERBOSITY"] = "ERROR"
+    os.environ["GRPC_CPP_MIN_LOG_LEVEL"] = "ERROR"
+    # Disable fork support (stops "skipping fork() handlers")
+    os.environ["GRPC_ENABLE_FORK_SUPPORT"] = "0"
+    # Reduce absl/glog verbosity
+    os.environ["GLOG_minloglevel"] = "2"
+    os.environ["ABSL_LOG"] = "0"
+#### Has to be before grpc
+
 import grpc
 from flyteidl.service import admin_pb2_grpc, dataproxy_pb2_grpc
 


### PR DESCRIPTION
- This can be removed once the entire code is rustified.

These logs are now gone!
```
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1755442414.463529  826985 fork_posix.cc:71] Other threads are currently calling into gRPC, skipping fork() handlers
I0000 00:00:1755442414.830864  826985 fork_posix.cc:71] Other threads are currently calling into gRPC, skipping fork() handlers
```