### PR TITLE
bugfix: use correct field name for app metrics protocol

### DIFF
--- a/src/flyte/app/_runtime/app_serde.py
+++ b/src/flyte/app/_runtime/app_serde.py
@@ -218,9 +218,9 @@ def _get_scaling_metric(
         return None
 
     if isinstance(metric, Scaling.Concurrency):
-        return app_definition_pb2.ScalingMetric(concurrency=app_definition_pb2.Concurrency(val=metric.val))
+        return app_definition_pb2.ScalingMetric(concurrency=app_definition_pb2.Concurrency(target_value=metric.val))
     elif isinstance(metric, Scaling.RequestRate):
-        return app_definition_pb2.ScalingMetric(request_rate=app_definition_pb2.RequestRate(val=metric.val))
+        return app_definition_pb2.ScalingMetric(request_rate=app_definition_pb2.RequestRate(target_value=metric.val))
 
     return None
 

--- a/tests/flyte/app/runtime/test_app_serde.py
+++ b/tests/flyte/app/runtime/test_app_serde.py
@@ -206,26 +206,30 @@ def test_get_scaling_metric_none():
 
 def test_get_scaling_metric_concurrency():
     """
-    GOAL: Document bug in Concurrency metric serialization.
+    GOAL: Verify Concurrency metric is correctly serialized to protobuf.
 
-    The implementation uses 'val' field but protobuf expects 'target_value'.
+    Tests that Scaling.Concurrency.val is mapped to ScalingMetric.concurrency.target_value.
     """
     metric = Scaling.Concurrency(val=10)
-    # Note: Implementation currently has a bug - uses 'val' instead of 'target_value'
-    with pytest.raises(ValueError, match='has no "val" field'):
-        _get_scaling_metric(metric)
+    result = _get_scaling_metric(metric)
+
+    assert result is not None
+    assert result.HasField("concurrency")
+    assert result.concurrency.target_value == 10
 
 
 def test_get_scaling_metric_request_rate():
     """
-    GOAL: Document bug in RequestRate metric serialization.
+    GOAL: Verify RequestRate metric is correctly serialized to protobuf.
 
-    The implementation uses 'val' field but protobuf expects 'target_value'.
+    Tests that Scaling.RequestRate.val is mapped to ScalingMetric.request_rate.target_value.
     """
     metric = Scaling.RequestRate(val=100)
-    # Note: Implementation currently has a bug - uses 'val' instead of 'target_value'
-    with pytest.raises(ValueError, match='has no "val" field'):
-        _get_scaling_metric(metric)
+    result = _get_scaling_metric(metric)
+
+    assert result is not None
+    assert result.HasField("request_rate")
+    assert result.request_rate.target_value == 100
 
 
 def test_get_proto_container_basic():


### PR DESCRIPTION
This pull request fixes a bug in the serialization of scaling metrics to protobuf by ensuring that the correct field (`target_value`) is used instead of the incorrect field (`val`). It also updates the related unit tests to verify the correct serialization behavior.

**Bug fix: Scaling metric serialization**

* Updated `_get_scaling_metric` in `app_serde.py` to serialize `Scaling.Concurrency` and `Scaling.RequestRate` metrics using the `target_value` field, as expected by the protobuf definitions, instead of the incorrect `val` field.

**Testing improvements**

* Modified tests in `test_app_serde.py` to verify that the `target_value` field is correctly set in the resulting protobuf objects for both `Concurrency` and `RequestRate` metrics, replacing previous tests that documented the bug.