### PR TITLE
add get git root config to config auto

### DIFF
--- a/examples/advanced/cancel_tasks.py
+++ b/examples/advanced/cancel_tasks.py
@@ -34,7 +34,5 @@ async def main(n: int, f: float):
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     print(flyte.run(main, 30, 10.0))

--- a/examples/advanced/container_task.py
+++ b/examples/advanced/container_task.py
@@ -25,8 +25,6 @@ async def say_hello(name: str = "flyte") -> str:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.with_runcontext(mode="remote").run(say_hello, "Union")
     print(run.url)

--- a/examples/advanced/display_names.py
+++ b/examples/advanced/display_names.py
@@ -23,8 +23,6 @@ async def main() -> str:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     r = flyte.run(main)
     print(r.url)

--- a/examples/advanced/fractal.py
+++ b/examples/advanced/fractal.py
@@ -43,9 +43,7 @@ async def main_builder():
 
 
 async def main():
-    import flyte.git
-
-    await flyte.init_from_config.aio(flyte.git.config_from_root())
+    await flyte.init_from_config.aio()
     out = await flyte.run.aio(tree, max_depth=2, n_children=2)
 
     print(f"Total nodes in the tree: {out}")

--- a/examples/advanced/large_inline_io.py
+++ b/examples/advanced/large_inline_io.py
@@ -32,9 +32,7 @@ async def large_inline_io() -> str:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root(), log_level=logging.DEBUG)
+    flyte.init_from_config(log_level=logging.DEBUG)
     run = flyte.run(large_inline_io)
     print(run.url)
     print("Run completed.")

--- a/examples/advanced/leaky_coroutines.py
+++ b/examples/advanced/leaky_coroutines.py
@@ -33,9 +33,7 @@ async def main(seconds: int):
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(main, seconds=30)
     print(run.url)
     run.wait(run)

--- a/examples/advanced/local_tasks.py
+++ b/examples/advanced/local_tasks.py
@@ -114,8 +114,6 @@ async def input_output_task(a: str, b: str, c: int) -> int:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root(), log_level="DEBUG")
+    flyte.init_from_config(log_level="DEBUG")
     a = flyte.run(parallel_main_no_io, "hello world")
     print(a.url)

--- a/examples/advanced/multi_loops.py
+++ b/examples/advanced/multi_loops.py
@@ -62,9 +62,7 @@ async def main(n: int) -> List[int]:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(main, n=3)
     print(run.name)
     print(run.url)

--- a/examples/advanced/multi_run.py
+++ b/examples/advanced/multi_run.py
@@ -30,7 +30,5 @@ async def main() -> List[int]:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     asyncio.run(main())

--- a/examples/advanced/pod_template.py
+++ b/examples/advanced/pod_template.py
@@ -42,8 +42,6 @@ async def say_hello_nested(data: str = "default string") -> str:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     result = flyte.run(say_hello_nested, data="hello world")
     print(result.url)

--- a/examples/advanced/resource_tuner.py
+++ b/examples/advanced/resource_tuner.py
@@ -85,9 +85,7 @@ async def main(n: int) -> list[int]:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(main, n=3)
     print(run.name)
     print(run.url)

--- a/examples/advanced/side_effect_traces.py
+++ b/examples/advanced/side_effect_traces.py
@@ -87,9 +87,7 @@ async def traces_complex(n: int = 3) -> int:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.with_runcontext().run(traces_complex, n=5)
     print(run.name)
     print(run.url)

--- a/examples/advanced/use_anyio.py
+++ b/examples/advanced/use_anyio.py
@@ -110,9 +110,7 @@ async def dc_wf(batch: BatchRequest):
 if __name__ == "__main__":
     # result_one = asyncio.run(predict_one(InferenceRequest(feature_a=1.0, feature_b=2.0)))
     # print(f"Prediction for single request: {result_one}")
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     # Can run programmatically
     # run = flyte.run(predict_one, InferenceRequest(feature_a=1.0, feature_b=2.0))
     # print(run.url)

