### PR TITLE
**Breaking** flyte.io.File sync/async api and Faster data

### DIFF
--- a/examples/basics/dataframe_usage.py
+++ b/examples/basics/dataframe_usage.py
@@ -80,5 +80,5 @@ async def get_employee_data() -> pd.DataFrame:
 if __name__ == "__main__":
     # Use local execution mode
     flyte.init_from_config()
-    run = flyte.with_runcontext(mode="local").run(get_employee_data)
+    run = flyte.run(get_employee_data)
     print("Results:", run.outputs())

--- a/examples/basics/dir.py
+++ b/examples/basics/dir.py
@@ -1,0 +1,327 @@
+import os
+import tempfile
+
+import flyte
+from flyte.io import Dir, File
+
+# To control how offloaded types like Files and Dirs behave with respect to caching, please see the
+# content_based_caching.py example.
+
+env = flyte.TaskEnvironment(
+    name="dir",
+    reusable=flyte.ReusePolicy(replicas=1, concurrency=10),
+    image=flyte.Image.from_debian_base().with_pip_packages("unionai-reuse"),
+)
+
+
+async def create_test_local_directory() -> str:
+    """
+    Create a local directory with some test files for demonstration.
+    """
+    # Create a temporary directory
+    temp_dir = tempfile.mkdtemp(prefix="flyte_dir_example_")
+
+    # Create some test files
+    with open(os.path.join(temp_dir, "file1.txt"), "w") as f:  # noqa: ASYNC230
+        f.write("Content of file 1")
+
+    with open(os.path.join(temp_dir, "file2.txt"), "w") as f:  # noqa: ASYNC230
+        f.write("Content of file 2")
+
+    # Create a subdirectory with a file
+    sub_dir = os.path.join(temp_dir, "subdir")
+    os.makedirs(sub_dir)
+    with open(os.path.join(sub_dir, "file3.txt"), "w") as f:  # noqa: ASYNC230
+        f.write("Content of file 3 in subdirectory")
+
+    print(f"Created test directory at: {temp_dir}")
+    return temp_dir
+
+
+@env.task
+async def upload_directory_from_local() -> Dir:
+    """
+    Demonstrates Dir.from_local() - uploading a local directory asynchronously.
+    """
+    local_path = await create_test_local_directory()
+    uploaded_dir = await Dir.from_local(local_path)
+    print(f"Uploaded local directory {local_path} to remote: {uploaded_dir.path}")
+    return uploaded_dir
+
+
+@env.task
+async def create_reference_to_existing_remote(remote_path: str) -> Dir:
+    """
+    Demonstrates Dir.from_existing_remote() - referencing an existing remote directory.
+    """
+    dir_ref = Dir.from_existing_remote(remote_path)
+    print(f"Created Dir reference to existing remote directory: {dir_ref.path}")
+    return dir_ref
+
+
+@env.task
+async def check_directory_exists(d: Dir) -> bool:
+    """
+    Demonstrates Dir.exists() - checking if a directory exists asynchronously.
+    """
+    exists = await d.exists()
+    print(f"Directory {d.path} exists: {exists}")
+    return exists
+
+
+@env.task
+async def list_files_in_directory(d: Dir) -> list[File]:
+    """
+    Demonstrates Dir.list_files() - getting a list of files in the directory (non-recursive).
+    """
+    files = await d.list_files()
+    print(f"Found {len(files)} files in directory {d.path}:")
+    for file in files:
+        print(f"  - {file.name}: {file.path}")
+    return files
+
+
+@env.task
+async def walk_directory_async(d: Dir) -> list[File]:
+    """
+    Demonstrates Dir.walk() - asynchronously walking through the directory.
+    """
+    all_files = []
+    print(f"Walking directory {d.path} (recursive):")
+    async for file in d.walk(recursive=True):
+        print(f"  Found file: {file.name} at {file.path}")
+        all_files.append(file)
+    return all_files
+
+
+@env.task
+async def walk_directory_non_recursive(d: Dir) -> list[File]:
+    """
+    Demonstrates Dir.walk() - walking directory non-recursively.
+    """
+    files = []
+    print(f"Walking directory {d.path} (non-recursive):")
+    async for file in d.walk(recursive=False):
+        print(f"  Found file: {file.name} at {file.path}")
+        files.append(file)
+    return files
+
+
+@env.task
+async def walk_directory_with_max_depth(d: Dir) -> list[File]:
+    """
+    Demonstrates Dir.walk() - walking directory with max depth limit.
+    """
+    files = []
+    print(f"Walking directory {d.path} (max depth 2):")
+    async for file in d.walk(recursive=True, max_depth=2):
+        print(f"  Found file: {file.name} at {file.path}")
+        files.append(file)
+    return files
+
+
+@env.task
+async def get_specific_file(d: Dir, file_name: str) -> File | None:
+    """
+    Demonstrates Dir.get_file() - getting a specific file from the directory.
+    """
+    file = await d.get_file(file_name)
+    if file:
+        print(f"Found file {file_name}: {file.path}")
+        return file
+    else:
+        print(f"File {file_name} not found in directory {d.path}")
+        return None
+
+
+@env.task
+async def read_files_in_directory(d: Dir) -> dict[str, str]:
+    """
+    Demonstrates reading the contents of files in a directory.
+    """
+    file_contents = {}
+    async for file in d.walk(recursive=False):
+        if file.name.endswith(".txt"):  # Only read text files
+            try:
+                async with file.open("rb") as f:
+                    content = bytes(await f.read()).decode("utf-8")
+                    file_contents[file.name] = content
+                    print(f"Read {file.name}: {content}")
+            except Exception as e:
+                print(f"Error reading {file.name}: {e}")
+                file_contents[file.name] = f"Error: {e}"
+
+    return file_contents
+
+
+@env.task
+async def download_directory_async(d: Dir) -> str:
+    """
+    Demonstrates Dir.download() - downloading a directory asynchronously.
+    """
+    local_path = await d.download()
+    print(f"Downloaded directory to: {local_path}")
+
+    # List what was downloaded
+    print("Downloaded files:")
+    for root, dirs, files in os.walk(local_path):
+        for file in files:
+            file_path = os.path.join(root, file)
+            rel_path = os.path.relpath(file_path, local_path)
+            print(f"  - {rel_path}")
+
+    return local_path
+
+
+@env.task
+async def download_directory_to_specific_path(d: Dir) -> str:
+    """
+    Demonstrates Dir.download() - downloading to a specific local path.
+    """
+    temp_dir = tempfile.mkdtemp(prefix="flyte_downloaded_dir_")
+    local_path = await d.download(temp_dir)
+    print(f"Downloaded directory to specific path: {local_path}")
+    return local_path
+
+
+@env.task
+async def demonstrate_directory_properties(d: Dir) -> None:
+    """
+    Demonstrates accessing Dir properties.
+    """
+    print(f"Directory path: {d.path}")
+    print(f"Directory name: {d.name}")
+    print(f"Directory format: {d.format}")
+    print(f"Directory hash: {d.hash}")
+
+
+@env.task
+async def create_directory_with_cache_key() -> Dir:
+    """
+    Demonstrates creating a Dir with a specific cache key.
+    """
+    # Create a local directory first
+    temp_dir = tempfile.mkdtemp(prefix="flyte_cache_key_example_")
+    with open(os.path.join(temp_dir, "cached_file.txt"), "w") as f:  # noqa: ASYNC230
+        f.write("This directory has a specific cache key")
+
+    # Upload with a cache key
+    dir_with_cache = await Dir.from_local(temp_dir, dir_cache_key="my_custom_cache_key_123")
+    print(f"Created directory with cache key: {dir_with_cache.hash}")
+    return dir_with_cache
+
+
+@env.task
+async def process_files_in_parallel(d: Dir) -> dict[str, int]:
+    """
+    Demonstrates processing multiple files in a directory concurrently.
+    """
+    import asyncio
+
+    async def process_file(file: File) -> tuple[str, int]:
+        """Process a single file and return its name and size."""
+        try:
+            async with file.open("rb") as f:
+                content = await f.read()
+                size = len(content)
+                print(f"Processed {file.name}: {size} bytes")
+                return file.name, size
+        except Exception as e:
+            print(f"Error processing {file.name}: {e}")
+            return file.name, 0
+
+    # Get all files
+    files = []
+    async for file in d.walk(recursive=True):
+        files.append(file)
+
+    # Process all files concurrently
+    tasks = [process_file(file) for file in files]
+    results = await asyncio.gather(*tasks)
+
+    return dict(results)
+
+
+@env.task
+async def main() -> None:
+    """
+    Main function demonstrating all Dir async APIs.
+    """
+    print("=== Flyte Dir Async API Examples ===\n")
+
+    # 2. Upload directory from local
+    print("\n2. Uploading directory from local...")
+    remote_dir = await upload_directory_from_local()
+
+    # 3. Check if directory exists
+    print("\n3. Checking if directory exists...")
+    await check_directory_exists(remote_dir)
+
+    # 4. List files in directory (non-recursive)
+    print("\n4. Listing files in directory (non-recursive)...")
+    files = await list_files_in_directory(remote_dir)
+    print(f"\nTotal files found (non-recursive): {len(files)}")
+
+    # 5. Walk directory recursively
+    print("\n5. Walking directory recursively...")
+    all_files = await walk_directory_async(remote_dir)
+    print("\nTotal files found recursively:", len(all_files))
+
+    # 6. Walk directory non-recursively
+    print("\n6. Walking directory non-recursively...")
+    await walk_directory_non_recursive(remote_dir)
+
+    # 7. Walk directory with max depth
+    print("\n7. Walking directory with max depth...")
+    await walk_directory_with_max_depth(remote_dir)
+
+    # 8. Get specific file
+    print("\n8. Getting specific file...")
+    specific_file = await get_specific_file(remote_dir, "file1.txt")
+    if specific_file:
+        print(f"Specific file path: {specific_file.path}")
+    else:
+        print("Specific file not found.")
+
+    # 9. Read file contents
+    print("\n9. Reading file contents...")
+    file_contents = await read_files_in_directory(remote_dir)
+    print(f"File contents: {file_contents}")
+
+    # 10. Download directory
+    print("\n10. Downloading directory...")
+    downloaded_path = await download_directory_async(remote_dir)
+    print(f"Directory downloaded to: {downloaded_path}")
+
+    # 11. Download to specific path
+    print("\n11. Downloading to specific path...")
+    await download_directory_to_specific_path(remote_dir)
+
+    # 12. Create reference to existing remote
+    print("\n12. Creating reference to existing remote...")
+    dir_ref = await create_reference_to_existing_remote(remote_dir.path)
+    print(f"Referenced directory path: {dir_ref.path}")
+
+    # 13. Demonstrate directory properties
+    print("\n13. Directory properties...")
+    await demonstrate_directory_properties(remote_dir)
+
+    # 14. Create directory with cache key
+    print("\n14. Creating directory with cache key...")
+    cached_dir = await create_directory_with_cache_key()
+    print(f"Directory with cache key path: {cached_dir.path}, hash: {cached_dir.hash}")
+
+    # 15. Process files in parallel
+    print("\n15. Processing files in parallel...")
+    file_sizes = await process_files_in_parallel(remote_dir)
+    print(f"File sizes: {file_sizes}")
+
+    print("\n=== All Dir async API examples completed! ===")
+
+
+if __name__ == "__main__":
+    import flyte.git
+
+    flyte.init_from_config(flyte.git.config_from_root())
+    r = flyte.run(main)
+    print(r.url)

