### PR TITLE
fix: accept enum names as valid CLI inputs in EnumTransformer

### DIFF
--- a/src/flyte/types/_type_engine.py
+++ b/src/flyte/types/_type_engine.py
@@ -1038,8 +1038,13 @@ class EnumTransformer(TypeTransformer[enum.Enum]):
         raise ValueError(f"Enum transformer cannot reverse {literal_type}")
 
     def assert_type(self, t: Type[enum.Enum], v: T):
-        val = v.value if isinstance(v, enum.Enum) else v
-        if val not in [t_item.value for t_item in t]:
+        if isinstance(v, enum.Enum):
+            if not isinstance(v, t):
+                raise TypeTransformerFailedError(f"Value {v} is not in Enum {t}")
+            return
+        # For string inputs (e.g. from the CLI), accept enum names since the transformer
+        # serializes regular enums by name (get_literal_type returns names, not values).
+        if v not in [t_item.name for t_item in t] and v not in [t_item.value for t_item in t]:
             raise TypeTransformerFailedError(f"Value {v} is not in Enum {t}")
 
 

--- a/tests/flyte/type_engine/test_enum.py
+++ b/tests/flyte/type_engine/test_enum.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Literal
+from typing import List, Literal
 
 import pytest
 
@@ -11,6 +11,12 @@ class Foo(Enum):
     A = "AAA"
     B = "BBB"
     C = "CCC"
+
+
+class Color(Enum):
+    RED = "red"
+    GREEN = "green"
+    BLUE = "blue"
 
 
 @pytest.mark.asyncio
@@ -57,3 +63,35 @@ async def test_literal_string_serialization():
         # For LiteralEnum types, to_python_value returns the string value directly
         pv = await TypeEngine.to_python_value(lv, Intensity)
         assert pv == name
+
+
+@pytest.mark.asyncio
+async def test_enum_assert_type_accepts_name():
+    """Test that assert_type accepts enum names (e.g. 'RED') as valid values.
+
+    When using the CLI (e.g. flyte run --c '["RED"]'), inputs are passed as strings
+    matching the enum name. Previously assert_type only checked enum values ('red'),
+    causing a TypeTransformerFailedError for valid enum names.
+    """
+    lit = TypeEngine.to_literal_type(Color)
+    # Names are used on the wire for regular enums
+    assert lit.enum_type.values == ["RED", "GREEN", "BLUE"]
+
+    # Passing enum name as string should be accepted by assert_type and to_literal
+    lv = await TypeEngine.to_literal("RED", Color, lit)
+    assert lv.scalar.primitive.string_value == "RED"
+    pv = await TypeEngine.to_python_value(lv, Color)
+    assert pv == Color.RED
+
+    # Passing an actual enum instance should still work
+    lv2 = await TypeEngine.to_literal(Color.GREEN, Color, lit)
+    assert lv2.scalar.primitive.string_value == "GREEN"
+
+
+@pytest.mark.asyncio
+async def test_enum_in_list_accepts_name():
+    """Test that List[Enum] accepts enum names as strings (as passed by the CLI)."""
+    list_lit = TypeEngine.to_literal_type(List[Color])
+    lv = await TypeEngine.to_literal(["RED", "BLUE"], List[Color], list_lit)
+    assert lv.collection.literals[0].scalar.primitive.string_value == "RED"
+    assert lv.collection.literals[1].scalar.primitive.string_value == "BLUE"


### PR DESCRIPTION
## Summary

- `EnumTransformer.assert_type` was validating string inputs against enum **values** (e.g. `"red"`), but the transformer serializes regular enums by **name** (e.g. `"RED"`) everywhere else (`get_literal_type`, `to_literal`, `to_python_value`)
- This caused `flyte run --param '["RED"]'` to fail with `Value RED is not in Enum <enum 'Color'>` even though `"RED"` is a valid enum name
- Fix `assert_type` to accept both enum names and values for string inputs, consistent with the rest of the transformer

## Test plan

- [x] `pytest tests/flyte/type_engine/test_enum.py` — all 4 tests pass, including two new tests:
  - `test_enum_assert_type_accepts_name`: verifies `"RED"` is accepted for `Color.RED = "red"`
  - `test_enum_in_list_accepts_name`: verifies `["RED", "BLUE"]` works for `List[Color]` (the original failing case)
- [x] Manually verified: `flyte run kevin_examples/test.py test_enum --c '["RED"]'` now succeeds

```python
import enum
import typing

import flyte


class Color(enum.Enum):
    RED = "red"
    GREEN = "green"
    BLUE = "blue"


env = flyte.TaskEnvironment(name="test")


@env.task
def test_enum(c: typing.List[Color]) -> str:
    return f"Color is {c[0].value}"


if __name__ == "__main__":
    flyte.init_from_config(images="docker.io/pingsutw/test:latest")
    result = flyte.run(test_enum, c=[Color.RED])
    print(result.url)
```