### PR TITLE
Add module docstrings and improve class/field docs for BigQuery, Databricks, Anthropic, Gemini plugins

### DIFF
--- a/plugins/anthropic/src/flyteplugins/anthropic/__init__.py
+++ b/plugins/anthropic/src/flyteplugins/anthropic/__init__.py
@@ -1,7 +1,43 @@
 """Anthropic Claude plugin for Flyte.
 
 This plugin provides integration between Flyte tasks and Anthropic's Claude API,
-enabling you to use Flyte tasks as tools for Claude agents.
+enabling you to use Flyte tasks as tools for Claude agents. Tool calls run with
+full Flyte observability, retries, and caching.
+
+Key features:
+
+- Use any Flyte task as a Claude tool via ``function_tool``
+- Full agent loop with automatic tool dispatch via ``run_agent``
+- Configurable agent via ``Agent`` (model, system prompt, tools, iteration limits)
+
+Basic usage example:
+
+```python
+import flyte
+from flyteplugins.anthropic import Agent, function_tool, run_agent
+
+env = flyte.TaskEnvironment(
+    name="agent_env",
+    image=flyte.Image.from_debian_base(name="agent").with_pip_packages(
+        "flyteplugins-anthropic"
+    ),
+)
+
+@env.task
+async def get_weather(city: str) -> str:
+    '''Get the current weather for a city.'''
+    return f"Weather in {city}: sunny, 22°C"
+
+weather_tool = function_tool(get_weather)
+
+@env.task
+async def run_weather_agent(question: str) -> str:
+    return await run_agent(
+        prompt=question,
+        tools=[weather_tool],
+        model="claude-sonnet-4-20250514",
+    )
+```
 """
 
 from .agents import Agent, function_tool, run_agent

--- a/plugins/anthropic/src/flyteplugins/anthropic/agents/_function_tools.py
+++ b/plugins/anthropic/src/flyteplugins/anthropic/agents/_function_tools.py
@@ -144,6 +144,18 @@ class Agent:
 
     This class represents the configuration for a Claude agent, including
     the model to use, system instructions, and available tools.
+
+    Attributes:
+        name: A human-readable name for this agent. Used for logging and
+            identification only; not sent to the API.
+        instructions: The system prompt passed to Claude on every turn.
+            Describes the agent's role, tone, and constraints.
+        model: The Claude model ID to use, e.g. ``"claude-sonnet-4-20250514"``.
+        tools: List of ``FunctionTool`` instances the agent can invoke.
+            Create tools with ``function_tool()``.
+        max_tokens: Maximum number of tokens in each Claude response.
+        max_iterations: Maximum number of tool-call / response cycles before
+            ``run_agent`` returns with a timeout message.
     """
 
     name: str = "assistant"

--- a/plugins/bigquery/src/flyteplugins/bigquery/__init__.py
+++ b/plugins/bigquery/src/flyteplugins/bigquery/__init__.py
@@ -1,3 +1,42 @@
+"""BigQuery connector plugin for Flyte.
+
+This plugin provides integration between Flyte tasks and Google BigQuery,
+enabling you to run parameterized SQL queries as Flyte tasks with full
+observability, retries, and caching.
+
+Key features:
+
+- Parameterized SQL queries with typed inputs
+- Returns query results as DataFrames
+- Automatic links to the BigQuery job console in the Flyte UI
+- Query cancellation on task abort
+
+Basic usage example:
+
+```python
+import flyte
+from flyte.io import DataFrame
+from flyteplugins.bigquery import BigQueryConfig, BigQueryTask
+
+config = BigQueryConfig(
+    ProjectID="my-gcp-project",
+    Location="US",
+)
+
+query_task = BigQueryTask(
+    name="count_events",
+    query_template="SELECT COUNT(*) AS total FROM `{ds}.events` WHERE date = @date",
+    plugin_config=config,
+    inputs={"date": str},
+    output_dataframe_type=DataFrame[dict],
+)
+
+@flyte.task
+def run_query(date: str) -> DataFrame[dict]:
+    return query_task(date=date)
+```
+"""
+
 from flyteplugins.bigquery.connector import BigQueryConnector
 from flyteplugins.bigquery.task import BigQueryConfig, BigQueryTask
 

--- a/plugins/bigquery/src/flyteplugins/bigquery/task.py
+++ b/plugins/bigquery/src/flyteplugins/bigquery/task.py
@@ -12,8 +12,15 @@ from google.cloud import bigquery
 
 @dataclass
 class BigQueryConfig(object):
-    """
-    BigQueryConfig should be used to configure a BigQuery Task.
+    """Configuration for a BigQuery task.
+
+    Attributes:
+        ProjectID: The Google Cloud project ID that owns the BigQuery dataset.
+        Location: The geographic location of the dataset, e.g. ``"US"`` or ``"EU"``.
+            Defaults to the project's default location if not specified.
+        QueryJobConfig: Optional advanced job configuration passed directly to the
+            BigQuery client. Use this to set query parameters, destination tables,
+            time partitioning, etc.
     """
 
     ProjectID: str

