### PR TITLE
Update docs variant system: byoc+selfmanaged -> union

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -92,7 +92,7 @@ async def parallel_training(hyperparams: list[dict]) -> dict:
 
 ## CLI
 
-The Flyte CLI follows a **verb noun** structure. Full reference: [CLI Docs](https://www.union.ai/docs/v2/byoc/api-reference/flyte-cli/)
+The Flyte CLI follows a **verb noun** structure. Full reference: [CLI Docs](https://www.union.ai/docs/v2/union/api-reference/flyte-cli/)
 
 ```bash
 flyte run hello.py main --numbers '[1,2,3]'     # Run a task

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-orange)](LICENSE)
 [![Try in Browser](https://img.shields.io/badge/Try%20in%20Browser-Live%20Demo-7652a2)](https://flyte2intro.apps.demo.hosted.unionai.cloud/)
 [![Docs](https://img.shields.io/badge/Docs-flyte-blue)](https://www.union.ai/docs/v2/flyte/user-guide/running-locally/)
-[![SDK Reference](https://img.shields.io/badge/SDK%20Reference-API-brightgreen)](https://www.union.ai/docs/v2/byoc/api-reference/flyte-sdk/)
-[![CLI Reference](https://img.shields.io/badge/CLI%20Reference-API-brightgreen)](https://www.union.ai/docs/v2/byoc/api-reference/flyte-cli/)
+[![SDK Reference](https://img.shields.io/badge/SDK%20Reference-API-brightgreen)](https://www.union.ai/docs/v2/union/api-reference/flyte-sdk/)
+[![CLI Reference](https://img.shields.io/badge/CLI%20Reference-API-brightgreen)](https://www.union.ai/docs/v2/union/api-reference/flyte-cli/)
 
 ## Install
 
@@ -124,8 +124,8 @@ pip install flyte[tui]
 
 - **[Live Demo](https://flyte2intro.apps.demo.hosted.unionai.cloud/)** — Try Flyte 2 in your browser
 - **[Documentation](https://www.union.ai/docs/v2/flyte/user-guide/running-locally/)** — Get started running locally
-- **[SDK Reference](https://www.union.ai/docs/v2/byoc/api-reference/flyte-sdk/)** — API reference docs
-- **[CLI Reference](https://www.union.ai/docs/v2/byoc/api-reference/flyte-cli/)** — CLI docs
+- **[SDK Reference](https://www.union.ai/docs/v2/union/api-reference/flyte-sdk/)** — API reference docs
+- **[CLI Reference](https://www.union.ai/docs/v2/union/api-reference/flyte-cli/)** — CLI docs
 - **[Join the Flyte 2 Production Preview](https://www.union.ai/try-flyte-2)** — Get early access
 - **[Features](FEATURES.md)** — Async parallelism, app serving, tracing, and more
 - **[Examples](examples/)** — Ready-to-run examples for every feature

--- a/src/flyte/cli/_gen.py
+++ b/src/flyte/cli/_gen.py
@@ -22,7 +22,7 @@ def gen():
     "plugin_variants",
     type=str,
     default=None,
-    help="Hugo variant names for plugin commands (e.g., 'byoc selfmanaged'). "
+    help="Hugo variant names for plugin commands (e.g., 'union'). "
     "When set, plugin command sections and index entries are wrapped in "
     "{{< variant >}} shortcodes. Core commands appear unconditionally.",
 )
@@ -433,13 +433,13 @@ def markdown(cfg: common.CLIConfig, plugin_variants: str | None = None):
 def _non_plugin_variants(plugin_variants: str) -> str:
     """Derive core variant names from the page's variant list minus plugin variants.
 
-    The page frontmatter declares all variants (e.g., +flyte +byoc +selfmanaged).
-    Plugin variants are the ones that should show plugin commands (e.g., byoc selfmanaged).
+    The page frontmatter declares all variants (e.g., +flyte +union).
+    Plugin variants are the ones that should show plugin commands (e.g., union).
     This function returns the remaining variants (e.g., flyte).
     """
     # For now, we hardcode "flyte" as the core variant since that's the only
     # non-plugin variant. A more robust approach would read the page frontmatter.
-    all_variants = {"flyte", "byoc", "selfmanaged"}
+    all_variants = {"flyte", "union"}
     plugin_set = set(plugin_variants.split())
     core = all_variants - plugin_set
     return " ".join(sorted(core))


### PR DESCRIPTION
## Summary

- Update `_non_plugin_variants()` in `flyte gen docs` to use `{"flyte", "union"}` instead of `{"flyte", "byoc", "selfmanaged"}`
- Update `--plugin-variants` help text to reflect new variant names
- Update documentation URLs in README.md and FEATURES.md from `/byoc/` to `/union/`

This is part of the docs variant consolidation: the unionai-docs site is merging the `byoc` and `selfmanaged` variants into a single `union` variant. The `flyte gen docs --plugin-variants 'union'` command will now correctly generate `{{< variant union >}}` and `{{< variant flyte >}}` shortcodes.

Companion PRs: unionai/unionai-docs-infra and unionai/unionai-docs

## Test plan

- [ ] Verify `flyte gen docs --type markdown --plugin-variants 'union'` produces correct shortcodes
- [ ] Verify generated CLI docs build correctly with the updated unionai-docs variant system

🤖 Generated with [Claude Code](https://claude.com/claude-code)