### PR TITLE
Replacing bytes with chuck as keywords should not be shadowed

### DIFF
--- a/src/flyte/_code_bundle/_utils.py
+++ b/src/flyte/_code_bundle/_utils.py
@@ -153,10 +153,10 @@ def ls_relative_files(relative_paths: list[str], source_path: pathlib.Path) -> t
 def _filehash_update(path: Union[os.PathLike, str], hasher: hashlib._Hash) -> None:
     blocksize = 65536
     with open(path, "rb") as f:
-        bytes = f.read(blocksize)
-        while bytes:
-            hasher.update(bytes)
-            bytes = f.read(blocksize)
+        chunk = f.read(blocksize)
+        while chunk:
+            hasher.update(chunk)
+            chunk = f.read(blocksize)
 
 
 def _pathhash_update(path: Union[os.PathLike, str], hasher: hashlib._Hash) -> None:


### PR DESCRIPTION
Hi,

The `_filehash_update` has `bytes` as a variable which is a bad practice to shadow standard keywords. Replacing it with variable name `chunk`

Regards