### PR TITLE
Update SDK to call Dataproxy.GetActionData

### DIFF
--- a/src/flyte/remote/_action.py
+++ b/src/flyte/remote/_action.py
@@ -23,6 +23,7 @@ import rich.repr
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from flyteidl2.common import identifier_pb2, list_pb2, phase_pb2
+from flyteidl2.dataproxy import dataproxy_service_pb2
 from flyteidl2.task import common_pb2
 from flyteidl2.workflow import run_definition_pb2, run_service_pb2
 from flyteidl2.workflow.run_service_pb2 import WatchActionDetailsResponse
@@ -963,8 +964,8 @@ class ActionDetails(ToJSONMixin):
             return True
         if self._inputs and not self.done():
             return False
-        resp = await get_client().run_service.get_action_data(
-            request=run_service_pb2.GetActionDataRequest(
+        resp = await get_client().dataproxy_service.get_action_data(
+            request=dataproxy_service_pb2.GetActionDataRequest(
                 action_id=self.pb2.id,
             )
         )

--- a/src/flyte/remote/_client/_protocols.py
+++ b/src/flyte/remote/_client/_protocols.py
@@ -112,6 +112,10 @@ class DataProxyService(Protocol):
         self, request: dataproxy_service_pb2.UploadInputsRequest
     ) -> dataproxy_service_pb2.UploadInputsResponse: ...
 
+    async def get_action_data(
+        self, request: dataproxy_service_pb2.GetActionDataRequest
+    ) -> dataproxy_service_pb2.GetActionDataResponse: ...
+
     def tail_logs(
         self, request: dataproxy_service_pb2.TailLogsRequest
     ) -> AsyncIterator[dataproxy_service_pb2.TailLogsResponse]: ...

--- a/src/flyte/remote/_client/controlplane.py
+++ b/src/flyte/remote/_client/controlplane.py
@@ -220,6 +220,20 @@ class ClusterAwareDataProxy:
         )
         return await client.upload_inputs(request)
 
+    async def get_action_data(
+        self, request: dataproxy_service_pb2.GetActionDataRequest
+    ) -> dataproxy_service_pb2.GetActionDataResponse:
+        run = request.action_id.run
+        client = await self._resolve_by_action(
+            int(cluster_payload_pb2.SelectClusterRequest.Operation.OPERATION_GET_ACTION_DATA),
+            run.org,
+            run.project,
+            run.domain,
+            run.name,
+            request.action_id.name,
+        )
+        return await client.get_action_data(request)
+
     def tail_logs(
         self, request: dataproxy_service_pb2.TailLogsRequest
     ) -> AsyncIterator[dataproxy_service_pb2.TailLogsResponse]:

--- a/tests/flyte/remote/test_cluster_aware_dataproxy.py
+++ b/tests/flyte/remote/test_cluster_aware_dataproxy.py
@@ -33,6 +33,7 @@ def _make_wrapper(
         yield dataproxy_service_pb2.TailLogsResponse()
 
     default_client.tail_logs = MagicMock(side_effect=_stream_one)
+    default_client.get_action_data = AsyncMock(return_value=dataproxy_service_pb2.GetActionDataResponse())
     return (
         ClusterAwareDataProxy(
             cluster_service=cluster_service,
@@ -225,3 +226,21 @@ async def test_tail_logs_routes_by_action_id():
     assert sent.WhichOneof("resource") == "action_id"
     assert sent.action_id == action_id
     default_client.tail_logs.assert_called_once_with(req)
+
+
+@pytest.mark.asyncio
+async def test_get_action_data_routes_by_action_id():
+    wrapper, cluster_service, default_client = _make_wrapper()
+    action_id = identifier_pb2.ActionIdentifier(
+        run=identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="r"),
+        name="a",
+    )
+    req = dataproxy_service_pb2.GetActionDataRequest(action_id=action_id)
+
+    await wrapper.get_action_data(req)
+
+    sent = cluster_service.select_cluster.await_args[0][0]
+    assert sent.operation == cluster_payload_pb2.SelectClusterRequest.Operation.OPERATION_GET_ACTION_DATA
+    assert sent.WhichOneof("resource") == "action_id"
+    assert sent.action_id == action_id
+    default_client.get_action_data.assert_awaited_once_with(req)


### PR DESCRIPTION
Which has now been deprecated in RunsService

---
Tested against the flyte2 demo local cluster with the prerequisite back-end changes after triggering a run:

```
.venv/bin/python -c "
  import asyncio, flyte
  from flyte.remote._run import Run

  async def main():
      await flyte.init_from_config.aio('.flyte/config-oss-local.yaml', project='flytesnacks', domain='development')
      run = await Run.get.aio('rjwnhmwkflr7dcr6k4rf')
      print('Run:', run.name)
      print('Phase:', run.phase)
      inputs = await run.inputs.aio()
      print('Inputs:', inputs)
      outputs = await run.outputs.aio()
      print('Outputs:', outputs)

  asyncio.run(main())
  "

  Output:
  Run: rjwnhmwkflr7dcr6k4rf
  Phase: ActionPhase.SUCCEEDED
  Inputs: {'x': 4}
  Outputs: ActionOutputs(o0=13)
```