--- a/examples/basics/dir_sync.py
+++ b/examples/basics/dir_sync.py
@@ -1,0 +1,465 @@
+import os
+import tempfile
+
+import flyte
+from flyte.io import Dir, File
+
+env = flyte.TaskEnvironment("dir_sync")
+
+
+def create_test_local_directory() -> str:
+    """
+    Create a local directory with some test files for demonstration.
+    """
+    # Create a temporary directory
+    temp_dir = tempfile.mkdtemp(prefix="flyte_dir_sync_example_")
+
+    # Create some test files
+    with open(os.path.join(temp_dir, "file1.txt"), "w") as f:
+        f.write("Content of file 1")
+
+    with open(os.path.join(temp_dir, "file2.txt"), "w") as f:
+        f.write("Content of file 2")
+
+    # Create a subdirectory with a file
+    sub_dir = os.path.join(temp_dir, "subdir")
+    os.makedirs(sub_dir)
+    with open(os.path.join(sub_dir, "file3.txt"), "w") as f:
+        f.write("Content of file 3 in subdirectory")
+
+    print(f"Created test directory at: {temp_dir}")
+    return temp_dir
+
+
+@env.task
+def create_reference_to_existing_remote(remote_path: str) -> Dir:
+    """
+    Demonstrates Dir.from_existing_remote() - referencing an existing remote directory.
+    """
+    dir_ref = Dir.from_existing_remote(remote_path)
+    print(f"Created Dir reference to existing remote directory: {dir_ref.path}")
+    return dir_ref
+
+
+@env.task
+def check_directory_exists(d: Dir) -> bool:
+    """
+    Demonstrates Dir.exists_sync() - checking if a directory exists synchronously.
+    """
+    exists = d.exists_sync()
+    print(f"Directory {d.path} exists: {exists}")
+    return exists
+
+
+@env.task
+def list_files_in_directory_sync(d: Dir) -> list[File]:
+    """
+    Demonstrates Dir.list_files_sync() - getting a list of files in the directory (non-recursive).
+    """
+    files = d.list_files_sync()
+    print(f"Found {len(files)} files in directory {d.path}:")
+    for file in files:
+        print(f"  - {file.name}: {file.path}")
+    return files
+
+
+@env.task
+def walk_directory_sync(d: Dir) -> list[File]:
+    """
+    Demonstrates Dir.walk_sync() - synchronously walking through the directory.
+    """
+    all_files = []
+    print(f"Walking directory {d.path} (recursive):")
+    for file in d.walk_sync(recursive=True):
+        print(f"  Found file: {file.name} at {file.path}")
+        all_files.append(file)
+    return all_files
+
+
+@env.task
+def walk_directory_non_recursive_sync(d: Dir) -> list[File]:
+    """
+    Demonstrates Dir.walk_sync() - walking directory non-recursively.
+    """
+    files = []
+    print(f"Walking directory {d.path} (non-recursive):")
+    for file in d.walk_sync(recursive=False):
+        print(f"  Found file: {file.name} at {file.path}")
+        files.append(file)
+    return files
+
+
+@env.task
+def walk_directory_with_max_depth_sync(d: Dir) -> list[File]:
+    """
+    Demonstrates Dir.walk_sync() - walking directory with max depth limit.
+    """
+    files = []
+    print(f"Walking directory {d.path} (max depth 2):")
+    for file in d.walk_sync(recursive=True, max_depth=2):
+        print(f"  Found file: {file.name} at {file.path}")
+        files.append(file)
+    return files
+
+
+@env.task
+def walk_directory_with_pattern_sync(d: Dir) -> list[File]:
+    """
+    Demonstrates Dir.walk_sync() - walking directory with file pattern filtering.
+    """
+    files = []
+    print(f"Walking directory {d.path} with pattern '*.txt':")
+    for file in d.walk_sync(recursive=True, file_pattern="*.txt"):
+        print(f"  Found file: {file.name} at {file.path}")
+        files.append(file)
+    return files
+
+
+@env.task
+def get_specific_file_sync(d: Dir, file_name: str) -> File | None:
+    """
+    Demonstrates Dir.get_file_sync() - getting a specific file from the directory.
+    """
+    file = d.get_file_sync(file_name)
+    if file:
+        print(f"Found file {file_name}: {file.path}")
+        return file
+    else:
+        print(f"File {file_name} not found in directory {d.path}")
+        return None
+
+
+@env.task
+def read_files_in_directory_sync(d: Dir) -> dict[str, str]:
+    """
+    Demonstrates reading the contents of files in a directory synchronously.
+    """
+    file_contents = {}
+    for file in d.walk_sync(recursive=False):
+        if file.name.endswith(".txt"):  # Only read text files
+            try:
+                with file.open_sync("rb") as f:
+                    content = f.read().decode("utf-8")
+                    file_contents[file.name] = content
+                    print(f"Read {file.name}: {content}")
+            except Exception as e:
+                print(f"Error reading {file.name}: {e}")
+                file_contents[file.name] = f"Error: {e}"
+
+    return file_contents
+
+
+@env.task
+def demonstrate_directory_properties(d: Dir) -> None:
+    """
+    Demonstrates accessing Dir properties.
+    """
+    print(f"Directory path: {d.path}")
+    print(f"Directory name: {d.name}")
+    print(f"Directory format: {d.format}")
+    print(f"Directory hash: {d.hash}")
+
+
+@env.task
+def count_files_by_extension(d: Dir) -> dict[str, int]:
+    """
+    Demonstrates practical use case: counting files by extension.
+    """
+    extension_counts = {}
+    for file in d.walk_sync(recursive=True):
+        _, ext = os.path.splitext(file.name)
+        ext = ext.lower() if ext else "no_extension"
+        extension_counts[ext] = extension_counts.get(ext, 0) + 1
+
+    print("File counts by extension:")
+    for ext, count in extension_counts.items():
+        print(f"  {ext}: {count} files")
+
+    return extension_counts
+
+
+@env.task
+def find_largest_files(d: Dir, top_n: int = 3) -> list[tuple[str, int]]:
+    """
+    Demonstrates practical use case: finding the largest files in a directory.
+    """
+    file_sizes = []
+    for file in d.walk_sync(recursive=True):
+        try:
+            with file.open_sync("rb") as f:
+                content = f.read()
+                size = len(content)
+                file_sizes.append((file.name, size))
+        except Exception as e:
+            print(f"Error reading {file.name}: {e}")
+            file_sizes.append((file.name, 0))
+
+    # Sort by size (descending) and take top N
+    file_sizes.sort(key=lambda x: x[1], reverse=True)
+    largest_files = file_sizes[:top_n]
+
+    print(f"Top {top_n} largest files:")
+    for name, size in largest_files:
+        print(f"  {name}: {size} bytes")
+
+    return largest_files
+
+
+@env.task
+def search_files_by_content(d: Dir, search_term: str) -> list[str]:
+    """
+    Demonstrates practical use case: searching for files containing specific content.
+    """
+    matching_files = []
+    for file in d.walk_sync(recursive=True):
+        if file.name.endswith(".txt"):  # Only search text files
+            try:
+                with file.open_sync("rb") as f:
+                    content = f.read().decode("utf-8")
+                    if search_term.lower() in content.lower():
+                        matching_files.append(file.name)
+                        print(f"Found '{search_term}' in {file.name}")
+            except Exception as e:
+                print(f"Error searching {file.name}: {e}")
+
+    print(f"Found {len(matching_files)} files containing '{search_term}'")
+    return matching_files
+
+
+@env.task
+def create_directory_structure_report(d: Dir) -> dict[str, int]:
+    """
+    Demonstrates practical use case: creating a directory structure report.
+    """
+    report = {
+        "total_files": 0,
+        "total_directories": 0,
+        "text_files": 0,
+        "empty_files": 0,
+        "total_size": 0,
+    }
+
+    # Count files and calculate sizes
+    for file in d.walk_sync(recursive=True):
+        report["total_files"] += 1
+        if file.name.endswith(".txt"):
+            report["text_files"] += 1
+
+        try:
+            with file.open_sync("rb") as f:
+                content = f.read()
+                size = len(content)
+                report["total_size"] += size
+                if size == 0:
+                    report["empty_files"] += 1
+        except Exception as e:
+            print(f"Error reading {file.name}: {e}")
+
+    # Note: We can't easily count directories with the current API
+    # since we're iterating over files, not directories
+    report["total_directories"] = -1  # Indicates not available
+
+    print("Directory structure report:")
+    for key, value in report.items():
+        if value == -1:
+            print(f"  {key}: Not available with current API")
+        else:
+            print(f"  {key}: {value}")
+
+    return report
+
+
+@env.task
+def filter_files_by_size(d: Dir, min_size: int = 0, max_size: int = 1000) -> list[str]:
+    """
+    Demonstrates practical use case: filtering files by size range.
+    """
+    filtered_files = []
+    for file in d.walk_sync(recursive=True):
+        try:
+            with file.open_sync("rb") as f:
+                content = f.read()
+                size = len(content)
+                if min_size <= size <= max_size:
+                    filtered_files.append(file.name)
+                    print(f"File {file.name}: {size} bytes (within range)")
+        except Exception as e:
+            print(f"Error reading {file.name}: {e}")
+
+    print(f"Found {len(filtered_files)} files between {min_size} and {max_size} bytes")
+    return filtered_files
+
+
+@env.task
+def backup_text_files_content(d: Dir) -> dict[str, str]:
+    """
+    Demonstrates practical use case: backing up all text file contents.
+    """
+    backup_data = {}
+    for file in d.walk_sync(recursive=True):
+        if file.name.endswith(".txt"):
+            try:
+                with file.open_sync("rb") as f:
+                    content = f.read().decode("utf-8")
+                    # Use relative path as key to maintain directory structure
+                    backup_data[file.path] = content
+                    print(f"Backed up content of {file.name}")
+            except Exception as e:
+                print(f"Error backing up {file.name}: {e}")
+                backup_data[file.path] = f"Error: {e}"
+
+    print(f"Backed up {len(backup_data)} text files")
+    return backup_data
+
+
+@env.task
+def main():
+    """
+    Main function demonstrating all Dir sync APIs.
+    """
+    print("=== Flyte Dir Sync API Examples ===\n")
+
+    # 1. Create a test local directory and upload it
+    print("1. Creating test local directory and uploading...")
+    local_dir_path = create_test_local_directory()
+
+    remote_dir = Dir.from_local_sync(local_dir_path)
+    print(f"Created reference to remote directory: {remote_dir.path}")
+
+    # 2. Create reference to existing remote
+    print("\n2. Creating reference to existing remote...")
+    dir_ref = create_reference_to_existing_remote(remote_dir.path)
+
+    # 3. Check if directory exists
+    print("\n3. Checking if directory exists...")
+    exists = check_directory_exists(dir_ref)
+    print(f"Directory exists: {exists}")
+
+    # Note: The following operations would work with an actual remote directory
+    # For demonstration purposes, we'll show the API usage patterns
+
+    print("\n=== Directory Navigation APIs ===")
+
+    # 4. List files in directory (non-recursive)
+    print("\n4. Listing files in directory (non-recursive)...")
+    try:
+        files = list_files_in_directory_sync(remote_dir)
+        print(f"Total files found (non-recursive): {len(files)}")
+    except Exception as e:
+        print(f"Note: {e} (expected for demo directory)")
+
+    # 5. Walk directory recursively
+    print("\n5. Walking directory recursively...")
+    try:
+        all_files = walk_directory_sync(remote_dir)
+        print(f"Total files found recursively: {len(all_files)}")
+    except Exception as e:
+        print(f"Note: {e} (expected for demo directory)")
+
+    # 6. Walk directory non-recursively
+    print("\n6. Walking directory non-recursively...")
+    try:
+        walk_directory_non_recursive_sync(remote_dir)
+    except Exception as e:
+        print(f"Note: {e} (expected for demo directory)")
+
+    # 7. Walk directory with max depth
+    print("\n7. Walking directory with max depth...")
+    try:
+        walk_directory_with_max_depth_sync(remote_dir)
+    except Exception as e:
+        print(f"Note: {e} (expected for demo directory)")
+
+    # 8. Walk directory with pattern
+    print("\n8. Walking directory with file pattern...")
+    try:
+        walk_directory_with_pattern_sync(remote_dir)
+    except Exception as e:
+        print(f"Note: {e} (expected for demo directory)")
+
+    # 9. Get specific file
+    print("\n9. Getting specific file...")
+    try:
+        specific_file = get_specific_file_sync(remote_dir, "file1.txt")
+        if specific_file:
+            print(f"Specific file path: {specific_file.path}")
+        else:
+            print("Specific file not found.")
+    except Exception as e:
+        print(f"Note: {e} (expected for demo directory)")
+
+    print("\n=== File Content Operations ===")
+
+    # 10. Read file contents
+    print("\n10. Reading file contents...")
+    try:
+        file_contents = read_files_in_directory_sync(remote_dir)
+        print(f"File contents: {file_contents}")
+    except Exception as e:
+        print(f"Note: {e} (expected for demo directory)")
+
+    # 11. Demonstrate directory properties
+    print("\n11. Directory properties...")
+    demonstrate_directory_properties(remote_dir)
+
+    print("\n=== Practical Use Cases ===")
+
+    # 12. Count files by extension
+    print("\n12. Counting files by extension...")
+    try:
+        extension_counts = count_files_by_extension(remote_dir)
+        print(f"Extension counts: {extension_counts}")
+    except Exception as e:
+        print(f"Note: {e} (expected for demo directory)")
+
+    # 13. Find largest files
+    print("\n13. Finding largest files...")
+    try:
+        largest_files = find_largest_files(remote_dir, top_n=3)
+        print(f"Largest files: {largest_files}")
+    except Exception as e:
+        print(f"Note: {e} (expected for demo directory)")
+
+    # 14. Search files by content
+    print("\n14. Searching files by content...")
+    try:
+        matching_files = search_files_by_content(remote_dir, "Content")
+        print(f"Files containing 'Content': {matching_files}")
+    except Exception as e:
+        print(f"Note: {e} (expected for demo directory)")
+
+    # 15. Create directory structure report
+    print("\n15. Creating directory structure report...")
+    try:
+        report = create_directory_structure_report(remote_dir)
+        print(f"Directory report: {report}")
+    except Exception as e:
+        print(f"Note: {e} (expected for demo directory)")
+
+    # 16. Filter files by size
+    print("\n16. Filtering files by size...")
+    try:
+        filtered_files = filter_files_by_size(remote_dir, min_size=10, max_size=100)
+        print(f"Files in size range: {filtered_files}")
+    except Exception as e:
+        print(f"Note: {e} (expected for demo directory)")
+
+    # 17. Backup text files content
+    print("\n17. Backing up text files content...")
+    try:
+        backup_data = backup_text_files_content(remote_dir)
+        print(f"Backup data keys: {list(backup_data.keys())}")
+    except Exception as e:
+        print(f"Note: {e} (expected for demo directory)")
+
+    print("\n=== All Dir sync API examples completed! ===")
+    print("\nNote: Some operations may show errors because we're using a demo")
+    print("directory path. In practice, these would work with actual remote directories.")
+
+
+if __name__ == "__main__":
+    import flyte.git
+
+    flyte.init_from_config(flyte.git.config_from_root())
+    r = flyte.run(main)
+    print(r.url)

