### PR TITLE
Fix stale auth header accumulation on ConnectRPC retry

### DIFF
--- a/src/flyte/remote/_client/auth/_authenticators/passthrough.py
+++ b/src/flyte/remote/_client/auth/_authenticators/passthrough.py
@@ -32,7 +32,7 @@ class PassthroughAuthenticator(Authenticator):
         )
         self._creds_id: str = "passthrough"
 
-    def refresh_credentials(self, creds_id: str | None = None):
+    async def refresh_credentials(self, creds_id: str | None = None):
         return
 
     def get_credentials(self) -> typing.Optional[Credentials]:

--- a/src/flyte/remote/_client/auth/_interceptors/auth.py
+++ b/src/flyte/remote/_client/auth/_interceptors/auth.py
@@ -6,7 +6,7 @@ from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 
 if typing.TYPE_CHECKING:
-    from flyte.remote._client.auth._authenticators.base import Authenticator
+    from flyte.remote._client.auth._authenticators.base import AuthHeaders, Authenticator
 
 
 class _BaseAuthInterceptor:
@@ -22,18 +22,27 @@ class _BaseAuthInterceptor:
             self._authenticator = self._get_authenticator()
         return self._authenticator
 
-    async def _inject_auth_headers(self, ctx) -> str:
-        """Inject auth headers into request context. Returns creds_id for refresh tracking."""
+    async def _inject_auth_headers(self, ctx, *, previous: AuthHeaders | None = None) -> AuthHeaders | None:
+        """Inject auth headers into request context, removing any previously injected headers first."""
+        # The old gRPC interceptor rebuilt ClientCallDetails from scratch on each attempt, so stale
+        # auth headers could never accumulate across retries. ConnectRPC's RequestContext is mutable
+        # and shared across retries, so we must explicitly remove headers from the previous attempt
+        # before injecting fresh ones — otherwise a header key change (e.g. "authorization" →
+        # "flyte-authorization") leaves the stale key behind.
+        if previous is not None:
+            headers = ctx.request_headers()
+            for key in previous.headers:
+                headers.pop(key, None)
+
         auth_headers = await self.authenticator.get_auth_headers()
         if auth_headers:
             ctx.request_headers().update(auth_headers.headers)
-            return auth_headers.creds_id
-        return ""
+        return auth_headers
 
-    async def _refresh_and_reinject(self, creds_id: str, ctx) -> None:
-        """Refresh credentials and re-inject auth headers."""
-        await self.authenticator.refresh_credentials(creds_id=creds_id)
-        await self._inject_auth_headers(ctx)
+    async def _refresh_and_reinject(self, previous: AuthHeaders | None, ctx) -> None:
+        """Refresh credentials and re-inject auth headers, removing stale ones."""
+        await self.authenticator.refresh_credentials(creds_id=previous.creds_id if previous else None)
+        await self._inject_auth_headers(ctx, previous=previous)
 
 
 _RETRYABLE_AUTH_CODES = frozenset({Code.UNAUTHENTICATED, Code.UNKNOWN})
@@ -43,12 +52,12 @@ class AuthUnaryInterceptor(_BaseAuthInterceptor):
     """ConnectRPC unary interceptor that injects auth headers and retries on UNAUTHENTICATED."""
 
     async def intercept_unary(self, call_next, request, ctx):
-        creds_id = await self._inject_auth_headers(ctx)
+        auth_headers = await self._inject_auth_headers(ctx)
         try:
             return await call_next(request, ctx)
         except ConnectError as e:
             if e.code in _RETRYABLE_AUTH_CODES:
-                await self._refresh_and_reinject(creds_id, ctx)
+                await self._refresh_and_reinject(auth_headers, ctx)
                 return await call_next(request, ctx)
             raise
 
@@ -64,12 +73,12 @@ class AuthClientStreamInterceptor(_BaseAuthInterceptor):
     """
 
     async def intercept_client_stream(self, call_next, request, ctx):
-        creds_id = await self._inject_auth_headers(ctx)
+        auth_headers = await self._inject_auth_headers(ctx)
         try:
             return await call_next(request, ctx)
         except ConnectError as e:
             if e.code in _RETRYABLE_AUTH_CODES:
-                await self._refresh_and_reinject(creds_id, ctx)
+                await self._refresh_and_reinject(auth_headers, ctx)
                 return await call_next(request, ctx)
             raise
 
@@ -78,13 +87,13 @@ class AuthServerStreamInterceptor(_BaseAuthInterceptor):
     """ConnectRPC server-stream interceptor that injects auth headers and retries on UNAUTHENTICATED."""
 
     async def intercept_server_stream(self, call_next, request, ctx):
-        creds_id = await self._inject_auth_headers(ctx)
+        auth_headers = await self._inject_auth_headers(ctx)
         try:
             async for response in call_next(request, ctx):
                 yield response
         except ConnectError as e:
             if e.code in _RETRYABLE_AUTH_CODES:
-                await self._refresh_and_reinject(creds_id, ctx)
+                await self._refresh_and_reinject(auth_headers, ctx)
                 async for response in call_next(request, ctx):
                     yield response
             else:
@@ -98,13 +107,13 @@ class AuthBidiStreamInterceptor(_BaseAuthInterceptor):
     """
 
     async def intercept_bidi_stream(self, call_next, request, ctx):
