### PR TITLE
Enable custom accelerator device name

### DIFF
--- a/src/flyte/_internal/runtime/resources_serde.py
+++ b/src/flyte/_internal/runtime/resources_serde.py
@@ -89,7 +89,7 @@ def _get_disk_resource_entry(disk: str) -> tasks_pb2.Resources.ResourceEntry:
 def get_proto_extended_resources(resources: Resources | None) -> Optional[tasks_pb2.ExtendedResources]:
     """
     Get extended resources (GPU accelerator, shared memory) for the task.
-    
+
     :param resources: Resources object containing GPU and shared memory configuration
     :return: ExtendedResources protobuf or None if no extended resources are configured
     """
@@ -138,7 +138,6 @@ def _convert_resources_to_resource_entries(
                 # Partitioned GPUs (MIG) are handled separately at Pod spec creation
                 if device.partition is None:
                     request_entries.append(_get_gpu_resource_entry(device.quantity))
-
 
     if resources.disk is not None:
         request_entries.append(_get_disk_resource_entry(resources.disk))

--- a/src/flyte/_internal/runtime/resources_serde.py
+++ b/src/flyte/_internal/runtime/resources_serde.py
@@ -24,6 +24,9 @@ ACCELERATOR_DEVICE_MAP = {
     "V6E": "tpu-v6e-slice",
 }
 
+# Default prefix for GPU partition (MIG) resources
+DEFAULT_GPU_PARTITION_RESOURCE_PREFIX = "nvidia.com/mig"
+
 _DeviceClassToProto: Dict[DeviceClass, "tasks_pb2.GPUAccelerator.DeviceClass"] = {
     "GPU": tasks_pb2.GPUAccelerator.NVIDIA_GPU,
     "TPU": tasks_pb2.GPUAccelerator.GOOGLE_TPU,
@@ -85,8 +88,10 @@ def _get_disk_resource_entry(disk: str) -> tasks_pb2.Resources.ResourceEntry:
 
 def get_proto_extended_resources(resources: Resources | None) -> Optional[tasks_pb2.ExtendedResources]:
     """
-    TODO Implement partitioning logic string handling for GPU
-    :param resources:
+    Get extended resources (GPU accelerator, shared memory) for the task.
+    
+    :param resources: Resources object containing GPU and shared memory configuration
+    :return: ExtendedResources protobuf or None if no extended resources are configured
     """
     if resources is None:
         return None
@@ -128,7 +133,12 @@ def _convert_resources_to_resource_entries(
     if resources.gpu is not None:
         device = resources.get_device()
         if device is not None:
-            request_entries.append(_get_gpu_resource_entry(device.quantity))
+            if device.partition is None:
+                # Only add standard GPU resource if NO partition
+                # Partitioned GPUs (MIG) are handled separately at Pod spec creation
+                if device.partition is None:
+                    request_entries.append(_get_gpu_resource_entry(device.quantity))
+
 
     if resources.disk is not None:
         request_entries.append(_get_disk_resource_entry(resources.disk))

--- a/src/flyte/_internal/runtime/task_serde.py
+++ b/src/flyte/_internal/runtime/task_serde.py
@@ -287,7 +287,7 @@ def _get_mig_resources_from_extended_resources(
                                 Can be overridden via Resources.gpu_partition_resource_prefix
     :return: Dict mapping MIG resource name to quantity (e.g., {"nvidia.com/mig-1g.10gb": "1"})
     """
-    mig_resources = {}
+    mig_resources = Dict[str, str] = {}
 
     if extended_resources is None or not extended_resources.gpu_accelerator:
         return mig_resources

--- a/src/flyte/_resources.py
+++ b/src/flyte/_resources.py
@@ -367,8 +367,8 @@ class Resources:
     :param shm: The amount of shared memory to allocate to the task. This is a string of the form "10GiB" or "auto".
         If "auto", then the shared memory will be set to max amount of shared memory available on the node.
     :param gpu_partition_resource_prefix: Optional override for the GPU partition (MIG) resource name prefix.
-+       Defaults to "nvidia.com/mig" when a GPU partition is specified.  Only applies when GPU partition is requested.
-+       For example, set to "custom. company.com/mig" to override the resource name prefix.
+        Defaults to "nvidia.com/mig" when a GPU partition is specified. Only applies when GPU partition is requested.
+        For example, set to "custom.company.com/mig" to override the resource name prefix.
     """
 
     cpu: Union[CPUBaseType, Tuple[CPUBaseType, CPUBaseType], None] = None

--- a/src/flyte/_resources.py
+++ b/src/flyte/_resources.py
@@ -366,6 +366,9 @@ class Resources:
     :param disk: The amount of disk to allocate to the task. This is a string of the form "10GiB".
     :param shm: The amount of shared memory to allocate to the task. This is a string of the form "10GiB" or "auto".
         If "auto", then the shared memory will be set to max amount of shared memory available on the node.
+    :param gpu_partition_resource_prefix: Optional override for the GPU partition (MIG) resource name prefix.
++       Defaults to "nvidia.com/mig" when a GPU partition is specified.  Only applies when GPU partition is requested.
++       For example, set to "custom. company.com/mig" to override the resource name prefix.
     """
 
     cpu: Union[CPUBaseType, Tuple[CPUBaseType, CPUBaseType], None] = None
@@ -373,6 +376,7 @@ class Resources:
     gpu: Union[Accelerators, int, Device, None] = None
     disk: Union[str, None] = None
     shm: Union[str, Literal["auto"], None] = None
+    gpu_partition_resource_prefix: Optional[str] = None
 
     def __post_init__(self):
         if isinstance(self.cpu, tuple):

--- a/src/flyte/app/_runtime/app_serde.py
+++ b/src/flyte/app/_runtime/app_serde.py
@@ -99,7 +99,7 @@ def _get_mig_resources_from_extended_resources(
     :param device_quantity: The quantity of GPUs/partitions requested
     :return: Dict mapping MIG resource name to quantity (e.g., {"nvidia.com/mig-1g. 5gb": "1"})
     """
-    mig_resources = {}
+    mig_resources: Dict[str, str] = {}
 
     if extended_resources is None or not extended_resources.gpu_accelerator:
         return mig_resources

--- a/tests/flyte/internal/runtime/test_task_serde.py
+++ b/tests/flyte/internal/runtime/test_task_serde.py
@@ -16,6 +16,7 @@ from kubernetes.client import (
 
 import flyte
 from flyte import PodTemplate
+from flyte._internal.runtime.resources_serde import get_proto_extended_resources
 from flyte._internal.runtime.task_serde import (
     _get_k8s_pod,
     _get_urun_container,
@@ -242,7 +243,8 @@ def test_get_proto_k8s_pod_task():
     assert isinstance(proto_task, tasks_pb2.TaskTemplate)
 
     # Check k8s_pod
-    k8s_pod = _get_k8s_pod(_get_urun_container(context, t1), pod_template1)
+    extended_resources = get_proto_extended_resources(t1.resources)
+    k8s_pod = _get_k8s_pod(_get_urun_container(context, t1), pod_template1, t1, extended_resources)
     assert proto_task.k8s_pod == k8s_pod
     assert proto_task.k8s_pod.metadata.labels == {"foo": "bar"}
     assert proto_task.k8s_pod.metadata.annotations == {"baz": "qux"}


### PR DESCRIPTION
Design criteria:
- Construct the device name using a default `nvidia.com/mig` prefix but allow customers to override it if needed
- Don't alter the current behavior when GPUs are requested only by quantity or device name