### PR TITLE
pass --image CLI args to init in recursive deploy mode

### DIFF
--- a/src/flyte/cli/_deploy.py
+++ b/src/flyte/cli/_deploy.py
@@ -195,6 +195,7 @@ class DeployEnvRecursiveCommand(click.Command):
             self.deploy_args.project,
             self.deploy_args.domain,
             sync_local_sys_paths=not self.deploy_args.no_sync_local_sys_paths,
+            images=tuple(self.deploy_args.image) or None,
         )
         with console.status("Deploying...", spinner="dots"):
             deployments = flyte.deploy(


### PR DESCRIPTION
## Summary
Fixes `--image` CLI args being ignored when using `--recursive` flag in deploy command.

## Bug
The `DeployEnvRecursiveCommand.invoke()` method doesn't pass `images` parameter to `obj.init()`, causing image reference lookup to fail.

## Fix
Add missing `images=tuple(self.deploy_args.image) or None` parameter at line 197.

## Test Cases

**Minimal repro code** (`wf.py`):
```python
import flyte

image = flyte.Image.from_ref_name("test")
env = flyte.TaskEnvironment(name="hello_world",
image=image)

@env.task
def fn(x: int) -> int:
    return x + 1

Before (broken):
$ flyte deploy --image
test=ghcr.io/flyteorg/flytekit:py3.9 --recursive .
Error: Image name 'test' not found in config.
Available: []

After (fixed):
$ flyte deploy --image
test=ghcr.io/flyteorg/flytekit:py3.9 --recursive .
✅ Deploying... (works correctly)
