### PR TITLE
Raise error when dev mode dist folder is missing

### DIFF
--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -575,6 +575,11 @@ class Image:
             if dev_mode:
                 if os.path.exists(DIST_FOLDER):
                     image = image.with_local_v2()
+                else:
+                    raise FileNotFoundError(
+                        f"Dev mode detected (version={flyte_version}) but '{DIST_FOLDER}' not found. "
+                        f"Run 'uv build' to create a distribution wheel before building images."
+                    )
             else:
                 flyte_version = typing.cast(str, flyte_version)
                 if Version(flyte_version).is_devrelease or Version(flyte_version).is_prerelease:


### PR DESCRIPTION
## Summary
- When running in dev mode (version string contains "dev") without a `dist/` folder, the image builder previously **silently skipped installing the flyte package**. This produced container images missing the `a0` entrypoint binary, which failed at runtime with a confusing `exec: "a0": executable file not found in $PATH` error.
- Now raises `FileNotFoundError` with a clear message telling the developer to run `uv build` first.

## Context
This is easy to hit when running examples from within the `flyte-sdk` repo using `uv run`. Because `setuptools_scm` derives the version from git tags, any dirty working tree or distance from a release tag produces a `.devN` version string (e.g. `2.0.7.dev13+ga9acdb41`). This triggers dev mode, which expects a pre-built wheel in `dist/` — but if `dist/` doesn't exist, the `flyte` package is silently omitted from the container image layers.

The resulting image builds and pushes successfully but contains no `flyte` package and no `a0` binary, leading to runtime failures that are very difficult to diagnose.

## Test plan
- [ ] Run `uv run examples/basics/hello.py` from the repo root without `dist/` — should now get a clear `FileNotFoundError`
- [ ] Run `uv build && uv run examples/basics/hello.py` — should work as before
- [ ] Run `pip install flyte && python examples/basics/hello.py` (released version) — unaffected, dev mode not triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)