### PR TITLE
Add a default interpreter_path and entrypoint_path

### DIFF
--- a/examples/stress/long_running.py
+++ b/examples/stress/long_running.py
@@ -43,5 +43,3 @@ if __name__ == "__main__":
     flyte.init_from_config("../../config.yaml")
     run = flyte.run(main_task, duration=timedelta(days=5))
     print(run.url)
-
-

--- a/examples/stress/long_running_reuse.py
+++ b/examples/stress/long_running_reuse.py
@@ -11,7 +11,7 @@ env = flyte.TaskEnvironment(
         replicas=1,
         concurrency=2,
         idle_ttl=timedelta(minutes=5),
-    )
+    ),
 )
 
 
@@ -49,5 +49,3 @@ if __name__ == "__main__":
     flyte.init_from_config("../../config.yaml")
     run = flyte.run(main_task, duration=timedelta(days=5))
     print(run.url)
-
-

--- a/plugins/spark/src/flyteplugins/spark/task.py
+++ b/plugins/spark/src/flyteplugins/spark/task.py
@@ -72,7 +72,7 @@ class PysparkFunctionTask(AsyncFunctionTaskTemplate):
         job = SparkJob(
             sparkConf=self.plugin_config.spark_conf,
             hadoopConf=self.plugin_config.hadoop_conf,
-            mainApplicationFile=self.plugin_config.applications_path or "local://" + sctx.entrypoint_path,
+            mainApplicationFile=self.plugin_config.applications_path or "local://" + sctx.get_entrypoint_path(),
             executorPath=self.plugin_config.executor_path or sctx.interpreter_path,
             mainClass="",
             applicationType=SparkApplication.PYTHON,

--- a/plugins/spark/src/flyteplugins/spark/task.py
+++ b/plugins/spark/src/flyteplugins/spark/task.py
@@ -72,8 +72,8 @@ class PysparkFunctionTask(AsyncFunctionTaskTemplate):
         job = SparkJob(
             sparkConf=self.plugin_config.spark_conf,
             hadoopConf=self.plugin_config.hadoop_conf,
-            mainApplicationFile=self.plugin_config.applications_path,
-            executorPath=self.plugin_config.executor_path,
+            mainApplicationFile=self.plugin_config.applications_path or "local://" + sctx.entrypoint_path,
+            executorPath=self.plugin_config.executor_path or sctx.interpreter_path,
             mainClass="",
             applicationType=SparkApplication.PYTHON,
             driverPod=driver_pod,

--- a/plugins/spark/tests/test_task.py
+++ b/plugins/spark/tests/test_task.py
@@ -1,0 +1,68 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flyte import PodTemplate
+from kubernetes.client import V1Container, V1EnvVar, V1LocalObjectReference, V1PodSpec
+
+from flyteplugins.spark.task import PysparkFunctionTask, Spark
+
+
+class DummySerializationContext:
+    entrypoint_path = "/main.py"
+    interpreter_path = "/usr/bin/python3"
+
+
+@pytest.mark.parametrize("spark_conf,hadoop_conf", [(None, None), ({"a": "b"}, {"c": "d"})])
+def test_spark_post_init(spark_conf, hadoop_conf):
+    s = Spark(spark_conf=spark_conf, hadoop_conf=hadoop_conf)
+    assert isinstance(s.spark_conf, dict)
+    assert isinstance(s.hadoop_conf, dict)
+
+
+@patch("flyteplugins.spark.task.flyte.ctx")
+@patch("flyteplugins.spark.task.shutil.make_archive")
+@pytest.mark.asyncio
+async def test_pre_cluster(mock_make_archive, mock_ctx):
+    # Patch pyspark in sys.modules
+    mock_spark_session = MagicMock()
+    mock_spark_context = MagicMock()
+    mock_spark_session.builder.appName.return_value.getOrCreate.return_value = mock_spark_session
+    mock_spark_session.sparkContext = mock_spark_context
+    sys.modules["pyspark"] = MagicMock()
+    sys.modules["pyspark"].sql = MagicMock()
+    sys.modules["pyspark"].sql.SparkSession = mock_spark_session
+
+    mock_ctx.return_value.is_in_cluster.return_value = True
+    task = PysparkFunctionTask(plugin_config=Spark(), name="n", interface=None, func=lambda: None)
+    result = await task.pre()
+    assert "spark_session" in result
+    mock_make_archive.assert_called()
+    mock_spark_context.addPyFile.assert_called()
+
+
+def test_custom_config():
+    pod_template = PodTemplate(
+        pod_spec=V1PodSpec(
+            containers=[V1Container(name="foo", env=[V1EnvVar(name="hello", value="world")])],
+            image_pull_secrets=[V1LocalObjectReference(name="regcred-test")],
+        )
+    )
+
+    spark = Spark(
+        spark_conf={"a": "b"},
+        hadoop_conf={"c": "d"},
+        applications_path="/main.py",
+        executor_path="/usr/bin/python3",
+        driver_pod=pod_template,
+        executor_pod=pod_template,
+    )
+    task = PysparkFunctionTask(plugin_config=spark, name="n", interface=None, func=lambda: None)
+    sctx = DummySerializationContext()
+    result = task.custom_config(sctx)
+    assert result["sparkConf"] == {"a": "b"}
+    assert result["hadoopConf"] == {"c": "d"}
+    assert result["mainApplicationFile"] == "/main.py"
+    assert result["executorPath"] == "/usr/bin/python3"
+    assert "driverPod" in result
+    assert "executorPod" in result

--- a/src/flyte/_pod.py
+++ b/src/flyte/_pod.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Dict, Optional
 
 if TYPE_CHECKING:
     from flyteidl.core.tasks_pb2 import K8sPod
-    from kubernetes.client import ApiClient, V1PodSpec
+    from kubernetes.client import V1PodSpec
 
 
 _PRIMARY_CONTAINER_NAME_FIELD = "primary_container_name"
@@ -21,6 +21,7 @@ class PodTemplate(object):
 
     def to_k8s_pod(self) -> "K8sPod":
         from flyteidl.core.tasks_pb2 import K8sObjectMetadata, K8sPod
+        from kubernetes.client import ApiClient
 
         return K8sPod(
             metadata=K8sObjectMetadata(labels=self.labels, annotations=self.annotations),

--- a/src/flyte/models.py
+++ b/src/flyte/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import os
 import pathlib
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Literal, Optional, Tuple, Type
@@ -410,6 +411,14 @@ class SerializationContext:
     input_path: str = "{{.input}}"
     output_path: str = "{{.outputPrefix}}"
     interpreter_path: str = "/opt/venv/bin/python"
-    entrypoint_path: str = "/opt/venv/bin/runtime.py"
     image_cache: ImageCache | None = None
     root_dir: Optional[pathlib.Path] = None
+
+    def get_entrypoint_path(self, interpreter_path: Optional[str] = None) -> str:
+        """
+        Get the entrypoint path for the task. This is used to determine the entrypoint for the task execution.
+        :param interpreter_path: The path to the interpreter (python)
+        """
+        if interpreter_path is None:
+            interpreter_path = self.interpreter_path
+        return os.path.join(os.path.dirname(interpreter_path), "runtime.py")

--- a/src/flyte/models.py
+++ b/src/flyte/models.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import inspect
-import os
 import pathlib
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Literal, Optional, Tuple, Type
@@ -410,13 +409,7 @@ class SerializationContext:
     code_bundle: Optional[CodeBundle] = None
     input_path: str = "{{.input}}"
     output_path: str = "{{.outputPrefix}}"
-    _entrypoint_path: str = field(default="_bin/runtime.py", init=False)
+    interpreter_path: str = "/opt/venv/bin/python"
+    entrypoint_path: str = "/opt/venv/bin/runtime.py"
     image_cache: ImageCache | None = None
     root_dir: Optional[pathlib.Path] = None
-
-    def get_entrypoint_path(self, interpreter_path: str) -> str:
-        """
-        Get the entrypoint path for the task. This is used to determine the entrypoint for the task execution.
-        :param interpreter_path: The path to the interpreter (python)
-        """
-        return os.path.join(os.path.dirname(os.path.dirname(interpreter_path)), self._entrypoint_path)


### PR DESCRIPTION
This pull request introduces improvements and fixes for Spark task configuration, testing, and code organization. The most significant changes include enhancements to the Spark plugin's configuration logic, the addition of comprehensive tests for Spark tasks, and refactoring for better code clarity and maintainability.

### Spark plugin configuration improvements
* Updated `custom_config` in `Spark` to provide sensible defaults for `mainApplicationFile` and `executorPath` when not explicitly set, using the serialization context to determine these paths. This ensures more robust and predictable Spark job configuration.
* Refactored the `SerializationContext` class to introduce an `interpreter_path` field and improved the logic for determining the entrypoint path, making path resolution clearer and more flexible.

### Testing enhancements
* Added new tests in `plugins/spark/tests/test_task.py` to cover Spark plugin initialization, pre-cluster setup, and custom configuration logic, increasing test coverage and reliability of Spark-related code.
