### PR TITLE
Stop truncating App URLs, include console deployment link too

### DIFF
--- a/src/flyte/app/_deploy.py
+++ b/src/flyte/app/_deploy.py
@@ -44,7 +44,7 @@ class DeployedAppEnvironment:
         return [
             [
                 ("type", "App"),
-                ("name", f"[link={self.deployed_app.url}]{self.deployed_app.name}[/link]"),
+                ("name", self.deployed_app.name),
                 ("revision", str(self.deployed_app.revision)),
                 (
                     "desired state",
@@ -53,6 +53,14 @@ class DeployedAppEnvironment:
                 (
                     "current state",
                     app_definition_pb2.Status.DeploymentStatus.Name(self.deployed_app.deployment_status),
+                ),
+                (
+                    "public_url",
+                    f"[link={self.deployed_app.url}]{self.deployed_app.url}[/link]",
+                ),
+                (
+                    "console_url",
+                    f"[link={self.deployed_app.endpoint}]{self.deployed_app.endpoint}[/link]",
                 ),
             ],
         ]

--- a/src/flyte/cli/_deploy.py
+++ b/src/flyte/cli/_deploy.py
@@ -149,15 +149,6 @@ class DeployEnvCommand(click.RichCommand):
         console.print(common.format("Environments", deployment[0].env_repr(), obj.output_format))
         console.print(common.format("Entities", deployment[0].table_repr(), obj.output_format))
 
-        # Print URLs on separate lines for apps
-        from flyte.app._deploy import DeployedAppEnvironment
-
-        # Check if any of the deployed environments is an app
-        for deployed_env in deployment[0].envs.values():
-            if isinstance(deployed_env, DeployedAppEnvironment):
-                console.print(f"\n[bold]App public url:[/bold] {deployed_env.deployed_app.endpoint}")
-                console.print(f"[bold]Union console:[/bold] {deployed_env.deployed_app.url}")
-
 
 class DeployEnvRecursiveCommand(click.Command):
     """


### PR DESCRIPTION
Before it was impossible to click the app public url
<img width="1022" height="260" alt="Screenshot 2026-01-20 at 9 58 27 AM" src="https://github.com/user-attachments/assets/20ee9dd2-a11b-495d-b293-916a50f761d1" />

Now you can access it and the deployment url in the Union console
<img width="948" height="305" alt="Screenshot 2026-01-20 at 9 58 01 AM" src="https://github.com/user-attachments/assets/d5a219d8-9e79-473c-89a0-547318e98ac6" />