--- a/examples/basics/container_images.py
+++ b/examples/basics/container_images.py
@@ -40,9 +40,7 @@ async def workflow():
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(workflow)
     print(run.name)
     print(run.url)

--- a/examples/basics/dataclass_examples.py
+++ b/examples/basics/dataclass_examples.py
@@ -91,9 +91,7 @@ async def dc_wf(batch: BatchRequest):
 if __name__ == "__main__":
     # result_one = asyncio.run(predict_one(InferenceRequest(feature_a=1.0, feature_b=2.0)))
     # print(f"Prediction for single request: {result_one}")
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     # Can run programmatically
     # run = flyte.run(predict_one, InferenceRequest(feature_a=1.0, feature_b=2.0))
     # print(run.url)

--- a/examples/basics/dataframe_usage.py
+++ b/examples/basics/dataframe_usage.py
@@ -78,9 +78,7 @@ async def get_employee_data() -> pd.DataFrame:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
     # Use local execution mode
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.with_runcontext(mode="local").run(get_employee_data)
     print("Results:", run.outputs())

--- a/examples/basics/devbox_one.py
+++ b/examples/basics/devbox_one.py
@@ -34,9 +34,7 @@ async def say_hello_nested(data: str = "default string", n: int = 3) -> str:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.with_runcontext(
         log_level=logging.DEBUG,
         env_vars={"KEY": "V"},

--- a/examples/basics/exception_handling.py
+++ b/examples/basics/exception_handling.py
@@ -46,7 +46,5 @@ async def failure_recovery() -> int:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     print(flyte.run(failure_recovery))

--- a/examples/basics/file.py
+++ b/examples/basics/file.py
@@ -32,7 +32,5 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     print(flyte.run(main))

--- a/examples/basics/from_scratch.py
+++ b/examples/basics/from_scratch.py
@@ -11,8 +11,6 @@ def main(name: Optional[str] = None):
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(main, "xyz")
     print(run.url)

--- a/examples/basics/grouping.py
+++ b/examples/basics/grouping.py
@@ -50,9 +50,7 @@ async def group_dynamic(x: int) -> List[int]:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
 
     run = flyte.run(group_dynamic, x=10)
     print(run.url)

--- a/examples/basics/hello.py
+++ b/examples/basics/hello.py
@@ -24,9 +24,7 @@ def main(x_list: list[int]) -> float:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())  # establish remote connection from within your script.
+    flyte.init_from_config()  # establish remote connection from within your script.
     run = flyte.run(main, x_list=list(range(10)))  # run remotely inline and pass data.
 
     # print various attributes of the run.

--- a/examples/basics/hello_polyglot.py
+++ b/examples/basics/hello_polyglot.py
@@ -48,9 +48,7 @@ def main(letter: str) -> dict[str, str]:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
 
     input_letter = sys.argv[1] if len(sys.argv) > 1 else "e"
     execution = flyte.run(main, letter=input_letter)

--- a/examples/basics/hello_v2.py
+++ b/examples/basics/hello_v2.py
@@ -26,9 +26,7 @@ async def hello_driver(ids: List[int] = [1, 2, 3]) -> List[str]:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
 
     run = flyte.run(hello_driver)
     print(run.name)

--- a/examples/basics/map.py
+++ b/examples/basics/map.py
@@ -56,9 +56,7 @@ async def async_to_sync_main(n: int) -> List[str]:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     # flyte.init()
     run = flyte.run(async_to_sync_main, 10)
     print(run.url)

--- a/examples/basics/map_with_partials.py
+++ b/examples/basics/map_with_partials.py
@@ -60,8 +60,6 @@ def error_handling_main(n: int):
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(main)
     print(run.url)

--- a/examples/basics/no_outputs.py
+++ b/examples/basics/no_outputs.py
@@ -16,9 +16,7 @@ async def main():
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     # flyte.init()
     run = flyte.run(main)
     print(run.url)

--- a/examples/basics/offloaded_types.py
+++ b/examples/basics/offloaded_types.py
@@ -59,7 +59,5 @@ async def create_and_check_dir():
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     flyte.run(create_and_check_dir)

