### PR TITLE
Add --plugin-variants flag to flyte gen docs

### DIFF
--- a/src/flyte/cli/_gen.py
+++ b/src/flyte/cli/_gen.py
@@ -16,13 +16,28 @@ def gen():
 
 @gen.command(cls=common.CommandBase)
 @click.option("--type", "doc_type", type=str, required=True, help="Type of documentation (valid: markdown)")
+@click.option(
+    "--plugin-variants",
+    "plugin_variants",
+    type=str,
+    default=None,
+    help="Hugo variant names for plugin commands (e.g., 'byoc selfmanaged'). "
+    "When set, plugin command sections and index entries are wrapped in "
+    "{{< variant >}} shortcodes. Core commands appear unconditionally.",
+)
 @click.pass_obj
-def docs(cfg: common.CLIConfig, doc_type: str, project: str | None = None, domain: str | None = None):
+def docs(
+    cfg: common.CLIConfig,
+    doc_type: str,
+    plugin_variants: str | None,
+    project: str | None = None,
+    domain: str | None = None,
+):
     """
     Generate documentation.
     """
     if doc_type == "markdown":
-        markdown(cfg)
+        markdown(cfg, plugin_variants=plugin_variants)
     else:
         raise click.ClickException("Invalid documentation type: {}".format(doc_type))
 
@@ -116,47 +131,198 @@ def get_plugin_info(cmd: click.Command) -> tuple[bool, str | None]:
     return False, None
 
 
-def markdown(cfg: common.CLIConfig):
+def _render_command(
+    cmd_path: str, cmd: click.Command, cmd_ctx: click.Context, is_plugin: bool, plugin_module: str | None
+) -> list[str]:
+    """Render a single command's documentation as a list of markdown lines."""
+    output = []
+    cmd_path_parts = cmd_path.split(" ")
+
+    output.append(f"{'#' * (len(cmd_path_parts) + 1)} {cmd_path}")
+
+    # Add plugin notice if this is a plugin command
+    if is_plugin and plugin_module:
+        output.append("")
+        output.append(f"> **Note:** This command is provided by the [`{plugin_module}`](#plugin-commands) plugin.")
+
+    # Add usage information
+    output.append("")
+    usage_line = f"{cmd_path}"
+
+    # Add [OPTIONS] if command has options
+    if any(isinstance(p, click.Option) for p in cmd.params):
+        usage_line += " [OPTIONS]"
+
+    # Add command-specific usage pattern
+    if isinstance(cmd, click.Group):
+        usage_line += " COMMAND [ARGS]..."
+    else:
+        # Add arguments if any
+        args = [p for p in cmd.params if isinstance(p, click.Argument)]
+        for arg in args:
+            if arg.name:  # Check if name is not None
+                if arg.required:
+                    usage_line += f" {arg.name.upper()}"
+                else:
+                    usage_line += f" [{arg.name.upper()}]"
+
+    output.append(f"**`{usage_line}`**")
+
+    if cmd.help:
+        output.append("")
+        output.append(f"{dedent(cmd.help)}")
+
+    if not cmd.params:
+        return output
+
+    params = cmd.get_params(cmd_ctx)
+
+    # Collect all data first to calculate column widths
+    table_data = []
+    for param in params:
+        if isinstance(param, click.Option):
+            # Format each option with backticks before joining
+            all_opts = param.opts + param.secondary_opts
+            if len(all_opts) == 1:
+                opts = f"`{all_opts[0]}`"
+            else:
+                opts = "".join(
+                    [
+                        "{{< multiline >}}",
+                        "\n".join([f"`{opt}`" for opt in all_opts]),
+                        "{{< /multiline >}}",
+                    ]
+                )
+            default_value = ""
+            if param.default is not None:
+                default_value = f"`{param.default}`"
+                default_value = default_value.replace(f"{getcwd()}/", "")
+            help_text = dedent(param.help) if param.help else ""
+            # Escape Hugo shortcode delimiters that may appear in help text
+            help_text = help_text.replace("{{<", r"{{&lt;").replace("{{%", r"{{&percnt;")
+            table_data.append([opts, f"`{param.type.name}`", default_value, help_text])
+
+    if not table_data:
+        return output
+
+    # Add table header with proper alignment
+    output.append("")
+    output.append("| Option | Type | Default | Description |")
+    output.append("|--------|------|---------|-------------|")
+
+    # Add table rows with proper alignment
+    for row in table_data:
+        output.append(f"| {row[0]} | {row[1]} | {row[2]} | {row[3]} |")
+
+    return output
+
+
+def _build_index_table(
+    groups: dict[str, list[tuple[str, bool, str | None]]],
+    metadata: dict[str, tuple[bool, str | None]] | None,
+    is_verb_table: bool,
+    include_plugins: bool,
+) -> list[str]:
+    """Build an index table (verb or noun), optionally filtering plugin entries.
+
+    Args:
+        groups: verb->nouns or noun->verbs mapping.
+        metadata: verb->(is_plugin, module) mapping (only for verb tables).
+        is_verb_table: True for verb (Action/On) table, False for noun (Object/Action) table.
+        include_plugins: Whether to include plugin entries.
     """
