### PR TITLE
account for duplicate env deployment

### DIFF
--- a/src/flyte/_deploy.py
+++ b/src/flyte/_deploy.py
@@ -565,7 +565,9 @@ def plan_deploy(*envs: Environment, version: Optional[str] = None) -> List[Deplo
     visited_envs: Dict[str, Environment] = {}
     for env in envs:
         if env.name in visited_envs:
-            _check_duplicate_env(visited_envs[env.name], env)
+            if visited_envs[env.name] is not env:
+                _check_duplicate_env(visited_envs[env.name], env)
+            continue  # already included via depends_on of a prior env
         planned_envs = _recursive_discover({}, env)
         deployment_plans.append(DeploymentPlan(planned_envs, version=version))
         visited_envs.update(planned_envs)

--- a/tests/flyte/test_deploy.py
+++ b/tests/flyte/test_deploy.py
@@ -259,6 +259,14 @@ def test_plan_deploy_dual_import_raises(dual_import_envs):
         plan_deploy(env1, env2)
 
 
+def test_plan_deploy_explicit_dep_no_false_positive():
+    """flyte.deploy(env_a, env_b) where env_a.depends_on=[env_b] must not raise."""
+    env_b = flyte.TaskEnvironment(name="b", image="python:3.10")
+    env_a = flyte.TaskEnvironment(name="a", image="python:3.10", depends_on=[env_b])
+    plans = plan_deploy(env_a, env_b)  # must not raise
+    assert len(plans) == 1  # env_b already covered, no second plan
+
+
 def test_recursive_discover_dual_import_raises(dual_import_envs):
     """_recursive_discover surfaces the dual-import error via the identity guard."""
     env1, env2, modules = dual_import_envs


### PR DESCRIPTION
when env_data depends on env_train:
```
env_train = flyte.TaskEnvironment(name="training", image=env_train_image)
env_data = flyte.TaskEnvironment(name="data-prep", image=env_data_image, depends_on=[env_train])
````

```
flyte.deploy(env_data, copy_style="none", version="3.0.0")
```
will deploy both.

```
flyte.deploy(env_data, copy_style="none", version="3.0.0")
flyte.deploy(env_train, copy_style="none", version="3.0.0")
```
also works. but

```
flyte.deploy(env_data, env_train, copy_style="none", version="3.0.0")
```
gives:
```
ValueError: Environment 'training' is defined in '/Users/danielsola/repos/multi_image_repro/v2_guide/remote_builder/main.py' but was imported twice under different module names ('__main__' and '__main__'). This is usually caused by running `flyte deploy` from the project root of a src/ layout project without --root-dir. Try adding --root-dir src (or your source root directory)
```

I think that we should be able to accommodate this pattern by adding `_check_duplicate_env` to each env in `plan_deploy`