### PR TITLE
feat: Add retry logic to file upload function

### DIFF
--- a/src/flyte/remote/_data.py
+++ b/src/flyte/remote/_data.py
@@ -62,7 +62,7 @@ async def _upload_with_retry(
     max_retries: int = 3,
     min_backoff_sec: float = 0.5,
     max_backoff_sec: float = 10.0,
-) -> httpx.Response:
+):
     """
     Upload file to signed URL with exponential backoff retry.
 
@@ -77,9 +77,6 @@ async def _upload_with_retry(
         max_retries: Maximum retry attempts (default: 3)
         min_backoff_sec: Initial backoff delay (default: 0.5)
         max_backoff_sec: Maximum backoff delay (default: 10.0)
-
-    Returns:
-        httpx.Response from successful upload
 
     Raises:
         RuntimeSystemError: If upload fails after all retries
@@ -124,8 +121,6 @@ async def _upload_with_retry(
                         f"Failed to upload {fp} to {signed_url}, status code: {put_resp.status_code}, "
                         f"response: {put_resp.text}",
                     )
-        return put_resp
-
     return None
 
 


### PR DESCRIPTION
This pull request introduces a robust retry mechanism for file uploads in the `src/flyte/remote/_data.py` module. The main improvement is the addition of an exponential backoff strategy for handling transient network and server errors during file uploads, replacing the previous single-attempt upload logic. This enhances reliability, especially in unstable network conditions.

**Resilience improvements for file uploads:**

* Added a new `_upload_with_retry` async function that uploads files using exponential backoff and retries on transient network errors and retryable HTTP status codes (408, 429, 500, 502, 503, 504). This function logs retries and raises a `RuntimeSystemError` if all attempts fail.
* Introduced a custom `_RetryableUploadError` exception and a helper function `_is_retryable_status_code` to distinguish between retryable and non-retryable HTTP errors.

**Integration with file upload flow:**

* Updated the `_upload_single_file` function to use `_upload_with_retry` instead of directly uploading the file in a single attempt, ensuring all uploads benefit from the new retry logic.
* Refactored header preparation and removed redundant file open/close logic in `_upload_single_file`, delegating the upload responsibility to the new retry-enabled function.