### PR TITLE
adding additional files and folders to be ignored

### DIFF
--- a/src/flyte/_code_bundle/_ignore.py
+++ b/src/flyte/_code_bundle/_ignore.py
@@ -71,7 +71,25 @@ class GitIgnore(Ignore):
         return False
 
 
-STANDARD_IGNORE_PATTERNS = ["*.pyc", ".cache", ".cache/*", "__pycache__", "**/__pycache__"]
+STANDARD_IGNORE_PATTERNS = [
+    "*.pyc",
+    "__pycache__",
+    "**/__pycache__",
+    ".cache",
+    ".cache/*",
+    ".pytest_cache",
+    "**/.pytest_cache",
+    ".venv",
+    "venv",
+    "env",
+    "*.log",
+    ".env",
+    "*.egg-info",
+    "*.egg",
+    "dist",
+    "build",
+    "*.whl",
+]
 
 
 class StandardIgnore(Ignore):


### PR DESCRIPTION
Hi,

Adding additional files to be ignored while packaging the code file.

Initial ignore files include :

```
STANDARD_IGNORE_PATTERNS = ["*.pyc", ".cache", ".cache/*", "__pycache__", "**/__pycache__"]
```

New list of ignore files include:

```
STANDARD_IGNORE_PATTERNS = [
    "*.pyc",
    "__pycache__",
    "**/__pycache__",
    ".cache",
    ".cache/*",
    ".pytest_cache",
    "**/.pytest_cache",
    ".venv",
    "venv",
    "env",
    "*.log",
    ".env",
    "*.egg-info",
    "*.egg",
    "dist",
    "build",
    "*.whl",
]
```

Regards,