### PR TITLE
Add nested group example to grouping.py

### DIFF
--- a/examples/basics/grouping.py
+++ b/examples/basics/grouping.py
@@ -45,6 +45,8 @@ async def group_dynamic(x: int) -> List[int]:
         o1 = await asyncio.gather(*vals["even"])
     with flyte.group("odd-group"):
         o2 = await asyncio.gather(*vals["odd"])
+    with flyte.group("root_wf"):
+        await root_wf(x=10)
 
     return o1 + o2
 


### PR DESCRIPTION
## Summary
- Adds a nested group example to demonstrate that groups can be nested within other groups
- Calls `root_wf` within a new "root_wf" group inside the `group_dynamic` function

## Test plan
- Run the `grouping.py` example to verify nested groups work correctly
- Verify the group hierarchy is properly displayed in the Flyte UI


<img width="597" height="1057" alt="Screenshot 2026-02-12 at 4 04 04 PM" src="https://github.com/user-attachments/assets/9a48aa60-247d-4cc9-bcfa-af22356450f7" />
