### PR TITLE
Mock exit for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,3 +74,11 @@ def local_dummy_directory():
         yield temp_dir.name
     finally:
         temp_dir.cleanup()
+
+
+@pytest.fixture(autouse=True)
+def patch_os_exit(monkeypatch):
+    def mock_exit(code):
+        raise SystemExit(code)
+
+    monkeypatch.setattr(os, "_exit", mock_exit)


### PR DESCRIPTION
#478 and #475 added a force exit as a temporary measure until we can figure out grpc cleanup lags.  This messes with pytest/CLIRunner though so we should mock it out with the original.