### PR TITLE
ci: Increase PyPI publish wait time to 5 mins

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
             echo "No tagged version found, exiting"
             exit 1
           fi
-          sleep 120
+          sleep 300
           LINK="https://pypi.org/project/flyte/${VERSION}/"
           for i in {1..60}; do
             result=$(curl -L -I -s -f ${LINK})


### PR DESCRIPTION
Increased the sleep time from 120 seconds to 300 seconds in the `.github/workflows/publish.yml` workflow to allow more time for the package to appear on PyPI.