### PR TITLE
feat: accept str as a valid Docker image path

### DIFF
--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -848,13 +848,13 @@ class Image:
         platform = _ensure_tuple(platform) if platform else None
         if type(file) is str:
             file = Path(file)
-        kwargs = {
+        kwargs: dict[str, Any] = {
             "dockerfile": file,
             "registry": registry,
             "name": name,
             "extendable": False,  # Dockerfile-based images cannot have additional layers
         }
-        if platform:
+        if platform is not None:
             kwargs["platform"] = platform
         img = cls._new(**kwargs)
 

--- a/tests/flyte/test_image.py
+++ b/tests/flyte/test_image.py
@@ -253,7 +253,6 @@ def test_dockerfile_with_str_path():
         file=str(Path(__file__).parent / "resources/Dockerfile.test_sample"),
         registry="localhost",
         name="test-image",
-        platform=("linux/amd64"),
     )
     assert img.uri.startswith("localhost/test-image"), f"Unexpected URI: {img.uri}"
     assert img.platform == ("linux/amd64",)


### PR DESCRIPTION
## Motivation
Previously, defining a path to a Docker image required a `Path` object. For better usability, we now accept `str` as well. 

## Summary of Changes
- Updated the `from_dockerfile` definition to accept either a `Path` or `str`
- If a `str` is provided, it is automatically converted to a `Path`
- In `from_dockerfile` allow kwargs values to be of type `Any` -  fix for mypy type mismatch

## Test Plan
- Added a unit test: `test_dockerfile_with_str_path()` which builds an image using a string file path. 