### PR TITLE
Allow local builder's command to use mounted secrets, fix secret command generation from env vars

### DIFF
--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -332,8 +332,9 @@ class CommandsHandler:
     @staticmethod
     async def handle(layer: Commands, _: Path, dockerfile: str) -> str:
         # Append raw commands to the dockerfile
+        secret_mounts = _get_secret_mounts_layer(layer.secret_mounts)
         for command in layer.commands:
-            dockerfile += f"\nRUN {command}\n"
+            dockerfile += f"\nRUN {secret_mounts} {command}\n"
 
         return dockerfile
 
@@ -365,7 +366,7 @@ def _get_secret_commands(layers: typing.Tuple[Layer, ...]) -> typing.List[str]:
         return ["--secret", f"id={secret_id},src={secret_file_path}"]
 
     for layer in layers:
-        if isinstance(layer, (PipOption, AptPackages)):
+        if isinstance(layer, (PipOption, AptPackages, Commands)):
             if layer.secret_mounts:
                 for secret_mount in layer.secret_mounts:
                     commands.extend(_get_secret_command(secret_mount))

--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -356,9 +356,8 @@ def _get_secret_commands(layers: typing.Tuple[Layer, ...]) -> typing.List[str]:
             secret = Secret(key=secret)
         secret_id = hash(secret)
         secret_env_key = "_".join([k.upper() for k in filter(None, (secret.group, secret.key))])
-        secret_env = os.getenv(secret_env_key)
-        if secret_env:
-            return ["--secret", f"id={secret_id},env={secret_env}"]
+        if os.getenv(secret_env_key):
+            return ["--secret", f"id={secret_id},env={secret_env_key}"]
         secret_file_name = "_".join(list(filter(None, (secret.group, secret.key))))
         secret_file_path = f"/etc/secrets/{secret_file_name}"
         if not os.path.exists(secret_file_path):

--- a/tests/flyte/imagebuild/test_docker_builder.py
+++ b/tests/flyte/imagebuild/test_docker_builder.py
@@ -58,10 +58,28 @@ async def test_image_with_secrets(monkeypatch):
         Image.from_debian_base(registry="localhost:30000", name="img_with_secrets")
         .with_apt_packages("vim", secret_mounts="flyte")
         .with_pip_packages("requests", secret_mounts=[Secret(group="group", key="key")])
+        .with_commands(["echo foobar"], secret_mounts=[Secret(group="group", key="key")])
     )
 
     builder = DockerImageBuilder()
     await builder.build_image(img)
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.parametrize("secret_mounts", [["flyte"], [Secret(group="group", key="key")]])
+async def test_image_with_secrets_fails_if_secret_missing(secret_mounts):
+
+    base = Image.from_debian_base(registry="localhost:30000", name="img_with_missing_secrets")
+    builder = DockerImageBuilder()
+
+    for func in [
+        lambda img: img.with_apt_packages("vim", secret_mounts=secret_mounts),
+        lambda img: img.with_pip_packages("requests", secret_mounts=secret_mounts),
+        lambda img: img.with_commands(["echo foobar"], secret_mounts=secret_mounts),
+    ]:
+        layered = func(base)
+        with pytest.raises(FileNotFoundError, match="Secret not found"):
+            await builder.build_image(layered)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

This PR includes a bug fix in how secret env vars are added to the docker build command - the format should be `--secret id=<SOME_ID>,env=<ENV_VAR_NAME>` however currently `env=<ENV_VAR_VALUE>`.

Additionally, we add support for the `CommandsHandler` to pass secret mounts given the commands layer can accept those as arguments - it is also useful to run commands with some secret mounted. 