### PR TITLE
Improve error message for type engine

### DIFF
--- a/examples/basics/dataframe_usage.py
+++ b/examples/basics/dataframe_usage.py
@@ -71,7 +71,7 @@ async def create_flyte_dataframe() -> Annotated[flyte.io.DataFrame, "csv"]:
 async def get_employee_data(raw_dataframe: pd.DataFrame, flyte_dataframe: pd.DataFrame) -> pd.DataFrame:
     """
     This task takes two dataframes as input. We'll pass one raw pandas dataframe, and one flyte.io.DataFrame.
-    Flyte automatically converts the flyte.io.DataFrame to a pandas DataFrame. The actual download and conversion 
+    Flyte automatically converts the flyte.io.DataFrame to a pandas DataFrame. The actual download and conversion
     happens only when we access the data (in this case, when we do the merge)."""
     joined_df = raw_dataframe.merge(flyte_dataframe, on="employee_id", how="inner")
 
@@ -80,9 +80,10 @@ async def get_employee_data(raw_dataframe: pd.DataFrame, flyte_dataframe: pd.Dat
 
 if __name__ == "__main__":
     import flyte.git
+
     flyte.init_from_config(flyte.git.config_from_root())
     # Get the data sources
-    
+
     raw_df = flyte.with_runcontext(mode="local").run(create_raw_dataframe)
     flyte_df = flyte.with_runcontext(mode="local").run(create_flyte_dataframe)
 
@@ -90,6 +91,6 @@ if __name__ == "__main__":
     run = flyte.with_runcontext(mode="local").run(
         get_employee_data,
         raw_dataframe=raw_df.outputs(),
-        flyte_dataframe=flyte_df.outputs(), 
+        flyte_dataframe=flyte_df.outputs(),
     )
     print("Results:", run.outputs())

--- a/examples/stress/long_running.py
+++ b/examples/stress/long_running.py
@@ -41,6 +41,7 @@ async def main_task(duration: timedelta) -> str:
 
 if __name__ == "__main__":
     import flyte.git
+
     flyte.init_from_config(flyte.git.config_from_root())
     run = flyte.run(main_task, duration=timedelta(days=5))
     print(run.url)

--- a/examples/stress/long_running_reuse.py
+++ b/examples/stress/long_running_reuse.py
@@ -47,6 +47,7 @@ async def main_task(duration: timedelta) -> str:
 
 if __name__ == "__main__":
     import flyte.git
+
     flyte.init_from_config(flyte.git.config_from_root())
     run = flyte.run(main_task, duration=timedelta(days=5))
     print(run.url)

--- a/examples/stress/rewrite_example.py
+++ b/examples/stress/rewrite_example.py
@@ -56,7 +56,8 @@ if __name__ == "__main__":
     flyte.init_from_config(flyte.git.config_from_root())
 
     # Try read the data without acceleration and with acceleration
-    r = flyte.run(pathrewrite_read,
+    r = flyte.run(
+        pathrewrite_read,
         flyte.io.File.from_existing_remote("s3://union-cloud-oc-canary-playground-persistent/my_data.dat"),
     )
     print(r.url)

--- a/src/flyte/errors.py
+++ b/src/flyte/errors.py
@@ -174,7 +174,7 @@ class RuntimeDataValidationError(RuntimeUserError):
 
     def __init__(self, var: str, e: Exception | str, task_name: str = ""):
         super().__init__(
-            "DataValiationError", f"In task {task_name} variable {var}, failed to serialize/deserialize because of {e}"
+            "DataValidationError", f"In task {task_name} variable {var}, failed to serialize/deserialize because of {e}"
         )
 
 

--- a/src/flyte/io/_dataframe/dataframe.py
+++ b/src/flyte/io/_dataframe/dataframe.py
@@ -647,17 +647,21 @@ class DataFrameTransformerEngine(TypeTransformer[DataFrame]):
                 f"Already registered a handler for {(h.python_type, protocol, h.supported_format)}"
             )
         lowest_level[h.supported_format] = h
-        logger.debug(f"Registered {h} as handler for {h.python_type}, protocol {protocol}, fmt {h.supported_format}")
+        logger.debug(
+            f"Registered {h.__class__.__name__} as handler for {h.python_type.__class__.__name__},"
+            f" protocol {protocol}, fmt {h.supported_format}"
+        )
 
         if (default_format_for_type or default_for_type) and h.supported_format != GENERIC_FORMAT:
             if h.python_type in cls.DEFAULT_FORMATS and not override:
                 if cls.DEFAULT_FORMATS[h.python_type] != h.supported_format:
                     logger.info(
-                        f"Not using handler {h} with format {h.supported_format}"
-                        f" as default for {h.python_type}, {cls.DEFAULT_FORMATS[h.python_type]} already specified."
+                        f"Not using handler {h.__class__.__name__} with format {h.supported_format}"
+                        f" as default for {h.python_type.__class__.__name__},"
+                        f" {cls.DEFAULT_FORMATS[h.python_type]} already specified."
                     )
             else:
-                logger.debug(f"Use {type(h).__name__} as default handler for {h.python_type}.")
+                logger.debug(f"Use {type(h).__name__} as default handler for {h.python_type.__class__.__name__}.")
                 cls.DEFAULT_FORMATS[h.python_type] = h.supported_format
         if default_storage_for_type or default_for_type:
             if h.protocol in cls.DEFAULT_PROTOCOLS and not override:

--- a/src/flyte/types/_type_engine.py
+++ b/src/flyte/types/_type_engine.py
@@ -1216,7 +1216,7 @@ class TypeEngine(typing.Generic[T]):
                 e: BaseException = literal_map[k].exception()  # type: ignore
                 if isinstance(e, TypeError):
                     raise TypeError(
-                        f"Error converting: Var:{k}, type:{type(v)}, into:{python_type}, received_value {v}"
+                        f"Error converting: Var:{k}, type:{type(d[k])}, into:{python_type}, received_value {d[k]}"
                     )
                 else:
                     raise e


### PR DESCRIPTION
Before:
```
Error converting: Var:additional_properties, type:<class '_asyncio.Task'>, into:dict[str, float | None | str | bool | datetime.datetime | datetime.date | list[str]] | None, received_value <Task finished name='Task-36' coro=<TypeEngine.to_literal() done, defined at /opt/venv/lib/python3.12/site-packages/flyte/types/_type_engine.py:1082> exception=TypeTransformerFailedError("Value [{'c': ['hello'], 'algorithm': 'xgboost'}] is not of type dict[str, float | None | str | bool | datetime.datetime | datetime.date | list[str]] | None")>
```
<img width="1241" height="192" alt="Screenshot 2025-10-03 at 4 31 46 PM" src="https://github.com/user-attachments/assets/272f3f67-09bf-4fb0-9338-01e8fe75b04e" />

After:
```
Error converting: Var:additional_properties, type:<class 'list'>, into:dict[str, float | None | str | bool | datetime.datetime | datetime.date | list[str]] | None, received_value [{'algorithm': 'xgboost', 'c': ['hello']}]
```

<img width="1251" height="161" alt="Screenshot 2025-10-03 at 4 33 08 PM" src="https://github.com/user-attachments/assets/193bcd96-225e-4f8d-b8d4-196d1cd1f226" />



```python
from datetime import datetime, date
from enum import StrEnum
from pathlib import Path

import flyte

image = (
    flyte.Image.from_debian_base()
    .with_apt_packages("git")
)

task_env = flyte.TaskEnvironment(
    name="hello_type", resources=flyte.Resources(cpu=(1, 2), memory=("400Mi", "1000Mi")), image=image
)

class ArtifactRelType(StrEnum):
    DOWNSTREAM_OF = "downstream_of"
    RELATED_TO = "related_to"


FlytePropertyValue = float | None | str | bool | datetime | date | list[str]


@task_env.task
def say_hello(
    my_val: dict[str, float | int],
    artifact_rel_type: dict[str, ArtifactRelType] | None = None,
    additional_properties: dict[str, FlytePropertyValue] | None = None,
) -> dict[str, float | int]:
    print(my_val)
    return my_val


@task_env.task
def gen_outputs(
) -> dict[str, FlytePropertyValue] | None:
    return [{"c": ["hello"], "algorithm": "xgboost"}]


@task_env.task
def gen_outputs1(
) -> list[dict[str, FlytePropertyValue]] | dict[str, FlytePropertyValue] | None:
    return [{"c": ["hello"], "algorithm": "xgboost"}]


@task_env.task
def wf():
    # Wrong outputs
    say_hello(
        my_val={"a": 1, "b": 2},
        artifact_rel_type={"a": ArtifactRelType.DOWNSTREAM_OF},
        additional_properties=gen_outputs(),
    )


@task_env.task
def wf1():
    # Wrong binding
    say_hello(
        my_val={"a": 1, "b": 2},
        artifact_rel_type={"a": ArtifactRelType.DOWNSTREAM_OF},
        additional_properties=[{"c": ["hello"], "algorithm": "xgboost"}],
    )


@task_env.task
def wf2(additional_properties: dict[str, FlytePropertyValue] | None = [{"c": ["hello"], "algorithm": "xgboost"}]):
    # Wrong default inputs
    say_hello(
        my_val={"a": 1, "b": 2},
        artifact_rel_type={"a": ArtifactRelType.DOWNSTREAM_OF},
        additional_properties=additional_properties,
    )


@task_env.task
def wf3():
    # Wrong inputs
    res = gen_outputs1()
    say_hello(
        my_val={"a": 1, "b": 2},
        artifact_rel_type={"a": ArtifactRelType.DOWNSTREAM_OF},
        additional_properties=res,
    )


if __name__ == "__main__":
    flyte.init_from_config()
    run = flyte.with_runcontext(env_vars={"LOG_LEVEL": "10"}).run(wf3)
    print("run name:", run.name)
    print("run url:", run.url)
```