### PR TITLE
 fix: surface worker errors hidden inside BaseExceptionGroup in parallel reader

### DIFF
--- a/src/flyte/storage/_parallel_reader.py
+++ b/src/flyte/storage/_parallel_reader.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import io
-import logging
 import os
 import pathlib
 import sys
@@ -15,7 +14,7 @@ import aiofiles
 import aiofiles.os
 import obstore
 
-logger = logging.getLogger(__name__)
+from flyte._logging import logger
 
 if typing.TYPE_CHECKING:
     from obstore import Bytes, ObjectMeta
@@ -158,10 +157,13 @@ class ObstoreParallelReader:
                 pass
 
         async def _worker():
-            task: DownloadTask | None = None
             try:
                 while not done.is_set():
-                    task = await inq.get()
+                    try:
+                        task: DownloadTask = await inq.get()
+                    except Exception:
+                        logger.exception("Worker failed before receiving a task")
+                        raise
                     if task is sentinel:
                         inq.put_nowait(sentinel)
                         break
@@ -170,12 +172,20 @@ class ObstoreParallelReader:
                     # The actual file position is the sum of both
                     file_offset = task.chunk.offset + task.source.offset
                     buf = active[task.source.id]
-                    data_to_write = await obstore.get_range_async(
-                        self._store,
-                        str(task.source.path),
-                        start=file_offset,
-                        end=file_offset + task.chunk.length,
-                    )
+                    try:
+                        data_to_write = await obstore.get_range_async(
+                            self._store,
+                            str(task.source.path),
+                            start=file_offset,
+                            end=file_offset + task.chunk.length,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Worker failed downloading chunk of %s at offset %d",
+                            task.source.path,
+                            task.chunk.offset,
+                        )
+                        raise
                     await buf.write(
                         task.chunk.offset,
                         task.chunk.length,
@@ -193,16 +203,6 @@ class ObstoreParallelReader:
                     del active[task.source.id]
             except asyncio.CancelledError:
                 pass
-            except Exception:
-                if task is not None:
-                    logger.exception(
-                        "Worker failed downloading chunk of %s at offset %d",
-                        task.source.path,
-                        task.chunk.offset,
-                    )
-                else:
-                    logger.exception("Worker failed before receiving a task")
-                raise
             finally:
                 done.set()
 

--- a/tests/flyte/storage/test_parallel_reader.py
+++ b/tests/flyte/storage/test_parallel_reader.py
@@ -2,6 +2,7 @@ import asyncio
 import filecmp
 import os
 import time
+import unittest.mock as mock
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -13,6 +14,67 @@ from flyte import storage
 from flyte._context import internal_ctx
 from flyte.storage import S3
 from flyte.storage._parallel_reader import ObstoreParallelReader
+
+
+@pytest.mark.asyncio
+async def test_worker_logs_exception_on_download_failure(tmp_path):
+    """Worker should log the failing file path before re-raising so the real
+    error is visible instead of being swallowed inside a BaseExceptionGroup."""
+
+    store = mock.MagicMock()
+    reader = ObstoreParallelReader(store, max_concurrency=1)
+
+    async def _mock_list(*args, **kwargs):
+        yield [{"path": "prefix/file.txt", "size": 100}]
+
+    with (
+        mock.patch("flyte.storage._parallel_reader.obstore") as mock_obstore,
+        mock.patch("flyte.storage._parallel_reader.logger") as mock_logger,
+    ):
+        mock_obstore.list = _mock_list
+        mock_obstore.get_range_async = mock.AsyncMock(side_effect=RuntimeError("GCS 429: Too Many Requests"))
+
+        with pytest.raises(Exception):
+            await reader.download_files(Path("prefix"), tmp_path)
+
+    mock_logger.exception.assert_called_once()
+    call_args = str(mock_logger.exception.call_args)
+    assert "prefix/file.txt" in call_args
+
+
+@pytest.mark.asyncio
+async def test_worker_logs_exception_before_task_received(tmp_path):
+    """Worker should log a fallback message when inq.get() raises before any
+    task is dequeued (task is still None at that point)."""
+
+    store = mock.MagicMock()
+    reader = ObstoreParallelReader(store, max_concurrency=1)
+
+    async def _mock_list(*args, **kwargs):
+        yield [{"path": "prefix/file.txt", "size": 100}]
+
+    class _RaisingInQueue(asyncio.Queue):
+        # inq is created with maxsize > 0; outq has maxsize == 0.
+        # Only raise for inq so the main outq.get() loop is unaffected.
+        async def get(self):
+            if self.maxsize > 0:
+                raise RuntimeError("inq exploded before task received")
+            return await super().get()
+
+    with (
+        mock.patch("flyte.storage._parallel_reader.obstore") as mock_obstore,
+        mock.patch("flyte.storage._parallel_reader.logger") as mock_logger,
+        mock.patch("flyte.storage._parallel_reader.asyncio.Queue", _RaisingInQueue),
+    ):
+        mock_obstore.list = _mock_list
+        mock_obstore.get_range_async = mock.AsyncMock()
+
+        with pytest.raises(Exception):
+            await reader.download_files(Path("prefix"), tmp_path)
+
+    mock_logger.exception.assert_called_once()
+    call_args = str(mock_logger.exception.call_args)
+    assert "before receiving a task" in call_args
 
 
 @pytest.mark.skip


### PR DESCRIPTION
When `obstore.get_range_async` raised a transient error (e.g. GCS 429), it was swallowed inside a BaseExceptionGroup by asyncio.TaskGroup, showing only "Filtered traceback" with no actionable message in task logs.

 ## Summary

  - Replaced logging.getLogger(__name__) with the shared flyte._logging.logger, consistentwith other storage modules
  - Added inline try/except around task = await inq.get() — logs "Worker failed before receiving a task" if the queue itself raises
  - Added inline try/except around obstore.get_range_async(...) — logs the failing file path and chunk offset before re-raising

 ## Test Plan

  - test_worker_logs_exception_on_download_failure — mocks obstore.get_range_async to raise RuntimeError("GCS 429"), asserts logger.exception is called with the failing file path, and that the exception still propagates
  - test_worker_logs_exception_before_task_received — replaces asyncio.Queue with a subclass that raises on get() only for bounded queues (targeting inq, not outq), asserts the fallback log message is emitted