### PR TITLE
Fix `from_ref_name`

### DIFF
--- a/examples/image/image_from_ref_name.py
+++ b/examples/image/image_from_ref_name.py
@@ -8,7 +8,7 @@ logger.setLevel(logging.DEBUG)
 noop_env = flyte.TaskEnvironment(
     name="env_from_image_ref_name",
     resources=flyte.Resources(cpu=1, memory="1Gi"),
-    image=flyte.Image.from_ref_name("custom-image").with_pip_packages("pandas"),
+    image=flyte.Image.from_ref_name("custom-image"),
 )
 
 


### PR DESCRIPTION
Previously, calling `from_ref_name` without subsequent builder commands
caused innappropriate call to `Image.uri` without prepopulating
`Image.base_image`.

This is a quickish fix but it may make sense to update Image class so
that every classmethod generator always yields a valid image and does
not rely on runtime order of operations

Signed-off-by: Michael Hotan <mike@union.ai>
