### PR TITLE
Update spark plugin to stable release >= 2.0.0

### DIFF
--- a/examples/plugins/spark_example.py
+++ b/examples/plugins/spark_example.py
@@ -10,7 +10,7 @@ import flyte.remote
 image = (
     flyte.Image.from_base("apache/spark-py:v3.4.0")
     .clone(name="spark", python_version=(3, 10), registry="ghcr.io/flyteorg", extendable=True)
-    .with_pip_packages("flyteplugins-spark", pre=True)
+    .with_pip_packages("flyteplugins-spark>=2.0.0")
 )
 
 task_env = flyte.TaskEnvironment(


### PR DESCRIPTION
## Summary
- Replace `pre=True` with a version constraint `>=2.0.0` when installing `flyteplugins-spark`
- This pins the dependency to stable releases instead of pre-release versions

## Test plan
- [x] Verify the Spark example builds correctly with the updated image definition