--- a/examples/basics/oomer.py
+++ b/examples/basics/oomer.py
@@ -39,9 +39,7 @@ async def failure_recovery() -> int:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
 
     run = flyte.run(failure_recovery)
     print(run.url)

--- a/examples/basics/repeated_tasks.py
+++ b/examples/basics/repeated_tasks.py
@@ -20,9 +20,7 @@ async def main_task() -> int:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
 
     run = flyte.run(main_task)
     print(run)

--- a/examples/basics/report_example.py
+++ b/examples/basics/report_example.py
@@ -25,8 +25,6 @@ async def main():
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(main)
     print(run.url)

--- a/examples/basics/union_type_simple.py
+++ b/examples/basics/union_type_simple.py
@@ -20,9 +20,7 @@ def union_type_simple_task(input_val: Union[str, None] = None) -> str:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(union_type_simple_task, input_val="hello world")
     print(run.name)
     print(run.url)

--- a/examples/basics/union_types.py
+++ b/examples/basics/union_types.py
@@ -9,9 +9,7 @@ def complex_task(data: dict[str, list[str] | None] | None) -> dict[str, list[str
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(complex_task, data={"key": ["value1", "value2"]})
     print(run)
     print(run.url)

--- a/examples/basics/using_dockerfiles.py
+++ b/examples/basics/using_dockerfiles.py
@@ -28,7 +28,5 @@ env.add_task(version_task)
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     print(flyte.run(version_task))

--- a/examples/basics/vscode.py
+++ b/examples/basics/vscode.py
@@ -21,9 +21,7 @@ async def say_hello_nested(data: str = "default string") -> str:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root(), log_level=logging.DEBUG)
+    flyte.init_from_config()
     run = flyte.with_runcontext(env_vars={"LOG_LEVEL": "10", "_F_E_VS": "True"}).run(
         say_hello_nested, data="hello world"
     )

--- a/examples/caching/content_based_caching.py
+++ b/examples/caching/content_based_caching.py
@@ -114,8 +114,6 @@ async def demo_cache_behavior() -> str:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     result = flyte.with_runcontext("local").run(demo_cache_behavior)
     print(f"\nFinal result: {result}")

--- a/examples/code-runner/code_runner.py
+++ b/examples/code-runner/code_runner.py
@@ -49,8 +49,6 @@ async def build_run_code2() -> int:
 if __name__ == "__main__":
     # NOTE the root_dir is set to the current directory so that the "copy_style=all" only copies the parent directory
     # and all files in it, including the script.
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root(), root_dir=pathlib.Path(__file__).parent)
+    flyte.init_from_config(root_dir=pathlib.Path(__file__).parent)
     r = flyte.with_runcontext(copy_style="all").run(build_run_code2)  # Copy all files, including the script
     print(r.url)

--- a/examples/code-runner/code_runner_agent.py
+++ b/examples/code-runner/code_runner_agent.py
@@ -61,9 +61,7 @@ Use the following pattern to execute the code:
 
 ```
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     print(flyte.run(...))
 ```
 
@@ -371,8 +369,6 @@ Result of code execution:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(main)
     print(run.url)

--- a/examples/deploy_patterns/dockerfile/dockerfile_env.py
+++ b/examples/deploy_patterns/dockerfile/dockerfile_env.py
@@ -35,9 +35,7 @@ def main(x: int) -> int:
 if __name__ == "__main__":
     from pathlib import Path
 
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
 
     run = flyte.run(main, x=10)
     print(run.url)

--- a/examples/deploy_patterns/dockerfile/src/docker_env_in_dir.py
+++ b/examples/deploy_patterns/dockerfile/src/docker_env_in_dir.py
@@ -35,8 +35,6 @@ def main(x: int) -> int:
 if __name__ == "__main__":
     from pathlib import Path
 
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(main, x=10)
     print(run.url)

