### PR TITLE
[Demo cluster] Skip cluster status check in dev mode

### DIFF
--- a/src/flyte/cli/_demo.py
+++ b/src/flyte/cli/_demo.py
@@ -192,6 +192,5 @@ def launch_demo(image_name: str, is_dev_mode: bool) -> None:
     _switch_k8s_context()
     if not is_dev_mode:
         _wait_for_console_ready(_CONSOLE_READYZ_URL)
-
-    click.echo("\nFlyte demo cluster is ready!")
-    click.echo("UI is available at http://localhost:30080/v2")
+        click.echo("\nFlyte demo cluster is ready!")
+        click.echo("UI is available at http://localhost:30080/v2")


### PR DESCRIPTION
## Goal

In dev mode, user will need to start sandbox outside the cluster. Thus, the cli should skip cluster status check in dev mode.