### PR TITLE
supporting the file_name parameter in the new_remote function

### DIFF
--- a/src/flyte/io/_file.py
+++ b/src/flyte/io/_file.py
@@ -231,7 +231,7 @@ class File(BaseModel, Generic[T], SerializableType):
 
     @classmethod
     @requires_initialization
-    def new_remote(cls, hash_method: Optional[HashMethod | str] = None) -> File[T]:
+    def new_remote(cls, file_name: Optional[str] = None, hash_method: Optional[HashMethod | str] = None) -> File[T]:
         """
         Create a new File reference for a remote file that will be written to.
 
@@ -250,6 +250,8 @@ class File(BaseModel, Generic[T], SerializableType):
         ```
 
         Args:
+            file_name: Optional string specifying a remote file name. If not set,
+                      a generated file name will be returned.
             hash_method: Optional HashMethod or string to use for cache key computation. If a string is provided,
                         it will be used as a precomputed cache key. If a HashMethod is provided, it will be used
                         to compute the hash as data is written.
@@ -261,7 +263,9 @@ class File(BaseModel, Generic[T], SerializableType):
         known_cache_key = hash_method if isinstance(hash_method, str) else None
         method = hash_method if isinstance(hash_method, HashMethod) else None
 
-        return cls(path=ctx.raw_data.get_random_remote_path(), hash=known_cache_key, hash_method=method)
+        return cls(
+            path=ctx.raw_data.get_random_remote_path(file_name=file_name), hash=known_cache_key, hash_method=method
+        )
 
     @classmethod
     def from_existing_remote(cls, remote_path: str, file_cache_key: Optional[str] = None) -> File[T]:

--- a/tests/flyte/io_types/test_files.py
+++ b/tests/flyte/io_types/test_files.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import filecmp
 import os
 import tempfile
+from typing import Optional
 
 import pandas as pd
 import pytest
@@ -95,19 +96,29 @@ async def test_task_write_file_streaming(ctx_with_test_raw_data_path):
     flyte.init()
 
     # Simulate writing a file by streaming it directly to blob storage
-    async def my_task() -> File[pd.DataFrame]:
+    async def my_task(
+        file_name: Optional[str] = None,
+    ) -> File[pd.DataFrame]:
         df = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
-        file = File.new_remote()
+        file = File.new_remote(file_name=file_name)
         with file.open_sync("wb") as fh:
             df.to_csv(fh, index=False)
         return file
 
-    file = await my_task()
-    assert file.hash is None
-    async with file.open() as f:
-        content = await f.read()
-    content = content.decode("utf-8")
-    assert "col1,col2" in content
+    file_names = [None, "data.csv"]
+    for file_name in file_names:
+        file = await my_task(file_name=file_name)
+        _, ext = os.path.splitext(os.path.basename(file.path))
+        if file_name is None:
+            assert len(ext) == 0
+        else:
+            assert len(ext) > 0
+
+        assert file.hash is None
+        async with file.open() as f:
+            content = await f.read()
+        content = content.decode("utf-8")
+        assert "col1,col2" in content
 
 
 @pytest.mark.sandbox


### PR DESCRIPTION
## Tracking issues
flyteorg/flyte#6745

## Why are the changes needed?
Allow user to set remote file name in flyte-sdk.

## What changes were proposed in this pull request?
Adding the file_name parameter in new_remote function to new the remote file which path is joined with the file_name.

## How was this patch tested?

```python
@env.task
async def demonstrate_streaming_write(content: str) -> File:
    """
    Demonstrates streaming write to a remote file.
    """
    f = File.new_remote(file_name="chunk.txt")
    async with f.open("wb") as fh:
        # Write in chunks to demonstrate streaming
        data = content.encode("utf-8")
        chunk_size = 10
        for i in range(0, len(data), chunk_size):
            chunk = data[i : i + chunk_size]
            await fh.write(chunk)
    print(f"Streamed content to file: {f.path}")
    return f
```


Run following step to reproduce.
```shell
uv venv -p 3.13
source .venv/bin/activate
uv pip install -e ./flyte-sdk
flyte run --local file.py demonstrate_streaming_write --content "This is streaming content that will be written in chunks!"
```
<img width="1315" height="167" alt="image" src="https://github.com/user-attachments/assets/a32af19a-d9d4-4486-9d6e-e1446888e43a" />


## Check all the applicable boxes
- [x] make fmt (done)
- [x] make mypy  (pass)
- [x] make unit_test (pass)

## Docs link
