### PR TITLE
Fix duplicate secrets in image build commands

### DIFF
--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -415,6 +415,7 @@ class WorkDirHandler:
 
 def _get_secret_commands(layers: typing.Tuple[Layer, ...]) -> typing.List[str]:
     commands = []
+    seen_secrets: typing.Set[int] = set()
 
     def _get_secret_command(secret: str | Secret) -> typing.List[str]:
         if isinstance(secret, str):
@@ -433,7 +434,11 @@ def _get_secret_commands(layers: typing.Tuple[Layer, ...]) -> typing.List[str]:
         if isinstance(layer, (PipOption, AptPackages, Commands)):
             if layer.secret_mounts:
                 for secret_mount in layer.secret_mounts:
-                    commands.extend(_get_secret_command(secret_mount))
+                    secret = Secret(key=secret_mount) if isinstance(secret_mount, str) else secret_mount
+                    secret_id = hash(secret)
+                    if secret_id not in seen_secrets:
+                        seen_secrets.add(secret_id)
+                        commands.extend(_get_secret_command(secret_mount))
     return commands
 
 


### PR DESCRIPTION
## Summary
- Fix `_get_secret_commands` in `docker_builder.py` to deduplicate secrets when the same secret is used across multiple layers
- Fix `_get_build_secrets_from_image` in `remote_builder.py` to deduplicate secrets similarly
- Add unit tests verifying deduplication works for both functions

## Problem
When the same secret is used across multiple image layers (e.g., `with_apt_packages` and `with_pip_packages`), the secret commands were being added multiple times to the build command.

Example that triggered duplicates:
```python
import flyte
from flyte import Image, Secret

private_package = "git+https://$GITHUB_TOKEN2@github.com/pingsutw/flytex.git@2e20a2acebfc3877d84af643fdd768edea41d533"
image = (
    Image.from_debian_base(install_flyte=True)
    .with_apt_packages("git", "vim", "curl", secret_mounts=Secret("GITHUB_TOKEN2"))
    .with_pip_packages(private_package, pre=True, secret_mounts=Secret("GITHUB_TOKEN2"))
)

env = flyte.TaskEnvironment(name="private_package", image=image)


@env.task
async def t1(data: str = "hello") -> str:
    return f"Hello {data}"


if __name__ == "__main__":
    flyte.init_from_config()
    run = flyte.run(t1, data="world")
    print(run.name)
    print(run.url)

```

## Solution
- **docker_builder.py**: Added `seen_secrets: Set[int]` to track secrets by their hash ID before adding to the commands list
- **remote_builder.py**: Added `seen_secrets: Set[Tuple[Optional[str], str]]` to track secrets by their `(group, key)` tuple

## Test plan
- [x] Added 8 unit tests covering various deduplication scenarios
- [x] All tests pass locally (`pytest tests/flyte/imagebuild/test_docker_builder.py -v`)