--- a/examples/deploy_patterns/pyproject/pyproject_test.py
+++ b/examples/deploy_patterns/pyproject/pyproject_test.py
@@ -35,9 +35,7 @@ def main(x_list: list[int]) -> float:
 
 if __name__ == "__main__":
     # Establish a remote connection from within your script.
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
 
     # Run your tasks remotely inline and pass parameter data.
     run = flyte.run(main, x_list=list(range(10)))

--- a/examples/deploy_patterns/pythonpath/workflows/workflow.py
+++ b/examples/deploy_patterns/pythonpath/workflows/workflow.py
@@ -14,9 +14,7 @@ async def greet(name: str) -> str:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
     current_dir = pathlib.Path(__file__).parent
-    flyte.init_from_config(flyte.git.config_from_root(), root_dir=current_dir.parent)
+    flyte.init_from_config(root_dir=current_dir.parent)
     r = flyte.run(greet, name="World")
     print(r.url)

--- a/examples/deploy_patterns/uvscript/dataframe.py
+++ b/examples/deploy_patterns/uvscript/dataframe.py
@@ -34,8 +34,6 @@ async def workflow():
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     r = flyte.run(workflow)
     print(r)

--- a/examples/genai/agent_simulation_loadtest.py
+++ b/examples/genai/agent_simulation_loadtest.py
@@ -126,9 +126,7 @@ async def research_coordinator(
 async def benchmark():
     import time
 
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
 
     async def _run() -> None:
         prompt = "What are the latest developments in AI?"

--- a/examples/genai/agent_simulation_traces_loadtest.py
+++ b/examples/genai/agent_simulation_traces_loadtest.py
@@ -118,9 +118,7 @@ async def research_coordinator(
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
 
     prompt = "What are the latest developments in AI?"
     runs = []

--- a/examples/genai/deep_research_agent/agent.py
+++ b/examples/genai/deep_research_agent/agent.py
@@ -624,9 +624,7 @@ if __name__ == "__main__":
     # flyte.run(main)
 
     # Remote execution
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(main)
     print(run.url)
     run.wait(run)

--- a/examples/genai/deep_research_agent/weave_evals.py
+++ b/examples/genai/deep_research_agent/weave_evals.py
@@ -240,7 +240,5 @@ async def main(datasets: list[str] = ["together-search-bench"], limit: int | Non
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     flyte.with_runcontext(raw_data_path="data").run(main)

--- a/examples/genai/hello_agent.py
+++ b/examples/genai/hello_agent.py
@@ -32,9 +32,7 @@ async def lead_agent(state: ResearchState, num_subagents: int = 3) -> ResearchSt
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     state = ResearchState(query="AI agent companies 2025")
     run = flyte.run(lead_agent, state)
     print(run.url)

--- a/examples/genai/langgraph_agent.py
+++ b/examples/genai/langgraph_agent.py
@@ -49,8 +49,6 @@ def main(in_str: str) -> list[BaseMessage]:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     r = flyte.run(main, in_str="what is the weather in sf")
     print(r.url)

--- a/examples/genai/openai_agent.py
+++ b/examples/genai/openai_agent.py
@@ -133,9 +133,7 @@ async def agent(goals: list[str]) -> list[str]:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(
         agent,
         [

--- a/examples/genai/openai_agents/tools.py
+++ b/examples/genai/openai_agents/tools.py
@@ -75,9 +75,7 @@ async def main() -> str:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(main)
     print(run.url)
     run.wait(run)

--- a/examples/genai/smolagent.py
+++ b/examples/genai/smolagent.py
@@ -117,9 +117,7 @@ async def main(goal: str) -> Dict[str, str]:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
     # asyncio.run(main("Make a peanut butter and jelly sandwich"))
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     r = flyte.run(main, goal="Make a peanut butter and jelly sandwich")
     print(r.url)

--- a/examples/genai/trading_agents/main.py
+++ b/examples/genai/trading_agents/main.py
@@ -190,9 +190,7 @@ async def reflect_on_decisions(
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(main)
     print(run.url)
 

--- a/examples/image/base_image.py
+++ b/examples/image/base_image.py
@@ -21,9 +21,7 @@ async def t1(data: str = "hello") -> str:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(t1, data="world")
     print(run.name)
     print(run.url)

--- a/examples/image/image_cache.py
+++ b/examples/image/image_cache.py
@@ -41,9 +41,7 @@ async def outer_task() -> str:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(outer_task)
     print(run.name)
     print(run.url)

--- a/examples/image/image_from_env.py
+++ b/examples/image/image_from_env.py
@@ -70,9 +70,7 @@ async def main(data: str = "hello") -> str:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(main, data="hello world")
     print(run.name)
     print(run.url)

--- a/examples/image/image_secret.py
+++ b/examples/image/image_secret.py
@@ -17,9 +17,7 @@ async def t1(data: str = "hello") -> str:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(t1, data="world")
     print(run.name)
     print(run.url)

--- a/examples/image/multi_image.py
+++ b/examples/image/multi_image.py
@@ -22,9 +22,7 @@ async def t4(data: str = "hello") -> str:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(t4, data="hello world")
     print(run.name)
     print(run.url)

--- a/examples/image/private_pypi.py
+++ b/examples/image/private_pypi.py
@@ -17,9 +17,7 @@ async def t1(data: str = "hello") -> str:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(t1, data="world")
     print(run.name)
     print(run.url)

--- a/examples/image/uv_image.py
+++ b/examples/image/uv_image.py
@@ -22,9 +22,7 @@ async def t1(data: str = "hello") -> str:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(t1, data="hello world")
     print(run.name)
     print(run.url)

--- a/examples/image/uv_project.py
+++ b/examples/image/uv_project.py
@@ -18,9 +18,7 @@ async def t1(data: str = "hello") -> str:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(t1, data="world")
     print(run.name)
     print(run.url)

--- a/examples/interactive/interactive.ipynb
+++ b/examples/interactive/interactive.ipynb
@@ -32,8 +32,7 @@
    },
    "outputs": [],
    "source": [
-    "import flyte\n",
-    "import flyte.git"
+    "import flyte"
    ]
   },
   {
@@ -43,7 +42,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flyte.init_from_config(flyte.git.config_from_root())"
+    "flyte.init_from_config()"
    ]
   },
   {

--- a/examples/interactive/remote.ipynb
+++ b/examples/interactive/remote.ipynb
@@ -18,7 +18,6 @@
    "outputs": [],
    "source": [
     "import flyte\n",
-    "import flyte.git\n",
     "import flyte.remote as remote"
    ]
   },
@@ -29,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flyte.init_from_config(flyte.git.config_from_root())"
+    "flyte.init_from_config()"
    ]
   },
   {

--- a/examples/migration/v1_workflow.py
+++ b/examples/migration/v1_workflow.py
@@ -23,9 +23,7 @@ def wf(name: str):
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root(), log_level=logging.DEBUG)
+    flyte.init_from_config(log_level=logging.DEBUG)
     run = flyte.with_runcontext(log_level=logging.DEBUG).run(wf, name="flyte")
     print(run.name)
     print(run.url)

--- a/examples/ml/distributed_random_forest.py
+++ b/examples/ml/distributed_random_forest.py
@@ -204,9 +204,7 @@ async def main(n_estimators: int = 16) -> tuple[File, float]:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(main)
     print(run.url)
 

--- a/examples/ml/embed_wikipedia.py
+++ b/examples/ml/embed_wikipedia.py
@@ -188,10 +188,8 @@ async def high_mem_examples():
 if __name__ == "__main__":
     # Usage:
     # Run this with limit=-1 to embed all articles in the dataset (~61MM rows)
-    import flyte.git
-
     # flyte.init()
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(main, 256, shard="20231101.en")
     print(run.url)
     # asyncio.run(high_mem_examples())

--- a/examples/ml/gridsearch_gpu.py
+++ b/examples/ml/gridsearch_gpu.py
@@ -145,9 +145,7 @@ if __name__ == "__main__":
     from datetime import datetime
     from pathlib import Path
 
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     sweep_name = f"hpo-gpu-sweep-{datetime.now().strftime('%Y%m%d%H%M%S')}"
     run = flyte.run(gridsearch, sweep_name, batch_sizes=[4, 8, 16])
     print(run.url)

--- a/examples/ml/model_training.py
+++ b/examples/ml/model_training.py
@@ -277,9 +277,7 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     flyte.run(main)
 
     # Run with:

--- a/examples/ml/optimizer.py
+++ b/examples/ml/optimizer.py
@@ -166,8 +166,6 @@ async def optimize(
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(optimize, 100, 10)
     print(run.url)

--- a/examples/ml/rfe.py
+++ b/examples/ml/rfe.py
@@ -70,9 +70,7 @@ async def rfe():  # -> list[dict[str, float]]:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(rfe)
     print(run.url)
 

--- a/examples/multi_env/af2/run_alphafold2.py
+++ b/examples/multi_env/af2/run_alphafold2.py
@@ -30,9 +30,7 @@ def run_af2(sequence: str) -> list[str]:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root(), root_dir=pathlib.Path(__file__).parent, log_level=logging.INFO)
+    flyte.init_from_config(root_dir=pathlib.Path(__file__).parent, log_level=logging.INFO)
     r = flyte.run(run_af2, "AAGGTTCCAA")
     print(r.url)
     # print(r.outputs())

--- a/examples/plugins/dask_example.py
+++ b/examples/plugins/dask_example.py
@@ -44,9 +44,7 @@ async def hello_dask_nested(n: int = 3) -> typing.List[int]:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(hello_dask_nested, n=3)
     print("run name:", run.name)
     print("run url:", run.url)

--- a/examples/plugins/ray_example.py
+++ b/examples/plugins/ray_example.py
@@ -56,9 +56,7 @@ async def hello_ray_nested(n: int = 3) -> typing.List[int]:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(hello_ray_nested)
     print("run name:", run.name)
     print("run url:", run.url)

--- a/examples/plugins/spark_example.py
+++ b/examples/plugins/spark_example.py
@@ -74,9 +74,7 @@ async def spark_overrider(executor_instances: int = 3, partitions: int = 4) -> f
 # You can execute the code locally as if it was a normal Python script.
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     # run = flyte.run(hello_spark_nested)
     # print("run name:", run.name)
     # print("run url:", run.url)

--- a/examples/queue-reader/processor.py
+++ b/examples/queue-reader/processor.py
@@ -129,8 +129,6 @@ async def main(queue_arn: str = DEFAULT_QUEUE_ARN, max_messages: int = 10) -> Li
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())  # establish remote connection from within your script.
+    flyte.init_from_config()  # establish remote connection from within your script.
     run = flyte.run(main, queue_arn=DEFAULT_QUEUE_ARN, max_messages=10)  # run remotely inline and pass data.
     print(run.url)

