### PR TITLE
Fix error message formatting for clickable build link

### DIFF
--- a/src/flyte/_internal/imagebuild/remote_builder.py
+++ b/src/flyte/_internal/imagebuild/remote_builder.py
@@ -134,7 +134,7 @@ class RemoteImageBuilder(ImageBuilder):
         if run_details.action_details.raw_phase == run_definition_pb2.PHASE_SUCCEEDED:
             logger.warning(f"[bold green]✅ Build completed in {elapsed}![/bold green]")
         else:
-            raise flyte.errors.ImageBuildError(f"❌ Build failed in {elapsed} at [cyan]{run.url}[/cyan]")
+            raise flyte.errors.ImageBuildError(f"❌ Build failed in {elapsed} at {run.url}")
 
         outputs = await run_details.outputs()
         return _get_fully_qualified_image_name(outputs)


### PR DESCRIPTION
## Summary
- Removed markdown formatting tags `[cyan]` and `[/cyan]` from the ImageBuildError message in remote_builder.py
- This change makes the build URL clickable in console output instead of displaying with formatting tags

## Changes
- Modified line 137 in `src/flyte/_internal/imagebuild/remote_builder.py` to remove the cyan color formatting around `run.url`
- The error message now displays as: `❌ Build failed in {elapsed} at {run.url}`

## Test plan
<img width="1317" height="377" alt="Screenshot 2025-10-22 at 10 41 48 PM" src="https://github.com/user-attachments/assets/3c06e5b6-d609-44ac-897d-87453f507d89" />
