### PR TITLE
feat: add flyte_map built-in for parallel task execution in code-mode workflow sandboxing

### DIFF
--- a/examples/sandbox/code_string.py
+++ b/examples/sandbox/code_string.py
@@ -154,6 +154,44 @@ validate = flyte.sandbox.orchestrator_from_str(
 # flyte.run(validate, items=[1, 2, 3])  → None (no error)
 
 
+# --- Example 8: Parallel mapping with flyte_map ------------------------------
+# ``flyte_map("task_name", iterable)`` runs a task over every element in
+# parallel — the sandbox equivalent of ``flyte.map``.  The first argument is
+# the task name as a string; remaining positional args are iterables that get
+# zipped. Keyword args ``concurrency``, ``group_name``, and
+# ``return_exceptions`` are forwarded to ``flyte.map``.
+
+batch_add = flyte.sandbox.orchestrator_from_str(
+    """
+    flyte_map("add", xs, ys)
+    """,
+    inputs={"xs": list, "ys": list},
+    output=list,
+    tasks=[add],
+    name="batch-add",
+)
+# flyte.run(batch_add, xs=[1, 2, 3], ys=[10, 20, 30])  → [11, 22, 33]
+
+
+# --- Example 9: flyte_map with post-processing -------------------------------
+# Collect mapped results and feed them into another task.
+
+map_then_reduce = flyte.sandbox.orchestrator_from_str(
+    """
+    doubled = flyte_map("multiply", items, items)
+    total = 0
+    for v in doubled:
+        total = total + v
+    total
+    """,
+    inputs={"items": list[int]},
+    output=int,
+    tasks=[multiply],
+    name="map-then-reduce",
+)
+# flyte.run(map_then_reduce, items=[1, 2, 3])  → 14  (1*1 + 2*2 + 3*3)
+
+
 # --- Attach to an environment for ``flyte run`` -----------------------------
 # ``orchestrator_from_str()`` creates standalone templates. ``flyte run`` requires
 # every task to belong to a TaskEnvironment.
@@ -167,6 +205,8 @@ sandbox_env = flyte.TaskEnvironment.from_task(
     classify,
     summarize,
     validate,
+    batch_add,
+    map_then_reduce,
 )
 
 

--- a/examples/sandbox/dynamic_code.py
+++ b/examples/sandbox/dynamic_code.py
@@ -163,6 +163,96 @@ map_scale_sum = make_map_reduce("scale", "+", scale)
 # → scale(1,10) + scale(2,10) + scale(3,10) = 10 + 20 + 30 = 60
 
 
+# --- Pattern 5: Parallel mapping with flyte_map ------------------------------
+# ``flyte_map`` is a sandbox built-in that delegates to ``flyte.map``.
+# It runs a task over an iterable in parallel and returns a list of results.
+# Use it instead of sequential for-loops when you want concurrency.
+
+
+@env.task
+def square(x: int) -> int:
+    return x * x
+
+
+# flyte_map with a single iterable
+parallel_squares = flyte.sandbox.orchestrator_from_str(
+    """
+    flyte_map("square", items)
+    """,
+    inputs={"items": list[int]},
+    output=list[int],
+    tasks=[square],
+    name="parallel-squares",
+)
+# flyte.run(parallel_squares, items=[1, 2, 3, 4])  → [1, 4, 9, 16]
+
+
+# flyte_map with multiple iterables (zipped) and concurrency limit
+parallel_add = flyte.sandbox.orchestrator_from_str(
+    """
+    flyte_map("add", xs, ys, concurrency=4)
+    """,
+    inputs={"xs": list, "ys": list},
+    output=list,
+    tasks=[add],
+    name="parallel-add",
+)
+# flyte.run(parallel_add, xs=[1, 2, 3], ys=[10, 20, 30])  → [11, 22, 33]
+
+
+# flyte_map results fed into further sandbox logic
+map_and_sum = flyte.sandbox.orchestrator_from_str(
+    """
+    squared = flyte_map("square", items)
+    total = 0
+    for v in squared:
+        total = total + v
+    total
+    """,
+    inputs={"items": list},
+    output=int,
+    tasks=[square],
+    name="map-and-sum",
+)
+# flyte.run(map_and_sum, items=[1, 2, 3])  → 14  (1 + 4 + 9)
+
+
+async def flyte_map_local():
+    """Run flyte_map examples locally via orchestrate_local()."""
+    # Basic parallel map
+    result = await flyte.sandbox.orchestrate_local(
+        'flyte_map("square", items)',
+        inputs={"items": [1, 2, 3, 4, 5]},
+        tasks=[square],
+    )
+    print(f"  squares: {result}")
+    assert result == [1, 4, 9, 16, 25]
+
+    # Multiple iterables
+    result = await flyte.sandbox.orchestrate_local(
+        'flyte_map("add", xs, ys)',
+        inputs={"xs": [1, 2, 3], "ys": [10, 20, 30]},
+        tasks=[add],
+    )
+    print(f"  pairwise add: {result}")
+    assert result == [11, 22, 33]
+
+    # Map then reduce
+    result = await flyte.sandbox.orchestrate_local(
+        """
+        squared = flyte_map("square", items)
+        total = 0
+        for v in squared:
+            total = total + v
+        total
+        """,
+        inputs={"items": [1, 2, 3, 4]},
+        tasks=[square],
+    )
+    print(f"  sum of squares: {result}")
+    assert result == 30  # 1 + 4 + 9 + 16
+
+
 # --- Attach to an environment for ``flyte run`` -----------------------------
 
 sandbox_env = flyte.TaskEnvironment.from_task(
@@ -173,6 +263,9 @@ sandbox_env = flyte.TaskEnvironment.from_task(
     area_of_triangle,
     bmi,
     map_scale_sum,
+    parallel_squares,
+    parallel_add,
+    map_and_sum,
 )
 
 
@@ -192,3 +285,6 @@ if __name__ == "__main__":
 
     print("\n--- Map-reduce pipeline ---")
     print(f"map_scale_sum: {map_scale_sum.name}, has_external_refs={map_scale_sum._has_external_refs}")
+
+    print("\n--- flyte_map local execution ---")
+    asyncio.run(flyte_map_local())

--- a/src/flyte/sandbox/__init__.py
+++ b/src/flyte/sandbox/__init__.py
@@ -171,7 +171,14 @@ Type restrictions:
 - Optional[T] and Union of allowed types are permitted.
 - Custom classes, dataclasses, Pydantic models, and any other user-defined types are NOT allowed.
 - set and frozenset are allowed as function parameter/return types but set literals and \
-set comprehensions are not supported in code."""
+set comprehensions are not supported in code.
+
+Built-in functions:
+- `flyte_map(task_name, *iterables, concurrency=0, group_name=None, return_exceptions=True)` \
+— Run a task over one or more iterables in parallel. The first argument is the task name as a \
+string (e.g. `"double"`). Returns a list of results. Mirrors `flyte.map` semantics including \
+concurrency limits and exception handling. Example: `flyte_map("double", items)` or \
+`flyte_map("add", xs, ys, concurrency=4)`."""
 
 __all__ = [
     "ORCHESTRATOR_SYNTAX_PROMPT",

--- a/src/flyte/sandbox/_bridge.py
+++ b/src/flyte/sandbox/_bridge.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, List
 
 from flyte.io import DataFrame, Dir, File
 
@@ -80,6 +80,44 @@ class ExternalFunctionBridge:
                 raise RuntimeError(f"External ref '{name}' is not callable")
         return result
 
+    async def _handle_flyte_map(
+        self,
+        args: List[Any],
+        kwargs: Dict[str, Any],
+    ) -> List[Any]:
+        """Handle a ``flyte_map("task_name", *iterables, **kwargs)`` call.
+
+        Resolves the task name to the real ``TaskTemplate``, then delegates
+        to ``flyte.map.aio`` so that concurrency, group tracking, and
+        ``return_exceptions`` all work identically to top-level ``flyte.map``.
+        """
+        from flyte._map import map as flyte_map
+
+        if len(args) < 2:
+            raise RuntimeError("flyte_map requires at least 2 arguments: flyte_map(task_name, iterable, ...)")
+
+        task_name = args[0]
+        if not isinstance(task_name, str):
+            raise RuntimeError(f"flyte_map first argument must be a task name string, got {type(task_name).__name__}")
+
+        task = self._all_refs.get(task_name)
+        if task is None:
+            available = ", ".join(sorted(self._all_refs.keys())) or "(none)"
+            raise RuntimeError(f"flyte_map: task '{task_name}' not found in registered tasks. Available: {available}")
+
+        iterables = [_from_monty(a) for a in args[1:]]
+
+        # Forward kwargs that flyte.map.aio accepts
+        map_kwargs: Dict[str, Any] = {}
+        for key in ("group_name", "concurrency", "return_exceptions"):
+            if key in kwargs:
+                map_kwargs[key] = kwargs[key]
+
+        results: List[Any] = []
+        async for r in flyte_map.aio(task, *iterables, **map_kwargs):
+            results.append(r)
+        return results
+
     async def execute_monty(self, monty_cls: Any, code: str, input_names: list[str], inputs: Dict[str, Any]) -> Any:
         """Run *code* in Monty, awaiting each external call before resuming.
 
@@ -110,6 +148,14 @@ class ExternalFunctionBridge:
             if isinstance(progress, MontyComplete):
                 return _from_monty(progress.output)
             elif isinstance(progress, FunctionSnapshot):
+                # Handle flyte_map as a special built-in for parallel execution
+                if progress.function_name == "flyte_map":
+                    args = [_from_monty(a) for a in progress.args]
+                    kwargs = {k: _from_monty(v) for k, v in progress.kwargs.items()}
+                    result = await self._handle_flyte_map(args, kwargs)
+                    progress = progress.resume(return_value=_to_monty(result))
+                    continue
+
                 fn = ext_fns.get(progress.function_name)
                 if fn is None:
                     raise RuntimeError(f"Sandboxed task called unknown external function: {progress.function_name}")

--- a/tests/flyte/sandbox/test_map_in_sandbox.py
+++ b/tests/flyte/sandbox/test_map_in_sandbox.py
@@ -1,0 +1,392 @@
+"""Tests for mapping over tasks inside sandboxed code strings.
+
+Monty sandbox cannot ``import flyte``. Python's built-in ``map(external_fn, iterable)``
+is also unsupported when the function is an external Monty reference.
+
+Two patterns are tested:
+
+1. **For-loop pattern** — ``for item in items: result = task(item)``
+   Works today via ``FunctionSnapshot`` pause/resume. Sequential but functional.
+
+2. **flyte_map built-in** — ``flyte_map("task_name", iterable)``
+   A bridge-level built-in that resolves the task name and runs ``flyte.map``.
+   The bridge handles this as a single ``FunctionSnapshot`` call and returns
+   all results at once.
+"""
+
+import pytest
+
+import flyte
+
+try:
+    from pydantic_monty import Monty  # noqa: F401
+
+    HAS_MONTY = True
+except ImportError:
+    HAS_MONTY = False
+
+
+# ---------------------------------------------------------------------------
+# Helper fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def env():
+    return flyte.TaskEnvironment(name="map-sandbox-test")
+
+
+# ---------------------------------------------------------------------------
+# Pattern 1: For-loop calling tasks individually (works today)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not HAS_MONTY, reason="pydantic-monty not installed")
+class TestForLoopPatternInSandbox:
+    """For-loop pattern: call the task per-item. Works via FunctionSnapshot."""
+
+    @pytest.mark.asyncio
+    async def test_for_loop_basic(self, env):
+        """Calling a task in a for-loop should work via pause/resume."""
+        from flyte.sandbox import orchestrate_local
+
+        @env.sandbox.orchestrator
+        def double(x: int) -> int:
+            return x * 2
+
+        result = await orchestrate_local(
+            """
+            results = []
+            for item in items:
+                results.append(double(item))
+            results
+            """,
+            inputs={"items": [1, 2, 3]},
+            tasks=[double],
+        )
+        assert result == [2, 4, 6]
+
+    @pytest.mark.asyncio
+    async def test_for_loop_multiple_args(self, env):
+        """For-loop with zip and multi-arg task calls."""
+        from flyte.sandbox import orchestrate_local
+
+        @env.sandbox.orchestrator
+        def add(x: int, y: int) -> int:
+            return x + y
+
+        result = await orchestrate_local(
+            """
+            results = []
+            for x, y in zip(xs, ys):
+                results.append(add(x, y))
+            results
+            """,
+            inputs={"xs": [1, 2, 3], "ys": [10, 20, 30]},
+            tasks=[add],
+        )
+        assert result == [11, 22, 33]
+
+    @pytest.mark.asyncio
+    async def test_for_loop_empty_iterable(self, env):
+        from flyte.sandbox import orchestrate_local
+
+        @env.sandbox.orchestrator
+        def double(x: int) -> int:
+            return x * 2
+
+        result = await orchestrate_local(
+            """
+            results = []
+            for item in items:
+                results.append(double(item))
+            results
+            """,
+            inputs={"items": []},
+            tasks=[double],
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_for_loop_with_aggregation(self, env):
+        """Results from loop can be aggregated."""
+        from flyte.sandbox import orchestrate_local
+
+        @env.sandbox.orchestrator
+        def square(x: int) -> int:
+            return x * x
+
+        result = await orchestrate_local(
+            """
+            total = 0
+            for item in items:
+                total = total + square(item)
+            total
+            """,
+            inputs={"items": [1, 2, 3, 4]},
+            tasks=[square],
+        )
+        assert result == 30  # 1 + 4 + 9 + 16
+
+    @pytest.mark.asyncio
+    async def test_for_loop_mixed_with_direct_calls(self, env):
+        """For-loop + direct task calls in same code string."""
+        from flyte.sandbox import orchestrate_local
+
+        @env.sandbox.orchestrator
+        def double(x: int) -> int:
+            return x * 2
+
+        @env.sandbox.orchestrator
+        def add(x: int, y: int) -> int:
+            return x + y
+
+        result = await orchestrate_local(
+            """
+            doubled = []
+            for item in items:
+                doubled.append(double(item))
+            add(doubled[0], doubled[1])
+            """,
+            inputs={"items": [3, 7]},
+            tasks=[double, add],
+        )
+        assert result == 20  # double(3) + double(7) = 6 + 14
+
+
+# ---------------------------------------------------------------------------
+# Pattern 2: flyte_map built-in (bridge resolves task name + runs flyte.map)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not HAS_MONTY, reason="pydantic-monty not installed")
+class TestFlyteMapBuiltinInSandbox:
+    """flyte_map("task_name", iterable) as a bridge-level built-in.
+
+    The bridge intercepts the ``flyte_map`` call, resolves the task name
+    from the registered external refs, and delegates to ``flyte.map``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_flyte_map_basic(self, env):
+        """flyte_map should map a task over items and return results."""
+        from flyte.sandbox import orchestrate_local
+
+        @env.sandbox.orchestrator
+        def double(x: int) -> int:
+            return x * 2
+
+        result = await orchestrate_local(
+            """
+            list(flyte_map("double", items))
+            """,
+            inputs={"items": [1, 2, 3]},
+            tasks=[double],
+        )
+        assert result == [2, 4, 6]
+
+    @pytest.mark.asyncio
+    async def test_flyte_map_with_aggregation(self, env):
+        """flyte_map results can be further processed."""
+        from flyte.sandbox import orchestrate_local
+
+        @env.sandbox.orchestrator
+        def square(x: int) -> int:
+            return x * x
+
+        result = await orchestrate_local(
+            """
+            total = 0
+            for r in flyte_map("square", items):
+                total = total + r
+            total
+            """,
+            inputs={"items": [1, 2, 3, 4]},
+            tasks=[square],
+        )
+        assert result == 30
+
+    @pytest.mark.asyncio
+    async def test_flyte_map_empty(self, env):
+        from flyte.sandbox import orchestrate_local
+
+        @env.sandbox.orchestrator
+        def double(x: int) -> int:
+            return x * 2
+
+        result = await orchestrate_local(
+            """
+            list(flyte_map("double", items))
+            """,
+            inputs={"items": []},
+            tasks=[double],
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_flyte_map_unknown_task_raises(self, env):
+        """Referencing an unknown task name should raise a clear error."""
+        from flyte.sandbox import orchestrate_local
+
+        @env.sandbox.orchestrator
+        def double(x: int) -> int:
+            return x * 2
+
+        with pytest.raises(RuntimeError, match=r"unknown.*task|not found"):
+            await orchestrate_local(
+                """
+                list(flyte_map("nonexistent", items))
+                """,
+                inputs={"items": [1, 2, 3]},
+                tasks=[double],
+            )
+
+    @pytest.mark.asyncio
+    async def test_flyte_map_with_other_calls(self, env):
+        """flyte_map coexists with direct task calls."""
+        from flyte.sandbox import orchestrate_local
+
+        @env.sandbox.orchestrator
+        def double(x: int) -> int:
+            return x * 2
+
+        @env.sandbox.orchestrator
+        def add(x: int, y: int) -> int:
+            return x + y
+
+        result = await orchestrate_local(
+            """
+            doubled = list(flyte_map("double", items))
+            add(doubled[0], doubled[1])
+            """,
+            inputs={"items": [3, 7]},
+            tasks=[double, add],
+        )
+        assert result == 20
+
+    @pytest.mark.asyncio
+    async def test_flyte_map_multiple_iterables(self, env):
+        """flyte_map with multiple iterables zips them like flyte.map."""
+        from flyte.sandbox import orchestrate_local
+
+        @env.sandbox.orchestrator
+        def add(x: int, y: int) -> int:
+            return x + y
+
+        result = await orchestrate_local(
+            """
+            flyte_map("add", xs, ys)
+            """,
+            inputs={"xs": [1, 2, 3], "ys": [10, 20, 30]},
+            tasks=[add],
+        )
+        assert result == [11, 22, 33]
+
+    @pytest.mark.asyncio
+    async def test_flyte_map_return_exceptions(self, env):
+        """return_exceptions kwarg is forwarded to flyte.map."""
+        from flyte.sandbox import orchestrate_local
+
+        @env.sandbox.orchestrator
+        def maybe_fail(x: int) -> int:
+            if x == 2:
+                raise ValueError("bad value")
+            return x * 10
+
+        result = await orchestrate_local(
+            """
+            flyte_map("maybe_fail", items, return_exceptions=True)
+            """,
+            inputs={"items": [1, 2, 3]},
+            tasks=[maybe_fail],
+        )
+        assert result[0] == 10
+        assert isinstance(result[1], Exception)
+        assert result[2] == 30
+
+    @pytest.mark.asyncio
+    async def test_flyte_map_concurrency_kwarg(self, env):
+        """concurrency kwarg is accepted and forwarded."""
+        from flyte.sandbox import orchestrate_local
+
+        @env.sandbox.orchestrator
+        def double(x: int) -> int:
+            return x * 2
+
+        result = await orchestrate_local(
+            """
+            flyte_map("double", items, concurrency=2)
+            """,
+            inputs={"items": [1, 2, 3, 4]},
+            tasks=[double],
+        )
+        assert result == [2, 4, 6, 8]
+
+    @pytest.mark.asyncio
+    async def test_flyte_map_group_name_kwarg(self, env):
+        """group_name kwarg is accepted and forwarded."""
+        from flyte.sandbox import orchestrate_local
+
+        @env.sandbox.orchestrator
+        def double(x: int) -> int:
+            return x * 2
+
+        result = await orchestrate_local(
+            """
+            flyte_map("double", items, group_name="my-batch")
+            """,
+            inputs={"items": [1, 2, 3]},
+            tasks=[double],
+        )
+        assert result == [2, 4, 6]
+
+
+# ---------------------------------------------------------------------------
+# orchestrator_from_str — reusable templates with map
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not HAS_MONTY, reason="pydantic-monty not installed")
+class TestMapInOrchestratorFromStr:
+    """Templates created via orchestrator_from_str with map patterns."""
+
+    def test_for_loop_template_creates(self, env):
+        from flyte.sandbox import orchestrator_from_str
+
+        @env.sandbox.orchestrator
+        def double(x: int) -> int:
+            return x * 2
+
+        t = orchestrator_from_str(
+            """
+            results = []
+            for item in items:
+                results.append(double(item))
+            results
+            """,
+            inputs={"items": list},
+            output=list,
+            tasks=[double],
+            name="for-loop-map",
+        )
+        assert t.name == "for-loop-map"
+        assert t._has_external_refs
+
+    def test_flyte_map_template_creates(self, env):
+        from flyte.sandbox import orchestrator_from_str
+
+        @env.sandbox.orchestrator
+        def double(x: int) -> int:
+            return x * 2
+
+        t = orchestrator_from_str(
+            """
+            list(flyte_map("double", items))
+            """,
+            inputs={"items": list},
+            output=list,
+            tasks=[double],
+            name="flyte-map-example",
+        )
+        assert t.name == "flyte-map-example"
+        assert t._has_external_refs


### PR DESCRIPTION
Sandbox code (Monty runtime) cannot `import flyte`, so `flyte.map` is not directly available. This adds `flyte_map` as a bridge-level built-in that delegates to `flyte.map.aio`, giving sandboxed code access to parallel task execution with the same semantics as `flyte.map`.

Usage in sandbox code strings:

    # Map a single-arg task over a list (parallel)
    flyte_map("double", items)

    # Multiple iterables are zipped, like flyte.map
    flyte_map("add", xs, ys)

    # All flyte.map kwargs are supported
    flyte_map("double", items, concurrency=4, return_exceptions=True)

    # Results are collected into a list for further processing
    squared = flyte_map("square", items)
    total = 0
    for v in squared:
        total = total + v
    total

The first argument is always the task name as a string. The task must be registered via the `tasks=[]` parameter of `orchestrator_from_str()` or `orchestrate_local()`.

Changes:
- _bridge.py: Handle `flyte_map` FunctionSnapshot in the execute loop, resolve task name from refs, delegate to flyte.map.aio, collect results
- __init__.py: Document flyte_map in ORCHESTRATOR_SYNTAX_PROMPT
- examples/sandbox/code_string.py: Add Examples 8-9 (batch map, map+reduce)
- examples/sandbox/dynamic_code.py: Add Pattern 5 with local execution tests
- tests/flyte/sandbox/test_map_in_sandbox.py: 16 tests covering for-loop pattern, flyte_map basics, kwargs forwarding, error handling, and templates