### PR TITLE
Fix container command to use empty string instead of empty list

### DIFF
--- a/src/flyte/_internal/runtime/task_serde.py
+++ b/src/flyte/_internal/runtime/task_serde.py
@@ -240,7 +240,7 @@ def _get_urun_container(
 
     return tasks_pb2.Container(
         image=img_uri,
-        command=[],
+        command=[""],
         args=task_template.container_args(serialize_context),
         resources=resources,
         env=env,


### PR DESCRIPTION
## Summary
• Changes container command from empty list `[]` to list with empty string `[""]` in task serialization
• Ensures proper container execution by providing a valid command format

## Test plan
- [ ] Verify container tasks execute correctly with the new command format
- [ ] Run existing tests to ensure no regressions
- [ ] Test task serialization and deserialization

🤖 Generated with [Claude Code](https://claude.ai/code)