### PR TITLE
set workdir to root earlier in image build process

### DIFF
--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -161,12 +161,14 @@ RUN uv venv $$VIRTUALENV --python=$PYTHON_VERSION && uv run --python=$$UV_PYTHON
 # Adds nvidia just in case it exists
 ENV PATH="$$PATH:/usr/local/nvidia/bin:/usr/local/cuda/bin" \
    LD_LIBRARY_PATH="/usr/local/nvidia/lib64"
+   
+   
+WORKDIR /root
 """)
 
 # This gets added on to the end of the dockerfile
 DOCKER_FILE_BASE_FOOTER = Template("""\
 ENV _F_IMG_ID=$F_IMG_ID
-WORKDIR /root
 SHELL ["/bin/bash", "-c"]
 """)
 


### PR DESCRIPTION
When `get_uv_editable_install_mounts` runs, it will add the target mount like so `target={editable_dep.relative_to(project_root)}`. If we set the WORKDIR in the footer, the wrong `project_root` is used as it's assumed to be `/`. This breaks the use or relative paths for editable installs like 
```
[tool.uv.sources]
flyte-env = { path = "../flyte-env", editable = true }
```