### PR TITLE
Test map concurrency 

### DIFF
--- a/examples/basics/map_concurrency_verify.py
+++ b/examples/basics/map_concurrency_verify.py
@@ -1,0 +1,94 @@
+"""
+Map Concurrency Verification
+=============================
+Demonstrates the concurrency bug in MapAsyncIterator._initialize():
+
+  Expected (after fix): with concurrency=2 and 8 tasks, tasks start in waves of 2.
+  Bug (current):        all 8 tasks start immediately regardless of concurrency.
+
+How to read the output
+-----------------------
+Each `timed_task` returns its Unix start time.  The parent task sorts them and
+prints the offset from the earliest start.
+
+If concurrency=2 is respected you see two groups of start times:
+
+    task 0  +0.0 s  ─┐
+    task 1  +0.1 s  ─┘ wave 1
+    task 2  +5.0 s  ─┐
+    task 3  +5.1 s  ─┘ wave 2 (after wave 1 finishes)
+    …
+
+If the bug is present all tasks show +0.x s.
+
+Run
+----
+    python examples/basics/map_concurrency_verify.py
+"""
+
+import time
+from typing import List
+
+import flyte
+
+env = flyte.TaskEnvironment(name="map-concurrency-verify")
+
+_TASK_DURATION_S = 5  # how long each task "works"
+
+
+@env.task
+async def timed_task(x: int) -> float:
+    """Sleep to hold a concurrency slot, then return the Unix timestamp of when we started."""
+    import asyncio
+
+    start = time.time()
+    print(f"task {x} started")
+    await asyncio.sleep(_TASK_DURATION_S)
+    return start
+
+
+@env.task
+async def verify_map_concurrency(n: int, concurrency: int) -> List[str]:
+    """
+    Run `timed_task` n times with the given concurrency limit and print a report.
+
+    Look at the 'started at' offsets in the output:
+    - Bug present  → all offsets ≈ 0 s  (all tasks launched at once)
+    - Bug fixed    → offsets increase in steps of ~5s per wave
+    """
+    start_times: List[float] = []
+    async for result in flyte.map.aio(
+        timed_task,
+        range(n),
+        concurrency=concurrency,
+        return_exceptions=True,
+    ):
+        if isinstance(result, Exception):
+            raise result
+        start_times.append(result)
+
+    t0 = min(start_times)
+    lines: List[str] = []
+    for i, t in enumerate(sorted(start_times)):
+        lines.append(f"task {i:2d}  started at +{t - t0:.1f}s")
+
+    # count tasks that started within the first wave window
+    first_wave = sum(1 for t in start_times if t - t0 < _TASK_DURATION_S * 0.5)
+
+    print(f"\n=== Map concurrency={concurrency}, n={n} ===")
+    for line in lines:
+        print(line)
+    print(f"\nTasks that started in first wave: {first_wave}  (expected ≤ {concurrency})")
+
+    if first_wave <= concurrency:
+        print("PASS: concurrency limit appears to be respected.")
+    else:
+        print(f"BUG: {first_wave} tasks started at once, expected at most {concurrency}.")
+
+    return lines
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(verify_map_concurrency, 8, 2)
+    print(run.url)

--- a/tests/user_api/test_mapping.py
+++ b/tests/user_api/test_mapping.py
@@ -97,6 +97,68 @@ def test_map_partials_unhappy():
 
 
 @pytest.mark.asyncio
+async def test_map_concurrency_is_respected():
+    """Regression test: MapAsyncIterator should not start more than `concurrency` tasks at once.
+
+    BUG: _initialize() ignores self.concurrency and creates all tasks immediately.
+    With concurrency=2 and 5 inputs, at most 2 tasks should run concurrently.
+    Currently all 5 are launched, so max_concurrent will equal 5.
+    """
+    import asyncio
+
+    from flyte._map import MapAsyncIterator
+
+    active = 0
+    max_concurrent = 0
+    gate = asyncio.Event()
+
+    async def slow_task():
+        nonlocal active, max_concurrent
+        active += 1
+        max_concurrent = max(max_concurrent, active)
+        await gate.wait()  # block until released
+        active -= 1
+
+    class FakeTask:
+        """Minimal stand-in for AsyncFunctionTaskTemplate.
+        .aio() returns a raw coroutine so asyncio.create_task wraps it directly —
+        no AsyncMock indirection that might swallow the coroutine body.
+        """
+
+        name = "slow_task"
+
+        def aio(self, *args, **kwargs):
+            del args, kwargs  # FakeTask accepts mapped args but slow_task ignores them
+            return slow_task()
+
+    iterator = MapAsyncIterator(
+        func=FakeTask(),
+        args=([1, 2, 3, 4, 5],),
+        name="test_concurrency",
+        concurrency=2,
+        return_exceptions=True,
+    )
+
+    # _initialize() has no awaits, so this completes synchronously and schedules
+    # all 5 task callbacks into the call_soon queue without running them yet.
+    await iterator._initialize()
+
+    # One sleep(0) yield: the event loop runs all 5 queued tasks until their first
+    # await (gate.wait()), then resumes this coroutine.
+    # With the bug all 5 reach gate.wait() simultaneously → max_concurrent == 5.
+    await asyncio.sleep(0)
+
+    # max_concurrent should be <= 2.
+    assert max_concurrent <= 2, (
+        f"Expected at most 2 concurrent tasks (concurrency=2), but {max_concurrent} ran at once. "
+        "MapAsyncIterator._initialize() is not honouring the concurrency parameter."
+    )
+
+    gate.set()
+    await asyncio.sleep(0)  # let remaining tasks complete
+
+
+@pytest.mark.asyncio
 async def test_map_async_iterator_initialize_with_partial():
     from functools import partial
     from unittest.mock import AsyncMock, Mock


### PR DESCRIPTION
Adds a task and test for map concurrency

test with `uv run pytest tests/user_api/test_mapping.py::test_map_concurrency_is_respected -v`