--- a/examples/basics/file.py
+++ b/examples/basics/file.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import tempfile
 
@@ -142,12 +143,12 @@ async def demonstrate_streaming_read(f: File) -> str:
     """
     Demonstrates streaming read from a remote file.
     """
+    print(f"File path: {f.path}", flush=True)
     content_parts = []
-    async with f.open("rb") as fh:
+    async with f.open("rb", block_size=10) as fh:
         # Read in chunks to demonstrate streaming
-        chunk_size = 10
         while True:
-            chunk = fh.read(chunk_size)
+            chunk = fh.read()
             if not chunk:
                 break
             content_parts.append(chunk)

--- a/examples/basics/file.py
+++ b/examples/basics/file.py
@@ -1,36 +1,221 @@
+import os
+import tempfile
+
+import aiofiles
+
 import flyte
 from flyte.io import File
 
 # To control how offloaded types like Files and Dirs behave with respect to caching, please see the
 # content_based_caching.py example.
 
-env = flyte.TaskEnvironment(name="file")
+env = flyte.TaskEnvironment(
+    name="file",
+    # reusable=flyte.ReusePolicy(replicas=1, concurrency=10),
+    # image=flyte.Image.from_debian_base().with_pip_packages("unionai-reuse"),
+)
 
 
 @env.task