--- a/examples/reference_tasks/deploy.py
+++ b/examples/reference_tasks/deploy.py
@@ -14,9 +14,7 @@ import flyte
 env.add_dependency(torch_env, spark_env)
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root(), root_dir=Path(__file__).parent)
+    flyte.init_from_config(root_dir=Path(__file__).parent)
     v = flyte.deploy(env)
     print(v[0].summary_repr())
 

--- a/examples/reference_tasks/root_env.py
+++ b/examples/reference_tasks/root_env.py
@@ -40,8 +40,6 @@ async def root_task() -> float:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     r = flyte.with_runcontext(labels={"x": "y"}, annotations={"x": "y"}).run(root_task)
     print(r.url)

--- a/examples/reports/globe_visualization.py
+++ b/examples/reports/globe_visualization.py
@@ -750,9 +750,7 @@ def generate_globe_data():
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(generate_globe_visualization)
     print(run.name)
     print(run.url)

--- a/examples/reports/interactive_dashboard.py
+++ b/examples/reports/interactive_dashboard.py
@@ -734,9 +734,7 @@ def generate_sample_data():
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(generate_interactive_dashboard)
     print(run.name)
     print(run.url)

--- a/examples/reports/network_graph.py
+++ b/examples/reports/network_graph.py
@@ -329,9 +329,7 @@ def generate_network_data():
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(generate_network_graph)
     print(run.name)
     print(run.url)

