### PR TITLE
adding config file exception

### DIFF
--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -542,10 +542,10 @@ def get_init_config() -> _InitConfig:
     cfg = _get_init_config()
     if cfg is None:
         raise InitializationError(
-            "StorageNotInitializedError",
+            "ClientNotInitializedError",
             "user",
-            "Configuration has not been initialized. Call flyte.init() with a valid endpoint or",
-            " api-key before using this function.",
+            "Configuration has not been initialized. Call flyte.init() with a valid endpoint/api-key before",
+            " using this function or Call flyte.init_from_config() with a valid path to the config file",
         )
     return cfg
 
@@ -561,8 +561,9 @@ def get_storage() -> Storage | None:
         raise InitializationError(
             "StorageNotInitializedError",
             "user",
-            "Configuration has not been initialized. Call flyte.init() with a valid endpoint or",
-            " api-key before using this function.",
+            "Configuration has not been initialized. Call flyte.init() with a valid"
+            " storage configuration before using this function or Call flyte.init_from_config()" 
+            " with a valid path to the config file",
         )
     return cfg.storage
 
@@ -578,8 +579,8 @@ def get_client() -> ClientSet:
         raise InitializationError(
             "ClientNotInitializedError",
             "user",
-            "Client has not been initialized. Call flyte.init() with a valid endpoint or"
-            " api-key before using this function.",
+            "Client has not been initialized. Call flyte.init() with a valid endpoint/api-key "
+            "before using this function or Call flyte.init_from_config() with a valid path to the config file",
         )
     return cfg.client
 
@@ -615,8 +616,8 @@ def ensure_client():
         raise InitializationError(
             "ClientNotInitializedError",
             "user",
-            "Client has not been initialized. Call flyte.init() with a valid endpoint"
-            " or api-key before using this function.",
+            "Client has not been initialized. Call flyte.init() with a valid endpoint/api-key before using"
+            " this function or Call flyte.init_from_config() with a valid path to the config file",
         )
 
 
@@ -636,7 +637,8 @@ def requires_storage(func: T) -> T:
                 "StorageNotInitializedError",
                 "user",
                 f"Function '{func.__name__}' requires storage to be initialized. "
-                f"Call flyte.init() with a valid storage configuration before using this function.",
+                "Call flyte.init() with a valid storage configuration before using this function."
+                "or Call flyte.init_from_config() with a valid path to the config file",
             )
         return func(*args, **kwargs)
 
@@ -662,7 +664,8 @@ def requires_upload_location(func: T) -> T:
                 "No upload path configured",
                 "user",
                 f"Function '{func.__name__}' requires client to be initialized. "
-                f"Call flyte.init() with storage configuration before using this function.",
+                "Call flyte.init() with storage configuration before using this function."
+                "or Call flyte.init_from_config() with a valid path to the config file."
             )
         return func(*args, **kwargs)
 
@@ -684,7 +687,8 @@ def requires_initialization(func: T) -> T:
             raise InitializationError(
                 "NotInitConfiguredError",
                 "user",
-                f"Function '{func.__name__}' requires initialization. Call flyte.init() before using this function.",
+                f"Function '{func.__name__}' requires initialization. Call flyte.init() before using this function"
+                " or Call flyte.init_from_config() with a valid path to the config file."
             )
         return func(*args, **kwargs)
 
@@ -773,6 +777,7 @@ def current_domain() -> str:
         raise InitializationError(
             "DomainNotInitializedError",
             "user",
-            "Domain has not been initialized. Call flyte.init() with a valid domain before using this function.",
+            "Domain has not been initialized. Call flyte.init() with a valid domain before using this function"
+            " or Call flyte.init_from_config() with a valid path to the config file"
         )
     return cfg.domain

--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -250,7 +250,8 @@ class _Runner:
                     "ClientNotInitializedError",
                     "user",
                     "flyte.run requires client to be initialized. "
-                    "Call flyte.init() with a valid endpoint or api-key before using this function.",
+                    "Call flyte.init() with a valid endpoint/api-key before using this function"
+                    "or Call flyte.init_from_config() with a valid path to the config file",
                 )
             run_id = None
             project_id = None

--- a/src/flyte/cli/main.py
+++ b/src/flyte/cli/main.py
@@ -214,8 +214,6 @@ def main(
     cfg = config.auto(config_file=config_file)
     if cfg.source:
         logger.debug(f"Using config file discovered at location `{cfg.source.absolute()}`")
-    else:
-        raise click.ClickException(f"Config file not found.Please provide the path to the config file or create one in the default path ~/.flyte/config.yaml")
 
     ctx.obj = CLIConfig(
         log_level=log_level,


### PR DESCRIPTION
Adding exception is config file is not provided by the user and if not present in the default path.
Currently it is not clear if the config file is missing as the error generated is for missing arguments like below:

`Error invoking command: Error invoking command: Missing required parameter(s): --name (type: TEXT) `

The config file might not be present in one of the default location as below:

```
a. ./config.yaml if it exists  (current working directory)   
b. ./.flyte/config.yaml if it exists (current working directory)       
c. <git_root>/.flyte/config.yaml if it exists         
d. `UCTL_CONFIG` environment variable                   
e. `FLYTECTL_CONFIG` environment variable         
f. ~/.union/config.yaml if it exists            
g. ~/.flyte/config.yaml if it exists   
```

This might not be the case. In such a scenario the user has to be made aware that the config file needs to be added in one of the default location or provide a path for the config file.
Regards