--- a/plugins/databricks/src/flyteplugins/databricks/__init__.py
+++ b/plugins/databricks/src/flyteplugins/databricks/__init__.py
@@ -1,3 +1,53 @@
+"""Databricks connector plugin for Flyte.
+
+This plugin provides integration between Flyte tasks and Databricks,
+enabling you to run PySpark jobs on Databricks clusters as Flyte tasks
+with full observability, retries, and caching.
+
+Key features:
+
+- Run PySpark tasks natively on Databricks clusters
+- Configurable cluster spec via the Databricks Jobs API
+- Automatic job lifecycle management: create, poll, cancel
+- Automatic links to the Databricks job run UI in the Flyte UI
+
+Basic usage example:
+
+```python
+import flyte
+from flyteplugins.databricks import Databricks
+
+databricks_config = Databricks(
+    spark_conf={"spark.executor.memory": "4g"},
+    databricks_conf={
+        "run_name": "my_job",
+        "new_cluster": {
+            "spark_version": "13.3.x-scala2.12",
+            "node_type_id": "i3.xlarge",
+            "num_workers": 2,
+        },
+    },
+    databricks_instance="myorg.cloud.databricks.com",
+    databricks_token="databricks_token_secret",
+)
+
+env = flyte.TaskEnvironment(
+    name="databricks_env",
+    plugin_config=databricks_config,
+    image=flyte.Image.from_debian_base(name="pyspark").with_pip_packages(
+        "flyteplugins-databricks"
+    ),
+)
+
+@env.task
+def process_data(input_path: str) -> int:
+    from pyspark.sql import SparkSession
+    spark = SparkSession.builder.getOrCreate()
+    df = spark.read.parquet(input_path)
+    return df.count()
+```
+"""
+
 from flyteplugins.databricks.connector import DatabricksConnector
 from flyteplugins.databricks.task import Databricks
 

--- a/plugins/databricks/src/flyteplugins/databricks/task.py
+++ b/plugins/databricks/src/flyteplugins/databricks/task.py
@@ -12,16 +12,30 @@ from google.protobuf.json_format import MessageToDict
 
 @dataclass
 class Databricks(Spark):
-    """
-    Use this to configure a Databricks task. Task's marked with this will automatically execute
-    natively onto databricks platform as a distributed execution of spark
+    """Configuration for a Databricks task.
 
