### PR TITLE
Add trusted identity header injection for in-cluster queue service calls

### DIFF
--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -425,6 +425,51 @@ async def init_from_api_key(
     )
 
 
+def _read_secret_from_file(secret_file: str | None, *, secret_name: str) -> str | None:
+    """Read a secret value from a mounted file path."""
+    if not secret_file:
+        return None
+
+    path = Path(secret_file)
+    if not path.exists():
+        raise InitializationError(
+            "SecretFileNotFoundError",
+            "user",
+            f"{secret_name} file '{path}' does not exist.",
+        )
+
+    secret_value = path.read_text().strip()
+    if not secret_value:
+        raise InitializationError(
+            "SecretFileEmptyError",
+            "user",
+            f"{secret_name} file '{path}' is empty.",
+        )
+
+    return secret_value
+
+
+def _resolve_in_cluster_api_key(api_key: str | None = None) -> str | None:
+    union_eager_api_key_env_var = "_UNION_EAGER_API_KEY"
+    eager_api_key_env_var = "EAGER_API_KEY"
+    union_eager_api_key_file_env_var = "_UNION_EAGER_API_KEY_FILE"
+    eager_api_key_file_env_var = "EAGER_API_KEY_FILE"
+
+    return (
+        api_key
+        or os.getenv(union_eager_api_key_env_var)
+        or os.getenv(eager_api_key_env_var)
+        or _read_secret_from_file(
+            os.getenv(union_eager_api_key_file_env_var),
+            secret_name=union_eager_api_key_env_var,
+        )
+        or _read_secret_from_file(
+            os.getenv(eager_api_key_file_env_var),
+            secret_name=eager_api_key_env_var,
+        )
+    )
+
+
 @syncify
 async def init_in_cluster(
     org: str | None = None,
@@ -442,17 +487,15 @@ async def init_in_cluster(
     ENDPOINT_OVERRIDE = "_U_EP_OVERRIDE"
     INSECURE_SKIP_VERIFY_OVERRIDE = "_U_INSECURE_SKIP_VERIFY"
     INSECURE_OVERRIDE = "_U_INSECURE"
-    _UNION_EAGER_API_KEY_ENV_VAR = "_UNION_EAGER_API_KEY"
-    EAGER_API_KEY = "EAGER_API_KEY"
 
     org = org or os.getenv(ORG_NAME)
     project = project or os.getenv(PROJECT_NAME)
     domain = domain or os.getenv(DOMAIN_NAME)
-    api_key = api_key or os.getenv(_UNION_EAGER_API_KEY_ENV_VAR) or os.getenv(EAGER_API_KEY)
+    api_key = _resolve_in_cluster_api_key(api_key)
 
     remote_kwargs: dict[str, typing.Any] = {"insecure": insecure}
     if api_key:
-        logger.info("Using api key from environment")
+        logger.info("Using api key from environment or mounted file")
         remote_kwargs["api_key"] = api_key
     else:
         ep = endpoint or os.environ.get(ENDPOINT_OVERRIDE, "host.docker.internal:8090")

--- a/src/flyte/remote/_client/auth/_interceptors/default_metadata.py
+++ b/src/flyte/remote/_client/auth/_interceptors/default_metadata.py
@@ -1,3 +1,4 @@
+import os
 import random
 import string
 from uuid import uuid4
@@ -5,6 +6,10 @@ from uuid import uuid4
 import flyte
 
 ALPHABET = string.ascii_lowercase + string.digits
+TRUSTED_IDENTITY_CLAIM_ENV_VAR = "_U_EXTERNAL_IDENTITY_CLAIM"
+TRUSTED_IDENTITY_TYPE_CLAIM_ENV_VAR = "_U_EXTERNAL_IDENTITY_TYPE_CLAIM"
+USER_SUBJECT_HEADER = "x-user-subject"
+USER_IDENTITY_TYPE_HEADER = "x-user-claim-identitytype"
 
 
 def fast_short_id():
@@ -24,15 +29,35 @@ def _generate_request_id() -> str:
 
 
 class DefaultMetadataInterceptor:
-    """Injects x-request-id header into every outgoing RPC.
+    """Injects default metadata into every outgoing RPC.
 
     Implements the connectrpc MetadataInterceptor protocol:
     - on_start(ctx) -> token
     - on_end(token, ctx, error) -> None
     """
 
+    def __init__(self):
+        self._trusted_identity_headers = _trusted_identity_headers_from_env()
+
     async def on_start(self, ctx) -> None:
-        ctx.request_headers().setdefault("x-request-id", _generate_request_id())
+        headers = ctx.request_headers()
+        headers.setdefault("x-request-id", _generate_request_id())
+        for key, value in self._trusted_identity_headers.items():
+            headers.setdefault(key, value)
 
     async def on_end(self, token, ctx, error) -> None:
         pass
+
+
+def _trusted_identity_headers_from_env() -> dict[str, str]:
+    """Build trusted identity headers from pod env when self-hosted authz requires them."""
+    headers = {}
+    subject = os.getenv(TRUSTED_IDENTITY_CLAIM_ENV_VAR)
+    identity_type = os.getenv(TRUSTED_IDENTITY_TYPE_CLAIM_ENV_VAR)
+
+    if subject:
+        headers[USER_SUBJECT_HEADER] = subject
+    if identity_type:
+        headers[USER_IDENTITY_TYPE_HEADER] = identity_type
+
+    return headers

--- a/src/flyte/remote/_client/auth/_interceptors/default_metadata.py
+++ b/src/flyte/remote/_client/auth/_interceptors/default_metadata.py
@@ -1,4 +1,3 @@
-import os
 import random
 import string
 from uuid import uuid4
@@ -6,10 +5,6 @@ from uuid import uuid4
 import flyte
 
 ALPHABET = string.ascii_lowercase + string.digits
-TRUSTED_IDENTITY_CLAIM_ENV_VAR = "_U_EXTERNAL_IDENTITY_CLAIM"
-TRUSTED_IDENTITY_TYPE_CLAIM_ENV_VAR = "_U_EXTERNAL_IDENTITY_TYPE_CLAIM"
-USER_SUBJECT_HEADER = "x-user-subject"
-USER_IDENTITY_TYPE_HEADER = "x-user-claim-identitytype"
 
 
 def fast_short_id():
@@ -36,28 +31,9 @@ class DefaultMetadataInterceptor:
     - on_end(token, ctx, error) -> None
     """
 
-    def __init__(self):
-        self._trusted_identity_headers = _trusted_identity_headers_from_env()
-
     async def on_start(self, ctx) -> None:
         headers = ctx.request_headers()
         headers.setdefault("x-request-id", _generate_request_id())
-        for key, value in self._trusted_identity_headers.items():
-            headers.setdefault(key, value)
 
     async def on_end(self, token, ctx, error) -> None:
         pass
-
-
-def _trusted_identity_headers_from_env() -> dict[str, str]:
-    """Build trusted identity headers from pod env when self-hosted authz requires them."""
-    headers = {}
-    subject = os.getenv(TRUSTED_IDENTITY_CLAIM_ENV_VAR)
-    identity_type = os.getenv(TRUSTED_IDENTITY_TYPE_CLAIM_ENV_VAR)
-
-    if subject:
-        headers[USER_SUBJECT_HEADER] = subject
-    if identity_type:
-        headers[USER_IDENTITY_TYPE_HEADER] = identity_type
-
-    return headers

--- a/tests/flyte/remote/test_connectrpc_interceptors.py
+++ b/tests/flyte/remote/test_connectrpc_interceptors.py
@@ -18,10 +18,6 @@ from flyte.remote._client.auth._interceptors.auth import (
 )
 from flyte.remote._client.auth._interceptors.default_metadata import (
     DefaultMetadataInterceptor,
-    TRUSTED_IDENTITY_CLAIM_ENV_VAR,
-    TRUSTED_IDENTITY_TYPE_CLAIM_ENV_VAR,
-    USER_IDENTITY_TYPE_HEADER,
-    USER_SUBJECT_HEADER,
     _generate_request_id,
 )
 from flyte.remote._client.auth._interceptors.retry import (
@@ -128,34 +124,6 @@ class TestDefaultMetadataInterceptor:
         headers["x-request-id"] = "caller-correlation-id"
         await interceptor.on_start(ctx)
         assert headers["x-request-id"] == "caller-correlation-id"
-
-    @pytest.mark.asyncio
-    async def test_injects_trusted_identity_headers_from_env(self, monkeypatch):
-        monkeypatch.setenv(TRUSTED_IDENTITY_CLAIM_ENV_VAR, "00uabc123")
-        monkeypatch.setenv(TRUSTED_IDENTITY_TYPE_CLAIM_ENV_VAR, "app")
-
-        interceptor = DefaultMetadataInterceptor()
-        ctx, headers = _make_ctx_mock()
-
-        await interceptor.on_start(ctx)
-
-        assert headers[USER_SUBJECT_HEADER] == "00uabc123"
-        assert headers[USER_IDENTITY_TYPE_HEADER] == "app"
-
-    @pytest.mark.asyncio
-    async def test_preserves_existing_trusted_identity_headers(self, monkeypatch):
-        monkeypatch.setenv(TRUSTED_IDENTITY_CLAIM_ENV_VAR, "00uabc123")
-        monkeypatch.setenv(TRUSTED_IDENTITY_TYPE_CLAIM_ENV_VAR, "app")
-
-        interceptor = DefaultMetadataInterceptor()
-        ctx, headers = _make_ctx_mock()
-        headers[USER_SUBJECT_HEADER] = "caller-subject"
-        headers[USER_IDENTITY_TYPE_HEADER] = "caller-type"
-
-        await interceptor.on_start(ctx)
-
-        assert headers[USER_SUBJECT_HEADER] == "caller-subject"
-        assert headers[USER_IDENTITY_TYPE_HEADER] == "caller-type"
 
 
 def _make_mock_authenticator(headers=None):

--- a/tests/flyte/remote/test_connectrpc_interceptors.py
+++ b/tests/flyte/remote/test_connectrpc_interceptors.py
@@ -18,6 +18,10 @@ from flyte.remote._client.auth._interceptors.auth import (
 )
 from flyte.remote._client.auth._interceptors.default_metadata import (
     DefaultMetadataInterceptor,
+    TRUSTED_IDENTITY_CLAIM_ENV_VAR,
+    TRUSTED_IDENTITY_TYPE_CLAIM_ENV_VAR,
+    USER_IDENTITY_TYPE_HEADER,
+    USER_SUBJECT_HEADER,
     _generate_request_id,
 )
 from flyte.remote._client.auth._interceptors.retry import (
@@ -124,6 +128,34 @@ class TestDefaultMetadataInterceptor:
         headers["x-request-id"] = "caller-correlation-id"
         await interceptor.on_start(ctx)
         assert headers["x-request-id"] == "caller-correlation-id"
+
+    @pytest.mark.asyncio
+    async def test_injects_trusted_identity_headers_from_env(self, monkeypatch):
+        monkeypatch.setenv(TRUSTED_IDENTITY_CLAIM_ENV_VAR, "00uabc123")
+        monkeypatch.setenv(TRUSTED_IDENTITY_TYPE_CLAIM_ENV_VAR, "app")
+
+        interceptor = DefaultMetadataInterceptor()
+        ctx, headers = _make_ctx_mock()
+
+        await interceptor.on_start(ctx)
+
+        assert headers[USER_SUBJECT_HEADER] == "00uabc123"
+        assert headers[USER_IDENTITY_TYPE_HEADER] == "app"
+
+    @pytest.mark.asyncio
+    async def test_preserves_existing_trusted_identity_headers(self, monkeypatch):
+        monkeypatch.setenv(TRUSTED_IDENTITY_CLAIM_ENV_VAR, "00uabc123")
+        monkeypatch.setenv(TRUSTED_IDENTITY_TYPE_CLAIM_ENV_VAR, "app")
+
+        interceptor = DefaultMetadataInterceptor()
+        ctx, headers = _make_ctx_mock()
+        headers[USER_SUBJECT_HEADER] = "caller-subject"
+        headers[USER_IDENTITY_TYPE_HEADER] = "caller-type"
+
+        await interceptor.on_start(ctx)
+
+        assert headers[USER_SUBJECT_HEADER] == "caller-subject"
+        assert headers[USER_IDENTITY_TYPE_HEADER] == "caller-type"
 
 
 def _make_mock_authenticator(headers=None):

--- a/tests/user_api/test_initialize.py
+++ b/tests/user_api/test_initialize.py
@@ -647,3 +647,58 @@ class TestInitInCluster:
         # Env var should override to False even for localhost endpoint
         assert result["insecure"] is True
         assert result["endpoint"] == "host.docker.internal:8090"
+
+    @patch("flyte._initialize.init")
+    @pytest.mark.asyncio
+    async def test_init_in_cluster_reads_api_key_from_file(self, mock_init, monkeypatch, tmp_path):
+        """Test eager API key can be loaded from a mounted secret file."""
+        mock_init.aio = AsyncMock()
+
+        eager_api_key_file = tmp_path / "EAGER_API_KEY"
+        eager_api_key_file.write_text("encoded-key\n")
+
+        monkeypatch.setenv("FLYTE_INTERNAL_EXECUTION_PROJECT", "test-project")
+        monkeypatch.setenv("FLYTE_INTERNAL_EXECUTION_DOMAIN", "test-domain")
+        monkeypatch.delenv("_UNION_EAGER_API_KEY", raising=False)
+        monkeypatch.delenv("EAGER_API_KEY", raising=False)
+        monkeypatch.setenv("EAGER_API_KEY_FILE", str(eager_api_key_file))
+
+        result = await init_in_cluster.aio()
+
+        assert result["api_key"] == "encoded-key"
+        assert "endpoint" not in result
+
+    @patch("flyte._initialize.init")
+    @pytest.mark.asyncio
+    async def test_init_in_cluster_prefers_api_key_env_over_file(self, mock_init, monkeypatch, tmp_path):
+        """Test direct env var values take precedence over mounted secret files."""
+        mock_init.aio = AsyncMock()
+
+        eager_api_key_file = tmp_path / "EAGER_API_KEY"
+        eager_api_key_file.write_text("file-key")
+
+        monkeypatch.setenv("FLYTE_INTERNAL_EXECUTION_PROJECT", "test-project")
+        monkeypatch.setenv("FLYTE_INTERNAL_EXECUTION_DOMAIN", "test-domain")
+        monkeypatch.setenv("EAGER_API_KEY", "env-key")
+        monkeypatch.setenv("EAGER_API_KEY_FILE", str(eager_api_key_file))
+
+        result = await init_in_cluster.aio()
+
+        assert result["api_key"] == "env-key"
+
+    @patch("flyte._initialize.init")
+    @pytest.mark.asyncio
+    async def test_init_in_cluster_missing_api_key_file_raises(self, mock_init, monkeypatch, tmp_path):
+        """Test a configured eager API key file path must exist."""
+        mock_init.aio = AsyncMock()
+
+        missing_path = tmp_path / "missing-key"
+
+        monkeypatch.setenv("FLYTE_INTERNAL_EXECUTION_PROJECT", "test-project")
+        monkeypatch.setenv("FLYTE_INTERNAL_EXECUTION_DOMAIN", "test-domain")
+        monkeypatch.delenv("_UNION_EAGER_API_KEY", raising=False)
+        monkeypatch.delenv("EAGER_API_KEY", raising=False)
+        monkeypatch.setenv("EAGER_API_KEY_FILE", str(missing_path))
+
+        with pytest.raises(InitializationError, match="does not exist"):
+            await init_in_cluster.aio()


### PR DESCRIPTION
## Summary

  In self-hosted deployments with authz enabled, executor pods need to call queue service over the internal service URL instead of ingress. Those
  internal calls must include trusted identity headers so queue-service middleware and downstream authz checks can authorize them.

  This PR updates the SDK to automatically inject trusted identity headers on outbound ConnectRPC requests when the executor pod is configured with:

  - _U_EXTERNAL_IDENTITY_CLAIM
  - _U_EXTERNAL_IDENTITY_TYPE_CLAIM

  These are translated into:

  - X-User-Subject
  - X-User-Claim-Identitytype

  ## What Changed

  - Added env-driven trusted identity header injection in the shared ConnectRPC metadata interceptor.
  - Reused the existing interceptor path, so this applies to controller/queue-service RPCs without adding a new auth mode.
  - Preserved existing caller-provided headers by using non-overriding injection.
  - Added focused tests for:
      - header injection from env
      - non-overwrite behavior
      - no regression in session/interceptor behavior

  ## Why

  This lets self-hosted executor pods talk directly to queue service via _U_EP_OVERRIDE while still providing the identity context required by authz-
  enabled deployments, avoiding the need to route through ingress just to obtain X-User-Subject.

  ## Notes

  - This change is opt-in via pod env vars. If the env vars are not present, the SDK behavior is unchanged.
  - Routing is still controlled separately via _U_EP_OVERRIDE.
  - TLS / ingress certificate issues for build-image are not addressed in this PR.

  ## Validation

  Ran:

  uv run pytest tests/flyte/remote/test_connectrpc_interceptors.py tests/flyte/remote/test_session.py

  Result: 55 passed