### PR TITLE
Wait for flyte-pypi package availability before building

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,30 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           uv run python -m twine upload --verbose dist/*
+      - name: Sleep until pypi is available
+        id: pypiwait
+        run: |
+          # from 'refs/tags/v1.2.3 get 1.2.3' and make sure it's not an empty string
+          VERSION=$(echo $GITHUB_REF | sed 's|refs/tags/v||')
+          if [ -z "$VERSION" ]
+          then
+            echo "No tagged version found, exiting"
+            exit 1
+          fi
+          sleep 120
+          LINK="https://pypi.org/project/flyte/${VERSION}/"
+          for i in {1..60}; do
+            result=$(curl -L -I -s -f ${LINK})
+            if [ $? -eq 0 ]; then
+              echo "Found pypi for $LINK"
+              exit 0
+            else
+              echo "Did not find - Retrying in 10 seconds..."
+              sleep 10
+            fi
+          done
+          exit 1
+        shell: bash
   plugin-pypi:
     name: PyPI package
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
• Adds wait logic for flyte-pypi package availability in CI workflow
• Ensures builds wait for package publishing to complete before proceeding

## Test plan
- [x] Verify workflow syntax is correct
- [ ] Test in CI environment to confirm wait behavior works as expected
