### PR TITLE
Nix pydantic & dataclass type structure

### DIFF
--- a/examples/image/image_from_env.py
+++ b/examples/image/image_from_env.py
@@ -35,16 +35,16 @@ flyte --config ../../config.yaml run deployed-task image_from_env.main
 """
 
 import os
-import flyte
 
+import flyte
 
 # Task environment for building the image
 build_env = flyte.TaskEnvironment(
     name="build_env",
     image=(
-        flyte.Image
-        .from_debian_base(name="base-image", python_version=(3, 12))
-        .with_pip_packages("flyte", pre=True, extra_args="--prerelease=allow")
+        flyte.Image.from_debian_base(name="base-image", python_version=(3, 12)).with_pip_packages(
+            "flyte", pre=True, extra_args="--prerelease=allow"
+        )
     ),
 )
 
@@ -62,6 +62,7 @@ env = flyte.TaskEnvironment(
 @env.task
 async def t1(data: str = "hello") -> str:
     return f"Hello {data}"
+
 
 @env.task
 async def main(data: str = "hello") -> str:

--- a/src/flyte/types/_type_engine.py
+++ b/src/flyte/types/_type_engine.py
@@ -372,10 +372,10 @@ class PydanticTransformer(TypeTransformer[BaseModel]):
             }
         )
 
+        # The type engine used to publish a type structure for attribute access. As of v2, this is no longer needed.
         return LiteralType(
             simple=SimpleType.STRUCT,
             metadata=schema,
-            # structure=ts,
             annotation=TypeAnnotation(annotations=meta_struct),
         )
 
@@ -615,10 +615,11 @@ class DataclassTransformer(TypeTransformer[object]):
                 }
             }
         )
+
+        # The type engine used to publish a type structure for attribute access. As of v2, this is no longer needed.
         return types_pb2.LiteralType(
             simple=types_pb2.SimpleType.STRUCT,
             metadata=schema,
-            # structure=ts,
             annotation=TypeAnnotation(annotations=meta_struct),
         )
 

--- a/src/flyte/types/_type_engine.py
+++ b/src/flyte/types/_type_engine.py
@@ -362,19 +362,6 @@ class PydanticTransformer(TypeTransformer[BaseModel]):
 
     def get_literal_type(self, t: Type[BaseModel]) -> LiteralType:
         schema = t.model_json_schema()
-        # fields = t.__annotations__.items()
-
-        # literal_type = {}
-        # for name, python_type in fields:
-        #     try:
-        #         literal_type[name] = TypeEngine.to_literal_type(python_type)
-        #     except Exception as e:
-        #         logger.warning(
-        #             "Field {} of type {} cannot be converted to a literal type. Error: {}".format(name, python_type, e)
-        #         )
-
-        # This is for attribute access in FlytePropeller.
-        # ts = TypeStructure(tag="", dataclass_type=literal_type)
 
         meta_struct = struct_pb2.Struct()
         meta_struct.update(
@@ -619,24 +606,6 @@ class DataclassTransformer(TypeTransformer[object]):
                 f"Failed to extract schema for object {t}, error: {e}\n"
                 f"Possibly remove `DataClassJsonMixin` and `dataclass_json` decorator from dataclass declaration"
             )
-
-        # Recursively construct the dataclass_type which contains the literal type of each field
-        # literal_type = {}
-
-        # hints = typing.get_type_hints(t)
-        # Get the type of each field from dataclass
-        # for field in t.__dataclass_fields__.values():  # type: ignore
-        #     try:
-        #         name = field.name
-        #         python_type = hints.get(name, field.type)
-        #         literal_type[name] = TypeEngine.to_literal_type(python_type)
-        #     except Exception as e:
-        #         logger.debug(
-        #             f"Field {field.name} of type {field.type} cannot be converted to a literal type. Error: {e}"
-        #         )
-
-        # This is for attribute access in FlytePropeller.
-        # ts = TypeStructure(tag="", dataclass_type=literal_type)
 
         meta_struct = struct_pb2.Struct()
         meta_struct.update(

--- a/src/flyte/types/_type_engine.py
+++ b/src/flyte/types/_type_engine.py
@@ -362,19 +362,19 @@ class PydanticTransformer(TypeTransformer[BaseModel]):
 
     def get_literal_type(self, t: Type[BaseModel]) -> LiteralType:
         schema = t.model_json_schema()
-        fields = t.__annotations__.items()
+        # fields = t.__annotations__.items()
 
-        literal_type = {}
-        for name, python_type in fields:
-            try:
-                literal_type[name] = TypeEngine.to_literal_type(python_type)
-            except Exception as e:
-                logger.warning(
-                    "Field {} of type {} cannot be converted to a literal type. Error: {}".format(name, python_type, e)
-                )
+        # literal_type = {}
+        # for name, python_type in fields:
+        #     try:
+        #         literal_type[name] = TypeEngine.to_literal_type(python_type)
+        #     except Exception as e:
+        #         logger.warning(
+        #             "Field {} of type {} cannot be converted to a literal type. Error: {}".format(name, python_type, e)
+        #         )
 
         # This is for attribute access in FlytePropeller.
-        ts = TypeStructure(tag="", dataclass_type=literal_type)
+        # ts = TypeStructure(tag="", dataclass_type=literal_type)
 
         meta_struct = struct_pb2.Struct()
         meta_struct.update(
@@ -388,7 +388,7 @@ class PydanticTransformer(TypeTransformer[BaseModel]):
         return LiteralType(
             simple=SimpleType.STRUCT,
             metadata=schema,
-            structure=ts,
+            # structure=ts,
             annotation=TypeAnnotation(annotations=meta_struct),
         )
 
@@ -621,22 +621,22 @@ class DataclassTransformer(TypeTransformer[object]):
             )
 
         # Recursively construct the dataclass_type which contains the literal type of each field
-        literal_type = {}
+        # literal_type = {}
 
-        hints = typing.get_type_hints(t)
+        # hints = typing.get_type_hints(t)
         # Get the type of each field from dataclass
-        for field in t.__dataclass_fields__.values():  # type: ignore
-            try:
-                name = field.name
-                python_type = hints.get(name, field.type)
-                literal_type[name] = TypeEngine.to_literal_type(python_type)
-            except Exception as e:
-                logger.debug(
-                    f"Field {field.name} of type {field.type} cannot be converted to a literal type. Error: {e}"
-                )
+        # for field in t.__dataclass_fields__.values():  # type: ignore
+        #     try:
+        #         name = field.name
+        #         python_type = hints.get(name, field.type)
+        #         literal_type[name] = TypeEngine.to_literal_type(python_type)
+        #     except Exception as e:
+        #         logger.debug(
+        #             f"Field {field.name} of type {field.type} cannot be converted to a literal type. Error: {e}"
+        #         )
 
         # This is for attribute access in FlytePropeller.
-        ts = TypeStructure(tag="", dataclass_type=literal_type)
+        # ts = TypeStructure(tag="", dataclass_type=literal_type)
 
         meta_struct = struct_pb2.Struct()
         meta_struct.update(
@@ -649,7 +649,7 @@ class DataclassTransformer(TypeTransformer[object]):
         return types_pb2.LiteralType(
             simple=types_pb2.SimpleType.STRUCT,
             metadata=schema,
-            structure=ts,
+            # structure=ts,
             annotation=TypeAnnotation(annotations=meta_struct),
         )
 

--- a/tests/flyte/internal/runtime/test_convert.py
+++ b/tests/flyte/internal/runtime/test_convert.py
@@ -622,43 +622,6 @@ def test_generate_inputs_hash_from_proto(name, inputs, expected_hash):
             ),
             "FHbQNnyP0k7IJt3Jpp8lfgJ/RU8EZEEcYXPuc2ieV5s=",
         ),
-        # (
-        #     "struct_with_dataclass",
-        #     TypedInterface(
-        #         inputs=VariableMap(
-        #             variables={
-        #                 "input_1": Variable(
-        #                     type=LiteralType(
-        #                         simple=SimpleType.STRUCT,
-        #                         structure=TypeStructure(
-        #                             dataclass_type={
-        #                                 "field1": LiteralType(simple=SimpleType.INTEGER),
-        #                                 "field2": LiteralType(simple=SimpleType.STRING)
-        #                             }
-        #                         )
-        #                     ),
-        #                     description="description",
-        #                 )
-        #             }
-        #         ),
-        #         outputs=VariableMap(
-        #             variables={
-        #                 "output_1": Variable(
-        #                     type=LiteralType(
-        #                         simple=SimpleType.STRUCT,
-        #                         structure=TypeStructure(
-        #                             dataclass_type={
-        #                                 "field1": LiteralType(simple=SimpleType.INTEGER),
-        #                                 "field2": LiteralType(simple=SimpleType.STRING)
-        #                             }
-        #                         )
-        #                     ),
-        #                 )
-        #             }
-        #         )
-        #     ),
-        #     "E91ntwbZiy78sCEB3NXilA1/AFD5N8PX6kftohfMaXU="
-        # ),
         (
             "structured_dataset",
             TypedInterface(

--- a/tests/flyte/internal/runtime/test_convert.py
+++ b/tests/flyte/internal/runtime/test_convert.py
@@ -155,7 +155,7 @@ async def test_generate_cache_key_hash_consistency(_):
 
     task_name = "test_task"
     cache_key = convert.generate_cache_key_hash(task_name, inputs_hash, typed_interface, "v1", [], inputs.proto_inputs)
-    assert cache_key == "kNWQdez6U7DYsYjqt9CBB07gmPgsaJ1CCUUtiUnDxpk="
+    assert cache_key == "gKUZZV2XwUZbIUl9tfLC7+n8tREvPR9jq9vzPEHqOKg="
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
TypeStructure for pydantic was for propeller attribute access.  Attribute access now happens in propeller.  Was leaving it in for future dag work but we can bring it back (correctly) if & when that comes to pass.