-    Args:
-        databricks_conf: Databricks job configuration compliant with API version 2.1, supporting 2.0 use cases.
-        For the configuration structure, visit here.https://docs.databricks.com/dev-tools/api/2.0/jobs.html#request-structure
-        For updates in API 2.1, refer to: https://docs.databricks.com/en/workflows/jobs/jobs-api-updates.html
-        databricks_instance: Domain name of your deployment. Use the form <account>.cloud.databricks.com.
-        databricks_token: the name of the secret containing the Databricks token for authentication.
+    Tasks configured with this will execute natively on Databricks as a
+    distributed PySpark job. Extends ``Spark`` with Databricks-specific
+    cluster and authentication settings.
+
+    Attributes:
+        spark_conf: Spark configuration key-value pairs, e.g.
+            ``{"spark.executor.memory": "4g"}``.
+        hadoop_conf: Hadoop configuration key-value pairs.
+        executor_path: Path to the Python binary used for PySpark execution.
+            Defaults to the interpreter path from the serialization context.
+        applications_path: Path to the main application file. Defaults to
+            the task entrypoint path.
+        driver_pod: Pod template applied to the Spark driver pod.
+        executor_pod: Pod template applied to the Spark executor pods.
+        databricks_conf: Databricks job configuration dict compliant with
+            the Databricks Jobs API v2.1 (also supports v2.0 use cases).
+            Typically includes ``new_cluster`` or ``existing_cluster_id``,
+            ``run_name``, and other job settings.
+        databricks_instance: Domain name of your Databricks deployment,
+            e.g. ``"myorg.cloud.databricks.com"``.
+        databricks_token: Name of the Flyte secret containing the Databricks
+            API token used for authentication.
     """
 
     databricks_conf: Optional[Dict[str, Union[str, dict]]] = None

--- a/plugins/gemini/src/flyteplugins/gemini/__init__.py
+++ b/plugins/gemini/src/flyteplugins/gemini/__init__.py
@@ -1,7 +1,43 @@
 """Google Gemini plugin for Flyte.
 
 This plugin provides integration between Flyte tasks and Google's Gemini API,
-enabling you to use Flyte tasks as tools for Gemini agents.
+enabling you to use Flyte tasks as tools for Gemini agents. Tool calls run with
+full Flyte observability, retries, and caching.
+
+Key features:
+
+- Use any Flyte task as a Gemini tool via ``function_tool``
+- Full agent loop with automatic tool dispatch via ``run_agent``
+- Configurable agent via ``Agent`` (model, system prompt, tools, iteration limits)
+
+Basic usage example:
+
+```python
+import flyte
+from flyteplugins.gemini import Agent, function_tool, run_agent
+
+env = flyte.TaskEnvironment(
+    name="agent_env",
+    image=flyte.Image.from_debian_base(name="agent").with_pip_packages(
+        "flyteplugins-gemini"
+    ),
+)
+
+@env.task
+async def get_weather(city: str) -> str:
+    '''Get the current weather for a city.'''
+    return f"Weather in {city}: sunny, 22°C"
+
+weather_tool = function_tool(get_weather)
+
+@env.task
+async def run_weather_agent(question: str) -> str:
+    return await run_agent(
+        prompt=question,
+        tools=[weather_tool],
+        model="gemini-2.5-flash",
+    )
+```
 """
 
 from .agents import Agent, function_tool, run_agent

--- a/plugins/gemini/src/flyteplugins/gemini/agents/_function_tools.py
+++ b/plugins/gemini/src/flyteplugins/gemini/agents/_function_tools.py
@@ -142,6 +142,18 @@ class Agent:
 
     This class represents the configuration for a Gemini agent, including
     the model to use, system instructions, and available tools.
+
+    Attributes:
+        name: A human-readable name for this agent. Used for logging and
+            identification only; not sent to the API.
+        instructions: The system prompt passed to Gemini on every turn.
+            Describes the agent's role, tone, and constraints.
+        model: The Gemini model ID to use, e.g. ``"gemini-2.5-flash"``.
+        tools: List of ``FunctionTool`` instances the agent can invoke.
+            Create tools with ``function_tool()``.
+        max_output_tokens: Maximum number of tokens in each Gemini response.
+        max_iterations: Maximum number of function-call / response cycles before
+            ``run_agent`` returns with a timeout message.
     """
 
     name: str = "assistant"


### PR DESCRIPTION
## Summary

- Add module-level docstrings with key features and a usage example to `bigquery`, `databricks`, `anthropic`, and `gemini` plugin `__init__.py` files
- Expand `BigQueryConfig` with `Attributes` field descriptions
- Expand `Databricks` class docstring to document all fields, including the inherited Spark fields that previously had no descriptions in the subclass
- Add `Attributes` sections to `Agent` classes in `anthropic` and `gemini` plugins

These docstrings feed into the auto-generated API reference in the Union.ai documentation site (`unionai-docs`). The module-level docstrings will populate the plugin index pages once the API generator is updated to emit them.

## Test plan

- [ ] `make -f unionai-docs-infra/Makefile.api.plugins` regenerates API docs with improved field descriptions
- [ ] No existing tests broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)