### PR TITLE
add start/stop app CLI

### DIFF
--- a/src/flyte/cli/_start.py
+++ b/src/flyte/cli/_start.py
@@ -1,5 +1,7 @@
 import rich_click as click
 
+import flyte.cli._common as common
+
 
 @click.group()
 def start():
@@ -43,3 +45,18 @@ def demo(image: str, dev: bool):
     from flyte.cli._demo import launch_demo
 
     launch_demo(image, dev)
+
+
+@start.command(cls=common.CommandBase)
+@click.argument("name", type=str, required=True)
+@click.pass_obj
+def app(cfg: common.CLIConfig, name: str, project: str | None = None, domain: str | None = None):
+    """Start (activate) a deployed Flyte app."""
+    from flyte.remote import App
+
+    cfg.init(project, domain)
+    console = common.get_console()
+    with console.status(f"Starting app {name}..."):
+        app_obj = App.get(name=name, project=project, domain=domain)
+        app_obj.activate(wait=True)
+    console.log(f"[green]Successfully started app {name}[/green]")

--- a/src/flyte/cli/_stop.py
+++ b/src/flyte/cli/_stop.py
@@ -1,0 +1,23 @@
+import rich_click as click
+
+import flyte.cli._common as common
+
+
+@click.group(name="stop")
+def stop():
+    """Stop various Flyte services."""
+
+
+@stop.command(cls=common.CommandBase)
+@click.argument("name", type=str, required=True)
+@click.pass_obj
+def app(cfg: common.CLIConfig, name: str, project: str | None = None, domain: str | None = None):
+    """Stop (deactivate) a deployed Flyte app."""
+    from flyte.remote import App
+
+    cfg.init(project, domain)
+    console = common.get_console()
+    with console.status(f"Stopping app {name}..."):
+        app_obj = App.get(name=name, project=project, domain=domain)
+        app_obj.deactivate(wait=True)
+    console.log(f"[green]Successfully stopped app {name}[/green]")

--- a/src/flyte/cli/main.py
+++ b/src/flyte/cli/main.py
@@ -18,6 +18,7 @@ from ._prefetch import prefetch
 from ._run import run
 from ._serve import serve
 from ._start import start
+from ._stop import stop
 from ._update import update
 from ._user import whoami
 
