### PR TITLE
skip final report flush when no report is available

### DIFF
--- a/src/flyte/_internal/runtime/taskrunner.py
+++ b/src/flyte/_internal/runtime/taskrunner.py
@@ -159,7 +159,10 @@ async def convert_and_run(
         if err is not None:
             return None, convert_from_native_to_error(err)
         if task.report:
-            await flyte.report.flush.aio()
+            # Check if report has content before flushing to avoid overwriting
+            # worker reports (from Elastic/distributed tasks) with empty main process report
+            if ctx.get_report():
+                await flyte.report.flush.aio()
         return await convert_from_native_to_outputs(out, task.native_interface, task.name), None
 
 


### PR DESCRIPTION
This PR fixes an issue where the main process overwrote valid worker reports with an empty one when using the elastic plugin. We now skip the final flush unless a report is actually available.