### PR TITLE
Disable cache for raw container task by default

### DIFF
--- a/src/flyte/_task.py
+++ b/src/flyte/_task.py
@@ -90,7 +90,7 @@ class TaskTemplate(Generic[P, R]):
     task_type_version: int = 0
     image: Union[str, Image, Literal["auto"]] = "auto"
     resources: Optional[Resources] = None
-    cache: CacheRequest = "auto"
+    cache: CacheRequest = "disable"
     interruptable: bool = False
     retries: Union[int, RetryStrategy] = 0
     reusable: Union[ReusePolicy, None] = None


### PR DESCRIPTION
Changed the default value of the `cache` parameter in the `TaskTemplate from `"auto"` to `"disable"`, which means all tasks will no longer be cached by default.