### PR TITLE
[Fix] Make batch size configurable in Dir `from_local`

### DIFF
--- a/src/flyte/io/_dir.py
+++ b/src/flyte/io/_dir.py
@@ -623,7 +623,7 @@ class Dir(BaseModel, Generic[T], SerializableType):
                           as an input to discoverable tasks. If not specified, the cache key will be based on
                           directory attributes.
             batch_size: Optional concurrency limit for uploading files. If not specified, the default value is
-              determined by the FLYTE_IO_MAX_CONCURRENCY environment variable (default: 32).
+              determined by the FLYTE_IO_BATCH_SIZE environment variable (default: 32).
 
         Returns:
             A new Dir instance pointing to the uploaded directory

--- a/src/flyte/storage/_storage.py
+++ b/src/flyte/storage/_storage.py
@@ -26,7 +26,7 @@ if typing.TYPE_CHECKING:
     from obstore import AsyncReadableFile, AsyncWritableFile
 
 _OBSTORE_SUPPORTED_PROTOCOLS = ["s3", "gs", "abfs", "abfss"]
-MAX_CONCURRENCY = int(os.getenv("FLYTE_IO_MAX_CONCURRENCY", str(32)))
+BATCH_SIZE = int(os.getenv("FLYTE_IO_BATCH_SIZE", str(32)))
 
 
 def _is_obstore_supported_protocol(protocol: str) -> bool:
@@ -279,7 +279,7 @@ async def put(
         to_path = ctx.raw_data.get_random_remote_path(file_name=name)
 
     if not batch_size:
-        batch_size = MAX_CONCURRENCY
+        batch_size = BATCH_SIZE
 
     file_system = get_underlying_filesystem(path=to_path)
     from_path = strip_file_header(from_path)


### PR DESCRIPTION
We discovered a large memory consumption when uploading large directory (e.g. `50GB`), the memory usage will reach `11GB` and throw timeout error. It's because in `fsspec`, the default batch size is set to the system file descriptor limit ([here](https://github.com/fsspec/filesystem_spec/blob/2576617e5cbe441bcc53b021bccd85ff3489fde7/fsspec/asyn.py#L185))

This PR did set the default to 32 same as the max concurrency set in `src/flyte/storage/_parallel_reader.py`

https://github.com/flyteorg/flyte-sdk/blob/6572a5d0b6e24badec6f7f5894158fd1ac6f99fc/src/flyte/storage/_parallel_reader.py#L22
