### PR TITLE
Don't use local file keyring when not in ipython

### DIFF
--- a/src/flyte/_keyring/file.py
+++ b/src/flyte/_keyring/file.py
@@ -98,7 +98,7 @@ class SimplePlainTextKeyring(KeyringBackend):
             try:
                 config = get_init_config()
                 config_path = config.source_config_path
-                if config_path and str(config_path.parent) == ".flyte":
+                if config_path and str(config_path.parent.name) == ".flyte":
                     # if the config is in a .flyte directory, use that as the path
                     return config_path.parent / "keyring.cfg"
             except Exception as e:


### PR DESCRIPTION
* All keyring backends are active by default - this should not be the case for our local file keyring - that one is meant only for notebooks.
* `get_init_config()` can raise an exception if flyte is not initialized, leading to keyring not storing the token and leading to web pages popping open again and again.