--- a/examples/reports/protein_3d.py
+++ b/examples/reports/protein_3d.py
@@ -418,9 +418,7 @@ async def generate_protein_3d():
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(generate_protein_3d)
     print(run.name)
     print(run.url)

--- a/examples/reports/run_all.py
+++ b/examples/reports/run_all.py
@@ -30,9 +30,7 @@ async def main():
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root(), root_dir=pathlib.Path(__file__).parent)
+    flyte.init_from_config(root_dir=pathlib.Path(__file__).parent)
     run = flyte.run(main)
     print(run.name)
     print(run.url)

--- a/examples/reports/satellite_images.py
+++ b/examples/reports/satellite_images.py
@@ -430,9 +430,7 @@ async def generate_satellite_images():
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(generate_satellite_images)
     print(run.name)
     print(run.url)

--- a/examples/reports/scatter_3d.py
+++ b/examples/reports/scatter_3d.py
@@ -117,9 +117,7 @@ async def generate_scatter_3d():
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(generate_scatter_3d)
     print(run.name)
     print(run.url)

--- a/examples/reports/streaming_reports.py
+++ b/examples/reports/streaming_reports.py
@@ -356,9 +356,7 @@ async def main():
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(main)
     print(f"Run Name: {run.name}", flush=True)
     print(f"Run URL: {run.url}", flush=True)

