### PR TITLE
Fix shell injection of version-constrained pip package specs in dockerfile

### DIFF
--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -197,7 +198,7 @@ class PipAndRequirementsHandler:
         else:
             mount = ""
             requirements = list(layer.packages) if layer.packages else []
-            reqs = " ".join(requirements)
+            reqs = " ".join(shlex.quote(r) for r in requirements)
             pip_install_args = layer.get_pip_install_args()
             pip_install_args.append(reqs)
 


### PR DESCRIPTION
Package version constraints containing '<' or '>' (e.g. apache-airflow<=3.0.0) were passed unquoted into the Dockerfile RUN shell command, causing the shell to interpret '<' as an input redirection operator and fail with 'cannot open =3.0.0'.

Use shlex.quote() on each package spec so metacharacters are safely single-quoted.