### PR TITLE
bugfix: cli common to dict when available

### DIFF
--- a/src/flyte/cli/_common.py
+++ b/src/flyte/cli/_common.py
@@ -430,11 +430,11 @@ def format(title: str, vals: Iterable[Any], of: OutputFormat = "table") -> Table
         case "json":
             if not vals:
                 return pretty_repr([])
-            return pretty_repr([dict(v) for v in vals])
+            return pretty_repr([v.to_dict() if hasattr(v, "to_dict") else dict(v) for v in vals])
         case "json-raw":
             if not vals:
                 return "[]"
-            return json.dumps([dict(v) for v in vals])
+            return json.dumps([v.to_dict() if hasattr(v, "to_dict") else dict(v) for v in vals])
 
     raise click.ClickException("Unknown output format. Supported formats are: table, table-simple, json.")
 


### PR DESCRIPTION
`flyte get run fbm4zqnjnxrzwtwbrcg9` is currently failing with
-> `Error invoking command: 'RunDetails' object is not iterable` 

same for 
`flyte get action -p jan-playground -d development rx558bjvt24frkk72g8z a0` 
-> `Error invoking command: 'Action' object is not iterable`


- _common.py (format function): assumes items are iterable for JSON.
- remote.Action  or remote.RunDetails is not iterable, so dict(Action) raises TypeError: 'Action' object is not iterable.

This PR:
- Update the JSON formatter to use to_dict() when available

``` bash
flyte get action -p jan-playground -d development rx558bjvt24frkk72g8z a0                                                                                                                                 
[
    {
        'id': {
            'run': {
                'org': 'dogfood',
                'project': 'jan-playground',
                'domain': 'development',
                'name': 'rx558bjvt24frkk72g8z'
            },
            'name': 'a0'
        },
        'metadata': {
            'executedBy': {
                'user': {
                    'id': {'subject': '00ucd5xbcxysOR9sS1d7'},
                    'spec': {
                        'firstName': 'Jan',
                        'lastName': 'Fiedler',
                        'email': 'jan@union.ai'
                    }
                }
            },
            'task': {
                'id': {
                    'org': 'dogfood',
                    'project': 'jan-playground',
                    'domain': 'development',
                    'name': 'another.entry',
                    'version': '60d3054b563d466fd42825134c2dbd43'
                },
                'taskType': 'python',
                'shortName': 'entry'
            },
            'actionType': 'ACTION_TYPE_TASK',
            'environmentName': 'another',
            'funtionName': 'entry'
        },
        'status': {
            'phase': 'ACTION_PHASE_SUCCEEDED',
            'startTime': '2026-02-19T11:25:20.421581Z',
            'endTime': '2026-02-19T11:25:33Z',
            'attempts': 1,
            'durationMs': '12578'
        }
    }
]
```
