### PR TITLE
[Breaking] Removes the need for `add_task` in TaskEnvironment

### DIFF
--- a/examples/advanced/container_task.py
+++ b/examples/advanced/container_task.py
@@ -1,12 +1,9 @@
 import flyte
 from flyte.extras import ContainerTask
 
-env = flyte.TaskEnvironment(name="hello_world")
-
-
 greeting_task = ContainerTask(
     name="echo_and_return_greeting",
-    image="alpine:latest",
+    image=flyte.Image.from_base("alpine:3.18"),
     input_data_dir="/var/inputs",
     output_data_dir="/var/outputs",
     inputs={"name": str},
@@ -14,8 +11,9 @@ greeting_task = ContainerTask(
     command=["/bin/sh", "-c", "echo 'Hello, my name is {{.inputs.name}}.' | tee -a /var/outputs/greeting"],
 )
 
-# Add it to the environment if you want to deploy it.
-env.add_task(greeting_task)
+container_env = flyte.TaskEnvironment.from_task("container_env", greeting_task)
+
+env = flyte.TaskEnvironment(name="hello_world", depends_on=[container_env])
 
 
 @env.task

--- a/examples/basics/using_dockerfiles.py
+++ b/examples/basics/using_dockerfiles.py
@@ -3,19 +3,13 @@ from pathlib import Path
 import flyte
 from flyte.extras import ContainerTask
 
-env = flyte.TaskEnvironment(
-    name="dockerfile_example",
+version_task = ContainerTask(
     image=flyte.Image.from_dockerfile(
         file=Path(__file__).parent / "Dockerfile.example",
         name="flyte-temp-dockerfile-example",
         registry="ghcr.io/flyteorg",
         platform=("linux/amd64", "linux/arm64"),
     ),
-)
-
-
-version_task = ContainerTask(
-    image=env.image,
     name="example_task",
     input_data_dir="/var/inputs",
     output_data_dir="/var/outputs",
@@ -24,8 +18,7 @@ version_task = ContainerTask(
     command=["/bin/sh", "-c", "python --version | tee -a /var/outputs/version"],
 )
 
-env.add_task(version_task)
-
+env = flyte.TaskEnvironment.from_task("dockerfile_env", version_task)
 
 if __name__ == "__main__":
     flyte.init_from_config()

--- a/src/flyte/_internal/imagebuild/remote_builder.py
+++ b/src/flyte/_internal/imagebuild/remote_builder.py
@@ -182,6 +182,11 @@ async def _validate_configuration(image: Image) -> Tuple[str, Optional[str]]:
 def _get_layers_proto(image: Image, context_path: Path) -> "image_definition_pb2.ImageSpec":
     from flyte._protos.imagebuilder import definition_pb2 as image_definition_pb2
 
+    if image.dockerfile is not None:
+        raise flyte.errors.ImageBuildError(
+            "Custom Dockerfile is not supported with remote image builder.You can use local image builder instead."
+        )
+
     layers = []
     for layer in image._layers:
         secret_mounts = None

--- a/src/flyte/_task_environment.py
+++ b/src/flyte/_task_environment.py
@@ -237,16 +237,32 @@ class TaskEnvironment(Environment):
         """
         return self._tasks
 
-    def add_task(self, task: TaskTemplate) -> TaskTemplate:
+    @classmethod
+    def from_task(cls, name: str, *tasks: TaskTemplate) -> TaskEnvironment:
         """
-        Add a task to the environment.
+        Create a TaskEnvironment from a list of tasks. All tasks should have the same image or no Image defined.
+        Similarity of Image is determined by the python reference, not by value.
 
-        Useful when you want to add a task to an environment that is not defined using the `task` decorator.
+        If images are different, an error is raised. If no image is defined, the image is set to "auto".
 
-        :param task: The TaskTemplate to add to this environment.
+        For any other tasks that need to be use these tasks, the returned environment can be used in the `depends_on`
+        attribute of the other TaskEnvironment.
+
+        :param name: The name of the environment.
+        :param tasks: The list of tasks to create the environment from.
+
+        :raises ValueError: If tasks are assigned to multiple environments or have different images.
+        :return: The created TaskEnvironment.
         """
-        if task.name in self._tasks:
-            raise ValueError(f"Task {task.name} already exists in the environment. Task names should be unique.")
-        self._tasks[task.name] = task
-        task.parent_env = weakref.ref(self)
-        return task
+        envs = [t.parent_env() for t in tasks if t.parent_env and t.parent_env() is not None]
+        if envs:
+            raise ValueError("Tasks cannot assigned to multiple environments.")
+        images = {t.image for t in tasks}
+        if len(images) > 1:
+            raise ValueError("Tasks must have the same image to be in the same environment.")
+        image: Union[str, Image] = images.pop() if images else "auto"
+        env = cls(name, image=image)
+        for t in tasks:
+            env._tasks[t.name] = t
+            t.parent_env = weakref.ref(env)
+        return env

--- a/tests/user_api/test_task_environment.py
+++ b/tests/user_api/test_task_environment.py
@@ -79,18 +79,6 @@ def test_reusable_conflict_pod_template(base_env):
         env.task(z, pod_template="tmpl")
 
 
-def test_add_task_and_duplicates(base_env):
-    class Dummy:
-        def __init__(self, name):
-            self.name = name
-
-    t1 = Dummy("t1")
-    base_env.add_task(t1)
-    assert "t1" in base_env.tasks
-    with pytest.raises(ValueError):
-        base_env.add_task(t1)
-
-
 def test_clone_no_tasks(base_env):
     # Ensure cloning does not carry over tasks
     clone = base_env.clone_with(name="clone_no_tasks")


### PR DESCRIPTION
```python
tk = flyte.ContainerTask(...)

env = flyte.from_tasks("my_env", tk)
```

This makes it consistent that everytime a Object task is created it can be added to an environment and every environment has one and only one image

 All Environments will now have one image and only one image. An environment has some common properties and 3 most important ones are 
1. Name,
2. Image
3. Depends_on

ImageCache is just a list of images per environment now.
