### PR TITLE
set ci plugin publishing fail-fast: false

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,6 +67,7 @@ jobs:
     name: PyPI package
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         workdir:
           - "plugins/ray"


### PR DESCRIPTION
sometimes Pypi will have intermittent server errors: https://github.com/flyteorg/flyte-sdk/actions/runs/22964963527/job/66665836975 will this happens, the plugin matrix will kill any subsequent attempt to publish the new version of a package. this change makes it so that plugin packages can independently be published without killing other jobs.