### PR TITLE
Add RequiresOption for CLI option dependencies

### DIFF
--- a/src/flyte/cli/_create.py
+++ b/src/flyte/cli/_create.py
@@ -5,7 +5,7 @@ import rich_click as click
 
 import flyte
 import flyte.cli._common as common
-from flyte.cli._option import MutuallyExclusiveOption
+from flyte.cli._option import DependentOption, MutuallyExclusiveOption
 from flyte.remote import SecretTypes
 
 
@@ -46,7 +46,9 @@ def create():
 @click.option(
     "--docker-config-path",
     type=click.Path(exists=True),
+    cls=DependentOption,
     help="Path to Docker config file (defaults to ~/.docker/config.json or $DOCKER_CONFIG).",
+    requires=["from_docker_config"],
 )
 @click.option(
     "--registries",

--- a/src/flyte/cli/_option.py
+++ b/src/flyte/cli/_option.py
@@ -1,4 +1,25 @@
+from typing import Set
+
 from click import Option, UsageError
+
+
+class RequiresMixin:
+    """Mixin that enforces that certain options must be present when this option is used."""
+
+    def __init__(self, *args, **kwargs):
+        self.requires: Set[str] = set(kwargs.pop("requires", []))
+        self.requires_error_format = kwargs.pop(
+            "requires_error_msg", "Illegal usage: option '{name}' requires '{required}' to be specified"
+        )
+        super().__init__(*args, **kwargs)
+
+    def handle_parse_result(self, ctx, opts, args):
+        self_present = self.name in opts and opts[self.name] is not None
+        if self_present and self.requires:
+            missing = [req for req in self.requires if req not in opts or opts[req] is None or opts[req] is False]
+            if missing:
+                raise UsageError(self.requires_error_format.format(name=self.name, required=", ".join(missing)))
+        return super().handle_parse_result(ctx, opts, args)
 
 
 class MutuallyExclusiveMixin:
@@ -30,4 +51,30 @@ class MutuallyExclusiveOption(MutuallyExclusiveMixin, Option):
         help = kwargs.get("help", "")
         if mutually_exclusive:
             kwargs["help"] = help + f" Mutually exclusive with {', '.join(mutually_exclusive)}."
+        super().__init__(*args, **kwargs)
+
+
+class RequiresOption(RequiresMixin, Option):
+    """Option that requires other options to be present."""
+
+    def __init__(self, *args, **kwargs):
+        requires = kwargs.get("requires", [])
+        help = kwargs.get("help", "")
+        if requires:
+            kwargs["help"] = help + f" Requires {', '.join(requires)}."
+        super().__init__(*args, **kwargs)
+
+
+class DependentOption(RequiresMixin, MutuallyExclusiveMixin, Option):
+    """Option that supports both 'requires' and 'mutually_exclusive' constraints."""
+
+    def __init__(self, *args, **kwargs):
+        requires = kwargs.get("requires", [])
+        mutually_exclusive = kwargs.get("mutually_exclusive", [])
+        help = kwargs.get("help", "")
+        if mutually_exclusive:
+            help = help + f" Mutually exclusive with {', '.join(mutually_exclusive)}."
+        if requires:
+            help = help + f" Requires {', '.join(requires)}."
+        kwargs["help"] = help
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
## Summary
- Add `RequiresMixin` and `DependentOption` classes to enforce CLI option dependencies
- `--docker-config-path` now requires `--from-docker-config` to be specified
- Users will see a clear error message if they provide `--docker-config-path` without `--from-docker-config`

## Test plan
- [x] Run `flyte create secret test --type image_pull --docker-config-path /tmp/config` and verify it errors with "requires 'from_docker_config' to be specified"
- [x] Run `flyte create secret test --type image_pull --from-docker-config --docker-config-path /tmp/config` and verify it works (with valid config)

Before:
```
(flyte-sdk) (flyte-sdk) ➜  flyte-sdk git:(main) ✗ flyte create secret --type image_pull t --docker-config-path ~/.docker/config.json   
Enter secret value: 

```

After:
```
(flyte-sdk) (flyte-sdk) ➜  flyte-sdk git:(docker-config) ✗ flyte create secret --type image_pull t --docker-config-path ~/.docker/config.json
╭─ Error ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Illegal usage: option 'docker_config_path' requires 'from_docker_config' to be specified                                                                                                               │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
