### PR TITLE
fix: always use .aio() for Flyte tasks in FunctionTool.execute()  

### DIFF
--- a/plugins/anthropic/src/flyteplugins/anthropic/agents/_function_tools.py
+++ b/plugins/anthropic/src/flyteplugins/anthropic/agents/_function_tools.py
@@ -50,12 +50,14 @@ class FunctionTool:
     async def execute(self, **kwargs) -> typing.Any:
         """Execute the tool with the given arguments.
 
-        Async functions are awaited directly. Sync functions are run in a
-        thread executor to avoid blocking the event loop.
+        If a Flyte task is associated, task.aio() is always used — this routes
+        through the Flyte controller in a task context (handling both sync and
+        async tasks correctly) and falls back to forward() locally.
+        For plain callables, async functions are awaited directly and sync
+        functions are run in a thread executor to avoid blocking the event loop.
         """
         if self.task is not None:
-            if self.is_async:
-                return await self.task.aio(**kwargs)
+            return await self.task.aio(**kwargs)
         if self.is_async:
             return await self.func(**kwargs)
         return await asyncio.to_thread(self.func, **kwargs)

--- a/plugins/anthropic/tests/test_agents.py
+++ b/plugins/anthropic/tests/test_agents.py
@@ -451,6 +451,25 @@ async def test_function_tool_execute_flyte_task():
 
 
 @pytest.mark.asyncio
+async def test_function_tool_execute_sync_flyte_task_uses_aio():
+    """Verify task.aio() is called (not self.func) for sync Flyte tasks."""
+    env = flyte.TaskEnvironment("test-exec-sync-aio-path")
+
+    @env.task
+    def multiply(a: int, b: int) -> int:
+        """Multiply two numbers."""
+        return a * b
+
+    tool = function_tool(multiply)
+
+    with patch.object(tool.task, "aio", new_callable=AsyncMock, return_value=42) as mock_aio:
+        result = await tool.execute(a=6, b=7)
+
+    mock_aio.assert_called_once_with(a=6, b=7)
+    assert result == 42
+
+
+@pytest.mark.asyncio
 async def test_function_tool_execute_async_flyte_task_uses_aio():
     """Verify task.aio() is called (not self.func) for async Flyte tasks."""
     env = flyte.TaskEnvironment("test-exec-aio-path")


### PR DESCRIPTION
## Summary:
  - FunctionTool.execute() was only calling task.aio() for async tasks; sync tasks fell through to asyncio.to_thread(self.func, ...), bypassing the Flyte task infrastructure entirely
  - Fix: always call task.aio() when a task is present, regardless of whether the underlying function is async

## Test plan:
  - test_function_tool_execute_sync_flyte_task_uses_aio — verifies task.aio() is called (not raw func) for sync Flyte tasks
  - test_function_tool_execute_async_flyte_task_uses_aio — verifies task.aio() is called for async Flyte tasks
  - test_function_tool_execute_flyte_task — verifies correct result is returned for sync
  Flyte tasks
  - Run full suite: cd plugins/anthropic && uv run pytest tests/test_agents.py
