### PR TITLE
feat: allow with_source_file to accept a list of paths 

### DIFF
--- a/tests/flyte/test_image.py
+++ b/tests/flyte/test_image.py
@@ -54,6 +54,25 @@ def test_with_source(tmp_path):
     file.touch()
     img.validate()
 
+    # list of paths — each becomes its own layer
+    file2 = tmp_path / "helper.py"
+    file2.touch()
+    img2 = Image.from_debian_base(registry="localhost", name="test-image", flyte_version="0.2.0b14").with_source_file(
+        [file, file2]
+    )
+    assert img2._layers[-2].src == file
+    assert img2._layers[-1].src == file2
+    img2.validate()
+
+    # duplicate filenames at the same dst must raise immediately
+    subdir = tmp_path / "sub"
+    subdir.mkdir()
+    file3 = subdir / "my_code.py"  # same name as file
+    with pytest.raises(ValueError, match="overwrite"):
+        Image.from_debian_base(registry="localhost", name="test-image", flyte_version="0.2.0b14").with_source_file(
+            [file, file3]
+        )
+
 
 def test_with_apt_packages():
     packages = ("curl", "vim")


### PR DESCRIPTION
## Summary         
`with_source_file` previously accepted only a single Path. This PR extends it to also accept a `List[Path]`, where each file becomes its own COPY layer in the image - equivalent to chaining multiple `with_source_file` calls. A ValueError is raised eagerly if two paths in the list share the same filename at the same destination, preventing silent overwrites in the Dockerfile.

  ## Test Plan
  - `pytest tests/flyte/test_image.py -k "test_with_source"` passes
  - Single Path argument still works (backward-compatible)
  - `[Path("a/x.py"), Path("b/x.py")]` raises ValueError with message mentioning "Multiple files with the same name would overwrite each other at destination [dst]"
  - `[Path("a.py"), Path("b.py")]` produces two separate CopyConfig layers in the correct order