### PR TITLE
adding blake2b instead of md5 for collision proof hashing

### DIFF
--- a/src/flyte/_code_bundle/_packaging.py
+++ b/src/flyte/_code_bundle/_packaging.py
@@ -168,7 +168,7 @@ def compute_digest(source: Union[os.PathLike, List[os.PathLike]], filter: Option
     :param callable filter:
     :return Text:
     """
-    hasher = hashlib.md5()
+    hasher = hashlib.blake2b()
 
     def compute_digest_for_file(path: os.PathLike, rel_path: os.PathLike) -> None:
         # Only consider files that exist (e.g. disregard symlinks that point to non-existent files)


### PR DESCRIPTION
Hi,

Below is the modification from `md5` hashing to `blake`. Could we give it a try.

MD5 :-> Collision, unsafe, fast
blake2b -> no collision, safe, faster
sha256 -> no collision, safe, slower
blake3 -> no collision, safe, fastest; but will require installation of `blake3 (pip install blake3)` package as it is not yet part of the standard `hashlib`. This is very good for file content hashing.

Regards