### PR TITLE
update logger rich styling to work on terminal and jupyter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.flyte
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/flyte/_deploy.py
+++ b/src/flyte/_deploy.py
@@ -5,7 +5,6 @@ import typing
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
-import rich.markup
 import rich.repr
 
 import flyte.errors
@@ -158,7 +157,7 @@ async def _build_images(deployment: DeploymentPlan) -> ImageCache:
     final_images = await asyncio.gather(*images)
 
     for env_name, image_uri in final_images:
-        logger.warning(f"Built Image for environment {env_name}, image: {rich.markup.escape(image_uri)}")
+        logger.warning(f"Built Image for environment {env_name}, image: {image_uri}")
         env = deployment.envs[env_name]
         if isinstance(env.image, Image):
             image_identifier_map[env.image.identifier] = image_uri

--- a/src/flyte/_deploy.py
+++ b/src/flyte/_deploy.py
@@ -5,6 +5,7 @@ import typing
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
+import rich.markup
 import rich.repr
 
 import flyte.errors
@@ -157,7 +158,7 @@ async def _build_images(deployment: DeploymentPlan) -> ImageCache:
     final_images = await asyncio.gather(*images)
 
     for env_name, image_uri in final_images:
-        logger.warning(f"Built Image for environment {env_name}, image: {image_uri}")
+        logger.warning(f"Built Image for environment {env_name}, image: {rich.markup.escape(image_uri)}")
         env = deployment.envs[env_name]
         if isinstance(env.image, Image):
             image_identifier_map[env.image.identifier] = image_uri

--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -110,6 +110,15 @@ async def _initialize_client(
     )
 
 
