### PR TITLE
Fix code bundle upload hanging indefinitely on network issues

### DIFF
--- a/src/flyte/remote/_data.py
+++ b/src/flyte/remote/_data.py
@@ -21,7 +21,8 @@ from flyte.errors import InitializationError, RuntimeSystemError
 from flyte.syncify import syncify
 
 _UPLOAD_EXPIRES_IN = timedelta(seconds=60)
-_UPLOAD_TIMEOUT = httpx.Timeout(timeout=600.0, connect=30.0)
+_UPLOAD_TIMEOUT_SECONDS = float(os.environ.get("FLYTE_UPLOAD_TIMEOUT", "600"))
+_UPLOAD_TIMEOUT = httpx.Timeout(timeout=_UPLOAD_TIMEOUT_SECONDS, connect=30.0)
 
 
 def get_extra_headers_for_protocol(native_url: str) -> typing.Dict[str, str]:

--- a/tests/flyte/remote/test_upload_retry.py
+++ b/tests/flyte/remote/test_upload_retry.py
@@ -33,9 +33,27 @@ async def test_upload_success(upload_file):
 
 
 @pytest.mark.asyncio
-async def test_upload_timeout_is_10_minutes():
+async def test_upload_timeout_default():
     assert _UPLOAD_TIMEOUT.read == 600.0
     assert _UPLOAD_TIMEOUT.connect == 30.0
+
+
+@pytest.mark.asyncio
+async def test_upload_timeout_env_override():
+    with patch.dict("os.environ", {"FLYTE_UPLOAD_TIMEOUT": "120"}):
+        import importlib
+
+        import flyte.remote._data as data_mod
+
+        importlib.reload(data_mod)
+        assert data_mod._UPLOAD_TIMEOUT.read == 120.0
+        assert data_mod._UPLOAD_TIMEOUT.connect == 30.0
+
+        # Restore default
+        del data_mod
+        import flyte.remote._data
+
+        importlib.reload(flyte.remote._data)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add 10-minute timeout (600s read, 30s connect) to the `httpx.AsyncClient` used for uploading code bundles to object storage. Previously no timeout was configured, causing `flyte run` to hang forever at "Uploading code bundle..." when the network connection was blocked or dropped.
- Catch `httpx.TimeoutException`, `httpx.ConnectError`, and `OSError` in the retry loop so transport-level errors are retried with backoff (previously only HTTP status codes were retried).
- Fix `last_error` tracking that was always `None` in retry warning logs.

## Context
Reported by a customer whose `flyte run` hung indefinitely at "Uploading code bundle..." from remote EC2 instances. The control plane connection worked fine, but the signed URL upload to object storage was silently blocked by network configuration. Without a timeout, the SDK gave no error — it just hung forever.

Slack thread: https://unionai.slack.com/archives/C05H8K48HPE/p1774990000333939

## Test plan
- [x] `pytest tests/flyte/remote/test_upload_retry.py` — 6 new tests covering timeout config, retry on timeout/connect errors, retry on 5xx then success, and no retry on 4xx
- [x] `pytest tests/flyte/remote/test_data_errors.py` — existing upload error tests still pass