### PR TITLE
init_from_config looks for .flyte/config.yaml files from cwd to home

### DIFF
--- a/examples/image/base_image.py
+++ b/examples/image/base_image.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import logging
 
 import flyte
 from flyte import Image
@@ -21,7 +22,7 @@ async def t1(data: str = "hello") -> str:
 
 
 if __name__ == "__main__":
-    flyte.init_from_config("../../config.yaml")
+    flyte.init_from_config(log_level=logging.INFO)
     run = flyte.run(t1, data="world")
     print(run.name)
     print(run.url)

--- a/src/flyte/cli/_create.py
+++ b/src/flyte/cli/_create.py
@@ -98,7 +98,7 @@ def secret(
     "-o",
     "--output",
     type=click.Path(exists=False, writable=True),
-    default=Path.cwd() / "config.yaml",
+    default=Path.cwd() / ".flyte" / "config.yaml",
     help="Path to the output directory where the configuration will be saved. Defaults to current directory.",
     show_default=True,
 )
@@ -146,6 +146,9 @@ def config(
     from flyte._utils import org_from_endpoint, sanitize_endpoint
 
     output_path = Path(output)
+
+    if not output_path.parent.exists():
+        output_path.parent.mkdir(parents=True)
 
     if output_path.exists() and not force:
         force = click.confirm(f"Overwrite [{output_path}]?", default=False)


### PR DESCRIPTION
As a user, I don't want to always think about config file paths. Often times I just want to make a single config for my repo, and be guaranteed that my flyte scripts use that config. If I need to override it, I can create a config in the current working directory of where I'm running the example from.

This PR makes the following changes:

1. `flyte create config` creates a config file in `./.flyte/config.yaml` by default
2. The `flyte get config` and `flyte.init_from_config` behavior is the same, for the most part, but adds the following logic: instead of looking at `./flyte/config.yaml` first, it will look for a `.flyte` directory in the current directory, then iteratively look at: `.`, `..`, etc..., until it reaches the home directory `~`.