--- a/examples/reports/youtube_embed.py
+++ b/examples/reports/youtube_embed.py
@@ -477,9 +477,7 @@ async def generate_youtube_embed():
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(generate_youtube_embed)
     print(run.name)
     print(run.url)

--- a/examples/reuse/errors.py
+++ b/examples/reuse/errors.py
@@ -56,8 +56,6 @@ async def main(n: int) -> int:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())  # establish remote connection from within your script.
+    flyte.init_from_config()  # establish remote connection from within your script.
     run = flyte.run(main, n=30)  # run remotely inline and pass data.
     print(run.url)

--- a/examples/reuse/oomer_reuse.py
+++ b/examples/reuse/oomer_reuse.py
@@ -62,9 +62,7 @@ async def failure_recovery() -> int:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
 
     run = flyte.run(failure_recovery)
     print(run.url)

--- a/examples/reuse/reusable.py
+++ b/examples/reuse/reusable.py
@@ -60,9 +60,7 @@ async def main(n: int) -> List[int]:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())  # establish remote connection from within your script.
+    flyte.init_from_config()  # establish remote connection from within your script.
     run = flyte.run(main, n=30)  # run remotely inline and pass data.
     print(run.url)
     run.wait()  # wait for the run to finish.

--- a/examples/reuse/reusable_with_mem.py
+++ b/examples/reuse/reusable_with_mem.py
@@ -69,9 +69,7 @@ async def main(n: int) -> list[int]:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())  # establish remote connection from within your script.
+    flyte.init_from_config()  # establish remote connection from within your script.
     run = flyte.run(main, n=30)  # run remotely inline and pass data.
     print(run.url)
     run.wait()  # wait for the run to finish.

--- a/examples/reuse/reuse_concurrency.py
+++ b/examples/reuse/reuse_concurrency.py
@@ -33,9 +33,7 @@ async def reuse_concurrency(n: int = 50) -> int:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.with_runcontext().run(reuse_concurrency, n=500)
     print(run.name)
     print(run.url)

--- a/examples/stress/cpu_gremlin.py
+++ b/examples/stress/cpu_gremlin.py
@@ -52,8 +52,6 @@ async def main(sleep: float = 1.0, n: int = 10) -> Tuple[List[str], int]:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     r = flyte.run(main, sleep=5.0, n=50)  # Adjust the number of sleeper tasks as needed
     print(r.url)

