### PR TITLE
Change setup to sync in dask plugin

### DIFF
--- a/plugins/dask/src/flyteplugins/dask/task.py
+++ b/plugins/dask/src/flyteplugins/dask/task.py
@@ -78,13 +78,12 @@ class DownloadCodeBundleWorkerPlugin(WorkerPlugin):
     def __init__(self, code_bundle: CodeBundle):
         self.code_bundle = code_bundle
 
-    def setup(self, worker):
+    async def setup(self, worker):
         """
         Runs on each worker as it is initialized.
         """
         sys.path.insert(0, ".")
-        download_code_bundle(self.code_bundle)
-
+        await download_code_bundle(self.code_bundle)
 
 @dataclass(kw_only=True)
 class DaskTask(AsyncFunctionTaskTemplate):


### PR DESCRIPTION
This PR is to change setup method to async in DownloadCodeBundleWorkerPlugin(WorkerPlugin) at dask to align official setup method in WorkerPlugin, and solve the original error `asyncio.run() cannot be called from a running event loop` when running the dask example.

https://github.com/dask/distributed/blob/1ee4756b97cd1cd5c074c40b2057d31613fe1ab9/distributed/diagnostics/plugin.py#L285
