### PR TITLE
with_uv_project for remote builder

### DIFF
--- a/examples/image/uv_project.py
+++ b/examples/image/uv_project.py
@@ -6,9 +6,7 @@ from flyte import Image
 image = (
     Image.from_debian_base(install_flyte=False)
     .with_apt_packages("git")
-    .with_env_vars({"hello": "world11122333333"})
-    .with_uv_project(uvlock=Path("../../uv.lock"), pyproject_file=Path("../../pyproject.toml"),)
-    # .with_local_v2()
+    .with_uv_project(uvlock=Path("../../uv.lock"), pyproject_file=Path("../../pyproject.toml"))
 )
 
 env = flyte.TaskEnvironment(name="uv_project", image=image)

--- a/examples/image/uv_project.py
+++ b/examples/image/uv_project.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import flyte
+from flyte import Image
+
+image = (
+    Image.from_debian_base(install_flyte=False)
+    .with_uv_project(uvlock=Path("../../uv.lock"), pyproject_file=Path("../../pyproject.toml"))
+    .with_local_v2()
+)
+
+env = flyte.TaskEnvironment(name="t1", image=image)
+
+
+@env.task
+async def t1(data: str = "hello") -> str:
+    return f"Hello {data}"
+
+
+if __name__ == "__main__":
+    flyte.init_from_config("../../config.yaml")
+    run = flyte.run(t1, data="world")
+    print(run.name)
+    print(run.url)

--- a/examples/image/uv_project.py
+++ b/examples/image/uv_project.py
@@ -5,11 +5,13 @@ from flyte import Image
 
 image = (
     Image.from_debian_base(install_flyte=False)
-    .with_uv_project(uvlock=Path("../../uv.lock"), pyproject_file=Path("../../pyproject.toml"))
-    .with_local_v2()
+    .with_apt_packages("git")
+    .with_env_vars({"hello": "world11122333333"})
+    .with_uv_project(uvlock=Path("../../uv.lock"), pyproject_file=Path("../../pyproject.toml"),)
+    # .with_local_v2()
 )
 
-env = flyte.TaskEnvironment(name="t1", image=image)
+env = flyte.TaskEnvironment(name="uv_project", image=image)
 
 
 @env.task

--- a/examples/plugins/spark_example.py
+++ b/examples/plugins/spark_example.py
@@ -9,7 +9,7 @@ from flyte._context import internal_ctx
 
 image = (
     flyte.Image.from_base("apache/spark-py:v3.4.0")
-    .clone(name="spark", python_version=(3, 10), registry="ghcr.io/flyteorg")
+    .clone(name="spark", python_version=(3, 10))
     .with_pip_packages("flyteplugins-spark", pre=True)
 )
 

--- a/examples/plugins/spark_example.py
+++ b/examples/plugins/spark_example.py
@@ -9,7 +9,7 @@ from flyte._context import internal_ctx
 
 image = (
     flyte.Image.from_base("apache/spark-py:v3.4.0")
-    .clone(name="spark", python_version=(3, 10))
+    .clone(name="spark", python_version=(3, 10), registry="ghcr.io/flyteorg")
     .with_pip_packages("flyteplugins-spark", pre=True)
 )
 

--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -887,7 +887,12 @@ class Image:
         Use this method to create a new image with the specified uv.lock file layered on top of the current image
         Must have a corresponding pyproject.toml file in the same directory
         Cannot be used in conjunction with conda
-        In the Union builders, using this will change the virtual env to /root/.venv
+
+        By default, this method copies the entire project into the image,
+         including files such as pyproject.toml, uv.lock, and the src/ directory.
+
+        If you prefer not to install the current project, you can pass the extra argument --no-install-project.
+         In this case, the image builder will only copy pyproject.toml and uv.lock into the image.
 
         :param pyproject_file: path to the pyproject.toml file, needs to have a corresponding uv.lock file
         :param uvlock: path to the uv.lock file, if not specified, will use the default uv.lock file in the same

