### PR TITLE
flyte.run using image with_code_bundle fails to discover all envs

### DIFF
--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -215,14 +215,13 @@ class _Runner:
                 # Must cover the parent env AND all depends_on envs (recursively)
                 # so that _build_images can compute the content hash for every image.
                 parent_env = cast(Environment, obj.parent_env())
-                from ._deploy import plan_deploy
                 from flyte._image import Image, resolve_code_bundle_layer
+
+                from ._deploy import plan_deploy
 
                 for _env in plan_deploy(parent_env)[0].envs.values():
                     if isinstance(_env.image, Image):
-                        _env.image = resolve_code_bundle_layer(
-                            _env.image, self._copy_files, pathlib.Path(cfg.root_dir)
-                        )
+                        _env.image = resolve_code_bundle_layer(_env.image, self._copy_files, pathlib.Path(cfg.root_dir))
 
                 if not self._dry_run:
                     image_cache = await build_images.aio(parent_env)

--- a/tests/flyte/test_deploy.py
+++ b/tests/flyte/test_deploy.py
@@ -373,7 +373,9 @@ def test_resolve_covers_depends_on_envs():
     from pathlib import Path
 
     dep_image = flyte.Image.from_base("python:3.10").clone(registry="r", name="dep", extendable=True).with_code_bundle()
-    parent_image = flyte.Image.from_base("python:3.10").clone(registry="r", name="parent", extendable=True).with_code_bundle()
+    parent_image = (
+        flyte.Image.from_base("python:3.10").clone(registry="r", name="parent", extendable=True).with_code_bundle()
+    )
 
     env_dep = flyte.TaskEnvironment(name="dep", image=dep_image)
     env_parent = flyte.TaskEnvironment(name="parent", image=parent_image, depends_on=[env_dep])


### PR DESCRIPTION
Replace the single-env resolve with a loop over plan_deploy(parent_env)[0].envs.values(). This is the same traversal `build_images` uses internally. This mirrors exactly what `apply()` in `_deploy.py` already did correctly: https://github.com/flyteorg/flyte-sdk/blob/f901848f21ad936e0a700081815406874178c3ce/src/flyte/_deploy.py#L458