-    Generate documentation in Markdown format
+    output = []
+
+    if is_verb_table:
+        output.append("| Action | On |")
+        output.append("| ------ | -- |")
+    else:
+        output.append("| Object | Action |")
+        output.append("| ------ | -- |")
+
+    for key, entries in groups.items():
+        if is_verb_table:
+            key_is_plugin, _ = metadata.get(key, (False, None)) if metadata else (False, None)
+            if key_is_plugin and not include_plugins:
+                continue
+
+            key_display = key
+            if key_is_plugin and include_plugins:
+                key_display = f"{key}⁺"
+
+            # Filter entries based on include_plugins
+            filtered = [(n, ip, pm) for n, ip, pm in entries if include_plugins or not ip]
+            if not filtered and not key_is_plugin:
+                # Verb has no non-plugin nouns — still show it if it's a core verb
+                verb_link = f"[`{key_display}`](#flyte-{key})"
+                output.append(f"| {verb_link} | - |")
+            elif not filtered:
+                continue
+            else:
+                noun_links = []
+                for noun, noun_is_plugin, _ in filtered:
+                    noun_display = noun
+                    if noun_is_plugin and include_plugins:
+                        noun_display = f"{noun}⁺"
+                    noun_links.append(f"[`{noun_display}`](#flyte-{key}-{noun})")
+                if len(filtered) == 0:
+                    verb_link = f"[`{key_display}`](#flyte-{key})"
+                    output.append(f"| {verb_link} | - |")
+                else:
+                    output.append(f"| `{key_display}` | {', '.join(noun_links)}  |")
+        else:
+            # Noun table
+            filtered = [(v, ip, pm) for v, ip, pm in entries if include_plugins or not ip]
+            if not filtered:
+                continue
+
+            action_links = []
+            for action, action_is_plugin, _ in filtered:
+                action_display = action
+                if action_is_plugin and include_plugins:
+                    action_display = f"{action}⁺"
+                action_links.append(f"[`{action_display}`](#flyte-{action}-{key})")
+            output.append(f"| `{key}` | {', '.join(action_links)}  |")
+
+    return output
+
+
+def markdown(cfg: common.CLIConfig, plugin_variants: str | None = None):
+    """
+    Generate documentation in Markdown format.
+
+    Args:
+        cfg: CLI configuration.
+        plugin_variants: Space-separated Hugo variant names for plugin commands.
+            When set, plugin sections are wrapped in {{< variant >}} shortcodes.
     """
     ctx = cfg.ctx
 
-    output = []
-    # Store verbs with their nouns: {verb_name: [(noun_name, is_plugin, plugin_module), ...]}
+    # Collect command data
+    # Each entry: (cmd_path, cmd, cmd_ctx, is_plugin, plugin_module, rendered_lines)
+    command_data = []
     output_verb_groups: dict[str, list[tuple[str, bool, str | None]]] = {}
-    # Store verb metadata: {verb_name: (is_plugin, plugin_module)}
     verb_metadata: dict[str, tuple[bool, str | None]] = {}
