### PR TITLE
Fix duration of previous runs not reported in TUI

### DIFF
--- a/src/flyte/cli/_tui/_explore.py
+++ b/src/flyte/cli/_tui/_explore.py
@@ -325,11 +325,14 @@ class RunDetailScreen(Screen):
                 log_links=log_links,
                 attempt_count=r.attempt_count,
                 attempts=attempts,
+                start_time=r.start_time,
             )
             if r.status == "succeeded":
-                self._tracker.record_complete(action_id=r.action_name, outputs=r.outputs)
+                self._tracker.record_complete(action_id=r.action_name, outputs=r.outputs, end_time=r.end_time)
             elif r.status == "failed":
-                self._tracker.record_failure(action_id=r.action_name, error=r.error or "Unknown error")
+                self._tracker.record_failure(
+                    action_id=r.action_name, error=r.error or "Unknown error", end_time=r.end_time
+                )
 
     def compose(self) -> ComposeResult:
         yield Header()

--- a/src/flyte/cli/_tui/_tracker.py
+++ b/src/flyte/cli/_tui/_tracker.py
@@ -92,6 +92,7 @@ class ActionTracker:
         log_links: list[tuple[str, str]] | None = None,
         attempt_count: int = 0,
         attempts: list[dict[str, Any]] | None = None,
+        start_time: float | None = None,
     ) -> None:
         with self._lock:
             initial_attempts = [_safe_json(a) for a in (attempts or []) if isinstance(a, dict)]
@@ -118,6 +119,8 @@ class ActionTracker:
                 selected_attempt=selected_attempt,
             )
             self._nodes[action_id] = node
+            if start_time:
+                node.start_time = start_time
 
             if group and parent_id is not None:
                 group_key = f"__group__{parent_id}__{group}"
@@ -191,14 +194,14 @@ class ActionTracker:
             node.selected_attempt = attempt_num
             self._version += 1
 
-    def record_complete(self, *, action_id: str, outputs: Any = None) -> None:
+    def record_complete(self, *, action_id: str, outputs: Any = None, end_time: float | None = None) -> None:
         with self._lock:
             node = self._nodes.get(action_id)
             if node is None:
                 return
             node.status = ActionStatus.SUCCEEDED
             node.outputs = outputs
-            node.end_time = time.monotonic()
+            node.end_time = end_time or time.monotonic()
             self._update_group_status(action_id)
             self._version += 1
 
@@ -210,7 +213,7 @@ class ActionTracker:
             node.log_links = log_links
             self._version += 1
 
-    def record_failure(self, *, action_id: str, error: str) -> None:
+    def record_failure(self, *, action_id: str, error: str, end_time: float | None = None) -> None:
         from flyte._internal.runtime.convert import Error
 
         with self._lock:
@@ -222,7 +225,7 @@ class ActionTracker:
                 node.error = error.err
             else:
                 node.error = error
-            node.end_time = time.monotonic()
+            node.end_time = end_time or time.monotonic()
             self._update_group_status(action_id)
             self._version += 1
 

--- a/tests/cli/test_tui_explore.py
+++ b/tests/cli/test_tui_explore.py
@@ -57,6 +57,7 @@ def test_run_detail_screen_tracker_reconstruction():
     RunStore.record_start_sync(run_name="run-1", action_name="a1", task_name="sub_task", parent_id="a0")
     RunStore.record_complete_sync(run_name="run-1", action_name="a1")
     RunStore.record_failure_sync(run_name="run-1", action_name="a0", error="boom")
+    actions = RunStore.list_actions_for_run_sync("run-1")
 
     from flyte.cli._tui._explore import RunDetailScreen
 
@@ -67,11 +68,15 @@ def test_run_detail_screen_tracker_reconstruction():
     assert root is not None
     assert root.task_name == "root_task"
     assert root.status == ActionStatus.FAILED
+    assert root.start_time == actions[0].start_time
+    assert root.end_time == actions[0].end_time
 
     sub = tracker.get_action("a1")
     assert sub is not None
     assert sub.task_name == "sub_task"
     assert sub.status == ActionStatus.SUCCEEDED
+    assert sub.start_time == actions[1].start_time
+    assert sub.end_time == actions[1].end_time
 
 
 def test_run_detail_screen_tracker_extended_fields():

--- a/tests/cli/test_tui_tracker.py
+++ b/tests/cli/test_tui_tracker.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import threading
-import time
 
 from flyte.cli._tui._tracker import ActionNode, ActionStatus, ActionTracker, _safe_json
 
@@ -110,12 +109,13 @@ class TestActionNode:
 class TestTrackerRecordStart:
     def test_basic_root(self):
         t = ActionTracker()
-        t.record_start(action_id="a1", task_name="task1")
+        t.record_start(action_id="a1", task_name="task1", start_time=100)
         node = t.get_action("a1")
         assert node is not None
         assert node.task_name == "task1"
         assert node.parent_id is None
         assert node.status == ActionStatus.RUNNING
+        assert node.start_time == 100
 
     def test_root_appears_in_snapshot(self):
         t = ActionTracker()
@@ -250,12 +250,11 @@ class TestTrackerRecordComplete:
 
     def test_complete_sets_end_time(self):
         t = ActionTracker()
-        t.record_start(action_id="a1", task_name="t")
-        before = time.monotonic()
-        t.record_complete(action_id="a1")
-        after = time.monotonic()
+        t.record_start(action_id="a1", task_name="t", start_time=100)
+        t.record_complete(action_id="a1", end_time=200)
         node = t.get_action("a1")
-        assert before <= node.end_time <= after
+        assert node.start_time == 100
+        assert node.end_time == 200
 
 
 # ---------------------------------------------------------------------------
@@ -284,6 +283,14 @@ class TestTrackerRecordFailure:
         node = t.get_action("a1")
         assert node.inputs == {"x": 1}
         assert node.error == "err"
+
+    def test_complete_sets_end_time(self):
+        t = ActionTracker()
+        t.record_start(action_id="a1", task_name="t", start_time=100)
+        t.record_failure(action_id="a1", error="err", end_time=200)
+        node = t.get_action("a1")
+        assert node.start_time == 100
+        assert node.end_time == 200
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the duration displayed in the terminal UI for execution of steps of previous runs. The duration has been 0 before, because start and end times stored in the database were ignored.