### PR TITLE
fix: skip auth interceptors when insecure=True

### DIFF
--- a/src/flyte/remote/_client/auth/_channel.py
+++ b/src/flyte/remote/_client/auth/_channel.py
@@ -211,16 +211,20 @@ async def create_channel(
     proxy_auth_interceptors = create_proxy_auth_interceptors(endpoint, http_session=http_session, **kwargs)
     interceptors.extend(proxy_auth_interceptors)
 
-    # Get auth interceptors
-    auth_interceptors = create_auth_interceptors(
-        endpoint=endpoint,
-        in_channel=unauthenticated_channel,
-        insecure=insecure,
-        insecure_skip_verify=insecure_skip_verify,
-        ca_cert_file_path=ca_cert_file_path,
-        http_session=http_session,
-        **kwargs,
-    )
+    # Get auth interceptors — skip when insecure=True,
+    # since a plaintext channel typically means no auth server is available.
+    if insecure:
+        auth_interceptors = []
+    else:
+        auth_interceptors = create_auth_interceptors(
+            endpoint=endpoint,
+            in_channel=unauthenticated_channel,
+            insecure=insecure,
+            insecure_skip_verify=insecure_skip_verify,
+            ca_cert_file_path=ca_cert_file_path,
+            http_session=http_session,
+            **kwargs,
+        )
 
     interceptors.extend(auth_interceptors)
 

--- a/tests/flyte/remote/test_auth.py
+++ b/tests/flyte/remote/test_auth.py
@@ -3,8 +3,43 @@ from unittest import mock
 
 import grpc
 import grpc.aio
+import pytest
 
 from flyte.remote._client.auth._channel import create_channel
+
+
+@pytest.mark.asyncio
+@mock.patch("flyte.remote._client.auth._channel.create_auth_interceptors")
+@mock.patch("flyte.remote._client.auth._channel.create_proxy_auth_interceptors", return_value=[])
+@mock.patch("flyte.remote._client.auth._channel.get_async_session")
+@mock.patch("grpc.aio.insecure_channel")
+async def test_insecure_skips_auth_interceptors(
+    mock_insecure_channel, mock_get_session, mock_proxy_auth, mock_create_auth
+):
+    """When insecure=True and no auth_type is given, auth interceptors should be skipped."""
+    mock_channel = mock.AsyncMock(spec=grpc.aio.Channel)
+    mock_insecure_channel.return_value = mock_channel
+
+    await create_channel("localhost:8080", insecure=True)
+
+    mock_create_auth.assert_not_called()
+
+
+@pytest.mark.asyncio
+@mock.patch("flyte.remote._client.auth._channel.create_auth_interceptors")
+@mock.patch("flyte.remote._client.auth._channel.create_proxy_auth_interceptors", return_value=[])
+@mock.patch("flyte.remote._client.auth._channel.get_async_session")
+@mock.patch("grpc.aio.insecure_channel")
+async def test_insecure_with_explicit_auth_type_still_skips_auth(
+    mock_insecure_channel, mock_get_session, mock_proxy_auth, mock_create_auth
+):
+    """When insecure=True, auth interceptors should be skipped even with an explicit auth_type."""
+    mock_channel = mock.AsyncMock(spec=grpc.aio.Channel)
+    mock_insecure_channel.return_value = mock_channel
+
+    await create_channel("localhost:8080", insecure=True, auth_type="ClientSecret", client_id="id", client_secret="s")
+
+    mock_create_auth.assert_not_called()
 
 
 class TestCreateChannel(unittest.TestCase):


### PR DESCRIPTION
## Summary
- When `insecure=True`, skip creating OAuth2/PKCE auth interceptors entirely in `create_channel()`
- Previously the SDK would attempt keyring access, token refresh, and OAuth2 metadata fetches even against servers that don't require auth
- Adds two unit tests verifying auth interceptors are skipped when `insecure=True`

## Test plan
- [x] `uv run pytest tests/flyte/remote/test_auth.py -v` — new tests pass
- [x] `uv run pytest tests/flyte/remote/test_passthrough.py -v` — existing tests unaffected