### PR TITLE
[Feat] Enable setting image in cli

### DIFF
--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -564,6 +564,17 @@ class Image:
         return img
 
     @classmethod
+    def from_name(cls, name: str) -> Image:
+        from ._initialize import _get_init_config
+
+        cfg = _get_init_config()
+        if name in cfg.images:
+            img = cls._new(name=name, base_image=cfg.images[name])
+        else:
+            img = cls._new()
+        return img
+
+    @classmethod
     def from_uv_script(
         cls,
         script: Path | str,

--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -568,7 +568,7 @@ class Image:
         from ._initialize import _get_init_config
 
         cfg = _get_init_config()
-        if name in cfg.images:
+        if cfg and name in cfg.images:
             img = cls._new(name=name, base_image=cfg.images[name])
         else:
             img = cls._new()

--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import functools
 import threading
 import typing
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, List, Literal, Optional, TypeVar
 
@@ -42,7 +42,7 @@ class _InitConfig(CommonInit):
     client: Optional[ClientSet] = None
     storage: Optional[Storage] = None
     image_builder: "ImageBuildEngine.ImageBuilderType" = "local"
-    images: typing.Dict[str, Image] | None = None
+    images: typing.Dict[str, str] = field(default_factory=dict)
 
     def replace(self, **kwargs) -> _InitConfig:
         return replace(self, **kwargs)
@@ -230,7 +230,7 @@ async def init(
             org=org or org_from_endpoint(endpoint),
             batch_size=batch_size,
             image_builder=image_builder,
-            images=images,
+            images=images or {},
             source_config_path=source_config_path,
         )
 

--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, List, Literal, Optional, TypeVar
 
+from flyte._image import Image
 from flyte.errors import InitializationError
 from flyte.syncify import syncify
 
@@ -41,6 +42,7 @@ class _InitConfig(CommonInit):
     client: Optional[ClientSet] = None
     storage: Optional[Storage] = None
     image_builder: "ImageBuildEngine.ImageBuilderType" = "local"
+    images: typing.Dict[str, Image] | None = None
 
     def replace(self, **kwargs) -> _InitConfig:
         return replace(self, **kwargs)
@@ -141,6 +143,7 @@ async def init(
     storage: Storage | None = None,
     batch_size: int = 1000,
     image_builder: ImageBuildEngine.ImageBuilderType = "local",
+    images: typing.Dict[str, Image] | None = None,
     source_config_path: Optional[Path] = None,
 ) -> None:
     """
@@ -177,6 +180,7 @@ async def init(
     :param batch_size: Optional batch size for operations that use listings, defaults to 1000, so limit larger than
       batch_size will be split into multiple requests.
     :param image_builder: Optional image builder configuration, if not provided, the default image builder will be used.
+    :param images: Optional dict of images that can be used by referencing the image name.
     :param source_config_path: Optional path to the source configuration file (This is only used for documentation)
     :return: None
     """
@@ -226,6 +230,7 @@ async def init(
             org=org or org_from_endpoint(endpoint),
             batch_size=batch_size,
             image_builder=image_builder,
+            images=images,
             source_config_path=source_config_path,
         )
 
@@ -294,6 +299,7 @@ async def init_from_config(
         root_dir=root_dir,
         log_level=log_level,
         image_builder=cfg.image.builder,
+        images=cfg.image.images,
         storage=storage,
         source_config_path=cfg_path,
     )

--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -181,12 +181,10 @@ class RunTaskCommand(click.RichCommand):
         for value in values:
             if "=" in value:
                 image_name, image_uri = value.split("=", 1)
-                image = Image.from_base(image_uri)
-                cfg.images[image_name] = image
+                cfg.images[image_name] = image_uri
             else:
                 # If no name specified, use "default" as the name
-                image = Image.from_base(value)
-                cfg.images["default"] = image
+                cfg.images["default"] = value
 
     def get_params(self, ctx: click.Context) -> List[click.Parameter]:
         # Note this function may be called multiple times by click.

--- a/src/flyte/config/_config.py
+++ b/src/flyte/config/_config.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 import rich.repr
 
+from flyte import Image
 from flyte._logging import logger
 from flyte.config import _internal
 from flyte.config._reader import ConfigFile, get_config_file, read_file_if_exists
@@ -148,6 +149,7 @@ class ImageConfig(object):
     """
 
     builder: str | None = None
+    images: typing.Dict[str, Image] = field(default_factory=dict)
 
     @classmethod
     def auto(cls, config_file: typing.Optional[typing.Union[str, ConfigFile]] = None) -> "ImageConfig":
@@ -159,7 +161,15 @@ class ImageConfig(object):
         config_file = get_config_file(config_file)
         kwargs: typing.Dict[str, typing.Any] = {}
         kwargs = set_if_exists(kwargs, "builder", _internal.Image.BUILDER.read(config_file))
+        # TODO: We can add support for setting images in the config file
         return ImageConfig(**kwargs)
+
+    @classmethod
+    def add_image(cls, name: str, image: Image) -> None:
+        """
+        Adds an image to the ImageConfig.
+        """
+        cls.images[name] = image
 
 
 @rich.repr.auto


### PR DESCRIPTION
## Description

In v1, user can set the image in cli using `pyflyte run --image image1=imageuri`, we should be able to support the same thing in v2.

## Changes

- add `--image` in flyte cli for setting image
- add `Image.from_name` to enable using image set in cli
- add test to ensure the image set in cli can be used by `Image.from_name`