-async def write_file(s: str) -> File:
+async def create_new_remote_file(content: str) -> File:
     """
-    This task writes a string to a file and returns the file object.
+    Demonstrates File.new_remote() - creating a new remote file asynchronously.
     """
     f = File.new_remote()
     async with f.open("wb") as fh:
-        fh.write(s.encode("utf-8"))
+        fh.write(content.encode("utf-8"))
+    print(f"Created new remote file at: {f.path}")
     return f
 
 
 @env.task
-async def print_file(f: File) -> None:
+async def read_file_async(f: File) -> str:
+    """
+    Demonstrates reading a file asynchronously using open().
+    """
     async with f.open("rb") as fh:
         contents = fh.read()
-        print(f"File {f.path} contents: {contents.decode('utf-8')}")
+        text_content = contents.decode("utf-8")
+        print(f"File {f.path} contents: {text_content}")
+        return text_content
+
+
+@env.task
+async def download_file_async(f: File) -> str:
+    """
+    Demonstrates File.download() - downloading a file to local storage asynchronously.
+    """
+    local_path = await f.download()
+    print(f"Downloaded file to: {local_path}")
+
+    # Verify the download worked
+    async with aiofiles.open(local_path, "rb") as fh:
+        contents = await fh.read()
+        text_content = contents.decode("utf-8")
+        print(f"Downloaded file contents: {text_content}")
+
+    return local_path
+
+
+@env.task
+async def upload_local_file_async(content: str) -> File:
+    """
+    Demonstrates File.from_local() - uploading a local file asynchronously.
+    """
+    # Create a temporary local file
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt") as tmp:
+        tmp.write(content)
+        tmp_path = tmp.name
+
+    try:
+        # Upload the local file
+        uploaded_file = await File.from_local(tmp_path)
+        print(f"Uploaded local file {tmp_path} to remote: {uploaded_file.path}")
+        return uploaded_file
+    finally:
+        # Clean up the temporary file
+        os.unlink(tmp_path)
+
+
+@env.task
+async def create_from_existing_remote(remote_path: str) -> File:
+    """
+    Demonstrates File.from_existing_remote() - referencing an existing remote file.
+    """
+    f = File.from_existing_remote(remote_path)
+    print(f"Created File reference to existing remote file: {f.path}")
+    return f
+
+
+@env.task
+async def check_file_exists_sync(f: File) -> bool:
+    """
+    Demonstrates File.exists_sync() - checking if a file exists (sync method).
+    Note: There's no async version of exists, so we use the sync version.
+    """
+    exists = f.exists_sync()
+    print(f"File {f.path} exists: {exists}")
+    return exists
+
+
+@env.task
+async def copy_file_by_reference(f: File) -> File:
+    """
+    Demonstrates creating a File by direct reference (no upload/download).
+    """
+    # This creates a new File object pointing to the same remote location
+    copied_file = File(path=f.path)
+    print(f"Created file reference to: {copied_file.path}")
+    return copied_file
+
+
+@env.task
+async def demonstrate_file_properties(f: File) -> None:
+    """
+    Demonstrates accessing File properties.
+    """
+    print(f"File path: {f.path}")
+    print(f"File name: {f.name}")
+    print(f"File format: {f.format}")
+    print(f"File hash: {f.hash}")
+
+
+@env.task
+async def demonstrate_streaming_write(content: str) -> File:
+    """
+    Demonstrates streaming write to a remote file.
+    """
+    f = File.new_remote()
+    async with f.open("wb") as fh:
+        # Write in chunks to demonstrate streaming
+        data = content.encode("utf-8")
+        chunk_size = 10
+        for i in range(0, len(data), chunk_size):
+            chunk = data[i : i + chunk_size]
+            fh.write(chunk)
+    print(f"Streamed content to file: {f.path}")
+    return f
+
+
+@env.task
+async def demonstrate_streaming_read(f: File) -> str:
+    """
+    Demonstrates streaming read from a remote file.
+    """
+    content_parts = []
+    async with f.open("rb") as fh:
+        # Read in chunks to demonstrate streaming
+        chunk_size = 10
+        while True:
+            chunk = fh.read(chunk_size)
+            if not chunk:
+                break
+            content_parts.append(chunk)
+
+    full_content = b"".join(content_parts).decode("utf-8")
+    print(f"Streamed content from file: {full_content}")
+    return full_content
 
 
 @env.task
 async def main() -> None:
-    file = await write_file("Hello, Flyte!")
-    await print_file(file)
+    """
+    Main function demonstrating all File async APIs.
+    """
+    print("=== Flyte File Async API Examples ===\n")
+
+    # 1. Create a new remote file
+    print("1. Creating new remote file...")
+    file1 = await create_new_remote_file("Hello, Flyte Async API!")
+
+    # 2. Read the file
+    print("\n2. Reading file contents...")
+    await read_file_async(file1)
+
+    # 3. Check if file exists
+    print("\n3. Checking if file exists...")
+    await check_file_exists_sync(file1)
+
+    # 4. Download the file
+    print("\n4. Downloading file...")
+    await download_file_async(file1)
+
+    # 5. Upload a local file
+    print("\n5. Uploading local file...")
+    file2 = await upload_local_file_async("Content from local file!")
+
+    # 6. Create reference to existing file
+    print("\n6. Creating reference to existing file...")
+    file3 = await create_from_existing_remote(file1.path)
+    print("\nReferenced file path:", file3.path)
+
+    # 7. Copy file by reference
+    print("\n7. Copying file by reference...")
+    await copy_file_by_reference(file2)
+
+    # 8. Demonstrate file properties
+    print("\n8. File properties...")
+    await demonstrate_file_properties(file1)
+
+    # 10. Demonstrate streaming operations
+    print("\n10. Streaming write...")
+    stream_file = await demonstrate_streaming_write("This is streaming content that will be written in chunks!")
+
+    print("\n11. Streaming read...")
+    await demonstrate_streaming_read(stream_file)
+
+    print("\n=== All File async API examples completed! ===")
 
 
 if __name__ == "__main__":
-    flyte.init_from_config()
-    print(flyte.run(main))
+    import flyte.git
+
+    flyte.init_from_config(flyte.git.config_from_root())
+    # r = flyte.run(main)
+    r = flyte.run(
+        demonstrate_streaming_read,
+        flyte.io.File.from_existing_remote(
+            "s3://union-oc-canary-playground-playground/metadata/v2/playground/ketan/development/rhlhgd7vq4642lj2mvl5/9cgmlotghcre1d3s8y85sjxro/1/2f/rhlhgd7vq4642lj2mvl5-9cgmlotghcre1d3s8y85sjxro-0/892aa4d58a3ad40a0dd5f516f6e205c2"
+        ),
+    )
+    print(r.url)

--- a/examples/basics/file.py
+++ b/examples/basics/file.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import tempfile
 

--- a/examples/basics/sync_file.py
+++ b/examples/basics/sync_file.py
@@ -1,0 +1,159 @@
+import os
+import tempfile
+
+import flyte
+from flyte.io import File
+
+env = flyte.TaskEnvironment("sync_file")
+
+
+@env.task
+def create_new_remote_file(content: str) -> File:
+    """
+    Demonstrates File.new_remote() - creating a new remote file.
+    """
+    f = File.new_remote()
+    with f.open_sync("wb") as fh:
+        fh.write(content.encode("utf-8"))
+    print(f"Created new remote file at: {f.path}")
+    return f
+
+
+@env.task
+def read_file_sync(f: File) -> str:
+    """
+    Demonstrates reading a file synchronously using open_sync().
+    """
+    with f.open_sync("rb") as fh:
+        contents = fh.read().decode("utf-8")
+        print(f"File {f.path} contents: {contents}")
+        return contents
+
+
+@env.task
+def download_file_sync(f: File) -> str:
+    """
+    Demonstrates File.download_sync() - downloading a file to local storage.
+    """
+    local_path = f.download_sync()
+    print(f"Downloaded file to: {local_path}")
+
+    # Verify the download worked
+    with open(local_path, "rb") as fh:
+        contents = fh.read().decode("utf-8")
+        print(f"Downloaded file contents: {contents}")
+
+    return local_path
+
+
+@env.task
+def upload_local_file_sync(content: str) -> File:
+    """
+    Demonstrates File.from_local_sync() - uploading a local file.
+    """
+    # Create a temporary local file
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt") as tmp:
+        tmp.write(content)
+        tmp_path = tmp.name
+
+    try:
+        # Upload the local file
+        uploaded_file = File.from_local_sync(tmp_path)
+        print(f"Uploaded local file {tmp_path} to remote: {uploaded_file.path}")
+        return uploaded_file
+    finally:
+        # Clean up the temporary file
+        os.unlink(tmp_path)
+
+
+@env.task
+def create_from_existing_remote(remote_path: str) -> File:
+    """
+    Demonstrates File.from_existing_remote() - referencing an existing remote file.
+    """
+    f = File.from_existing_remote(remote_path)
+    print(f"Created File reference to existing remote file: {f.path}")
+    return f
+
+
+@env.task
+def check_file_exists(f: File) -> bool:
+    """
+    Demonstrates File.exists_sync() - checking if a file exists.
+    """
+    exists = f.exists_sync()
+    print(f"File {f.path} exists: {exists}")
+    return exists
+
+
+@env.task
+def copy_file_by_reference(f: File) -> File:
+    """
+    Demonstrates creating a File by direct reference (no upload/download).
+    """
+    # This creates a new File object pointing to the same remote location
+    copied_file = File(path=f.path)
+    print(f"Created file reference to: {copied_file.path}")
+    return copied_file
+
+
+@env.task
+def demonstrate_file_properties(f: File) -> None:
+    """
+    Demonstrates accessing File properties.
+    """
+    print(f"File path: {f.path}")
+    print(f"File name: {f.name}")
+    print(f"File format: {f.format}")
+    print(f"File hash: {f.hash}")
+
+
+@env.task
+def main():
+    """
+    Main function demonstrating all File sync APIs.
+    """
+    print("=== Flyte File Sync API Examples ===\n")
+
+    # 1. Create a new remote file
+    print("1. Creating new remote file...")
+    file1 = create_new_remote_file("Hello, Flyte Sync API!")
+
+    # 2. Read the file
+    print("\n2. Reading file contents...")
+    read_file_sync(file1)
+
+    # 3. Check if file exists
+    print("\n3. Checking if file exists...")
+    check_file_exists(file1)
+
+    # 4. Download the file
+    print("\n4. Downloading file...")
+    download_file_sync(file1)
+
+    # 5. Upload a local file
+    print("\n5. Uploading local file...")
+    file2 = upload_local_file_sync("Content from local file!")
+
+    # 6. Create reference to existing file
+    print("\n6. Creating reference to existing file...")
+    file3 = create_from_existing_remote(file1.path)
+    print("\nReferenced file path:", file3.path)
+
+    # 7. Copy file by reference
+    print("\n7. Copying file by reference...")
+    copy_file_by_reference(file2)
+
+    # 8. Demonstrate file properties
+    print("\n8. File properties...")
+    demonstrate_file_properties(file1)
+
+    print("\n=== All File sync API examples completed! ===")
+
+
+if __name__ == "__main__":
+    import flyte.git
+
+    flyte.init_from_config(flyte.git.config_from_root())
+    r = flyte.run(main)
+    print(r.url)

