### PR TITLE
fix UvProjectHandler handle function

### DIFF
--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -267,7 +267,7 @@ class UVProjectHandler:
         layer: UVProject, context_path: Path, dockerfile: str, docker_ignore_patterns: list[str] = []
     ) -> str:
         secret_mounts = _get_secret_mounts_layer(layer.secret_mounts)
-        if layer.extra_index_urls and "--no-install-project" in layer.extra_index_urls:
+        if layer.extra_args and "--no-install-project" in layer.extra_args:
             # Only Copy pyproject.yaml and uv.lock.
             pyproject_dst = copy_files_to_context(layer.pyproject, context_path)
             uvlock_dst = copy_files_to_context(layer.uvlock, context_path)


### PR DESCRIPTION
## Changes 
The `--no-install-project` arg should be passed from `layer.extra_args` instead of `layer.extra_index_urls` in UVProject layer. This PR fixed it.