### PR TITLE
Add addition attributes in RunSpec

### DIFF
--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -132,7 +132,6 @@ class _Runner:
         from flyteidl2.core import literals_pb2, security_pb2
         from flyteidl2.task import run_pb2
         from flyteidl2.workflow import run_definition_pb2, run_service_pb2
-
         from google.protobuf import wrappers_pb2
 
         from flyte.remote import Run
@@ -259,9 +258,13 @@ class _Runner:
             env_kv = run_pb2.Envs(values=kv_pairs)
             annotations = run_pb2.Annotations(values=self._annotations)
             labels = run_pb2.Labels(values=self._labels)
-            raw_data_storage = run_pb2.RawDataStorage(raw_data_prefix=self._raw_data_path)
-            security_context = security_pb2.SecurityContext(
-                run_as=security_pb2.Identity(k8s_service_account=self._service_account)
+            raw_data_storage = (
+                run_pb2.RawDataStorage(raw_data_prefix=self._raw_data_path) if self._raw_data_path else None
+            )
+            security_context = (
+                security_pb2.SecurityContext(run_as=security_pb2.Identity(k8s_service_account=self._service_account))
+                if self._service_account
+                else None
             )
 
             try:

--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -92,7 +92,7 @@ class RunArguments:
             "click.option": click.Option(
                 ["--raw-data-path"],
                 type=str,
-                help="Override the output path to store the raw data. Example: s3://bucket/",
+                help="Override the output prefix used to store offloaded data types. e.g. s3://bucket/",
             )
         },
     )
@@ -102,7 +102,7 @@ class RunArguments:
             "click.option": click.Option(
                 ["--service-account"],
                 type=str,
-                help="Kubernetes service account. If not provided, default will be used",
+                help="Kubernetes service account. If not provided, the configured default will be used",
             )
         },
     )


### PR DESCRIPTION
## Changes
1. Update `src/flyte/_run.py` to pass `service_account` and `raw_output_prefix` into RunSpec while creating a new run
2. Update protos