+def _initialize_logger(log_level: int | None = None):
+    from flyte._tools import ipython_check
+
+    # interactive_mode = not ipython_check()
+    initialize_logger(enable_rich=True)
+    if log_level:
+        initialize_logger(log_level=log_level, enable_rich=True)
+
+
 @syncify
 async def init(
     org: str | None = None,
@@ -172,14 +181,9 @@ async def init(
 
     :return: None
     """
-    from flyte._tools import ipython_check
     from flyte._utils import get_cwd_editable_install, org_from_endpoint, sanitize_endpoint
 
-    interactive_mode = ipython_check()
-
-    initialize_logger(enable_rich=interactive_mode)
-    if log_level:
-        initialize_logger(log_level=log_level, enable_rich=interactive_mode)
+    _initialize_logger(log_level=log_level)
 
     global _init_config  # noqa: PLW0603
 
@@ -265,6 +269,8 @@ async def init_from_config(
         cfg = config.auto(cfg_path)
     else:
         cfg = path_or_config
+
+    _initialize_logger(log_level=log_level)
 
     logger.info(f"Flyte config initialized as {cfg}")
     await init.aio(

--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -111,9 +111,6 @@ async def _initialize_client(
 
 
 def _initialize_logger(log_level: int | None = None):
-    from flyte._tools import ipython_check
-
-    # interactive_mode = not ipython_check()
     initialize_logger(enable_rich=True)
     if log_level:
         initialize_logger(log_level=log_level, enable_rich=True)

--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -250,7 +250,7 @@ async def init_from_config(
     :return: None
     """
     import flyte.config as config
-
+    from rich.highlighter import ReprHighlighter
     cfg: config.Config
     if path_or_config is None:
         # If no path is provided, use the default config file
@@ -272,7 +272,7 @@ async def init_from_config(
 
     _initialize_logger(log_level=log_level)
 
-    logger.info(f"Flyte config initialized as {cfg}")
+    logger.info(f"Flyte config initialized as {cfg}", extra={"highlighter": ReprHighlighter()})
     await init.aio(
         org=cfg.task.org,
         project=cfg.task.project,

--- a/src/flyte/_internal/imagebuild/remote_builder.py
+++ b/src/flyte/_internal/imagebuild/remote_builder.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Optional, Tuple, cast
 from uuid import uuid4
 
 import aiofiles
-import rich.markup
 
 import flyte
 import flyte.errors
@@ -88,7 +87,7 @@ class RemoteImageChecker(ImageChecker):
             logger.warning(f"[blue]Image {resp.image.fqin} found. Skip building.[/blue]")
             return resp.image.fqin
         except Exception:
-            logger.warning(f"Image {image_name} was not found or has expired.", extra={"markup": False})
+            logger.warning(f"[blue]Image {image_name} was not found or has expired.[/blue]", extra={"highlight": False})
             return None
 
 
@@ -139,7 +138,7 @@ class RemoteImageBuilder(ImageBuilder):
                 )
             except Exception as e:
                 # Ignore the error if optimize is not enabled in the backend.
-                logger.warning(f"Failed to run optimize task with error: {e}")
+                logger.debug(f"Failed to run optimize task with error: {e}")
         else:
             raise flyte.errors.ImageBuildError(f"❌ Build failed in {elapsed} at [cyan]{run.url}[/cyan]")
 

--- a/src/flyte/_logging.py
+++ b/src/flyte/_logging.py
@@ -68,6 +68,7 @@ def get_rich_handler(log_level: int) -> Optional[logging.Handler]:
         log_time_format="%H:%M:%S.%f",
         console=Console(width=width),
         level=log_level,
+        markup=True,
     )
 
     formatter = logging.Formatter(fmt="%(filename)s:%(lineno)d - %(message)s")

--- a/src/flyte/_logging.py
+++ b/src/flyte/_logging.py
@@ -40,6 +40,21 @@ def log_format_from_env() -> str:
     return os.environ.get("LOG_FORMAT", "json")
 
 
+def _get_console():
+    """
+    Get the console.
+    """
+    from rich.console import Console
+
+    try:
+        width = os.get_terminal_size().columns
+    except Exception as e:
+        logger.debug(f"Failed to get terminal size: {e}")
+        width = 160
+
+    return Console(width=width)
+
+
 def get_rich_handler(log_level: int) -> Optional[logging.Handler]:
     """
     Upgrades the global loggers to use Rich logging.
@@ -51,14 +66,8 @@ def get_rich_handler(log_level: int) -> Optional[logging.Handler]:
         return None
 
     import click
-    from rich.console import Console
     from rich.logging import RichHandler
-
-    try:
-        width = os.get_terminal_size().columns
-    except Exception as e:
-        logger.debug(f"Failed to get terminal size: {e}")
-        width = 160
+    from rich.highlighter import NullHighlighter
 
     handler = RichHandler(
         tracebacks_suppress=[click],
@@ -66,8 +75,9 @@ def get_rich_handler(log_level: int) -> Optional[logging.Handler]:
         omit_repeated_times=False,
         show_path=False,
         log_time_format="%H:%M:%S.%f",
-        console=Console(width=width),
+        console=_get_console(),
         level=log_level,
+        highlighter=NullHighlighter(),
         markup=True,
     )
 

--- a/src/flyte/remote/_client/auth/_authenticators/device_code.py
+++ b/src/flyte/remote/_client/auth/_authenticators/device_code.py
@@ -92,7 +92,7 @@ class DeviceCodeAuthenticator(Authenticator):
         )
 
         full_uri = f"{resp.verification_uri}?user_code={resp.user_code}"
-        text = f"To Authenticate, navigate in a browser to the following URL: [blue]{full_uri}[/blue]"
+        text = f"To Authenticate, navigate in a browser to the following URL: [blue link={full_uri}]{full_uri}[/blue link]"
         logger.warning(text)
         try:
             token, refresh_token, expires_in = await token_client.poll_token_endpoint(

--- a/src/flyte/remote/_client/auth/_authenticators/device_code.py
+++ b/src/flyte/remote/_client/auth/_authenticators/device_code.py
@@ -1,3 +1,4 @@
+from rich import print as rich_print
 
 from flyte._logging import logger
 from flyte.remote._client.auth import _token_client as token_client
@@ -93,7 +94,7 @@ class DeviceCodeAuthenticator(Authenticator):
 
         full_uri = f"{resp.verification_uri}?user_code={resp.user_code}"
         text = f"To Authenticate, navigate in a browser to the following URL: [blue link={full_uri}]{full_uri}[/blue link]"
-        logger.warning(text)
+        rich_print(text)
         try:
             token, refresh_token, expires_in = await token_client.poll_token_endpoint(
                 resp,

--- a/src/flyte/remote/_client/auth/_authenticators/device_code.py
+++ b/src/flyte/remote/_client/auth/_authenticators/device_code.py
@@ -1,4 +1,3 @@
-import click
 
 from flyte._logging import logger
 from flyte.remote._client.auth import _token_client as token_client
@@ -93,11 +92,8 @@ class DeviceCodeAuthenticator(Authenticator):
         )
 
         full_uri = f"{resp.verification_uri}?user_code={resp.user_code}"
-        text = (
-            f"To Authenticate, navigate in a browser to the following URL: "
-            f"{click.style(full_uri, fg='blue', underline=True)}"
-        )
-        click.secho(text)
+        text = f"To Authenticate, navigate in a browser to the following URL: [blue]{full_uri}[/blue]"
+        logger.warning(text)
         try:
             token, refresh_token, expires_in = await token_client.poll_token_endpoint(
                 resp,

--- a/src/flyte/remote/_data.py
+++ b/src/flyte/remote/_data.py
@@ -91,7 +91,7 @@ async def _upload_single_file(
             raise RuntimeSystemError(e.code().value, f"Failed to get signed url for {fp}: {e.details()}")
     except Exception as e:
         raise RuntimeSystemError(type(e).__name__, f"Failed to get signed url for {fp}.") from e
-    logger.debug(f"Uploading to {make_hyperlink('signed url', resp.signed_url)} for {fp}")
+    logger.debug(f"Uploading to [link={resp.signed_url}]signed url[/link] for [link=file://{fp}]{fp}[/link]")
     extra_headers = get_extra_headers_for_protocol(resp.native_url)
     extra_headers.update(resp.headers)
     encoded_md5 = b64encode(md5_bytes)


### PR DESCRIPTION
This PR updates `logging` and `click.secho` statements to use rich so that it all looks good on a terminal and jupyter notebook.

Terminal:
<img width="934" height="487" alt="image" src="https://github.com/user-attachments/assets/2c9e7d5d-dafb-4de6-a7d3-af42d1206551" />

Jupyter notebook (before):
<img width="1323" height="244" alt="image" src="https://github.com/user-attachments/assets/8c0175e7-836f-466c-a147-451060e710ad" />

Jupyter notebook (after):
<img width="1178" height="208" alt="image" src="https://github.com/user-attachments/assets/15c098bd-e0a5-4564-9776-256ba6e576f1" />
