### PR TITLE
set deref_symlinks to True

### DIFF
--- a/src/flyte/_code_bundle/bundle.py
+++ b/src/flyte/_code_bundle/bundle.py
@@ -144,7 +144,9 @@ async def build_code_bundle(
 
     logger.debug("Building code bundle.")
     with tempfile.TemporaryDirectory() as tmp_dir:
-        bundle_path, tar_size, archive_size = create_bundle(from_dir, pathlib.Path(tmp_dir), files, digest)
+        bundle_path, tar_size, archive_size = create_bundle(
+            from_dir, pathlib.Path(tmp_dir), files, digest, deref_symlinks=True
+        )
         logger.info(f"Code bundle created at {bundle_path}, size: {tar_size} MB, archive size: {archive_size} MB")
         if not dryrun:
             hash_digest, remote_path = await upload_file.aio(bundle_path)


### PR DESCRIPTION
<img width="748" height="118" alt="image" src="https://github.com/user-attachments/assets/9fe4c2ff-01ba-4991-aa7a-e5e456a4e126" />

``` python
import flyte
from utils.sym_cool_function import really_cool

image = (
    flyte.Image.from_debian_base(install_flyte=False)
    .with_apt_packages("git")
    .with_pip_packages("git+https://github.com/flyteorg/flyte-sdk.git@jan/symlinks")
)
env = flyte.TaskEnvironment("test", image=image)


@env.task
async def say_hii(x: str) -> str:
    print(really_cool())
    return f"The Python package says, {x}"


@env.task
async def jantestbazel(x: str = "Remote Bazel") -> str:
    return await say_hii(x=x)


if __name__ == "__main__":
    flyte.init_from_config()
    run = flyte.run(jantestbazel)
    print(run.url)
```

succeeds -> https://demo.hosted.unionai.cloud/v2/domain/development/project/jan-playground/runs/rckf5ktzkwfj4rtlh28r?i=a0