### PR TITLE
Add resource to env.task decorator

### DIFF
--- a/src/flyte/_task_environment.py
+++ b/src/flyte/_task_environment.py
@@ -134,6 +134,7 @@ class TaskEnvironment(Environment):
         _func=None,
         *,
         name: Optional[str] = None,
+        resources: Optional[Resources] = None,
         cache: CacheRequest | None = None,
         retries: Union[int, RetryStrategy] = 0,
         timeout: Union[timedelta, int] = 0,
@@ -149,6 +150,7 @@ class TaskEnvironment(Environment):
         :param _func: Optional The function to decorate. If not provided, the decorator will return a callable that
         accepts a function to be decorated.
         :param name: Optional A friendly name for the task (defaults to the function name)
+        :param resources: Optional The resources for the task, defaults to the environment resources.
         :param cache: Optional The cache policy for the task, defaults to auto, which will cache the results of the
         task.
         :param retries: Optional The number of retries for the task, defaults to 0, which means no retries.
@@ -197,7 +199,7 @@ class TaskEnvironment(Environment):
                 func=func,
                 name=task_name,
                 image=self.image,
-                resources=self.resources,
+                resources=resources or self.resources,
                 cache=cache or self.cache,
                 retries=retries,
                 timeout=timeout,


### PR DESCRIPTION
This use case has come up in several Flyte 2.0 demo conversations so far: as a user, I want to be able to specify resources at a task-level, overriding the resources specified in the `TaskEnvironment`. This is effectively the same as `task.override`, where overriding resources is already available.

