### PR TITLE
feat: .flyteinclude allowlist for code bundling 

### DIFF
--- a/src/flyte/_code_bundle/_include.py
+++ b/src/flyte/_code_bundle/_include.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+from typing import List
+
+from flyte._logging import logger
+
+
+class FlyteInclude:
+    """
+    Reads a .flyteinclude file and exposes patterns for allowlist-based bundling.
+
+    When a .flyteinclude file is present in the bundle root, build_code_bundle()
+    switches from ignore-based (walk everything, filter out) to include-based
+    (only bundle what is listed here).
+
+    Each line is a path, directory, or glob pattern relative to the root directory —
+    the same syntax accepted by AppEnvironment.include and ls_relative_files():
+      - A directory name (e.g. "lib1/") includes all files recursively within it.
+      - A glob pattern (e.g. "src/**/*.py") is expanded via Python's glob.glob().
+      - A plain file path (e.g. "config.yaml") includes that single file.
+
+    Lines starting with # and blank lines are ignored.
+    """
+
+    INCLUDE_FILE = ".flyteinclude"
+
+    def __init__(self, root: Path):
+        self.root = root
+        self.patterns = self._load_patterns()
+
+    def _load_patterns(self) -> List[str]:
+        include_file = self.root / self.INCLUDE_FILE
+        if not include_file.exists():
+            return []
+        logger.debug(f"Found .flyteinclude at {include_file}")
+        lines = include_file.read_text(encoding="utf-8").splitlines()
+        patterns = [line.strip() for line in lines if line.strip() and not line.strip().startswith("#")]
+        logger.debug(f"Loaded {len(patterns)} include patterns: {patterns}")
+        return patterns
+
+    @property
+    def has_patterns(self) -> bool:
+        return bool(self.patterns)

--- a/tests/flyte/code_bundle/test_include.py
+++ b/tests/flyte/code_bundle/test_include.py
@@ -1,0 +1,117 @@
+import tarfile
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from flyte._code_bundle._include import FlyteInclude
+from flyte._code_bundle.bundle import build_code_bundle
+
+
+def test_flyte_include_no_file():
+    """When no .flyteinclude file exists, has_patterns is False and patterns is empty."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir).resolve()
+        fi = FlyteInclude(root)
+        assert fi.has_patterns is False
+        assert fi.patterns == []
+
+
+def test_flyte_include_with_patterns():
+    """Parses paths, glob patterns, comments, and blank lines correctly."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir).resolve()
+        (root / ".flyteinclude").write_text(
+            "# this is a comment\n"
+            "\n"
+            "lib1/\n"
+            "  project2/  \n"  # leading/trailing whitespace stripped
+            "src/**/*.py\n"
+            "# another comment\n"
+            "pyproject.toml\n"
+        )
+        fi = FlyteInclude(root)
+        assert fi.has_patterns is True
+        assert fi.patterns == ["lib1/", "project2/", "src/**/*.py", "pyproject.toml"]
+
+
+def test_flyte_include_empty_file():
+    """An empty .flyteinclude (or all comments/blanks) yields no patterns."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir).resolve()
+        (root / ".flyteinclude").write_text("# just a comment\n\n")
+        fi = FlyteInclude(root)
+        assert fi.has_patterns is False
+        assert fi.patterns == []
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — full bundle flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_code_bundle_uses_flyteinclude():
+    """When .flyteinclude is present, build_code_bundle() bundles only the listed paths
+    and ignores everything else in the root directory."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir).resolve()
+
+        # Simulate a monorepo: lib1/ and project/ should be included, lib2/ should not.
+        (root / "lib1").mkdir()
+        (root / "lib1" / "utils.py").write_text("def helper(): pass")
+        (root / "lib1" / "models.py").write_text("class Model: pass")
+
+        (root / "lib2").mkdir()
+        (root / "lib2" / "other.py").write_text("def other(): pass")
+
+        (root / "project").mkdir()
+        (root / "project" / "workflow.py").write_text("import lib1")
+
+        (root / ".flyteinclude").write_text("lib1/\nproject/\n")
+
+        bundle_out = root / "bundle_out"
+        bundle_out.mkdir()
+
+        bundle = await build_code_bundle(root, dryrun=True, copy_bundle_to=bundle_out)
+
+        rel_files = {str(Path(f).relative_to(root)) for f in bundle.files}
+
+        assert "lib1/utils.py" in rel_files
+        assert "lib1/models.py" in rel_files
+        assert "project/workflow.py" in rel_files
+        # lib2 was not listed in .flyteinclude — must be absent
+        assert "lib2/other.py" not in rel_files
+
+        # Verify the tarball on disk matches: extract and check member names
+        assert bundle.tgz is not None
+        with tarfile.open(bundle.tgz, "r:gz") as tar:
+            names = set(tar.getnames())
+        assert "lib1/utils.py" in names
+        assert "project/workflow.py" in names
+        assert "lib2/other.py" not in names
+
+
+@pytest.mark.asyncio
+async def test_build_code_bundle_without_flyteinclude_walks_normally():
+    """Without .flyteinclude, build_code_bundle() falls back to the normal ignore-based
+    walk and includes all non-ignored files under the root."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir).resolve()
+
+        (root / "lib1").mkdir()
+        (root / "lib1" / "utils.py").write_text("def helper(): pass")
+
+        (root / "lib2").mkdir()
+        (root / "lib2" / "other.py").write_text("def other(): pass")
+
+        # No .flyteinclude — all files should be bundled
+        bundle_out = root / "bundle_out"
+        bundle_out.mkdir()
+
+        bundle = await build_code_bundle(root, dryrun=True, copy_bundle_to=bundle_out, copy_style="all")
+
+        rel_files = {str(Path(f).relative_to(root)) for f in bundle.files}
+
+        assert "lib1/utils.py" in rel_files
+        assert "lib2/other.py" in rel_files


### PR DESCRIPTION
## Summary

   - Adds `.flyteinclude` as an allowlist alternative to `.flyteignore` for code bundle control
   - When present in `root_dir`, only the listed paths are bundled — no ignore filtering applied
   - When absent, all existing behaviour is completely unchanged

   ## Motivation

   In large monorepos, `.flyteignore` requires enumerating hundreds of directories to exclude.
   `.flyteinclude` flips this: list only what you need, everything else is excluded automatically.

   ```
   # .flyteinclude
   lib1/
   lib2/
   ```
   
   ## root-dir and .flyteinclude

   `.flyteinclude` must live at `root_dir` and all patterns are resolved relative to it. For monorepos, point `root_dir` at the repo root:

   ```bash
   flyte run --root-dir /path/to/monorepo workflow.py my_task
   ```

   ## Test plan

     - `pytest tests/flyte/code_bundle/test_include.py -v`
     - `FlyteInclude` unit tests: no file, valid patterns, empty file
     - Integration: `.flyteinclude` present → only listed dirs in bundle + tarball 
     - Integration: `.flyteinclude` absent → normal walk unchanged
