### PR TITLE
fix: Populate creator field when deploying apps

### DIFF
--- a/src/flyte/app/_deploy.py
+++ b/src/flyte/app/_deploy.py
@@ -79,9 +79,11 @@ async def _deploy_app(
     """
     Deploy the given app.
     """
-    import flyte.errors
     from flyteidl2.auth import identity_pb2 as auth_identity_pb2
-    from flyteidl2.common import identifier_pb2, identity_pb2 as common_identity_pb2
+    from flyteidl2.common import identifier_pb2
+    from flyteidl2.common import identity_pb2 as common_identity_pb2
+
+    import flyte.errors
     from flyte.app._runtime import translate_app_env_to_idl
     from flyte.remote import App
 

--- a/tests/flyte/app/test_app_deploy.py
+++ b/tests/flyte/app/test_app_deploy.py
@@ -5,7 +5,6 @@ from flyteidl2.app import app_definition_pb2
 from flyteidl2.auth import identity_pb2
 
 from flyte.app._deploy import _deploy_app
-from flyte.app._app_environment import AppEnvironment
 from flyte.models import SerializationContext
 
 
@@ -86,9 +85,7 @@ class TestDeployAppCreator:
             mock_create.aio.assert_called_once_with(mock_app_idl)
 
     @pytest.mark.asyncio
-    async def test_deploy_app_continues_if_user_info_fails(
-        self, mock_serialization_context, mock_app_idl
-    ):
+    async def test_deploy_app_continues_if_user_info_fails(self, mock_serialization_context, mock_app_idl):
         """Test that _deploy_app continues even if fetching user info fails."""
         mock_identity_service = AsyncMock()
         mock_identity_service.UserInfo = AsyncMock(side_effect=Exception("auth error"))


### PR DESCRIPTION
## Summary

The server requires `spec.creator.principal` (an `EnrichedIdentity` with a `User` or `Application`) when creating apps. The SDK was not setting this field, causing app deployments to fail with:

```
INVALID_ARGUMENT: validation error:
- app.spec.creator.principal: exactly one field is required in oneof [required]
```

## Changes

- **`src/flyte/app/_deploy.py`**: After building the app IDL and before sending the create request, fetch the current authenticated user via `identity_service.UserInfo()` and populate `spec.creator` with an `EnrichedIdentity` containing the user's subject. Wrapped in try/except so deploy continues gracefully if the identity call fails.
- **`tests/flyte/app/test_app_deploy.py`**: New tests verifying creator is set from user info, and that deploy continues with a warning if the identity call fails.

## Test Plan

- 2 new unit tests pass
- All 23 existing app tests pass