### PR TITLE
Fix Literal string serialization

### DIFF
--- a/src/flyte/types/_type_engine.py
+++ b/src/flyte/types/_type_engine.py
@@ -973,7 +973,6 @@ class EnumTransformer(TypeTransformer[enum.Enum]):
         values = [v.value for v in t]  # type: ignore
         if not isinstance(values[0], str):
             raise TypeTransformerFailedError("Only EnumTypes with name of value are supported")
-        # Check if this is a LiteralEnum (Python 3.10+ compatible)
         if hasattr(t, "__name__") and t.__name__ == LITERAL_ENUM:
             # Use enum values directly when use Literal. e.g., Literal["low", "medium", "high"]
             return LiteralType(enum_type=types_pb2.EnumType(values=values))

--- a/tests/flyte/type_engine/test_enum.py
+++ b/tests/flyte/type_engine/test_enum.py
@@ -57,5 +57,3 @@ async def test_literal_string_serialization():
         # For LiteralEnum types, to_python_value returns the string value directly
         pv = await TypeEngine.to_python_value(lv, Intensity)
         assert pv == name
-
-


### PR DESCRIPTION
## Summary

This PR fixes a bug where serializing `Literal["low", "medium", "high"]` would fail with an `AttributeError`. The issue occurred because the code incorrectly tried to access the `name` attribute on string values, which don't have that attribute.

### Changes Made

- **Fixed `EnumTransformer.to_literal`**: Replaced `python_val.__getattribute__("name")` with `hasattr(python_val, "name")` check to prevent AttributeError on string values
- **Enhanced `EnumTransformer.get_literal_type`**: Added special handling for `LiteralEnum` types to use enum values directly instead of enum names
- **Added test**: Created `test_literal_string_serialization` to verify the fix works correctly with `Literal["low", "medium", "high"]`

### Before the Fix

```python
Intensity = Literal["low", "medium", "high"]
# Would fail with: AttributeError: 'str' object has no attribute 'name'
```

### After the Fix

```python
Intensity = Literal["low", "medium", "high"]
# Works correctly - strings are serialized properly
```

## Test Plan

1. Run the new test: `pytest tests/flyte/type_engine/test_enum.py::test_literal_string_serialization -v`
2. Verify the example works: `python examples/basics/enum_vals.py`
3. All enum tests pass: `pytest tests/flyte/type_engine/test_enum.py -v`

The test verifies:
- Literal types with string values can be converted to LiteralTypes
- String values can be serialized without AttributeError
- Roundtrip conversion (serialize → deserialize) works correctly