### PR TITLE
Add _U_AUTH_TYPE env var to init_in_cluster()

### DIFF
--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -451,6 +451,7 @@ async def init_in_cluster(
     ENDPOINT_OVERRIDE = "_U_EP_OVERRIDE"
     INSECURE_SKIP_VERIFY_OVERRIDE = "_U_INSECURE_SKIP_VERIFY"
     INSECURE_OVERRIDE = "_U_INSECURE"
+    AUTH_TYPE_OVERRIDE = "_U_AUTH_TYPE"
     _UNION_EAGER_API_KEY_ENV_VAR = "_UNION_EAGER_API_KEY"
     EAGER_API_KEY = "EAGER_API_KEY"
 
@@ -478,6 +479,13 @@ async def init_in_cluster(
     if str2bool(insecure_skip_verify_str):
         remote_kwargs["insecure_skip_verify"] = True
         logger.info("SSL certificate verification disabled (insecure_skip_verify=True)")
+
+    # Check for auth_type override (e.g. "Passthrough" for selfhosted deployments
+    # where the endpoint is the queue service which doesn't implement AuthMetadataService)
+    auth_type_str = os.getenv(AUTH_TYPE_OVERRIDE, "")
+    if auth_type_str:
+        remote_kwargs["auth_type"] = auth_type_str
+        logger.info(f"Auth type overridden to: {auth_type_str}")
 
     await init.aio(
         org=org, project=project, domain=domain, root_dir=Path.cwd(), image_builder="remote", **remote_kwargs


### PR DESCRIPTION
## Summary

- Adds support for the `_U_AUTH_TYPE` environment variable in `init_in_cluster()`, allowing task pods to override the default PKCE auth type
- When set to `"Passthrough"`, the SDK skips OAuth metadata fetching (`AuthMetadataService.GetOAuth2Metadata()`), which prevents cascading `DEADLINE_EXCEEDED` errors against endpoints that don't implement `AuthMetadataService`
- Intended for selfhosted / closed network environments where OAuth is not required and task pods connect directly to internal services (e.g. the queue service) bypassing ingress and authentication

## Test plan

- [x] Verify `_U_AUTH_TYPE=Passthrough` is picked up by `init_in_cluster()` and passed through to `init.aio()` as `auth_type`
- [x] Verify task pods in selfhosted deployments no longer hit `DEADLINE_EXCEEDED` on `EnqueueAction` gRPC calls
- [ ] Verify default behavior (no env var set) is unchanged — PKCE auth is used as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)