### PR TITLE
Remove BigQuery handlers from dataframe module

### DIFF
--- a/src/flyte/io/_dataframe/__init__.py
+++ b/src/flyte/io/_dataframe/__init__.py
@@ -61,27 +61,6 @@ def register_arrow_handlers():
     DataFrameTransformerEngine.register_renderer(pa.Table, ArrowRenderer())
 
 
-@functools.lru_cache(maxsize=None)
-def register_bigquery_handlers():
-    try:
-        from .bigquery import (
-            ArrowToBQEncodingHandlers,
-            BQToArrowDecodingHandler,
-            BQToPandasDecodingHandler,
-            PandasToBQEncodingHandlers,
-        )
-
-        DataFrameTransformerEngine.register(PandasToBQEncodingHandlers())
-        DataFrameTransformerEngine.register(BQToPandasDecodingHandler())
-        DataFrameTransformerEngine.register(ArrowToBQEncodingHandlers())
-        DataFrameTransformerEngine.register(BQToArrowDecodingHandler())
-    except ImportError:
-        logger.info(
-            "We won't register bigquery handler for structured dataset because "
-            "we can't find the packages google-cloud-bigquery-storage and google-cloud-bigquery"
-        )
-
-
 def lazy_import_dataframe_handler():
     if is_imported("pandas"):
         try:
@@ -94,11 +73,6 @@ def lazy_import_dataframe_handler():
             register_arrow_handlers()
         except DuplicateHandlerError:
             logger.debug("Transformer for arrow is already registered.")
-    if is_imported("google.cloud.bigquery"):
-        try:
-            register_bigquery_handlers()
-        except DuplicateHandlerError:
-            logger.debug("Transformer for bigquery is already registered.")
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- Remove `register_bigquery_handlers` function from the dataframe module
- Remove BigQuery handler registration from `lazy_import_dataframe_handler`
- This removes BigQuery-specific encoding/decoding handlers for structured datasets (ArrowToBQ, BQToArrow, PandasToBQ, BQToPandas)

## Test plan
- Verify existing dataframe tests pass without BigQuery handlers
- Ensure other dataframe handlers (pandas, arrow) still work correctly