@@ -33,6 +34,10 @@ help_config = click.RichHelpConfiguration(
             {
                 "name": "Serve Apps",
                 "commands": ["serve"],
+            },
+            {
+                "name": "Start and stop Flyte apps and local services",
+                "commands": ["start", "stop"],
             },
             {
                 "name": "Management of various objects.",
@@ -248,6 +253,7 @@ main.add_command(whoami)  # type: ignore
 main.add_command(update)  # type: ignore
 main.add_command(serve)  # type: ignore
 main.add_command(start)  # type: ignore
+main.add_command(stop)  # type: ignore
 main.add_command(prefetch)  # type: ignore
 
 # Discover and register CLI plugins from installed packages

--- a/tests/cli/test_start_stop_app.py
+++ b/tests/cli/test_start_stop_app.py
@@ -1,0 +1,75 @@
+"""Tests for `flyte start app` and `flyte stop app` CLI commands."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from flyte.cli.main import main
+
+
+@pytest.fixture(scope="function")
+def runner():
+    return CliRunner()
+
+
+class TestStartApp:
+    @patch("flyte.remote.App.get")
+    @patch("flyte.cli._common.CLIConfig", return_value=Mock())
+    def test_activate_called_with_wait(self, mock_cli_config, mock_app_get, runner):
+        mock_app = Mock()
+        mock_app.activate = Mock(return_value=mock_app)
+        mock_app_get.return_value = mock_app
+
+        result = runner.invoke(main, ["start", "app", "my-app"])
+
+        assert result.exit_code == 0, result.output
+        mock_app_get.assert_called_once_with(name="my-app", project=None, domain=None)
+        mock_app.activate.assert_called_once_with(wait=True)
+
+    @patch("flyte.remote.App.get")
+    @patch("flyte.cli._common.CLIConfig", return_value=Mock())
+    def test_project_and_domain(self, mock_cli_config, mock_app_get, runner):
+        mock_app = Mock()
+        mock_app.activate = Mock(return_value=mock_app)
+        mock_app_get.return_value = mock_app
+
+        result = runner.invoke(
+            main,
+            ["start", "app", "my-app", "-p", "my-project", "-d", "development"],
+        )
+
+        assert result.exit_code == 0, result.output
+        mock_app_get.assert_called_once_with(name="my-app", project="my-project", domain="development")
+        mock_app.activate.assert_called_once_with(wait=True)
+
+
+class TestStopApp:
+    @patch("flyte.remote.App.get")
+    @patch("flyte.cli._common.CLIConfig", return_value=Mock())
+    def test_deactivate_called_with_wait(self, mock_cli_config, mock_app_get, runner):
+        mock_app = Mock()
+        mock_app.deactivate = Mock(return_value=mock_app)
+        mock_app_get.return_value = mock_app
+
+        result = runner.invoke(main, ["stop", "app", "my-app"])
+
+        assert result.exit_code == 0, result.output
+        mock_app_get.assert_called_once_with(name="my-app", project=None, domain=None)
+        mock_app.deactivate.assert_called_once_with(wait=True)
+
+    @patch("flyte.remote.App.get")
+    @patch("flyte.cli._common.CLIConfig", return_value=Mock())
+    def test_project_and_domain(self, mock_cli_config, mock_app_get, runner):
+        mock_app = Mock()
+        mock_app.deactivate = Mock(return_value=mock_app)
+        mock_app_get.return_value = mock_app
+
+        result = runner.invoke(
+            main,
+            ["stop", "app", "my-app", "-p", "my-project", "-d", "development"],
+        )
+
+        assert result.exit_code == 0, result.output
+        mock_app_get.assert_called_once_with(name="my-app", project="my-project", domain="development")
+        mock_app.deactivate.assert_called_once_with(wait=True)


### PR DESCRIPTION
This pull request introduces new CLI commands to start and stop deployed Flyte apps, updates the CLI main entry point to register these commands, and adds comprehensive tests to ensure their correct behavior. The changes improve the CLI's usability for managing app lifecycle and enhance test coverage.

**New CLI commands for app lifecycle management:**

- Added a `flyte start app` command to activate (start) a deployed Flyte app, with support for specifying project and domain. (`src/flyte/cli/_start.py` [src/flyte/cli/_start.pyR48-R62](diffhunk://#diff-b5bcf50f1dfc9a1b2038e659c67aa8f8dce102240e96d332819e24f33cc2b535R48-R62))
- Added a `flyte stop app` command to deactivate (stop) a deployed Flyte app, also supporting project and domain selection. (`src/flyte/cli/_stop.py` [src/flyte/cli/_stop.pyR1-R23](diffhunk://#diff-7e2d1e048b8e8a3b49f46fada659c4c54aee1c67380bcce497e69c391ba7e594R1-R23))

**CLI integration and documentation:**

- Registered the new `start` and `stop` command groups in the main CLI entry point and updated the help menu to describe their purpose. (`src/flyte/cli/main.py` [[1]](diffhunk://#diff-df5383518be653a60f5b150e7b223fd39b340e58e35a0a9bfe7fef6b3cafaeb2R21) [[2]](diffhunk://#diff-df5383518be653a60f5b150e7b223fd39b340e58e35a0a9bfe7fef6b3cafaeb2R38-R41) [[3]](diffhunk://#diff-df5383518be653a60f5b150e7b223fd39b340e58e35a0a9bfe7fef6b3cafaeb2R256)

**Testing improvements:**

- Added tests for the new `start app` and `stop app` CLI commands, verifying correct invocation and argument passing, including project and domain parameters. (`tests/cli/test_start_stop_app.py` [tests/cli/test_start_stop_app.pyR1-R75](diffhunk://#diff-e67936bf8b688c18cd246b1ea91544950c6476b306e249699977015249a1822cR1-R75))