### PR TITLE
Add support for `--image` to deploy

### DIFF
--- a/src/flyte/cli/_deploy.py
+++ b/src/flyte/cli/_deploy.py
@@ -96,6 +96,17 @@ class DeployArguments:
             )
         },
     )
+    image: List[str] = field(
+        default_factory=list,
+        metadata={
+            "click.option": click.Option(
+                ["--image"],
+                type=str,
+                multiple=True,
+                help="Image to be used in the run. Format: imagename=imageuri. Can be specified multiple times.",
+            )
+        },
+    )
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> "DeployArguments":
@@ -121,10 +132,11 @@ class DeployEnvCommand(click.RichCommand):
         console.print(f"Deploying root - environment: {self.env_name}")
         obj: CLIConfig = ctx.obj
         obj.init(
-            self.deploy_args.project,
-            self.deploy_args.domain,
+            project=self.deploy_args.project,
+            domain=self.deploy_args.domain,
             root_dir=self.deploy_args.root_dir,
             sync_local_sys_paths=not self.deploy_args.no_sync_local_sys_paths,
+            images=tuple(self.deploy_args.image) or None,
         )
         with console.status("Deploying...", spinner="dots"):
             deployment = flyte.deploy(
@@ -287,7 +299,96 @@ class EnvFiles(common.FileGroup):
 deploy = EnvFiles(
     name="deploy",
     help="""
-    Deploy one or more environments from a python file.
-    This command will create or update environments in the Flyte system.
-    """,
+Deploy one or more environments from a python file.
+
+This command will create or update environments in the Flyte system, registering
+all tasks and their dependencies.
+
+Example usage:
+
+```bash
+flyte deploy hello.py my_env
+```
+
+Arguments to the deploy command are provided right after the `deploy` command and before the file name.
+
+To deploy all environments in a file, use the `--all` flag:
+
+```bash
+flyte deploy --all hello.py
+```
+
+To recursively deploy all environments in a directory and its subdirectories, use the `--recursive` flag:
+
+```bash
+flyte deploy --recursive ./src
+```
+
+You can combine `--all` and `--recursive` to deploy everything:
+
+```bash
+flyte deploy --all --recursive ./src
+```
+
+You can provide image mappings with `--image` flag. This allows you to specify
+the image URI for the task environment during CLI execution without changing
+the code. Any images defined with `Image.from_ref_name("name")` will resolve to the
+corresponding URIs you specify here.
+
+```bash
+flyte deploy --image my_image=ghcr.io/myorg/my-image:v1.0 hello.py my_env
+```
+
+If the image name is not provided, it is regarded as a default image and will
+be used when no image is specified in TaskEnvironment:
+
+```bash
+flyte deploy --image ghcr.io/myorg/default-image:latest hello.py my_env
+```
+
+You can specify multiple image arguments:
+
+```bash
+flyte deploy --image ghcr.io/org/default:latest --image gpu=ghcr.io/org/gpu:v2.0 hello.py my_env
+```
+
+To deploy a specific version, use the `--version` flag:
+
+```bash
+flyte deploy --version v1.0.0 hello.py my_env
+```
+
+To preview what would be deployed without actually deploying, use the `--dry-run` flag:
+
+```bash
+flyte deploy --dry-run hello.py my_env
+```
+
+You can specify the `--config` flag to point to a specific Flyte cluster:
+
+```bash
+flyte deploy --config my-config.yaml hello.py my_env
+```
+
+You can override the default configured project and domain:
+
+```bash
+flyte deploy --project my-project --domain development hello.py my_env
+```
+
+If loading some files fails during recursive deployment, you can use the `--ignore-load-errors` flag
+to continue deploying the environments that loaded successfully:
+
+```bash
+flyte deploy --recursive --ignore-load-errors ./src
+```
+
+Other arguments to the deploy command are listed below.
+
+To see the environments available in a file, use `--help` after the file name:
+
+```bash
+flyte deploy hello.py --help
+```
+""",
 )

--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -301,11 +301,11 @@ class RunReferenceTaskCommand(click.RichCommand):
     def invoke(self, ctx: click.Context):
         obj: CLIConfig = common.initialize_config(
             ctx,
-            self.run_args.project,
-            self.run_args.domain,
-            self.run_args.root_dir,
-            tuple(self.run_args.image) or None,
-            not self.run_args.no_sync_local_sys_paths,
+            project=self.run_args.project,
+            domain=self.run_args.domain,
+            root_dir=self.run_args.root_dir,
+            images=tuple(self.run_args.image) or None,
+            sync_local_sys_paths=not self.run_args.no_sync_local_sys_paths,
         )
 
         async def _run():
@@ -522,16 +522,14 @@ run = TaskFiles(
     help=f"""
 Run a task from a python file or deployed task.
 
-To run a remote task that already exists in Flyte, use the {RUN_REMOTE_CMD} command:
-
 Example usage:
 
 ```bash
-flyte run --project my-project --domain development hello.py my_task --arg1 value1 --arg2 value2
+flyte run hello.py my_task --arg1 value1 --arg2 value2
 ```
 
 Arguments to the run command are provided right after the `run` command and before the file name.
-For example, the command above specifies the project and domain.
+Arguments for the task itself are provided after the task name.
 
 To run a task locally, use the `--local` flag. This will run the task in the local environment instead of the remote
 Flyte environment:
@@ -546,20 +544,20 @@ the code. Any images defined with `Image.from_ref_name("name")` will resolve to 
 corresponding URIs you specify here.
 
 ```bash
-flyte run hello.py my_task --image my_image=ghcr.io/myorg/my-image:v1.0
+flyte run --image my_image=ghcr.io/myorg/my-image:v1.0 hello.py my_task
 ```
 
 If the image name is not provided, it is regarded as a default image and will
 be used when no image is specified in TaskEnvironment:
 
 ```bash
-flyte run hello.py my_task --image ghcr.io/myorg/default-image:latest
+flyte run --image ghcr.io/myorg/default-image:latest hello.py my_task
 ```
 
 You can specify multiple image arguments:
 
 ```bash
-flyte run hello.py my_task --image ghcr.io/org/default:latest --image gpu=ghcr.io/org/gpu:v2.0
+flyte run --image ghcr.io/org/default:latest --image gpu=ghcr.io/org/gpu:v2.0 hello.py my_task
 ```
 
 To run tasks that you've already deployed to Flyte, use the {RUN_REMOTE_CMD} command:
@@ -578,6 +576,12 @@ You can specify the `--config` flag to point to a specific Flyte cluster:
 
 ```bash
 flyte run --config my-config.yaml {RUN_REMOTE_CMD} ...
+```
+
+You can override the default configured project and domain:
+
+```bash
+flyte run --project my-project --domain development hello.py my_task
 ```
 
 You can discover what deployed tasks are available by running:

--- a/src/flyte/cli/main.py
+++ b/src/flyte/cli/main.py
@@ -1,8 +1,8 @@
 import rich_click as click
 from typing_extensions import get_args
 
+import flyte
 from flyte._logging import LogFormat, initialize_logger, logger
-from flyte import __version__ as flyte_version
 
 from . import _common as common
 from ._abort import abort
@@ -71,7 +71,7 @@ def _verbosity_to_loglevel(verbosity: int) -> int | None:
 
 @click.group(cls=click.RichGroup)
 @click.version_option(
-    message=f"Flyte SDK version: {flyte_version}",
+    message=f"Flyte SDK version: {flyte.version()}",
 )
 @click.option(
     "--endpoint",


### PR DESCRIPTION
This pull request introduces improvements to the Flyte CLI, focusing on enhanced support for specifying container images during deployment and execution, as well as clearer documentation and argument handling. The changes provide users with more flexibility in configuring image URIs via CLI flags, improve help text for the `deploy` and `run` commands, and refine argument passing for better consistency.

### Image specification and argument handling:

* Added support for the `--image` flag in `DeployArguments` to allow specifying multiple image URIs directly from the CLI, enabling users to map image names to URIs at deploy time without code changes. (`src/flyte/cli/_deploy.py`)
* Updated initialization logic for both `deploy` and `run` commands to consistently pass image mappings and other arguments using keyword parameters, improving clarity and maintainability. (`src/flyte/cli/_deploy.py`, `src/flyte/cli/_run.py`) [[1]](diffhunk://#diff-f1ee3bed4e510702f771960eff179cf1a290e365db6b13c34baa8e772469f39aL124-R139) [[2]](diffhunk://#diff-db6fcfb5640e750d38d2804766e92759199a666731872af457a4d7133fa59afdL304-R308)

### Documentation and help text improvements:

* Significantly expanded the help text for the `deploy` command, including detailed usage instructions, flag explanations, and example commands for common scenarios such as recursive deployment, image overrides, versioning, and error handling. (`src/flyte/cli/_deploy.py`)
* Improved the help text for the `run` command, clarifying argument order, image flag usage, and providing more accurate example commands for local and remote task execution. (`src/flyte/cli/_run.py`) [[1]](diffhunk://#diff-db6fcfb5640e750d38d2804766e92759199a666731872af457a4d7133fa59afdL525-R532) [[2]](diffhunk://#diff-db6fcfb5640e750d38d2804766e92759199a666731872af457a4d7133fa59afdL549-R560)
* Added documentation for overriding project and domain via CLI flags in both `deploy` and `run` commands. (`src/flyte/cli/_run.py`)

### Minor codebase cleanup:

* Fixed import and version reporting in CLI main entrypoint to use `flyte.version()` for consistent SDK version output. (`src/flyte/cli/main.py`) [[1]](diffhunk://#diff-df5383518be653a60f5b150e7b223fd39b340e58e35a0a9bfe7fef6b3cafaeb2R4-L5) [[2]](diffhunk://#diff-df5383518be653a60f5b150e7b223fd39b340e58e35a0a9bfe7fef6b3cafaeb2L74-R74)