### PR TITLE
Fix secret

### DIFF
--- a/examples/image/image_from_env.py
+++ b/examples/image/image_from_env.py
@@ -35,16 +35,16 @@ flyte --config ../../config.yaml run deployed-task image_from_env.main
 """
 
 import os
-import flyte
 
+import flyte
 
 # Task environment for building the image
 build_env = flyte.TaskEnvironment(
     name="build_env",
     image=(
-        flyte.Image
-        .from_debian_base(name="base-image", python_version=(3, 12))
-        .with_pip_packages("flyte", pre=True, extra_args="--prerelease=allow")
+        flyte.Image.from_debian_base(name="base-image", python_version=(3, 12)).with_pip_packages(
+            "flyte", pre=True, extra_args="--prerelease=allow"
+        )
     ),
 )
 
@@ -62,6 +62,7 @@ env = flyte.TaskEnvironment(
 @env.task
 async def t1(data: str = "hello") -> str:
     return f"Hello {data}"
+
 
 @env.task
 async def main(data: str = "hello") -> str:

--- a/src/flyte/_secret.py
+++ b/src/flyte/_secret.py
@@ -1,9 +1,7 @@
-import logging
 import pathlib
 import re
 from dataclasses import dataclass
 from typing import List, Optional, Union
-from venv import logger
 
 
 @dataclass
@@ -21,7 +19,8 @@ class Secret:
     ```python
     @task(secrets="my-secret")
     async def my_task():
-        os.environ["MY_SECRET"]  # This will be set to the value of the secret. Note: Upper and - replace with _.
+        # This will be set to the value of the secret. Note: The env var is always uppercase, and - is replaced with _.
+        os.environ["MY_SECRET"]
 
     @task(secrets=Secret("my-openai-api-key", as_env_var="OPENAI_API_KEY"))
     async def my_task2():

--- a/tests/flyte/internal/runtime/test_task_serde.py
+++ b/tests/flyte/internal/runtime/test_task_serde.py
@@ -46,8 +46,8 @@ def test_get_security_context():
     assert len(security_context.secrets) == 1
     assert security_context.secrets[0].group == "group2"
     assert security_context.secrets[0].key == "key2"
-    assert security_context.secrets[0].mount_requirement == ProtoSecret.MountType.FILE
-    assert security_context.secrets[0].env_var == ""
+    assert security_context.secrets[0].mount_requirement == ProtoSecret.MountType.ENV_VAR
+    assert security_context.secrets[0].env_var == "GROUP2_KEY2"
 
     # Case 4: Multiple secrets
     secrets = [
@@ -63,8 +63,8 @@ def test_get_security_context():
     assert security_context.secrets[0].env_var == "ENV_VAR1"
     assert security_context.secrets[1].group == "group2"
     assert security_context.secrets[1].key == "key2"
-    assert security_context.secrets[1].mount_requirement == ProtoSecret.MountType.FILE
-    assert security_context.secrets[1].env_var == ""
+    assert security_context.secrets[1].mount_requirement == ProtoSecret.MountType.ENV_VAR
+    assert security_context.secrets[1].env_var == "GROUP2_KEY2"
 
     # Case 5: Invalid secret input (not a Secret or list of Secrets)
     with pytest.raises(AttributeError):


### PR DESCRIPTION
This pull request introduces improvements to secret handling and environment variable naming conventions, updates documentation and examples for clarity, and refines related tests to match the new behavior. The main focus is on standardizing how secrets are exposed as environment variables and improving usability for developers.

### Secret handling and environment variable naming

* Updated the logic in the `Secret` class so that if neither `mount` nor `as_env_var` is specified, the environment variable name is automatically generated by combining the group and key, replacing hyphens with underscores, and converting to uppercase (e.g., `"my-secret"` becomes `"MY_SECRET"`). This ensures consistency and reduces manual configuration.
* Changed the default mounting behavior for secrets to use environment variables (`ENV_VAR`) instead of files, and updated the corresponding test assertions to expect the new environment variable names. [[1]](diffhunk://#diff-6879d1f1b565017eff78934f6cbd0abfc8c8071c030d17335420c30eb1708e8cL49-R50) [[2]](diffhunk://#diff-6879d1f1b565017eff78934f6cbd0abfc8c8071c030d17335420c30eb1708e8cL66-R67)

### Documentation and examples

* Updated the documentation and example code in `src/flyte/_secret.py` to clarify the new environment variable naming convention and usage, including how to specify custom environment variable names with `as_env_var`. Also added notes about current limitations and future TODOs.

### Minor code and formatting improvements

* Reformatted the `image_from_env.py` example for improved readability and added a blank line for consistency. [[1]](diffhunk://#diff-2a8726e816b1c21cbacb0d5ded9937167c4389d70e8df2d1cefcb85439035a3aL38-R47) [[2]](diffhunk://#diff-2a8726e816b1c21cbacb0d5ded9937167c4389d70e8df2d1cefcb85439035a3aR66)