### PR TITLE
fix(spark): guard against code_bundle being None in pre()

### DIFF
--- a/plugins/spark/src/flyteplugins/spark/task.py
+++ b/plugins/spark/src/flyteplugins/spark/task.py
@@ -59,7 +59,7 @@ class PysparkFunctionTask(AsyncFunctionTaskTemplate):
 
         sess = _pyspark.sql.SparkSession.builder.appName(DEFAULT_SPARK_CONTEXT_NAME).getOrCreate()
 
-        if flyte.ctx().is_in_cluster():
+        if flyte.ctx().is_in_cluster() and flyte.ctx().code_bundle is not None:
             base_dir = tempfile.mkdtemp()
             code_bundle_dir = flyte.ctx().code_bundle.destination
             file_name = "flyte_code_bundle"


### PR DESCRIPTION
- Fix `AttributeError: 'NoneType' object has no attribute 'destination'` in `PysparkFunctionTask.pre()` when `code_bundle` is `None`
- This occurs when a Spark task is registered with code baked into the Docker image (not via fast-register / code bundle upload)