### PR TITLE
Improve hash calculation for UV and Poetry project layers

### DIFF
--- a/examples/deploy_patterns/pyproject/pyproject_test.py
+++ b/examples/deploy_patterns/pyproject/pyproject_test.py
@@ -6,7 +6,9 @@ env = flyte.TaskEnvironment(
     name="pyproject_test_0",
     resources=flyte.Resources(memory="250Mi"),
     image=(
-        flyte.Image.from_debian_base(registry="docker.io/nielsbantilan").with_uv_project(
+        flyte.Image.from_debian_base()
+        .with_env_vars({"sdf": "3"})
+        .with_uv_project(
             pyproject_file=pathlib.Path("pyproject.toml"),
             pre=True,
         )

--- a/examples/deploy_patterns/pyproject/pyproject_test.py
+++ b/examples/deploy_patterns/pyproject/pyproject_test.py
@@ -7,7 +7,6 @@ env = flyte.TaskEnvironment(
     resources=flyte.Resources(memory="250Mi"),
     image=(
         flyte.Image.from_debian_base()
-        .with_env_vars({"sdf": "3"})
         .with_uv_project(
             pyproject_file=pathlib.Path("pyproject.toml"),
             pre=True,

--- a/examples/deploy_patterns/pyproject/pyproject_test.py
+++ b/examples/deploy_patterns/pyproject/pyproject_test.py
@@ -10,7 +10,7 @@ env = flyte.TaskEnvironment(
         .with_uv_project(
             pyproject_file=pathlib.Path("pyproject.toml"),
             pre=True,
-        ).with_local_v2()
+        )
     ),
 )
 

--- a/examples/deploy_patterns/pyproject/pyproject_test.py
+++ b/examples/deploy_patterns/pyproject/pyproject_test.py
@@ -10,7 +10,7 @@ env = flyte.TaskEnvironment(
         .with_uv_project(
             pyproject_file=pathlib.Path("pyproject.toml"),
             pre=True,
-        )
+        ).with_local_v2()
     ),
 )
 

--- a/examples/deploy_patterns/uv_workspace/src/workflows/albatross.py
+++ b/examples/deploy_patterns/uv_workspace/src/workflows/albatross.py
@@ -24,4 +24,5 @@ async def albatross_task() -> str:
 if __name__ == "__main__":
     current_dir = Path(__file__).parent
     flyte.init_from_config(root_dir=current_dir.parent)
-    flyte.run(albatross_task)
+    run = flyte.run(albatross_task)
+    print(run.url)

--- a/examples/deploy_patterns/uv_workspace/uv.lock
+++ b/examples/deploy_patterns/uv_workspace/uv.lock
@@ -1,10 +1,6 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
-resolution-markers = [
-    "python_full_version >= '3.11'",
-    "python_full_version < '3.11'",
-]
 
 [manifest]
 members = [
@@ -66,7 +62,7 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.10.0"
+version = "4.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
@@ -74,9 +70,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/b4/636b3b65173d3ce9a38ef5f0522789614e590dab6a8d505340a4efe4c567/anyio-4.10.0.tar.gz", hash = "sha256:3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6", size = 213252, upload-time = "2025-08-04T08:54:26.451Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/78/7d432127c41b50bccba979505f272c16cbcadcc33645d5fa3a738110ae75/anyio-4.11.0.tar.gz", hash = "sha256:82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4", size = 219094, upload-time = "2025-09-23T09:19:12.58Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/12/e5e0282d673bb9746bacfb6e2dba8719989d3660cdb2ea79aee9a9651afb/anyio-4.10.0-py3-none-any.whl", hash = "sha256:60e474ac86736bbfd6f210f7a61218939c318f43f9972497381f1c5e930ed3d1", size = 107213, upload-time = "2025-08-04T08:54:24.882Z" },
+    { url = "https://files.pythonhosted.org/packages/15/b3/9b1a8074496371342ec1e796a96f99c82c945a339cd81a8e73de28b4cf9e/anyio-4.11.0-py3-none-any.whl", hash = "sha256:0287e96f4d26d4149305414d4e3bc32f0dcd0862365a4bddea19d7a1ec38c4fc", size = 109097, upload-time = "2025-09-23T09:19:10.601Z" },
 ]
 
 [[package]]
@@ -264,7 +260,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [

--- a/src/flyte/_deploy.py
+++ b/src/flyte/_deploy.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-import typing
-import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional, Protocol, Set, Tuple, Type
 
@@ -380,7 +378,6 @@ def plan_deploy(*envs: Environment, version: Optional[str] = None) -> List[Deplo
         deployment_plans.append(DeploymentPlan(planned_envs, version=version))
         visited_envs.update(planned_envs.keys())
     return deployment_plans
-
 
 
 @syncify

--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -220,7 +220,6 @@ class PoetryProject(Layer):
                 hash_input += str(secret_mount)
         hasher.update(hash_input.encode("utf-8"))
 
-        super().update_hash(hasher)
         if self.extra_args and "--no-root" in self.extra_args:
             filehash_update(self.poetry_lock, hasher)
             filehash_update(self.pyproject, hasher)

--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -181,7 +181,7 @@ class UVProject(PipOption, Layer):
         from ._utils import filehash_update
 
         super().update_hash(hasher)
-        if "--no-install-project" in self.extra_args:
+        if self.extra_args and "--no-install-project" in self.extra_args:
             filehash_update(self.uvlock, hasher)
             filehash_update(self.pyproject, hasher)
         else:
@@ -221,7 +221,7 @@ class PoetryProject(Layer):
         hasher.update(hash_input.encode("utf-8"))
 
         super().update_hash(hasher)
-        if "--no-root" in self.extra_args:
+        if self.extra_args and "--no-root" in self.extra_args:
             filehash_update(self.poetry_lock, hasher)
             filehash_update(self.pyproject, hasher)
         else:

--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -54,7 +54,6 @@ RUN --mount=type=cache,sharing=locked,mode=0777,target=/root/.cache/uv,id=uv \
 """)
 
 UV_LOCK_INSTALL_TEMPLATE = Template("""\
-RUN mkdir -p /root/.flyte
 RUN --mount=type=cache,sharing=locked,mode=0777,target=/root/.cache/uv,id=uv \
    --mount=type=bind,target=/root/.flyte/$PYPROJECT_PATH,src=$PYPROJECT_PATH,rw \
    $SECRET_MOUNT \

--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -54,10 +54,11 @@ RUN --mount=type=cache,sharing=locked,mode=0777,target=/root/.cache/uv,id=uv \
 """)
 
 UV_LOCK_INSTALL_TEMPLATE = Template("""\
-COPY $PYPROJECT_PATH $PYPROJECT_PATH
+RUN mkdir -p /root/.flyte
 RUN --mount=type=cache,sharing=locked,mode=0777,target=/root/.cache/uv,id=uv \
+   --mount=type=bind,target=/root/.flyte/$PYPROJECT_PATH,src=$PYPROJECT_PATH,rw \
    $SECRET_MOUNT \
-   uv sync --active --inexact $PIP_INSTALL_ARGS --project $PYPROJECT_PATH
+   uv sync --active --inexact $PIP_INSTALL_ARGS --project /root/.flyte/$PYPROJECT_PATH
 """)
 
 POETRY_LOCK_WITHOUT_PROJECT_INSTALL_TEMPLATE = Template("""\

--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -57,7 +57,7 @@ UV_LOCK_INSTALL_TEMPLATE = Template("""\
 RUN --mount=type=cache,sharing=locked,mode=0777,target=/root/.cache/uv,id=uv \
    --mount=type=bind,target=/root/.flyte/$PYPROJECT_PATH,src=$PYPROJECT_PATH,rw \
    $SECRET_MOUNT \
-   uv sync --active --inexact $PIP_INSTALL_ARGS --project /root/.flyte/$PYPROJECT_PATH
+   uv sync --active --inexact --no-editable $PIP_INSTALL_ARGS --project /root/.flyte/$PYPROJECT_PATH
 """)
 
 POETRY_LOCK_WITHOUT_PROJECT_INSTALL_TEMPLATE = Template("""\

--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -50,14 +50,14 @@ RUN --mount=type=cache,sharing=locked,mode=0777,target=/root/.cache/uv,id=uv \
    --mount=type=bind,target=uv.lock,src=$UV_LOCK_PATH \
    --mount=type=bind,target=pyproject.toml,src=$PYPROJECT_PATH \
    $SECRET_MOUNT \
-   uv sync --active $PIP_INSTALL_ARGS
+   uv sync --active --inexact $PIP_INSTALL_ARGS
 """)
 
 UV_LOCK_INSTALL_TEMPLATE = Template("""\
 COPY $PYPROJECT_PATH $PYPROJECT_PATH
 RUN --mount=type=cache,sharing=locked,mode=0777,target=/root/.cache/uv,id=uv \
    $SECRET_MOUNT \
-   uv sync --active $PIP_INSTALL_ARGS --project $PYPROJECT_PATH
+   uv sync --active --inexact $PIP_INSTALL_ARGS --project $PYPROJECT_PATH
 """)
 
 POETRY_LOCK_WITHOUT_PROJECT_INSTALL_TEMPLATE = Template("""\

--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -78,14 +78,11 @@ POETRY_LOCK_INSTALL_TEMPLATE = Template("""\
 RUN --mount=type=cache,sharing=locked,mode=0777,target=/root/.cache/uv,id=uv \
    uv pip install poetry
 
-COPY $PYPROJECT_PATH $PYPROJECT_PATH
-
 ENV POETRY_CACHE_DIR=/tmp/poetry_cache \
    POETRY_VIRTUALENVS_IN_PROJECT=true
 
 RUN --mount=type=cache,sharing=locked,mode=0777,target=/tmp/poetry_cache,id=poetry \
-   --mount=type=bind,target=poetry.lock,src=poetry.lock \
-   --mount=type=bind,target=pyproject.toml,src=pyproject.toml \
+   --mount=type=bind,target=/root/.flyte/$PYPROJECT_PATH,src=$PYPROJECT_PATH,rw \
    $SECRET_MOUNT \
    poetry install $POETRY_INSTALL_ARGS
 """)

--- a/tests/flyte/imagebuild/test_docker_builder.py
+++ b/tests/flyte/imagebuild/test_docker_builder.py
@@ -398,8 +398,6 @@ async def test_poetry_handler_with_project_install():
 
             assert result.startswith(initial_dockerfile)
 
-            assert "COPY" in result
-            assert "pyproject.toml" in result
             assert "RUN --mount=type=cache,sharing=locked,mode=0777,target=/root/.cache/uv,id=uv" in result
             assert "RUN --mount=type=cache,sharing=locked,mode=0777,target=/tmp/poetry_cache,id=poetry" in result
             assert "uv pip install poetry" in result


### PR DESCRIPTION
## Summary
- Improves hash calculation for UV and Poetry project layers by hashing source code when project installation is enabled
- Adds `--inexact` flag to uv sync commands for better reliability  
- Cleans up unused imports in _deploy.py

## Changes
- **UVProject**: Now hashes the entire source directory when `--no-install-project` is not in extra_args, otherwise hashes just the lock and pyproject files
- **PoetryProject**: Similar logic - hashes source directory when `--no-root` is not in extra_args
- **Docker templates**: Added `--inexact` flag to uv sync commands for more robust dependency resolution
- **Code cleanup**: Removed unused imports in _deploy.py

