### PR TITLE
combining pkce enum types

### DIFF
--- a/src/flyte/cli/_common.py
+++ b/src/flyte/cli/_common.py
@@ -81,9 +81,7 @@ def sanitize_auth_type(auth_type: str | None) -> str:
     """
     Convert the auth type to the mode that is used by the Flyte backend.
     """
-    if auth_type is None:
-        return "pkce"
-    if auth_type.lower() in _pkce_options:
+    if auth_type is None or auth_type.lower() in _pkce_options:
         return "Pkce"
     if auth_type.lower() in _device_flow_options:
         return "DeviceFlow"


### PR DESCRIPTION
Converting the code below:

```
if auth_type is None:
        return "pkce"
if auth_type.lower() in _pkce_options:
        return "Pkce"
```

to

```
if auth_type is None or auth_type.lower() in _pkce_options:
        return "Pkce"
```




