### PR TITLE
Allow cli to turn off default on flags

### DIFF
--- a/examples/basics/devbox_one.py
+++ b/examples/basics/devbox_one.py
@@ -33,6 +33,14 @@ async def say_hello_nested(data: str = "default string", n: int = 3) -> str:
     return await say_hello(data=data, lt=vals)
 
 
+@env.task
+async def flag_example(
+    flag: bool, normally_off: bool = False, normally_on: bool = True, optional: bool | None = None
+) -> str:
+    print(f"Args: {flag=}, {normally_off=}, {normally_on=}, {optional=}")
+    return f"flag: {flag}, normally_off: {normally_off}, normally_on: {normally_on}, optional: {optional}"
+
+
 if __name__ == "__main__":
     flyte.init_from_config()
     run = flyte.with_runcontext(

--- a/examples/basics/devbox_one.py
+++ b/examples/basics/devbox_one.py
@@ -33,14 +33,6 @@ async def say_hello_nested(data: str = "default string", n: int = 3) -> str:
     return await say_hello(data=data, lt=vals)
 
 
-@env.task
-async def flag_example(
-    flag: bool, normally_off: bool = False, normally_on: bool = True, optional: bool | None = None
-) -> str:
-    print(f"Args: {flag=}, {normally_off=}, {normally_on=}, {optional=}")
-    return f"flag: {flag}, normally_off: {normally_off}, normally_on: {normally_on}, optional: {optional}"
-
-
 if __name__ == "__main__":
     flyte.init_from_config()
     run = flyte.with_runcontext(

--- a/examples/plugins/ray_example.py
+++ b/examples/plugins/ray_example.py
@@ -36,7 +36,7 @@ ray_env = flyte.TaskEnvironment(
     plugin_config=ray_config,
     image=image,
     resources=flyte.Resources(cpu=(3, 4), memory=("3000Mi", "5000Mi")),
-    depends_on=[task_env]
+    depends_on=[task_env],
 )
 
 

--- a/src/flyte/cli/_params.py
+++ b/src/flyte/cli/_params.py
@@ -531,17 +531,19 @@ def to_click_option(
         if literal_var.type.metadata:
             description_extra = f": {MessageToDict(literal_var.type.metadata)}"
 
-    # If a query has been specified, the input is never strictly required at this layer
     required = False if default_val is not None else True
     is_flag: typing.Optional[bool] = None
+    param_decls = [f"--{input_name}"]
     if literal_converter.is_bool():
         required = False
         is_flag = True
+        if default_val is True:
+            param_decls = [f"--{input_name}/--no-{input_name}"]
     if literal_converter.is_optional():
         required = False
 
     return click.Option(
-        param_decls=[f"--{input_name}"],
+        param_decls=param_decls,
         type=literal_converter.click_type,
         is_flag=is_flag,
         default=default_val,

--- a/tests/cli/test_params.py
+++ b/tests/cli/test_params.py
@@ -1,0 +1,42 @@
+from flyteidl.core.interface_pb2 import Variable
+from flyteidl.core.types_pb2 import LiteralType, SimpleType
+
+from flyte.cli._params import to_click_option
+
+
+def test_boolean_flag_false_default():
+    """Test boolean parameter with False default creates a simple flag."""
+    literal_var = Variable(type=LiteralType(simple=SimpleType.BOOLEAN), description="A boolean flag")
+
+    option = to_click_option(input_name="flag", literal_var=literal_var, python_type=bool, default_val=False)
+
+    assert option.opts == ["--flag"]
+    assert not option.secondary_opts
+    assert option.is_flag is True
+    assert option.default is False
+    assert option.required is False
+
+
+def test_boolean_flag_true_default():
+    """Test boolean parameter with True default creates a --flag/--no-flag pattern."""
+    literal_var = Variable(type=LiteralType(simple=SimpleType.BOOLEAN), description="A boolean flag with True default")
+
+    option = to_click_option(input_name="enabled", literal_var=literal_var, python_type=bool, default_val=True)
+
+    assert option.opts == ["--enabled"]
+    assert option.secondary_opts == ["--no-enabled"]
+    assert option.is_flag is True
+    assert option.default is True
+    assert option.required is False
+
+
+def test_boolean_flag_no_default():
+    """Test boolean parameter with no default creates a simple flag with False default."""
+    literal_var = Variable(type=LiteralType(simple=SimpleType.BOOLEAN), description="A boolean flag with no default")
+
+    option = to_click_option(input_name="debug", literal_var=literal_var, python_type=bool, default_val=None)
+
+    assert option.opts == ["--debug"]
+    assert option.is_flag is True
+    assert option.default is False  # Should default to False for boolean flags
+    assert option.required is False


### PR DESCRIPTION
click option parsing wasn't correct for boolean flags that are on by default.  These need a `--no` variant of the flag.

can test with
```python
@env.task
async def flag_example(
    flag: bool, normally_off: bool = False, normally_on: bool = True, optional: bool | None = None
) -> str:
    print(f"Args: {flag=}, {normally_off=}, {normally_on=}, {optional=}")
    return f"flag: {flag}, normally_off: {normally_off}, normally_on: {normally_on}, optional: {optional}"
```