-    # Store nouns with their verbs: {noun_name: [(verb_name, is_plugin, plugin_module), ...]}
     output_noun_groups: dict[str, list[tuple[str, bool, str | None]]] = {}
 
     processed = []
     commands = [*[("flyte", ctx.command, ctx)], *walk_commands(ctx)]
     for cmd_path, cmd, cmd_ctx in commands:
         if cmd in processed:
-            # We already processed this command, skip it
             continue
         processed.append(cmd)
-        output.append("")
 
         is_plugin, plugin_module = get_plugin_info(cmd)
-
         cmd_path_parts = cmd_path.split(" ")
 
         if len(cmd_path_parts) > 1:
             verb = cmd_path_parts[1]
-
-            # Store verb metadata
             if verb not in verb_metadata:
                 verb_metadata[verb] = (is_plugin, plugin_module)
-
-            # Initialize verb group if needed
             if verb not in output_verb_groups:
                 output_verb_groups[verb] = []
-
             if len(cmd_path_parts) > 2:
                 noun = cmd_path_parts[2]
-                # Add noun to verb's list
                 output_verb_groups[verb].append((noun, is_plugin, plugin_module))
 
         if len(cmd_path_parts) == 3:
@@ -166,147 +332,113 @@ def markdown(cfg: common.CLIConfig):
                 output_noun_groups[noun] = []
             output_noun_groups[noun].append((verb, is_plugin, plugin_module))
 
-        output.append(f"{'#' * (len(cmd_path_parts) + 1)} {cmd_path}")
+        rendered = _render_command(cmd_path, cmd, cmd_ctx, is_plugin, plugin_module)
+        command_data.append((cmd_path, is_plugin, plugin_module, rendered))
 
-        # Add plugin notice if this is a plugin command
-        if is_plugin and plugin_module:
-            output.append("")
-            output.append(
-                f"> **Note:** This command is provided by the `{plugin_module}` plugin. "
-                f"See the plugin documentation for installation instructions."
-            )
+    # --- Output ---
 
-        # Add usage information
-        output.append("")
-        usage_line = f"{cmd_path}"
+    has_plugins = any(ip for _, ip, _, _ in command_data)
+    use_variant_wrapping = plugin_variants and has_plugins
 
-        # Add [OPTIONS] if command has options
-        if any(isinstance(p, click.Option) for p in cmd.params):
-            usage_line += " [OPTIONS]"
+    # Index tables
+    if use_variant_wrapping:
+        # Core-only index (for non-plugin variants)
+        core_noun_index = _build_index_table(output_noun_groups, None, False, include_plugins=False)
+        core_verb_index = _build_index_table(output_verb_groups, verb_metadata, True, include_plugins=False)
+        # Full index (for plugin variants)
+        full_noun_index = _build_index_table(output_noun_groups, None, False, include_plugins=True)
+        full_verb_index = _build_index_table(output_verb_groups, verb_metadata, True, include_plugins=True)
 
