### PR TITLE
Skip listing relative module files

### DIFF
--- a/src/flyte/_code_bundle/_utils.py
+++ b/src/flyte/_code_bundle/_utils.py
@@ -201,7 +201,7 @@ def _file_is_in_directory(file: str, directory: str) -> bool:
 
 
 def list_imported_modules_as_files(source_path: str, modules: List[ModuleType]) -> List[str]:
-    """Copies modules into destination that are in modules. The module files are copied only if:
+    """Lists the files of modules that have been loaded.  The files are only included if:
 
     1. Not a site-packages. These are installed packages and not user files.
     2. Not in the sys.base_prefix or sys.prefix. These are also installed and not user files.
@@ -242,6 +242,12 @@ def list_imported_modules_as_files(source_path: str, modules: List[ModuleType]) 
             # Only upload files where the module file in the source directory
             # print log line for files that have common ancestor with source_path, but not in it.
             logger.debug(f"{mod_file} is not in {source_path}")
+            continue
+
+        if not pathlib.Path(mod_file).is_file():
+            # Some modules have a __file__ attribute that are relative to the base package. Let's skip these,
+            # can add more rigorous logic to really pull out the correct file location if we need to.
+            logger.debug(f"Skipping {mod_file} from {mod.__name__} because it is not a file")
             continue
 
         files.add(mod_file)


### PR DESCRIPTION
Some python modules have a `__file__` attribute that's not an absolute path.  This leads to errors like the below in our naive way of checking, but I think it's okay to just skip these for now.  We can get more in the weeds by inspecting the spec and loader but for now let's just skip these for now

```
Filtered traceback (most recent call last):
  File "/Users/johnvotta/code/flyte-sdk/examples/ml/embed_wikipedia.py", line 195, in <module>
    run = flyte.run(main, 256, shard="20231101.en")
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/johnvotta/code/flyte-sdk/.venv/lib/python3.12/site-packages/flyte/_run.py", line 695, in run
    return await _Runner().run.aio(task, *args, **kwargs)  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/johnvotta/code/flyte-sdk/.venv/lib/python3.12/site-packages/flyte/_run.py", line 571, in run
    return await self._run_remote(task, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/johnvotta/code/flyte-sdk/.venv/lib/python3.12/site-packages/flyte/_run.py", line 188, in _run_remote
    code_bundle = await build_code_bundle(
                  ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/johnvotta/code/flyte-sdk/.venv/lib/python3.12/site-packages/async_lru/__init__.py", line 221, in __call__
    return await asyncio.shield(fut)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '_classes.py'

Exception ignored in: <function ResourceTracker.__del__ at 0x1111abb00>
Traceback (most recent call last):
  File "/Users/johnvotta/code/flyte-sdk/.venv/lib/python3.12/site-packages/multiprocess/resource_tracker.py", line 80, in __del__
  File "/Users/johnvotta/code/flyte-sdk/.venv/lib/python3.12/site-packages/multiprocess/resource_tracker.py", line 89, in _stop
  File "/Users/johnvotta/code/flyte-sdk/.venv/lib/python3.12/site-packages/multiprocess/resource_tracker.py", line 102, in _stop_locked
AttributeError: '_thread.RLock' object has no attribute '_recursion_count'
```