### PR TITLE
feat: add pip options to Image.with_requirements()

### DIFF
--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -870,6 +870,10 @@ class Image:
     def with_requirements(
         self,
         file: str | Path,
+        index_url: Optional[str] = None,
+        extra_index_urls: Union[str, List[str], Tuple[str, ...], None] = None,
+        pre: bool = False,
+        extra_args: Optional[str] = None,
         secret_mounts: Optional[SecretRequest] = None,
     ) -> Image:
         """
@@ -877,6 +881,10 @@ class Image:
         Cannot be used in conjunction with conda
 
         :param file: path to the requirements file, must be a .txt file
+        :param index_url: index url to use for pip install, default is None
+        :param extra_index_urls: extra index urls to use for pip install, default is None
+        :param pre: if True, install pre-release packages, default is False
+        :param extra_args: extra arguments to pass to pip install, default is None
         :param secret_mounts: list of secret to mount for the build process.
         :return:
         """
@@ -884,8 +892,16 @@ class Image:
             file = Path(file)
         if file.suffix != ".txt":
             raise ValueError(f"Requirements file {file} must have a .txt extension")
+        new_extra_index_urls: Optional[Tuple] = _ensure_tuple(extra_index_urls) if extra_index_urls else None
         new_image = self.clone(
-            addl_layer=Requirements(file=file, secret_mounts=_ensure_tuple(secret_mounts) if secret_mounts else None)
+            addl_layer=Requirements(
+                file=file,
+                index_url=index_url,
+                extra_index_urls=new_extra_index_urls,
+                pre=pre,
+                extra_args=extra_args,
+                secret_mounts=_ensure_tuple(secret_mounts) if secret_mounts else None,
+            )
         )
         return new_image
 

--- a/tests/flyte/test_image.py
+++ b/tests/flyte/test_image.py
@@ -29,6 +29,64 @@ async def test_with_requirements(tmp_path):
     assert img._layers[-2].file == file
 
 
+def test_with_requirements_index_url(tmp_path):
+    file = Path(__file__).parent / "resources" / "sample_requirements.txt"
+    img = Image.from_debian_base(registry="localhost", name="test-image").with_requirements(
+        file, index_url="https://my-private-pypi.example.com/simple"
+    )
+    layer = img._layers[-1]
+    assert layer.file == file
+    assert layer.index_url == "https://my-private-pypi.example.com/simple"
+
+
+def test_with_requirements_extra_index_urls(tmp_path):
+    file = Path(__file__).parent / "resources" / "sample_requirements.txt"
+    img = Image.from_debian_base(registry="localhost", name="test-image").with_requirements(
+        file, extra_index_urls="https://extra.example.com/simple"
+    )
+    layer = img._layers[-1]
+    assert layer.extra_index_urls == ("https://extra.example.com/simple",)
+
+    img2 = Image.from_debian_base(registry="localhost", name="test-image").with_requirements(
+        file, extra_index_urls=["https://extra1.example.com", "https://extra2.example.com"]
+    )
+    layer2 = img2._layers[-1]
+    assert layer2.extra_index_urls == ("https://extra1.example.com", "https://extra2.example.com")
+
+
+def test_with_requirements_pre(tmp_path):
+    file = Path(__file__).parent / "resources" / "sample_requirements.txt"
+    img = Image.from_debian_base(registry="localhost", name="test-image").with_requirements(file, pre=True)
+    layer = img._layers[-1]
+    assert layer.pre is True
+
+
+def test_with_requirements_extra_args(tmp_path):
+    file = Path(__file__).parent / "resources" / "sample_requirements.txt"
+    img = Image.from_debian_base(registry="localhost", name="test-image").with_requirements(
+        file, extra_args="--no-deps"
+    )
+    layer = img._layers[-1]
+    assert layer.extra_args == "--no-deps"
+
+
+def test_with_requirements_all_pip_options(tmp_path):
+    file = Path(__file__).parent / "resources" / "sample_requirements.txt"
+    img = Image.from_debian_base(registry="localhost", name="test-image").with_requirements(
+        file,
+        index_url="https://private.example.com/simple",
+        extra_index_urls=["https://extra.example.com"],
+        pre=True,
+        extra_args="--no-deps",
+    )
+    layer = img._layers[-1]
+    assert layer.file == file
+    assert layer.index_url == "https://private.example.com/simple"
+    assert layer.extra_index_urls == ("https://extra.example.com",)
+    assert layer.pre is True
+    assert layer.extra_args == "--no-deps"
+
+
 def test_with_pip_packages():
     packages = ("numpy", "pandas")
     img = Image.from_debian_base(registry="localhost", name="test-image").with_pip_packages(*packages)


### PR DESCRIPTION
## Summary
- `Image.with_requirements()` was missing `index_url`, `extra_index_urls`, `pre`, and `extra_args` parameters that `with_pip_packages()` already supported
- The underlying `Requirements` layer inherits these fields from `PipOption` but `with_requirements()` wasn't exposing them
- Added all pip option parameters to `with_requirements()` for parity with `with_pip_packages()`

## Test plan
- Added 5 unit tests covering each new parameter individually and all combined
- All tests pass: `pytest tests/flyte/test_image.py -v -k with_requirements`