-        # Add command-specific usage pattern
-        if isinstance(cmd, click.Group):
-            usage_line += " COMMAND [ARGS]..."
+        # Core-only variant
+        print()
+        print(f"{{{{< variant {_non_plugin_variants(plugin_variants or '')} >}}}}")
+        print("{{< grid >}}")
+        print("{{< markdown >}}")
+        print("\n".join(core_noun_index))
+        print("{{< /markdown >}}")
+        print("{{< markdown >}}")
+        print("\n".join(core_verb_index))
+        print("{{< /markdown >}}")
+        print("{{< /grid >}}")
+        print("{{< /variant >}}")
+
+        # Full variant
+        print(f"{{{{< variant {plugin_variants} >}}}}")
+        print("{{< grid >}}")
+        print("{{< markdown >}}")
+        print("\n".join(full_noun_index))
+        print("{{< /markdown >}}")
+        print("{{< markdown >}}")
+        print("\n".join(full_verb_index))
+        print("{{< /markdown >}}")
+        print("{{< /grid >}}")
+        print("{{< /variant >}}")
+    else:
+        noun_index = _build_index_table(output_noun_groups, None, False, include_plugins=True)
+        verb_index = _build_index_table(output_verb_groups, verb_metadata, True, include_plugins=True)
+        print()
+        print("{{< grid >}}")
+        print("{{< markdown >}}")
+        print("\n".join(noun_index))
+        print("{{< /markdown >}}")
+        print("{{< markdown >}}")
+        print("\n".join(verb_index))
+        print("{{< /markdown >}}")
+        print("{{< /grid >}}")
+
+    # Plugin commands install section (if plugins are present)
+    if has_plugins:
+        plugin_section = [
+            "",
+            "## Union-specific functionality {#plugin-commands}",
+            "",
+            "> [!NOTE]",
+            "> Commands marked with **⁺** are provided by the `flyteplugins-union` plugin,",
+            "> which adds Union-specific functionality to the Flyte CLI",
+            "> (user management, RBAC, API keys).",
+            "> Install it with `pip install flyteplugins-union`.",
+            ">",
+            "> See the [flyteplugins.union API reference](../integrations/union/_index)",
+            "> for the programmatic interface.",
+            "",
+        ]
+
+        if use_variant_wrapping:
+            print(f"\n{{{{< variant {plugin_variants} >}}}}")
+            print("{{< markdown >}}")
+            print("\n".join(plugin_section))
+            print("{{< /markdown >}}")
+            print("{{< /variant >}}")
         else:
-            # Add arguments if any
-            args = [p for p in cmd.params if isinstance(p, click.Argument)]
-            for arg in args:
-                if arg.name:  # Check if name is not None
-                    if arg.required:
-                        usage_line += f" {arg.name.upper()}"
-                    else:
-                        usage_line += f" [{arg.name.upper()}]"
+            print("\n".join(plugin_section))
 
-        output.append(f"**`{usage_line}`**")
-
-        if cmd.help:
-            output.append("")
-            output.append(f"{dedent(cmd.help)}")
-
-        if not cmd.params:
-            continue
-
-        params = cmd.get_params(cmd_ctx)
-
-        # Collect all data first to calculate column widths
-        table_data = []
-        for param in params:
-            if isinstance(param, click.Option):
-                # Format each option with backticks before joining
-                all_opts = param.opts + param.secondary_opts
-                if len(all_opts) == 1:
-                    opts = f"`{all_opts[0]}`"
-                else:
-                    opts = "".join(
-                        [
-                            "{{< multiline >}}",
-                            "\n".join([f"`{opt}`" for opt in all_opts]),
-                            "{{< /multiline >}}",
-                        ]
-                    )
-                default_value = ""
-                if param.default is not None:
-                    default_value = f"`{param.default}`"
-                    default_value = default_value.replace(f"{getcwd()}/", "")
-                help_text = dedent(param.help) if param.help else ""
-                table_data.append([opts, f"`{param.type.name}`", default_value, help_text])
-
-        if not table_data:
-            continue
-
-        # Add table header with proper alignment
-        output.append("")
-        output.append("| Option | Type | Default | Description |")
-        output.append("|--------|------|---------|-------------|")
-
-        # Add table rows with proper alignment
-        for row in table_data:
-            output.append(f"| {row[0]} | {row[1]} | {row[2]} | {row[3]} |")
-
-    # Generate verb index table
-    output_verb_index = []
-    has_plugin_verbs = False
-
-    if len(output_verb_groups) > 0:
-        output_verb_index.append("| Action | On |")
-        output_verb_index.append("| ------ | -- |")
-        for verb, nouns in output_verb_groups.items():
-            verb_is_plugin, _ = verb_metadata.get(verb, (False, None))
-            verb_display = verb
-            if verb_is_plugin:
-                verb_display = f"{verb}⁺"
-                has_plugin_verbs = True
-
-            if len(nouns) == 0:
-                verb_link = f"[`{verb_display}`](#flyte-{verb})"
-                output_verb_index.append(f"| {verb_link} | - |")
-            else:
-                # Create links for nouns
-                noun_links = []
-                for noun, noun_is_plugin, _ in nouns:
-                    noun_display = noun
-                    if noun_is_plugin:
-                        noun_display = f"{noun}⁺"
-                        has_plugin_verbs = True
-                    noun_links.append(f"[`{noun_display}`](#flyte-{verb}-{noun})")
-                output_verb_index.append(f"| `{verb_display}` | {', '.join(noun_links)}  |")
-
-        if has_plugin_verbs:
-            output_verb_index.append("")
-            output_verb_index.append("**⁺** Plugin command - see command documentation for installation instructions")
-
-    # Generate noun index table
-    output_noun_index = []
-    has_plugin_nouns = False
-
-    if len(output_noun_groups) > 0:
-        output_noun_index.append("| Object | Action |")
-        output_noun_index.append("| ------ | -- |")
-        for obj, actions in output_noun_groups.items():
-            action_links = []
-            for action, action_is_plugin, _ in actions:
-                action_display = action
-                if action_is_plugin:
-                    action_display = f"{action}⁺"
-                    has_plugin_nouns = True
-                action_links.append(f"[`{action_display}`](#flyte-{action}-{obj})")
-            output_noun_index.append(f"| `{obj}` | {', '.join(action_links)}  |")
-
-        if has_plugin_nouns:
-            output_noun_index.append("")
-            output_noun_index.append("**⁺** Plugin command - see command documentation for installation instructions")
-
+    # Command detail sections
     print()