--- a/examples/stress/large_file_io.py
+++ b/examples/stress/large_file_io.py
@@ -28,7 +28,7 @@ async def create_large_file(size_gigabytes: int = 5) -> flyte.io.File:
 @env.task
 async def read_large_file(f: flyte.io.File) -> Tuple[int, float]:
     total_bytes = 0
-    chunk_size = 10*1024 * 1024
+    chunk_size = 10 * 1024 * 1024
     start = time.time()
     read = 0
     async with f.open("rb", block_size=chunk_size) as fp:

--- a/examples/stress/large_file_io.py
+++ b/examples/stress/large_file_io.py
@@ -51,5 +51,5 @@ if __name__ == "__main__":
     import flyte.git
 
     flyte.init_from_config(flyte.git.config_from_root())
-    r = flyte.run(main, 2)
+    r = flyte.run(main, 5)
     print(r.url)

--- a/examples/stress/large_file_io.py
+++ b/examples/stress/large_file_io.py
@@ -10,7 +10,7 @@ env = flyte.TaskEnvironment(
     resources=flyte.Resources(
         cpu=4,
         memory="16Gi",
-    )
+    ),
 )
 
 
@@ -19,7 +19,7 @@ async def create_large_file(size_gigabytes: int = 5) -> flyte.io.File:
     f = flyte.io.File.new_remote()
 
     async with f.open("wb") as fp:
-        chunk = b'\0' * (1024 * 1024)  # 1 MiB chunk
+        chunk = b"\0" * (1024 * 1024)  # 1 MiB chunk
         for _ in range(size_gigabytes * 1024):
             fp.write(chunk)
     return f
@@ -32,7 +32,7 @@ async def read_large_file(f: flyte.io.File) -> Tuple[int, float]:
     start = time.time()
     read = 0
     async with f.open("rb", block_size=chunk_size) as fp:
-        while chunk := await fp.read():
+        while _ := await fp.read():
             read += 1
 
     end = time.time()

--- a/examples/stress/large_file_io.py
+++ b/examples/stress/large_file_io.py
@@ -1,0 +1,55 @@
+import time
+from typing import Tuple
+
+import flyte
+import flyte.io
+import flyte.storage
+
+env = flyte.TaskEnvironment(
+    "large_file_io",
+    resources=flyte.Resources(
+        cpu=4,
+        memory="16Gi",
+    )
+)
+
+
+@env.task(cache="auto")
+async def create_large_file(size_gigabytes: int = 5) -> flyte.io.File:
+    f = flyte.io.File.new_remote()
+
+    async with f.open("wb") as fp:
+        chunk = b'\0' * (1024 * 1024)  # 1 MiB chunk
+        for _ in range(size_gigabytes * 1024):
+            fp.write(chunk)
+    return f
+
+
+@env.task
+async def read_large_file(f: flyte.io.File) -> Tuple[int, float]:
+    total_bytes = 0
+    chunk_size = 1024 * 1024
+    start = time.time()
+    read = 0
+    async with f.open("rb", block_size=chunk_size) as fp:
+        while chunk := await fp.read():
+            read += 1
+
+    end = time.time()
+    total = end - start
+    print(f"Read {total_bytes} bytes in {total:.2f} seconds ({total_bytes / total / (1024 * 1024):.2f} MiB/s)")
+    return total_bytes, total
+
+
+@env.task
+async def main(size_gigabytes: int = 5) -> Tuple[int, float]:
+    large_file = await create_large_file(size_gigabytes)
+    return await read_large_file(large_file)
+
+
+if __name__ == "__main__":
+    import flyte.git
+
+    flyte.init_from_config(flyte.git.config_from_root())
+    r = flyte.run(main, 5)
+    print(r.url)