--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -239,14 +239,16 @@ class UVProjectHandler:
             delta = UV_LOCK_WITHOUT_PROJECT_INSTALL_TEMPLATE.substitute(
                 UV_LOCK_PATH=uvlock_dst.relative_to(context_path),
                 PYPROJECT_PATH=pyproject_dst.relative_to(context_path),
-                PIP_INSTALL_ARGS=" ".join(layer.get_pip_install_args()), SECRET_MOUNT=secret_mounts
+                PIP_INSTALL_ARGS=" ".join(layer.get_pip_install_args()),
+                SECRET_MOUNT=secret_mounts,
             )
         else:
             # Copy the entire project.
             pyproject_dst = copy_files_to_context(layer.pyproject.parent, context_path)
             delta = UV_LOCK_INSTALL_TEMPLATE.substitute(
                 PYPROJECT_PATH=pyproject_dst.relative_to(context_path),
-                PIP_INSTALL_ARGS=" ".join(layer.get_pip_install_args()), SECRET_MOUNT=secret_mounts
+                PIP_INSTALL_ARGS=" ".join(layer.get_pip_install_args()),
+                SECRET_MOUNT=secret_mounts,
             )
 
         dockerfile += delta

--- a/src/flyte/_internal/imagebuild/remote_builder.py
+++ b/src/flyte/_internal/imagebuild/remote_builder.py
@@ -130,7 +130,7 @@ class RemoteImageBuilder(ImageBuilder):
                     auto_version="latest",
                 )
                 await flyte.with_runcontext(project=IMAGE_TASK_PROJECT, domain=IMAGE_TASK_DOMAIN).run.aio(
-                    entity, spec=spec, context=context, target_image=image_name
+                    entity, target_image=image_name
                 )
             except Exception as e:
                 # Ignore the error if optimize is not enabled in the backend.
@@ -249,9 +249,16 @@ def _get_layers_proto(image: Image, context_path: Path) -> "image_definition_pb2
                 if "tool.uv.index" in line:
                     raise ValueError("External sources are not supported in pyproject.toml")
 
+            if layer.extra_index_urls and "--no-install-project" in layer.extra_index_urls:
+                # Copy pyproject itself
+                pyproject_dst = copy_files_to_context(layer.pyproject, context_path)
+            else:
+                # Copy the entire project
+                pyproject_dst = copy_files_to_context(layer.pyproject.parent, context_path)
+
             uv_layer = image_definition_pb2.Layer(
                 uv_project=image_definition_pb2.UVProject(
-                    pyproject=str(copy_files_to_context(layer.pyproject, context_path).relative_to(context_path)),
+                    pyproject=str(pyproject_dst.relative_to(context_path)),
                     uvlock=str(copy_files_to_context(layer.uvlock, context_path).relative_to(context_path)),
                     options=pip_options,
                     secret_mounts=secret_mounts,

--- a/src/flyte/_internal/imagebuild/remote_builder.py
+++ b/src/flyte/_internal/imagebuild/remote_builder.py
@@ -251,8 +251,8 @@ def _get_layers_proto(image: Image, context_path: Path) -> "image_definition_pb2
 
             uv_layer = image_definition_pb2.Layer(
                 uv_project=image_definition_pb2.UVProject(
-                    pyproject=str(copy_files_to_context(layer.pyproject, context_path)),
-                    uvlock=str(copy_files_to_context(layer.uvlock, context_path)),
+                    pyproject=str(copy_files_to_context(layer.pyproject, context_path).relative_to(context_path)),
+                    uvlock=str(copy_files_to_context(layer.uvlock, context_path).relative_to(context_path)),
                     options=pip_options,
                     secret_mounts=secret_mounts,
                 )

--- a/src/flyte/_internal/imagebuild/utils.py
+++ b/src/flyte/_internal/imagebuild/utils.py
@@ -23,7 +23,8 @@ def copy_files_to_context(src: Path, context_path: Path) -> Path:
         dst_path = context_path / src
     dst_path.parent.mkdir(parents=True, exist_ok=True)
     if src.is_dir():
-        shutil.copytree(src, dst_path, dirs_exist_ok=True)
+        # TODO: Add support dockerignore
+        shutil.copytree(src, dst_path, dirs_exist_ok=True, ignore=shutil.ignore_patterns(".idea", ".venv"))
     else:
         shutil.copy(src, dst_path)
     return dst_path


### PR DESCRIPTION
This pull request makes two important updates to the `src/flyte/_internal/imagebuild/remote_builder.py` file, improving how files are copied to the build context and correcting the default secret directory path for image builds.

Improvements to file handling in layer definition:

* Updated `_get_layers_proto` to use the `copy_files_to_context` function for copying `pyproject` and `uvlock` files, ensuring files are properly placed in the build context and referenced relative to it. Also, added support for `options` and `secret_mounts` in the layer definition.

Fix to secret directory path:

* Changed the default secret directory path from `"etc/flyte/secrets"` to `"/etc/flyte/secrets"` in `_get_build_secrets_from_image`, ensuring secrets are mounted from the correct location.