-        creds_id = await self._inject_auth_headers(ctx)
+        auth_headers = await self._inject_auth_headers(ctx)
         try:
             async for response in call_next(request, ctx):
                 yield response
         except ConnectError as e:
             if e.code in _RETRYABLE_AUTH_CODES:
-                await self._refresh_and_reinject(creds_id, ctx)
+                await self._refresh_and_reinject(auth_headers, ctx)
                 async for response in call_next(request, ctx):
                     yield response
             else:

--- a/src/flyte/remote/_client/auth/_interceptors/auth.py
+++ b/src/flyte/remote/_client/auth/_interceptors/auth.py
@@ -6,7 +6,7 @@ from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 
 if typing.TYPE_CHECKING:
-    from flyte.remote._client.auth._authenticators.base import AuthHeaders, Authenticator
+    from flyte.remote._client.auth._authenticators.base import Authenticator, AuthHeaders
 
 
 class _BaseAuthInterceptor:

--- a/tests/flyte/remote/test_connectrpc_interceptors.py
+++ b/tests/flyte/remote/test_connectrpc_interceptors.py
@@ -237,6 +237,37 @@ class TestAuthUnaryInterceptor:
         assert "authorization" not in headers
 
 
+    @pytest.mark.asyncio
+    async def test_removes_stale_header_on_retry_when_key_changes(self):
+        """When refresh changes the header key (e.g. authorization → flyte-authorization),
+        the old header must be removed so the retry doesn't send both.
+        Non-auth headers must be preserved."""
+        auth = AsyncMock()
+        auth.get_auth_headers.side_effect = [
+            AuthHeaders(creds_id="old", headers={"authorization": "Bearer expired"}),
+            AuthHeaders(creds_id="new", headers={"flyte-authorization": "Bearer fresh"}),
+        ]
+        interceptor = AuthUnaryInterceptor(lambda: auth)
+
+        call_next = AsyncMock(
+            side_effect=[
+                ConnectError(Code.UNAUTHENTICATED, "expired"),
+                "success",
+            ]
+        )
+        ctx, headers = _make_ctx_mock()
+        headers["x-request-id"] = "req-123"
+        headers["content-type"] = "application/proto"
+
+        result = await interceptor.intercept_unary(call_next, "request", ctx)
+
+        assert result == "success"
+        assert "authorization" not in headers, "stale auth header should be removed on retry"
+        assert headers["flyte-authorization"] == "Bearer fresh"
+        assert headers["x-request-id"] == "req-123", "non-auth headers must be preserved"
+        assert headers["content-type"] == "application/proto", "non-auth headers must be preserved"
+
+
 class TestAuthServerStreamInterceptor:
     @pytest.mark.asyncio
     async def test_injects_auth_headers_and_streams(self):

--- a/tests/flyte/remote/test_connectrpc_interceptors.py
+++ b/tests/flyte/remote/test_connectrpc_interceptors.py
@@ -236,7 +236,6 @@ class TestAuthUnaryInterceptor:
         assert result == "response"
         assert "authorization" not in headers
 
-
     @pytest.mark.asyncio
     async def test_removes_stale_header_on_retry_when_key_changes(self):
         """When refresh changes the header key (e.g. authorization → flyte-authorization),


### PR DESCRIPTION
The old gRPC interceptor rebuilt ClientCallDetails from scratch on each attempt, so stale auth headers could never persist across retries. The ConnectRPC interceptor mutates a shared RequestContext via update(), which only adds/overwrites keys but never removes old ones. When the auth header key changes after credential refresh (e.g. "authorization" → "flyte-authorization"), both headers coexist on the retry. The backend's connect headerInterceptor maps both into the "authorization" gRPC metadata key, and if the expired token appears first, auth fails.

Fix: track injected auth headers and remove them before reinjecting on retry, restoring the gRPC-era "fresh metadata per attempt" property.