### PR TITLE
add detailed explaination about the datatype of the missing parameter…

### DIFF
--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -196,7 +196,7 @@ class RunTaskCommand(click.RichCommand):
             if isinstance(param, click.Option) and param.required:
                 param_name = param.name
                 if param_name not in ctx.params or ctx.params[param_name] is None:
-                    missing_params.append((param_name, param.type.get_metavar(param, ctx)))
+                    missing_params.append((param_name, param.type.get_metavar(param, ctx) or param.type.name.upper() or param.type))
 
         if missing_params:
             raise click.UsageError(
@@ -344,7 +344,7 @@ class RunRemoteTaskCommand(click.RichCommand):
             if isinstance(param, click.Option) and param.required:
                 param_name = param.name
                 if param_name not in ctx.params or ctx.params[param_name] is None:
-                    missing_params.append((param_name, param.type))
+                    missing_params.append((param_name, param.type.get_metavar(param, ctx) or param.type.name.upper() or param.type))
 
         if missing_params:
             raise click.UsageError(


### PR DESCRIPTION
A detailed explanation is required for the datatypes that is passes as an argument to the task. Currently when you run the below code:

```
flyte run --local hello.py main 
```
```
import flyte


# A TaskEnvironment provides a way of grouping the configuration used by tasks.
env = flyte.TaskEnvironment(name="hello_world")

# Use a TaskEnvironment to define tasks, which are regular Python functions.
@env.task
def fn(x: int) -> int: # Type annotations are recommended.
    slope, intercept = 2, 5
    return slope * x + intercept

# Tasks can call other tasks.
# All tasks defined with a given TaskEnvironment will run in their own separate containers,
# but those containers will all be configured identically.
@env.task
def main(x_list: list[int]) -> float:

    x_len = len(x_list)
    if x_len < 10:
        raise ValueError(f"x_list doesn't have a larger enough sample size, found: {x_len}")

    # flyte.map is like Python map, but runs in parallel.
    y_list = list(flyte.map(fn, x_list))
    y_mean = sum(y_list) / len(y_list)
    return y_mean

```

You get a result:
```
Error invoking command: Error invoking command: Missing required parameter(s): --x_list (type: None)
```

We need to provide the datatype in the exception so user are aware what needs to be passed.

Withe the changes you should get an error like below:

```
Error invoking command: Error invoking command: Missing required parameter(s): --x_list (type: json list) 
```

Regards
