### PR TITLE
Set root handler level to debug

### DIFF
--- a/src/flyte/_logging.py
+++ b/src/flyte/_logging.py
@@ -110,6 +110,7 @@ def initialize_logger(log_level: int = get_env_log_level(), enable_rich: bool = 
 
     # Add context filter to root handler for all logging
     root_handler.addFilter(ContextFilter())
+    root_handler.setLevel(logging.DEBUG)
     root.addHandler(root_handler)
 
     # Set up Flyte logger handler
@@ -198,6 +199,7 @@ def _setup_root_logger():
     handler = logging.StreamHandler()
     # Add context filter to ALL logging
     handler.addFilter(ContextFilter())
+    handler.setLevel(logging.DEBUG)
 
     # Simple formatter since filters handle prefixes
     root.addHandler(handler)


### PR DESCRIPTION
The handler level is not the same thing as the log level.  Currently without setting the root handler level, this code doesn't work.
```python
    flyte.init()
    logger = logging.getLogger()
    logger.setLevel(logging.DEBUG)
    logger.info("this doesn't print")
```

Let's set the handler level to the widest possible and users can control their logging just with logging levels on the logger.
