### PR TITLE
Only use localhost registry for dev-version default image

### DIFF
--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -603,7 +603,7 @@ class Image:
             preset_tag = f"py{python_version[0]}.{python_version[1]}-{suffix}"
         image = Image._new(
             base_image=f"python:{python_version[0]}.{python_version[1]}-slim-bookworm",
-            registry=_get_base_registry(),
+            registry=_get_base_registry() if dev_mode else _BASE_REGISTRY,
             name=_DEFAULT_IMAGE_NAME,
             python_version=python_version,
             platform=("linux/amd64", "linux/arm64") if platform is None else platform,

--- a/tests/flyte/test_image.py
+++ b/tests/flyte/test_image.py
@@ -784,3 +784,51 @@ def test_get_base_registry_returns_default_for_empty_endpoint():
     mock_config.client.endpoint = ""
     with patch("flyte._initialize._get_init_config", return_value=mock_config):
         assert _get_base_registry() == _BASE_REGISTRY
+
+
+def test_default_image_uses_base_registry_for_released_version_on_localhost():
+    """A released (non-dev) SDK must use the default registry even when pointed at a localhost endpoint."""
+    mock_config = MagicMock()
+    mock_config.client.endpoint = "localhost:8090"
+    with (
+        patch("flyte._version.__version__", "1.2.3"),
+        patch("flyte._initialize._get_init_config", return_value=mock_config),
+    ):
+        image = Image._get_default_image_for(python_version=(3, 12))
+    assert image.registry == _BASE_REGISTRY
+
+
+def test_default_image_uses_localhost_registry_for_dev_version_on_localhost():
+    """A dev SDK pointed at a localhost endpoint should use the localhost registry."""
+    mock_config = MagicMock()
+    mock_config.client.endpoint = "localhost:8090"
+    with (
+        patch("flyte._version.__version__", "1.2.3.dev0+abc"),
+        patch("flyte._initialize._get_init_config", return_value=mock_config),
+    ):
+        image = Image._get_default_image_for(python_version=(3, 12))
+    assert image.registry == _LOCALHOST_REGISTRY
+
+
+def test_default_image_uses_base_registry_for_dev_version_on_remote():
+    """A dev SDK pointed at a remote endpoint should still use the default registry."""
+    mock_config = MagicMock()
+    mock_config.client.endpoint = "dns:///my-cluster.example.com"
+    with (
+        patch("flyte._version.__version__", "1.2.3.dev0+abc"),
+        patch("flyte._initialize._get_init_config", return_value=mock_config),
+    ):
+        image = Image._get_default_image_for(python_version=(3, 12))
+    assert image.registry == _BASE_REGISTRY
+
+
+def test_default_image_uses_base_registry_when_install_flyte_false():
+    """When install_flyte=False, dev_mode is False and we should use the default registry even on localhost."""
+    mock_config = MagicMock()
+    mock_config.client.endpoint = "localhost:8090"
+    with (
+        patch("flyte._version.__version__", "1.2.3.dev0+abc"),
+        patch("flyte._initialize._get_init_config", return_value=mock_config),
+    ):
+        image = Image._get_default_image_for(python_version=(3, 12), install_flyte=False)
+    assert image.registry == _BASE_REGISTRY


### PR DESCRIPTION
## Summary
- Previously, a released Flyte SDK pointed at a localhost endpoint would pick up the localhost registry (`localhost:30000`) for the default image. Released SDKs should always pull the default image from `ghcr.io/flyteorg` — only dev versions (which don't exist on the public registry) should fall back to the localhost registry.
- Restrict the localhost-registry swap in `Image._get_default_image_for` to `dev_mode` only.
- Add tests covering released vs. dev version × localhost vs. remote endpoint, and the `install_flyte=False` path.

## Test plan
- [x] `uv run pytest tests/flyte/test_image.py -k "default_image_uses or get_base_registry"` — all pass
- [x] Released SDK pointed at a localhost demo cluster uses `ghcr.io/flyteorg` for the default image
- [x] Dev SDK pointed at localhost still uses `localhost:30000`