### PR TITLE
Fix WantReadError in _bootstrap_ssl_from_server

### DIFF
--- a/src/flyte/remote/_client/auth/_session.py
+++ b/src/flyte/remote/_client/auth/_session.py
@@ -83,10 +83,15 @@ def _bootstrap_ssl_from_server(endpoint: str) -> bytes:
     ctx.set_verify(SSL.VERIFY_NONE, lambda *args: True)
 
     sock = socket.create_connection(server_address, timeout=10)
-    conn = SSL.Connection(ctx, sock)
-    conn.set_tlsext_host_name(server_address[0].encode())
-    conn.set_connect_state()
+    # create_connection with a timeout leaves the fd in non-blocking mode.
+    # Restore blocking mode so pyOpenSSL's do_handshake() won't raise
+    # WantReadError/WantWriteError.
+    sock.settimeout(None)
+    conn = None
     try:
+        conn = SSL.Connection(ctx, sock)
+        conn.set_tlsext_host_name(server_address[0].encode())
+        conn.set_connect_state()
         conn.do_handshake()
 
         chain = conn.get_peer_cert_chain()
@@ -97,7 +102,10 @@ def _bootstrap_ssl_from_server(endpoint: str) -> bytes:
         logger.debug(f"Retrieved certificate chain ({len(pem_certs)} certs) from {server_address}")
         return b"\n".join(pem_certs)
     finally:
-        conn.close()
+        if conn is not None:
+            conn.close()
+        else:
+            sock.close()
 
 
 async def _resolve_tls_ca_cert(

--- a/src/flyte/remote/_client/auth/_session.py
+++ b/src/flyte/remote/_client/auth/_session.py
@@ -83,9 +83,16 @@ def _bootstrap_ssl_from_server(endpoint: str) -> bytes:
     ctx.set_verify(SSL.VERIFY_NONE, lambda *args: True)
 
     sock = socket.create_connection(server_address, timeout=10)
-    # create_connection with a timeout leaves the fd in non-blocking mode.
-    # Restore blocking mode so pyOpenSSL's do_handshake() won't raise
-    # WantReadError/WantWriteError.
+    # create_connection with a timeout sets O_NONBLOCK on the fd. pyOpenSSL's
+    # do_handshake() operates directly on the fd and raises WantReadError /
+    # WantWriteError when it sees EAGAIN. settimeout(None) restores blocking
+    # mode to avoid this. A positive timeout (e.g. settimeout(30)) won't help
+    # because CPython still sets O_NONBLOCK for any timeout > 0.
+    #
+    # This means the TLS handshake has no deadline, but that is acceptable:
+    # the 10s TCP connect timeout above already proves the peer is reachable,
+    # this is a one-time bootstrap path (not a hot path), and it runs inside
+    # asyncio.to_thread() so a stall won't block the event loop.
     sock.settimeout(None)
     conn = None
     try:

--- a/tests/flyte/remote/test_session.py
+++ b/tests/flyte/remote/test_session.py
@@ -219,6 +219,56 @@ class TestBootstrapSslFromServer:
 
         mock_socket.create_connection.assert_called_once_with(("example.com", 443), timeout=10)
 
+    def test_raises_on_empty_cert_chain(self):
+        """RuntimeError when server returns no certificates."""
+        mock_conn = MagicMock()
+        mock_conn.get_peer_cert_chain.return_value = []
+
+        with (
+            patch(f"{_SESSION_MOD}.SSL") as mock_ssl,
+            patch(f"{_SESSION_MOD}.crypto"),
+            patch(f"{_SESSION_MOD}.socket"),
+        ):
+            mock_ssl.Connection.return_value = mock_conn
+            with pytest.raises(RuntimeError, match="returned no certificates"):
+                _bootstrap_ssl_from_server("https://example.com:443")
+
+        mock_conn.close.assert_called_once()
+
+    def test_closes_conn_on_success(self):
+        """conn.close() is called after successful chain retrieval."""
+        mock_conn = MagicMock()
+        mock_conn.get_peer_cert_chain.return_value = [MagicMock()]
+
+        with (
+            patch(f"{_SESSION_MOD}.SSL") as mock_ssl,
+            patch(f"{_SESSION_MOD}.crypto") as mock_crypto,
+            patch(f"{_SESSION_MOD}.socket"),
+        ):
+            mock_ssl.Connection.return_value = mock_conn
+            mock_crypto.dump_certificate.return_value = (
+                b"-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n"
+            )
+            _bootstrap_ssl_from_server("https://example.com:443")
+
+        mock_conn.close.assert_called_once()
+
+    def test_closes_socket_if_connection_setup_fails(self):
+        """Socket is closed if SSL.Connection() raises before conn is set."""
+        mock_sock = MagicMock()
+
+        with (
+            patch(f"{_SESSION_MOD}.SSL") as mock_ssl,
+            patch(f"{_SESSION_MOD}.crypto"),
+            patch(f"{_SESSION_MOD}.socket") as mock_socket,
+        ):
+            mock_socket.create_connection.return_value = mock_sock
+            mock_ssl.Connection.side_effect = RuntimeError("SSL init failed")
+            with pytest.raises(RuntimeError, match="SSL init failed"):
+                _bootstrap_ssl_from_server("https://example.com:443")
+
+        mock_sock.close.assert_called_once()
+
 
 class TestClientSetSessionConfig:
     def test_exposes_session_config(self):

--- a/tests/flyte/remote/test_session.py
+++ b/tests/flyte/remote/test_session.py
@@ -239,18 +239,21 @@ class TestBootstrapSslFromServer:
         """conn.close() is called after successful chain retrieval."""
         mock_conn = MagicMock()
         mock_conn.get_peer_cert_chain.return_value = [MagicMock()]
+        mock_sock = MagicMock()
 
         with (
             patch(f"{_SESSION_MOD}.SSL") as mock_ssl,
             patch(f"{_SESSION_MOD}.crypto") as mock_crypto,
-            patch(f"{_SESSION_MOD}.socket"),
+            patch(f"{_SESSION_MOD}.socket") as mock_socket,
         ):
+            mock_socket.create_connection.return_value = mock_sock
             mock_ssl.Connection.return_value = mock_conn
             mock_crypto.dump_certificate.return_value = (
                 b"-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n"
             )
             _bootstrap_ssl_from_server("https://example.com:443")
 
+        mock_sock.settimeout.assert_called_once_with(None)
         mock_conn.close.assert_called_once()
 
     def test_closes_socket_if_connection_setup_fails(self):


### PR DESCRIPTION
## Summary

- Fix `WantReadError` / `WantWriteError` raised by pyOpenSSL's `do_handshake()` when `socket.create_connection()` leaves the fd in non-blocking mode (O_NONBLOCK set for any timeout > 0). Restore blocking mode with `sock.settimeout(None)` before the TLS handshake.
- Improve resource cleanup: close the raw socket if `SSL.Connection()` fails before `conn` is assigned.
- Add tests for empty cert chain, successful close, and socket cleanup on connection setup failure.
- Assert that `settimeout(None)` is called on the socket, directly covering the core fix.

## Test plan

- [x] `pytest tests/flyte/remote/test_session.py::TestBootstrapSslFromServer` — all 5 tests pass
- [ ] Manual verification against a Flyte cluster with `insecure_skip_verify=True`