### PR TITLE
fix sync map

### DIFF
--- a/src/flyte/_map.py
+++ b/src/flyte/_map.py
@@ -189,7 +189,7 @@ class _Mapper(Generic[P, R]):
         group_name: str | None = None,
         concurrency: int = 0,
         return_exceptions: bool = True,
-    ) -> Iterator[R]: ...
+    ) -> Iterator[Union[R, Exception]]: ...
 
     def __call__(
         self,


### PR DESCRIPTION
Since the type hints for `__call__` are already defined in the `_Mapper` class, mypy will provide proper type checking. We don't need to add overloads again.