### PR TITLE
Disable rich formatting (spinner, colors) for json and table-simple output formats

### DIFF
--- a/examples/plugins/polars/polars_dataframe_inputs.py
+++ b/examples/plugins/polars/polars_dataframe_inputs.py
@@ -42,12 +42,10 @@ import polars as pl
 
 import flyte
 import flyte.io
-from flyte._image import DIST_FOLDER, PythonWheels
 
 # Create task environment with required dependencies
-img = (
-    flyte.Image.from_debian_base(name="flyteplugins-polars-image")
-    .with_pip_packages("flyteplugins-polars>=2.0.0b52", "flyte>=2.0.0b52", pre=True)
+img = flyte.Image.from_debian_base(name="flyteplugins-polars-image").with_pip_packages(
+    "flyteplugins-polars>=2.0.0b52", "flyte>=2.0.0b52", pre=True
 )
 
 env = flyte.TaskEnvironment(

--- a/examples/plugins/polars_dataframe.py
+++ b/examples/plugins/polars_dataframe.py
@@ -12,9 +12,8 @@ import polars as pl
 import flyte
 
 # Create task environment with required dependencies
-img = (
-    flyte.Image.from_debian_base(name="flyteplugins-polars-image")
-    .with_pip_packages("flyteplugins-polars>=2.0.0b52", "flyte>=2.0.0b52", pre=True)
+img = flyte.Image.from_debian_base(name="flyteplugins-polars-image").with_pip_packages(
+    "flyteplugins-polars>=2.0.0b52", "flyte>=2.0.0b52", pre=True
 )
 
 env = flyte.TaskEnvironment(

--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -11,7 +11,6 @@ import aiofiles
 import click
 
 from flyte import Secret
-
 from flyte._code_bundle._ignore import STANDARD_IGNORE_PATTERNS
 from flyte._image import (
     AptPackages,

--- a/src/flyte/_internal/imagebuild/remote_builder.py
+++ b/src/flyte/_internal/imagebuild/remote_builder.py
@@ -13,9 +13,9 @@ import aiofiles
 from flyteidl2.common import phase_pb2
 
 import flyte
-from flyte._code_bundle._ignore import STANDARD_IGNORE_PATTERNS
 import flyte.errors
 from flyte import Image, remote
+from flyte._code_bundle._ignore import STANDARD_IGNORE_PATTERNS
 from flyte._code_bundle._utils import tar_strip_file_attributes
 from flyte._image import (
     _BASE_REGISTRY,
@@ -339,7 +339,9 @@ def _get_layers_proto(image: Image, context_path: Path) -> "image_definition_pb2
                 case "install_project":
                     # Copy the entire project
                     docker_ignore_patterns = get_and_list_dockerignore(image)
-                    pyproject_dir_dst = copy_files_to_context(layer.pyproject.parent, context_path, docker_ignore_patterns)
+                    pyproject_dir_dst = copy_files_to_context(
+                        layer.pyproject.parent, context_path, docker_ignore_patterns
+                    )
                 case _:
                     raise ValueError(f"Invalid project install mode: {layer.project_install_mode}")
 

--- a/src/flyte/cli/_common.py
+++ b/src/flyte/cli/_common.py
@@ -430,11 +430,11 @@ def format(title: str, vals: Iterable[Any], of: OutputFormat = "table") -> Table
         case "json":
             if not vals:
                 return pretty_repr([])
-            return pretty_repr([v.to_dict() for v in vals])
+            return pretty_repr([dict(v) for v in vals])
         case "json-raw":
             if not vals:
                 return []
-            return json.dumps([v.to_dict() for v in vals])
+            return json.dumps([dict(v) for v in vals])
 
     raise click.ClickException("Unknown output format. Supported formats are: table, table-simple, json.")
 
@@ -457,6 +457,18 @@ def get_console() -> Console:
     Get a console that is configured to use colors if the terminal supports it.
     """
     return Console(color_system="auto", force_terminal=True, width=120)
+
+
+def cli_status(output_format: OutputFormat, message: str, spinner: str = "dots"):
+    """
+    Return a context manager for status display.
+    Returns nullcontext for json/table-simple formats, otherwise a console status spinner.
+    """
+    from contextlib import nullcontext
+
+    if output_format in ("json", "table-simple"):
+        return nullcontext()
+    return get_console().status(message, spinner=spinner)
 
 
 def parse_images(cfg: Config, values: tuple[str, ...] | None) -> None:

--- a/src/flyte/cli/_deploy.py
+++ b/src/flyte/cli/_deploy.py
@@ -138,7 +138,7 @@ class DeployEnvCommand(click.RichCommand):
             sync_local_sys_paths=not self.deploy_args.no_sync_local_sys_paths,
             images=tuple(self.deploy_args.image) or None,
         )
-        with console.status("Deploying...", spinner="dots"):
+        with common.cli_status(obj.output_format, "Deploying..."):
             deployment = flyte.deploy(
                 self.env,
                 dryrun=self.deploy_args.dry_run,
@@ -203,7 +203,7 @@ class DeployEnvRecursiveCommand(click.Command):
                 f"Failed to load {len(failed_paths)} files. Use --ignore-load-errors to ignore these errors."
             )
 
-        with console.status("Deploying...", spinner="dots"):
+        with common.cli_status(obj.output_format, "Deploying..."):
             deployments = flyte.deploy(
                 *all_envs,
                 dryrun=self.deploy_args.dry_run,

--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -230,20 +230,16 @@ Missing required parameter(s): {", ".join(f"--{p[0]} (type: {p[1]})" for p in mi
 
     async def _execute_and_render(self, ctx: click.Context, config: common.CLIConfig):
         """Separate execution logic from the Click entry point for better testability."""
-        from contextlib import nullcontext
-
         import flyte
 
         console = common.get_console()
 
         # 2. Execute with a UX Status Spinner (disabled for json/table-simple)
-        status_ctx = (
-            nullcontext()
-            if config.output_format in ("json", "table-simple")
-            else console.status(f"[bold blue]Launching {'local' if self.run_args.local else 'remote'} execution...", spinner="dots")
-        )
         try:
-            with status_ctx:
+            with common.cli_status(
+                config.output_format,
+                f"[bold blue]Launching {'local' if self.run_args.local else 'remote'} execution...",
+            ):
                 execution_context = flyte.with_runcontext(
                     copy_style=self.run_args.copy_style,
                     mode="local" if self.run_args.local else "remote",
@@ -417,8 +413,6 @@ Missing required parameter(s): {", ".join(f"--{p[0]} (type: {p[1]})" for p in mi
         """Separate execution logic from the Click entry point for better testability."""
         import flyte.remote
 
-        from contextlib import nullcontext
-
         task = flyte.remote.Task.get(self.task_name, version=self.version, auto_version="latest")
         console = common.get_console()
         if self.run_args.run_project or self.run_args.run_domain:
@@ -427,13 +421,11 @@ Missing required parameter(s): {", ".join(f"--{p[0]} (type: {p[1]})" for p in mi
             )
 
         # 2. Execute with a UX Status Spinner (disabled for json/table-simple)
-        status_ctx = (
-            nullcontext()
-            if config.output_format in ("json", "table-simple")
-            else console.status(f"[bold blue]Launching {'local' if self.run_args.local else 'remote'} execution...", spinner="dots")
-        )
         try:
-            with status_ctx:
+            with common.cli_status(
+                config.output_format,
+                f"[bold blue]Launching {'local' if self.run_args.local else 'remote'} execution...",
+            ):
                 execution_context = flyte.with_runcontext(
                     copy_style=self.run_args.copy_style,
                     mode="local" if self.run_args.local else "remote",


### PR DESCRIPTION
## Summary
- Disable rich-formatted output (spinner, panels, colored text) when `--log-format json` is used
- Output pure JSON for run success/error messages to ensure machine-parseable output
- Suppress informational messages (e.g., "Waiting for log stream...") in JSON mode

## Test plan
- [ ] Run `flyte --log-format json run <task>` and verify only JSON output appears
- [ ] Run `flyte run <task>` (default) and verify rich formatting still works