### PR TITLE
common.initialize_config used instead of local initialize_config.Remo…

### DIFF
--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -18,7 +18,7 @@ from . import _common as common
 from ._params import to_click_option
 
 RUN_REMOTE_CMD = "deployed-task"
-
+initialize_config = common.initialize_config
 
 @lru_cache()
 def _list_tasks(


### PR DESCRIPTION
The run method uses initialize_config from the common package. Remove local package for clarity as it is unused