### PR TITLE
feat[rs_controller]: add Rust lint targets and GitHub Action job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,6 +39,18 @@ jobs:
       - name: fmt
         run: |
           make -C rs_controller check-fmt
+  rs-lint:
+    name: rust lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch the code
+        uses: actions/checkout@v4
+      - name: Install toolchain
+        run: |
+          rustup toolchain install
+      - name: lint
+        run: |
+          make -C rs_controller lint
   mypy:
     name: make mypy
     runs-on: ubuntu-latest

--- a/rs_controller/Makefile
+++ b/rs_controller/Makefile
@@ -66,3 +66,11 @@ fmt: check-nightly-toolchain
 .PHONY: check-fmt
 check-fmt: check-nightly-toolchain
 	cargo +nightly fmt --check
+
+.PHONY: lint
+lint:
+	cargo clippy --all-targets -- -D warnings
+
+.PHONY: lint-fix
+lint-fix:
+	cargo clippy --all-targets --fix

--- a/rs_controller/src/action.rs
+++ b/rs_controller/src/action.rs
@@ -199,7 +199,7 @@ impl Action {
             friendly_name: task_spec
                 .task_template
                 .as_ref()
-                .and_then(|tt| tt.id.as_ref().and_then(|id| Some(id.name.clone()))),
+                .and_then(|tt| tt.id.as_ref().map(|id| id.name.clone())),
             group: group_data,
             task: Some(task_spec),
             inputs_uri: Some(inputs_uri),

--- a/rs_controller/src/bin/test_auth.rs
+++ b/rs_controller/src/bin/test_auth.rs
@@ -9,7 +9,6 @@ use std::{env, sync::Arc};
 ///   cargo run --bin test_auth
 use flyte_controller_base::auth::{AuthConfig, ClientCredentialsAuthenticator};
 use tonic::transport::Endpoint;
-use tracing_subscriber;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/rs_controller/src/bin/test_controller.rs
+++ b/rs_controller/src/bin/test_controller.rs
@@ -6,7 +6,6 @@ use std::env;
 /// Or without auth:
 ///   cargo run --bin test_controller -- http://localhost:8089
 use flyte_controller_base::core::CoreBaseController;
-use tracing_subscriber;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt()
@@ -16,7 +15,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("=== Flyte Core Controller Test ===\n");
 
     // Try to create a controller
-    let controller = if let Ok(api_key) = env::var("_UNION_EAGER_API_KEY") {
+    let _controller = if let Ok(api_key) = env::var("_UNION_EAGER_API_KEY") {
         println!("Using auth from _UNION_EAGER_API_KEY");
         // Set the env var back since CoreBaseController::new_with_auth reads it
         env::set_var("_UNION_EAGER_API_KEY", api_key);

--- a/rs_controller/src/bin/try_list_tasks.rs
+++ b/rs_controller/src/bin/try_list_tasks.rs
@@ -75,7 +75,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             Err(status) => {
                 eprintln!("Error calling gRPC: {}", status);
-                break Err(format!("gRPC error: {}", status).into());
+                break Err(format!("gRPC error: {}", status));
             }
         }
     };

--- a/rs_controller/src/core.rs
+++ b/rs_controller/src/core.rs
@@ -446,7 +446,7 @@ impl CoreBaseController {
             .get(&action.get_run_identifier(), &action.parent_action_name)
             .await
         {
-            let _ = informer
+            informer
                 .fire_completion_event(&action.action_id.name)
                 .await?;
         } else {
@@ -496,14 +496,12 @@ impl CoreBaseController {
             .as_ref()
             .and_then(|task| task.task_template.as_ref())
             .and_then(|task_template| task_template.id.as_ref())
-            .and_then(|core_task_id| {
-                Some(TaskIdentifier {
-                    version: core_task_id.version.clone(),
-                    org: core_task_id.org.clone(),
-                    project: core_task_id.project.clone(),
-                    domain: core_task_id.domain.clone(),
-                    name: core_task_id.name.clone(),
-                })
+            .map(|core_task_id| TaskIdentifier {
+                version: core_task_id.version.clone(),
+                org: core_task_id.org.clone(),
+                project: core_task_id.project.clone(),
+                domain: core_task_id.domain.clone(),
+                name: core_task_id.name.clone(),
             })
             .ok_or(ControllerError::RuntimeError(format!(
                 "TaskIdentifier missing from Action {:?}",

--- a/rs_controller/src/error.rs
+++ b/rs_controller/src/error.rs
@@ -11,7 +11,7 @@ pub enum ControllerError {
     #[error("System error: {0}")]
     SystemError(String),
     #[error("gRPC error: {0}")]
-    GrpcError(#[from] tonic::Status),
+    GrpcError(#[from] Box<tonic::Status>),
     #[error("Task error: {0}")]
     TaskError(String),
     #[error("Informer error: {0}")]

--- a/rs_controller/src/informer.rs
+++ b/rs_controller/src/informer.rs
@@ -487,7 +487,7 @@ impl InformerCache {
             "Acquiring write lock to save watch handle for: {}",
             informer_name
         );
-        let _ = informer.watch_handle.write().await.insert(_watch_handle);
+        *informer.watch_handle.write().await = Some(_watch_handle);
         info!("Watch handle saved for: {}", informer_name);
 
         // Optimistically wait for ready (sentinel) with timeout
@@ -577,6 +577,10 @@ impl InformerCache {
 
 #[cfg(test)]
 mod tests {
+    use flyteidl2::flyteidl::workflow::state_service_client::StateServiceClient;
+    use tonic::transport::Endpoint;
+    use tracing_subscriber::fmt;
+
     use super::*;
 
     async fn informer_main() {


### PR DESCRIPTION
Add Makefile targets for linting and autofix:
- lint: run cargo clippy
- lint-fix: run cargo clippy --fix

Update CI workflow to run the Rust lint job:
- add rs-lint job that checks out code, ensures toolchain,
  and runs make -C rs_controller lint

Fix all clippy warnings.

Signed-off-by: Sergey Vilgelm <sergey@union.ai>

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #476 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #473 
<!-- GitButler Footer Boundary Bottom -->

