### PR TITLE
Reduce startup overhead for the debug button

### DIFF
--- a/src/flyte/_debug/constants.py
+++ b/src/flyte/_debug/constants.py
@@ -12,7 +12,6 @@ DEFAULT_CODE_SERVER_REMOTE_PATHS = {
 }
 DEFAULT_CODE_SERVER_EXTENSIONS = [
     "https://raw.githubusercontent.com/flyteorg/flytetools/master/flytekitplugins/flyin/ms-python.python-2023.20.0.vsix",
-    "https://raw.githubusercontent.com/flyteorg/flytetools/master/flytekitplugins/flyin/ms-toolsai.jupyter-2023.9.100.vsix",
 ]
 
 # Duration to pause the checking of the heartbeat file until the next one

--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -204,10 +204,11 @@ class _Runner:
             inputs = await convert_from_native_to_inputs(obj.native_interface, *args, **kwargs)
 
         env = self._env_vars or {}
-        if self._log_level:
-            env["LOG_LEVEL"] = str(self._log_level)
-        else:
-            env["LOG_LEVEL"] = str(logger.getEffectiveLevel())
+        if env.get("LOG_LEVEL") is None:
+            if self._log_level:
+                env["LOG_LEVEL"] = str(self._log_level)
+            else:
+                env["LOG_LEVEL"] = str(logger.getEffectiveLevel())
 
         if not self._dry_run:
             if get_client() is None:


### PR DESCRIPTION
## Summary
- Remove Jupyter extension from default code server extensions to reduce startup time
- Prevent overriding existing LOG_LEVEL environment variables in runner