--- a/examples/stress/large_file_io.py
+++ b/examples/stress/large_file_io.py
@@ -17,11 +17,11 @@ env = flyte.TaskEnvironment(
 @env.task(cache="auto")
 async def create_large_file(size_gigabytes: int = 5) -> flyte.io.File:
     f = flyte.io.File.new_remote()
-
-    async with f.open("wb") as fp:
-        chunk = b"\0" * (1024 * 1024)  # 1 MiB chunk
+    chunk_size = 1024 * 1024
+    async with f.open("wb", block_size=chunk_size) as fp:
+        chunk = b"\0" * chunk_size
         for _ in range(size_gigabytes * 1024):
-            fp.write(chunk)
+            await fp.write(chunk)
     return f
 
 
@@ -51,5 +51,5 @@ if __name__ == "__main__":
     import flyte.git
 
     flyte.init_from_config(flyte.git.config_from_root())
-    r = flyte.run(main, 5)
+    r = flyte.run(main, 2)
     print(r.url)

--- a/examples/stress/large_file_io.py
+++ b/examples/stress/large_file_io.py
@@ -28,7 +28,7 @@ async def create_large_file(size_gigabytes: int = 5) -> flyte.io.File:
 @env.task
 async def read_large_file(f: flyte.io.File) -> Tuple[int, float]:
     total_bytes = 0
-    chunk_size = 1024 * 1024
+    chunk_size = 10*1024 * 1024
     start = time.time()
     read = 0
     async with f.open("rb", block_size=chunk_size) as fp:

--- a/examples/stress/rewrite_example.py
+++ b/examples/stress/rewrite_example.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
 
     # Try read the data without acceleration and with acceleration
     r = flyte.with_runcontext(
-        env_vars={"_F_PATH_REWRITE": "s3://union-cloud-oc-canary-playground-persistent/->/mnt/mountpoint/data/"},
+        env_vars={"_F_PATH_REWRITE": "s3://union-cloud-oc-canary-playground-persistent/->/union-persistent-data/"},
     ).run(
         pathrewrite_read,
         flyte.io.File.from_existing_remote("s3://union-cloud-oc-canary-playground-persistent/my_data.dat"),

--- a/src/flyte/_internal/runtime/taskrunner.py
+++ b/src/flyte/_internal/runtime/taskrunner.py
@@ -144,9 +144,7 @@ async def convert_and_run(
         interactive_mode=interactive_mode,
     )
     with ctx.replace_task_context(tctx):
-        print(f"Running task {task.name} with action {action}, loading inputs", flush=True)
         inputs = await load_inputs(input_path, path_rewrite_config=raw_data_path.path_rewrite) if input_path else inputs
-        print(f"Inputs loaded, converting to native types", flush=True)
         inputs_kwargs = await convert_inputs_to_native(inputs, task.native_interface)
         out, err = await run_task(tctx=tctx, controller=controller, task=task, inputs=inputs_kwargs)
         if err is not None:

--- a/src/flyte/_internal/runtime/taskrunner.py
+++ b/src/flyte/_internal/runtime/taskrunner.py
@@ -144,7 +144,9 @@ async def convert_and_run(
         interactive_mode=interactive_mode,
     )
     with ctx.replace_task_context(tctx):
+        print(f"Running task {task.name} with action {action}, loading inputs", flush=True)
         inputs = await load_inputs(input_path, path_rewrite_config=raw_data_path.path_rewrite) if input_path else inputs
+        print(f"Inputs loaded, converting to native types", flush=True)
         inputs_kwargs = await convert_inputs_to_native(inputs, task.native_interface)
         out, err = await run_task(tctx=tctx, controller=controller, task=task, inputs=inputs_kwargs)
         if err is not None:

--- a/src/flyte/_logging.py
+++ b/src/flyte/_logging.py
@@ -71,7 +71,7 @@ def get_rich_handler(log_level: int) -> Optional[logging.Handler]:
 
     handler = RichHandler(
         tracebacks_suppress=[click],
-        rich_tracebacks=True,
+        rich_tracebacks=False,
         omit_repeated_times=False,
         show_path=False,
         log_time_format="%H:%M:%S.%f",

--- a/src/flyte/errors.py
+++ b/src/flyte/errors.py
@@ -232,3 +232,12 @@ class SlowDownError(RuntimeUserError):
 
     def __init__(self, message: str):
         super().__init__("SlowDownError", message, "user")
+
+
+class OnlyAsyncIOSupportedError(RuntimeUserError):
+    """
+    This error is raised when the user tries to use sync IO in an async task.
+    """
+
+    def __init__(self, message: str):
+        super().__init__("OnlyAsyncIOSupportedError", message, "user")

--- a/src/flyte/io/_dir.py
+++ b/src/flyte/io/_dir.py
@@ -27,6 +27,7 @@ class Dir(BaseModel, Generic[T], SerializableType):
     The generic type T represents the format of the files in the directory.
 
     Example:
+
     ```python
     # Async usage
     from pandas import DataFrame

--- a/src/flyte/io/_dir.py
+++ b/src/flyte/io/_dir.py
@@ -238,7 +238,8 @@ class Dir(BaseModel, Generic[T], SerializableType):
         """
         Asynchronously walk through the directory and yield File objects.
 
-        Use this to iterate through all files in a directory. Each yielded File can be read directly without downloading.
+        Use this to iterate through all files in a directory. Each yielded File can be read directly without
+        downloading.
 
         Example (Async - Recursive):
 

--- a/src/flyte/io/_file.py
+++ b/src/flyte/io/_file.py
@@ -221,7 +221,7 @@ class File(BaseModel, Generic[T], SerializableType):
             cache_options = {}
 
         # Configure the open parameters
-        open_kwargs = {"mode": mode, **kwargs}
+        open_kwargs = {**kwargs}
         if compression:
             open_kwargs["compression"] = compression
 
@@ -244,7 +244,7 @@ class File(BaseModel, Generic[T], SerializableType):
                 if "b" not in mode:
                     raise ValueError("Mode must include 'b' for binary access, when using remote files.")
                 if isinstance(fs, AsyncFileSystem):
-                    file_handle = await fs.open_async(self.path, mode)
+                    file_handle = await fs.open_async(self.path, mode, **open_kwargs)
                     yield file_handle
                     return
             except NotImplementedError:
@@ -253,7 +253,7 @@ class File(BaseModel, Generic[T], SerializableType):
                 if file_handle is not None:
                     file_handle.close()
 
-            with fs.open(self.path, mode) as file_handle:
+            with fs.open(self.path, mode, **open_kwargs) as file_handle:
                 if self.hash_method and self.hash is None:
                     logger.debug(f"Wrapping file handle with hashing writer using {self.hash_method}")
                     fh = HashingWriter(file_handle, accumulator=self.hash_method)

--- a/src/flyte/io/_file.py
+++ b/src/flyte/io/_file.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import os
 import typing
 from contextlib import asynccontextmanager, contextmanager
@@ -365,7 +366,10 @@ class File(BaseModel, Generic[T], SerializableType):
                 yield fh
                 return
             finally:
-                fh.close()
+                if inspect.iscoroutinefunction(fh.close):
+                    await fh.close()
+                else:
+                    fh.close()
         except flyte.errors.OnlyAsyncIOSupportedError:
             # Fall back to aiofiles
             fs = storage.get_underlying_filesystem(path=self.path)

--- a/src/flyte/io/_file.py
+++ b/src/flyte/io/_file.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import typing
 from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
 from typing import (
@@ -30,6 +31,9 @@ from flyte._context import internal_ctx
 from flyte._initialize import requires_initialization
 from flyte.io._hashing_io import AsyncHashingReader, HashingWriter, HashMethod, PrecomputedValue
 from flyte.types import TypeEngine, TypeTransformer, TypeTransformerFailedError
+
+if typing.TYPE_CHECKING:
+    from obstore import AsyncReadableFile, AsyncWritableFile
 
 # Type variable for the file format
 T = TypeVar("T")
@@ -292,7 +296,7 @@ class File(BaseModel, Generic[T], SerializableType):
         cache_options: Optional[dict] = None,
         compression: Optional[str] = None,
         **kwargs,
-    ) -> AsyncGenerator[Union[IO[Any], "HashingWriter"], None]:
+    ) -> AsyncGenerator[Union[AsyncWritableFile, AsyncReadableFile, "HashingWriter"], None]:
         """
         Asynchronously open the file and return a file-like object.
 
@@ -422,7 +426,7 @@ class File(BaseModel, Generic[T], SerializableType):
         cache_options: Optional[dict] = None,
         compression: Optional[str] = None,
         **kwargs,
-    ) -> Generator[IO[Any]]:
+    ) -> Generator[IO[Any], None, None]:
         """
         Synchronously open the file and return a file-like object.
 

--- a/src/flyte/storage/__init__.py
+++ b/src/flyte/storage/__init__.py
@@ -13,8 +13,8 @@ __all__ = [
     "get_underlying_filesystem",
     "is_remote",
     "join",
+    "open",
     "put",
-    "put_stream",
     "put_stream",
 ]
 
@@ -30,6 +30,7 @@ from ._storage import (
     get_underlying_filesystem,
     is_remote,
     join,
+    open,
     put,
     put_stream,
 )

--- a/src/flyte/storage/_storage.py
+++ b/src/flyte/storage/_storage.py
@@ -75,7 +75,7 @@ def get_random_local_directory() -> pathlib.Path:
 
 
 def get_configured_fsspec_kwargs(
-        protocol: typing.Optional[str] = None, anonymous: bool = False
+    protocol: typing.Optional[str] = None, anonymous: bool = False
 ) -> typing.Dict[str, typing.Any]:
     if protocol:
         # Try to get storage config safely - may not be initialized for local operations
@@ -121,10 +121,10 @@ def get_configured_fsspec_kwargs(
 
 
 def get_underlying_filesystem(
-        protocol: typing.Optional[str] = None,
-        anonymous: bool = False,
-        path: typing.Optional[str] = None,
-        **kwargs,
+    protocol: typing.Optional[str] = None,
+    anonymous: bool = False,
+    path: typing.Optional[str] = None,
+    **kwargs,
 ) -> fsspec.AbstractFileSystem:
     if protocol is None:
         # If protocol is None, get it from the path
@@ -168,11 +168,11 @@ async def get(from_path: str, to_path: Optional[str | pathlib.Path] = None, recu
 
 
 async def _get_from_filesystem(
-        file_system: fsspec.AbstractFileSystem,
-        from_path: str | pathlib.Path,
-        to_path: str | pathlib.Path,
-        recursive: bool,
-        **kwargs,
+    file_system: fsspec.AbstractFileSystem,
+    from_path: str | pathlib.Path,
+    to_path: str | pathlib.Path,
+    recursive: bool,
+    **kwargs,
 ):
     if isinstance(file_system, AsyncFileSystem):
         dst = await file_system._get(from_path, to_path, recursive=recursive, **kwargs)  # pylint: disable=W0212
@@ -215,11 +215,12 @@ async def _open_obstore_bypass(path: str, mode: str = "rb", **kwargs):
     bucket, file_path = fs._split_path(path)  # pylint: disable=W0212
     store: ObjectStore = fs._construct_store(bucket)
 
+    file_handle: obstore.AsyncWritableFile | obstore.AsyncReadableFile
     if "w" in mode:
         attributes = kwargs.pop("attributes", {})
         file_handle = obstore.open_writer_async(store, file_path, attributes=attributes)
     else:  # read mode
-        buffer_size = kwargs.pop("buffer_size", 10 * 2 ** 20)
+        buffer_size = kwargs.pop("buffer_size", 10 * 2**20)
         file_handle = await obstore.open_reader_async(store, file_path, buffer_size=buffer_size)
 
     return file_handle
@@ -259,8 +260,7 @@ async def open(path: str, mode: str = "rb", **kwargs):
 
 
 async def put_stream(
-        data_iterable: typing.AsyncIterable[bytes] | bytes, *, name: str | None = None, to_path: str | None = None,
-        **kwargs
+    data_iterable: typing.AsyncIterable[bytes] | bytes, *, name: str | None = None, to_path: str | None = None, **kwargs
 ) -> str:
     """
     Put a stream of data to a remote location. This is useful for streaming data to a remote location.
@@ -281,6 +281,7 @@ async def put_stream(
     """
     if not to_path:
         from flyte._context import internal_ctx
+
         ctx = internal_ctx()
         to_path = ctx.raw_data.get_random_remote_path(file_name=name)
 
@@ -302,7 +303,7 @@ async def put_stream(
     return str(to_path)
 
 
-async def get_stream(path: str, chunk_size=10 * 2 ** 20, **kwargs) -> AsyncGenerator[bytes, None]:
+async def get_stream(path: str, chunk_size=10 * 2**20, **kwargs) -> AsyncGenerator[bytes, None]:
     """
     Get a stream of data from a remote location.
     This is useful for downloading streaming data from a remote location.
@@ -324,7 +325,6 @@ async def get_stream(path: str, chunk_size=10 * 2 ** 20, **kwargs) -> AsyncGener
         # Set buffer_size for obstore if chunk_size is provided
         if "buffer_size" not in kwargs:
             kwargs["buffer_size"] = chunk_size
-        print(f"Using obstore bypass for {path} with buffer_size {kwargs['buffer_size']}", flush=True)
         file_handle = await _open_obstore_bypass(path, "rb", **kwargs)
         while chunk := await file_handle.read():
             yield bytes(chunk)

--- a/src/flyte/storage/_storage.py
+++ b/src/flyte/storage/_storage.py
@@ -276,7 +276,7 @@ async def put_stream(
 
     # Check if we should use obstore bypass
     fs = get_underlying_filesystem(path=to_path)
-    if _is_obstore_supported_protocol(fs.protocol) and hasattr(fs, "_split_path") and hasattr(fs, "_construct_store"):
+    try:
         file_handle = await open(to_path, "wb", **kwargs)
         if isinstance(data_iterable, bytes):
             await file_handle.write(data_iterable)
@@ -285,6 +285,8 @@ async def put_stream(
                 await file_handle.write(data)
         await file_handle.close()
         return str(to_path)
+    except OnlyAsyncIOSupportedError:
+        pass
 
     # Fallback to normal open
     file_handle = fs.open(to_path, mode="wb", **kwargs)

--- a/src/flyte/storage/_storage.py
+++ b/src/flyte/storage/_storage.py
@@ -283,7 +283,7 @@ async def put_stream(
     # Check if we should use obstore bypass
     fs = get_underlying_filesystem(path=to_path)
     try:
-        file_handle = typing.cast(AsyncWritableFile, await open(to_path, "wb", **kwargs))
+        file_handle = typing.cast("AsyncWritableFile", await open(to_path, "wb", **kwargs))
         if isinstance(data_iterable, bytes):
             await file_handle.write(data_iterable)
         else:
@@ -328,7 +328,7 @@ async def get_stream(path: str, chunk_size=10 * 2**20, **kwargs) -> AsyncGenerat
         # Set buffer_size for obstore if chunk_size is provided
         if "buffer_size" not in kwargs:
             kwargs["buffer_size"] = chunk_size
-        file_handle = typing.cast(AsyncReadableFile, await _open_obstore_bypass(path, "rb", **kwargs))
+        file_handle = typing.cast("AsyncReadableFile", await _open_obstore_bypass(path, "rb", **kwargs))
         while chunk := await file_handle.read():
             yield bytes(chunk)
         return

--- a/tests/flyte/type_engine/pydantic/test_pydantic_basemodel_transformer.py
+++ b/tests/flyte/type_engine/pydantic/test_pydantic_basemodel_transformer.py
@@ -86,26 +86,26 @@ async def test_flytetypes_in_pydantic_basemodel_wf(local_dummy_file, local_dummy
     o1, o2, o3, o4 = o.outputs()
 
     async with o1.open() as fh:
-        content = fh.read()
+        content = await fh.read()
         content = content.decode("utf-8")
         assert content == "Hello File"
 
     async with o2.open() as fh:
-        content = fh.read()
+        content = await fh.read()
         content = content.decode("utf-8")
         assert content == "Hello File"
 
     async for f in o3.walk():
         assert f.name == "file"
         async with f.open() as fh:
-            content = fh.read()
+            content = await fh.read()
             content = content.decode("utf-8")
             assert content == "Hello Dir"
 
     async for f in o4.walk():
         assert f.name == "file"
         async with f.open() as fh:
-            content = fh.read()
+            content = await fh.read()
             content = content.decode("utf-8")
             assert content == "Hello Dir"
 
@@ -177,22 +177,22 @@ async def test_all_types_in_pydantic_basemodel_wf(local_dummy_file, local_dummy_
         for ff in inner_bm.f:
             assert type(ff) is File
             async with ff.open() as f:
-                assert f.read().decode("utf-8") == "Hello File"
+                assert (await f.read()).decode("utf-8") == "Hello File"
         # j: Dict[int, File]
         for _, ff in inner_bm.j.items():
             assert type(ff) is File
             async with ff.open() as f:
-                assert f.read().decode("utf-8") == "Hello File"
+                assert (await f.read()).decode("utf-8") == "Hello File"
         # n: File
         assert type(inner_bm.n) is File
         async with inner_bm.n.open() as f:
-            assert f.read().decode("utf-8") == "Hello File"
+            assert (await f.read()).decode("utf-8") == "Hello File"
         # o: Dir
         assert type(inner_bm.o) is Dir
         async for f in inner_bm.o.walk():
             assert f.name == "file"
             async with f.open() as fh:
-                content = fh.read()
+                content = await fh.read()
                 content = content.decode("utf-8")
                 assert content == "Hello Dir"
 
@@ -384,22 +384,22 @@ async def test_all_types_with_optional_in_pydantic_basemodel_wf(local_dummy_file
         for ff in inner_bm.f:
             assert type(ff) is File
             async with ff.open() as f:
-                assert f.read().decode("utf-8") == "Hello File"
+                assert (await f.read()).decode("utf-8") == "Hello File"
         # j: Dict[int, File]
         for _, ff in inner_bm.j.items():
             assert type(ff) is File
             async with ff.open() as f:
-                assert f.read().decode("utf-8") == "Hello File"
+                assert (await f.read()).decode("utf-8") == "Hello File"
         # n: File
         assert type(inner_bm.n) is File
         async with inner_bm.n.open() as f:
-            assert f.read().decode("utf-8") == "Hello File"
+            assert (await f.read()).decode("utf-8") == "Hello File"
         # o: Dir
         assert type(inner_bm.o) is Dir
         async for f in inner_bm.o.walk():
             assert f.name == "file"
             async with f.open() as fh:
-                content = fh.read()
+                content = await fh.read()
                 content = content.decode("utf-8")
                 assert content == "Hello Dir"
 
@@ -666,22 +666,22 @@ async def test_input_from_ui_pydantic_basemodel(local_dummy_file, local_dummy_di
         for ff in inner_bm.f:
             assert type(ff) is File
             async with ff.open() as f:
-                assert f.read().decode("utf-8") == "Hello File"
+                assert (await f.read()).decode("utf-8") == "Hello File"
         # j: Dict[int, File]
         for _, ff in inner_bm.j.items():
             assert type(ff) is File
             async with ff.open() as f:
-                assert f.read().decode("utf-8") == "Hello File"
+                assert (await f.read()).decode("utf-8") == "Hello File"
         # n: File
         assert type(inner_bm.n) is File
         async with inner_bm.n.open() as f:
-            assert f.read().decode("utf-8") == "Hello File"
+            assert (await f.read()).decode("utf-8") == "Hello File"
         # o: Dir
         assert type(inner_bm.o) is Dir
         async for f in inner_bm.o.walk():
             assert f.name == "file"
             async with f.open() as fh:
-                content = fh.read()
+                content = await fh.read()
                 content = content.decode("utf-8")
                 assert content == "Hello Dir"
 


### PR DESCRIPTION

The File API is changed.
open now always returns an async file handle in async mode. open_sync returns a sync file handle.

open, fh.read, returns a memoryview, which has to be type casted to `bytes`. 

@wild-endeavor shall we modify it somehow to make it `bytes`? Memory view is faster