### PR TITLE
ci: check plugin uv.lock files are up-to-date

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,9 +61,17 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Python 3.12
         uses: ./.github/actions/setup-python-env
-      - name: Generate docs
+      - name: Check root uv.lock
         run: |
           uv lock --check
+      - name: Check plugin uv.lock files
+        run: |
+          for dir in plugins/*/; do
+            if [ -f "$dir/uv.lock" ]; then
+              echo "Checking $dir..."
+              uv lock --check --directory "$dir"
+            fi
+          done
 #  # Disabled for now, as it is failing
 #  check-import-profile:
 #    runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- The `uv-lock-check` CI job previously only verified the root `uv.lock` file
- Added a new step that iterates over all `plugins/*/` directories and runs `uv lock --check --directory` for each plugin that has a `uv.lock` file
- Uses auto-discovery so new plugins are automatically included

## Test plan
- [ ] Verify the lint workflow runs successfully on this PR
- [ ] Confirm that both root and plugin lock file checks pass