### PR TITLE
fix: Use error_info.message for clearer error msgs

### DIFF
--- a/src/flyte/remote/_action.py
+++ b/src/flyte/remote/_action.py
@@ -329,7 +329,7 @@ class Action(ToJSONMixin):
                     details = await self.details()
                     console.print(
                         f"[bold red]Action '{self.name}' in Run '{self.run_name}'"
-                        f" exited unsuccessfully in state {self.phase} with error: {details.error_info}[/bold red]"
+                        f" exited unsuccessfully in state {self.phase} with error: {details.error_info.message}[/bold red]"
                     )
             return
 
@@ -373,7 +373,7 @@ class Action(ToJSONMixin):
                         else:
                             console.print(
                                 f"[bold red]Run '{self.run_name}' exited unsuccessfully in state {ad.phase}"
-                                f" with error: {ad.error_info}[/bold red]"
+                                f" with error: {ad.error_info.message}[/bold red]"
                             )
                         break
         except asyncio.CancelledError:

--- a/src/flyte/remote/_action.py
+++ b/src/flyte/remote/_action.py
@@ -327,9 +327,10 @@ class Action(ToJSONMixin):
                     )
                 else:
                     details = await self.details()
+                    error_message = details.error_info.message if details.error_info else ""
                     console.print(
                         f"[bold red]Action '{self.name}' in Run '{self.run_name}'"
-                        f" exited unsuccessfully in state {self.phase} with error: {details.error_info.message}[/bold red]"
+                        f" exited unsuccessfully in state {self.phase} with error: {error_message}[/bold red]"
                     )
             return
 
@@ -371,9 +372,10 @@ class Action(ToJSONMixin):
                         if ad.pb2.status.phase == run_definition_pb2.PHASE_SUCCEEDED:
                             console.print(f"[bold green]Run '{self.run_name}' completed successfully.[/bold green]")
                         else:
+                            error_message = ad.error_info.message if ad.error_info else ""
                             console.print(
                                 f"[bold red]Run '{self.run_name}' exited unsuccessfully in state {ad.phase}"
-                                f" with error: {ad.error_info.message}[/bold red]"
+                                f" with error: {error_message}[/bold red]"
                             )
                         break
         except asyncio.CancelledError:


### PR DESCRIPTION
It will improve the error messages for the remote builder
Before:
<img width="1523" height="1075" alt="Screenshot 2025-08-27 at 4 28 31 PM" src="https://github.com/user-attachments/assets/b7664bb7-1afb-4088-8ec4-37d9f293c58a" />


After:
<img width="1459" height="1124" alt="Screenshot 2025-08-27 at 4 19 55 PM" src="https://github.com/user-attachments/assets/2bd456da-46fb-41e7-9257-5834c694f656" />