--- a/examples/stress/crash_recovery_trace.py
+++ b/examples/stress/crash_recovery_trace.py
@@ -47,8 +47,6 @@ async def main() -> list[int]:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     result = flyte.run(main)
     print(result.url)

--- a/examples/stress/fanout_concurrency.py
+++ b/examples/stress/fanout_concurrency.py
@@ -28,9 +28,7 @@ async def reuse_concurrency(n: int = 50) -> int:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     runs = []
     for i in range(10):
         run = flyte.run(reuse_concurrency, n=1000)

--- a/examples/stress/fast_crasher.py
+++ b/examples/stress/fast_crasher.py
@@ -42,8 +42,6 @@ async def main():
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     r = flyte.run(main)
     print(r.url)

--- a/examples/stress/large_fanout.py
+++ b/examples/stress/large_fanout.py
@@ -25,8 +25,6 @@ async def main(r: int) -> list[int]:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     r = flyte.run(main, r=1000)  # Adjust the number of fanouts as needed
     print(r.url)

--- a/examples/stress/long_recovery.py
+++ b/examples/stress/long_recovery.py
@@ -71,8 +71,6 @@ async def main() -> typing.List[int]:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     r = flyte.run(main)
     print(r.url)

--- a/examples/stress/long_running.py
+++ b/examples/stress/long_running.py
@@ -40,8 +40,6 @@ async def main_task(duration: timedelta) -> str:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(main_task, duration=timedelta(days=5))
     print(run.url)

--- a/examples/stress/long_running_reuse.py
+++ b/examples/stress/long_running_reuse.py
@@ -46,8 +46,6 @@ async def main_task(duration: timedelta) -> str:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     run = flyte.run(main_task, duration=timedelta(days=5))
     print(run.url)

--- a/examples/stress/network_gremlin.py
+++ b/examples/stress/network_gremlin.py
@@ -121,6 +121,6 @@ async def main(sleep: float = 5.0, n: int = 10) -> Tuple[List[str], int]:
 
 
 if __name__ == "__main__":
-    flyte.init_from_config("../../config.yaml")
+    flyte.init_from_config()
     r = flyte.run(main, sleep=2.0, n=20)  # Adjust parameters as needed
     print(r.url)

--- a/examples/stress/trace_fanout.py
+++ b/examples/stress/trace_fanout.py
@@ -22,8 +22,6 @@ async def compute_squares(n: int) -> list[int]:
 
 
 if __name__ == "__main__":
-    import flyte.git
-
-    flyte.init_from_config(flyte.git.config_from_root())
+    flyte.init_from_config()
     r = flyte.run(compute_squares, n=1000)
     print(r.url)

--- a/src/flyte/config/_config.py
+++ b/src/flyte/config/_config.py
@@ -231,10 +231,12 @@ def auto(config_file: typing.Union[str, pathlib.Path, ConfigFile, None] = None) 
       1. If specified, read the config from the provided file path.
       2. If not specified, the config file is searched in the default locations.
             a. ./config.yaml if it exists  (current working directory)
-            b. `UCTL_CONFIG` environment variable
-            c. `FLYTECTL_CONFIG` environment variable
-            d. ~/.union/config.yaml if it exists
-            e. ~/.flyte/config.yaml if it exists
+            b. ./.flyte/config.yaml if it exists (current working directory)
+            c. <git_root>/.flyte/config.yaml if it exists
+            d. `UCTL_CONFIG` environment variable
+            e. `FLYTECTL_CONFIG` environment variable
+            f. ~/.union/config.yaml if it exists
+            g. ~/.flyte/config.yaml if it exists
     3. If any value is not found in the config file, the default value is used.
     4. For any value there are environment variables that match the config variable names, those will override
 


### PR DESCRIPTION
This PR changes the `config.auto()` behavior to try to find the `<git_root>/.flyte/config.yaml` file, which makes the behavior between the SDK and CLI the same: the config file resolution will apply in both `flyte get config` and `flyte.init_from_config`