### PR TITLE
run sync app.server in a new event loop

### DIFF
--- a/examples/apps/single_script_fastapi_sync.py
+++ b/examples/apps/single_script_fastapi_sync.py
@@ -4,7 +4,6 @@ import uvicorn
 import flyte
 from flyte.app.extras import FastAPIAppEnvironment
 
-# {{docs-fragment fastapi-app}}
 app = fastapi.FastAPI()
 
 env = FastAPIAppEnvironment(
@@ -25,13 +24,11 @@ def server():
 @app.get("/")
 async def root() -> dict:
     return {"message": "Hello from FastAPI!"}
-# {{/docs-fragment fastapi-app}}
 
-# {{docs-fragment deploy}}
+
 if __name__ == "__main__":
     import logging
 
     flyte.init_from_config(log_level=logging.DEBUG)
     deployed_app = flyte.serve(env)
     print(f"App served at: {deployed_app.url}")
-# {{/docs-fragment deploy}}

--- a/src/flyte/_bin/serve.py
+++ b/src/flyte/_bin/serve.py
@@ -236,17 +236,12 @@ async def _serve(
         if asyncio.iscoroutinefunction(app_env._server):
             await app_env._server(**bound_params)
         else:
-            # Run the function on a new event loop, in case the sync function
+            # Run the function on a separate thread, in case the sync function
             # relies on third party libraries that use an event loop internally.
             def run_sync():
                 return app_env._server(**bound_params)
 
-            try:
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-                loop.run_until_complete(loop.run_in_executor(None, run_sync))
-            finally:
-                loop.close()
+            await loop.run_in_executor(None, run_sync)
     finally:
         await shutdown()
 


### PR DESCRIPTION
This PR fixes an issue where a user may use a library that leverages the existing event loop, which causes an error (e.g. `uvicorn.run`). It does so that creating a new event loop to run the user-defined synchronous code on.