### PR TITLE
chore: Remove uv dev-dependencies from pyproject.toml

### DIFF
--- a/examples/plugins/spark_dataframe_example.py
+++ b/examples/plugins/spark_dataframe_example.py
@@ -1,5 +1,4 @@
 import collections
-from pathlib import Path
 from typing import Annotated, OrderedDict, Type, cast
 
 import pyspark

--- a/examples/triggers/time_zone.py
+++ b/examples/triggers/time_zone.py
@@ -10,17 +10,13 @@ env = flyte.TaskEnvironment(
 
 nyc_trigger = flyte.Trigger(
     "nyc_tz",
-    flyte.Cron(
-        "1 12 * * *", timezone="America/New_York"
-    ), # Every day at 12:01 PM ET
+    flyte.Cron("1 12 * * *", timezone="America/New_York"),  # Every day at 12:01 PM ET
     inputs={"start_time": flyte.TriggerTime, "x": 1},
 )
 
 sf_trigger = flyte.Trigger(
     "sf_tz",
-    flyte.Cron(
-        "0 9 * * *", timezone="America/Los_Angeles"
-    ), # Every day at 9 AM PT
+    flyte.Cron("0 9 * * *", timezone="America/Los_Angeles"),  # Every day at 9 AM PT
     inputs={"start_time": flyte.TriggerTime, "x": 1},
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,10 +136,6 @@ ignore = ["PGH003", "PLC0415", "ASYNC210", "FURB122"]
 [tool.ruff.lint.per-file-ignores]
 "examples/*" = ["E402"]
 
-[tool.uv]
-dev-dependencies = [
-    "pytest>=8.3.5",
-]
 
 [tool.uv.sources]
 flyteidl2 = { git = "https://github.com/flyteorg/flyte.git", subdirectory = "gen/python", rev = "v2" }

--- a/src/flyte/_internal/imagebuild/remote_builder.py
+++ b/src/flyte/_internal/imagebuild/remote_builder.py
@@ -120,6 +120,7 @@ class RemoteImageBuilder(ImageBuilder):
             target_image = image_name
 
         from flyte._initialize import get_init_config
+
         cfg = get_init_config()
         run = cast(
             Run,

--- a/tests/flyte/internal/runtime/test_trigger_serde.py
+++ b/tests/flyte/internal/runtime/test_trigger_serde.py
@@ -24,7 +24,7 @@ class TestToSchedule:
         cron = Cron("0 * * * *")
         schedule = _to_schedule(cron)
 
-        assert schedule.cron.expression == f"0 * * * *"
+        assert schedule.cron.expression == "0 * * * *"
         assert schedule.cron.timezone == DEFAULT_TIMEZONE
         assert schedule.kickoff_time_input_arg == ""
 
@@ -33,7 +33,7 @@ class TestToSchedule:
         cron = Cron("0 0 * * *")
         schedule = _to_schedule(cron, kickoff_arg_name="trigger_time")
 
-        assert schedule.cron.expression == f"0 0 * * *"
+        assert schedule.cron.expression == "0 0 * * *"
         assert schedule.cron.timezone == DEFAULT_TIMEZONE
         assert schedule.kickoff_time_input_arg == "trigger_time"
 


### PR DESCRIPTION
Remove uv dev-dependencies from pyproject.toml since it's deprecated