-    print("{{< grid >}}")
-    print("{{< markdown >}}")
-    print("\n".join(output_noun_index))
-    print("{{< /markdown >}}")
-    print("{{< markdown >}}")
-    print("\n".join(output_verb_index))
-    print("{{< /markdown >}}")
-    print("{{< /grid >}}")
-    print()
-    print("\n".join(output))
+    for cmd_path, is_plugin, _pm, rendered in command_data:
+        if use_variant_wrapping and is_plugin:
+            print(f"\n{{{{< variant {plugin_variants} >}}}}")
+            print("{{< markdown >}}")
+            print("\n".join(rendered))
+            print("{{< /markdown >}}")
+            print("{{< /variant >}}")
+        else:
+            print()
+            print("\n".join(rendered))
+
+
+def _non_plugin_variants(plugin_variants: str) -> str:
+    """Derive core variant names from the page's variant list minus plugin variants.
+
+    The page frontmatter declares all variants (e.g., +flyte +byoc +selfmanaged).
+    Plugin variants are the ones that should show plugin commands (e.g., byoc selfmanaged).
+    This function returns the remaining variants (e.g., flyte).
+    """
+    # For now, we hardcode "flyte" as the core variant since that's the only
+    # non-plugin variant. A more robust approach would read the page frontmatter.
+    all_variants = {"flyte", "byoc", "selfmanaged"}
+    plugin_set = set(plugin_variants.split())
+    core = all_variants - plugin_set
+    return " ".join(sorted(core))
 
 
 def dedent(text: str) -> str:


### PR DESCRIPTION
## Summary

Adds a `--plugin-variants` option to `flyte gen docs --type markdown` that wraps plugin-contributed CLI commands in Hugo `{{< variant >}}` shortcodes.

When set (e.g., `--plugin-variants 'byoc selfmanaged'`):
- **Index tables**: Two sets are generated — core-only (for non-plugin variants) and full (for plugin variants), each in its own `{{< variant >}}` block
- **Detail sections**: Each plugin command's documentation is wrapped in a `{{< variant >}}` block
- **Core commands**: Always appear unconditionally

This enables the Union docs site to show plugin commands (roles, policies, assignments, API keys, users, members from `flyteplugins-union`) only in the byoc and selfmanaged variants, while keeping the flyte variant clean.

Also escapes Hugo shortcode delimiters (`{{<`, `{{%`) in CLI help text to prevent Hugo from interpreting them.

Without `--plugin-variants`, behavior is unchanged from before.

## Test plan

- [x] `flyte gen docs --type markdown` (no flag) produces identical output to before
- [x] `flyte gen docs --type markdown --plugin-variants 'byoc selfmanaged'` produces variant-wrapped output
- [x] Hugo builds all three variants (flyte, byoc, selfmanaged) successfully
- [x] Link checker passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)