### PR TITLE
Fix inconsistent default image platform

### DIFF
--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -398,7 +398,7 @@ class Image:
     dockerfile: Optional[Path] = field(default=None)
     registry: Optional[str] = field(default=None)
     name: Optional[str] = field(default=None)
-    platform: Tuple[Architecture, ...] = field(default=("linux/amd64", "linux/amd64"))
+    platform: Tuple[Architecture, ...] = field(default=("linux/amd64", "linux/arm64"))
     python_version: Tuple[int, int] = field(default_factory=_detect_python_version)
     # Refer to the image_refs (name:image-uri) set in CLI or config
     _ref_name: Optional[str] = field(default=None)


### PR DESCRIPTION
I found out that when we try and instantiate an Image through different functions such as:
[from_debian_base()](https://github.com/flyteorg/flyte-sdk/blob/9ed28d9bfa8d5966b576bf385318e28222545029/src/flyte/_image.py#L507)
[from_dockerfile()](https://github.com/flyteorg/flyte-sdk/blob/9ed28d9bfa8d5966b576bf385318e28222545029/src/flyte/_image.py#L689)
[from_uv_script()](https://github.com/flyteorg/flyte-sdk/blob/9ed28d9bfa8d5966b576bf385318e28222545029/src/flyte/_image.py#L566)

Right now both of from_debian_base and from_uv_script functions changes the platform to multi-arch through [_get_default_image_for](https://github.com/flyteorg/flyte-sdk/blob/9ed28d9bfa8d5966b576bf385318e28222545029/src/flyte/_image.py#L446). Whereas only one function from_dockerfile get passed through [here](https://github.com/flyteorg/flyte-sdk/blob/9ed28d9bfa8d5966b576bf385318e28222545029/src/flyte/_image.py#L401) in which creating default ("linux/amd64",). Would it be slightly better if align the behavior across all methods?