### PR TITLE
Use TailLogs defined in dataproxy

### DIFF
--- a/src/flyte/remote/_client/_protocols.py
+++ b/src/flyte/remote/_client/_protocols.py
@@ -112,6 +112,10 @@ class DataProxyService(Protocol):
         self, request: dataproxy_service_pb2.UploadInputsRequest
     ) -> dataproxy_service_pb2.UploadInputsResponse: ...
 
+    def tail_logs(
+        self, request: dataproxy_service_pb2.TailLogsRequest
+    ) -> AsyncIterator[dataproxy_service_pb2.TailLogsResponse]: ...
+
 
 class RunLogsService(Protocol):
     def tail_logs(

--- a/src/flyte/remote/_client/controlplane.py
+++ b/src/flyte/remote/_client/controlplane.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import AsyncIterator
 from urllib.parse import urlparse
 
 from async_lru import alru_cache
@@ -219,22 +220,66 @@ class ClusterAwareDataProxy:
         )
         return await client.upload_inputs(request)
 
+    def tail_logs(
+        self, request: dataproxy_service_pb2.TailLogsRequest
+    ) -> AsyncIterator[dataproxy_service_pb2.TailLogsResponse]:
+        return self._tail_logs(request)
+
+    async def _tail_logs(
+        self, request: dataproxy_service_pb2.TailLogsRequest
+    ) -> AsyncIterator[dataproxy_service_pb2.TailLogsResponse]:
+        run = request.action_id.run
+        client = await self._resolve_by_action(
+            int(cluster_payload_pb2.SelectClusterRequest.Operation.OPERATION_TAIL_LOGS),
+            run.org,
+            run.project,
+            run.domain,
+            run.name,
+            request.action_id.name,
+        )
+        async for resp in client.tail_logs(request):
+            yield resp
+
     @alru_cache
     async def _resolve(self, operation: int, org: str, project: str, domain: str) -> DataProxyService:
-        """Cached SelectCluster lookup + per-cluster DataProxy client construction.
+        """Cached SelectCluster lookup, routed by ProjectIdentifier."""
+        req = cluster_payload_pb2.SelectClusterRequest(operation=operation)
+        req.project_id.CopyFrom(identifier_pb2.ProjectIdentifier(name=project, domain=domain, organization=org))
+        return await self._select_and_build(req)
 
-        @alru_cache deduplicates concurrent callers (in-flight requests share one
-        coroutine) and only caches successful results, so a transient failure
-        won't poison the entry.
+    @alru_cache
+    async def _resolve_by_action(
+        self,
+        operation: int,
+        org: str,
+        project: str,
+        domain: str,
+        run_name: str,
+        action_name: str,
+    ) -> DataProxyService:
+        """Cached SelectCluster lookup, routed by ActionIdentifier."""
+        req = cluster_payload_pb2.SelectClusterRequest(operation=operation)
+        req.action_id.CopyFrom(
+            identifier_pb2.ActionIdentifier(
+                run=identifier_pb2.RunIdentifier(org=org, project=project, domain=domain, name=run_name),
+                name=action_name,
+            )
+        )
+        return await self._select_and_build(req)
+
+    async def _select_and_build(self, req: cluster_payload_pb2.SelectClusterRequest) -> DataProxyService:
+        """SelectCluster + build the per-cluster DataProxy client.
+
+        Wrapped by the @alru_cache resolvers above; @alru_cache deduplicates
+        concurrent callers and only caches successful results, so a transient
+        failure won't poison the entry.
         """
         from flyte._logging import logger
 
-        req = cluster_payload_pb2.SelectClusterRequest(operation=operation)
-        req.project_id.CopyFrom(identifier_pb2.ProjectIdentifier(name=project, domain=domain, organization=org))
         try:
             resp = await self._cluster_service.select_cluster(req)
         except Exception as e:
-            raise RuntimeError(f"SelectCluster failed for operation={operation}: {e}") from e
+            raise RuntimeError(f"SelectCluster failed for operation={req.operation}: {e}") from e
 
         endpoint = resp.cluster_endpoint
         if not endpoint or endpoint == self._session_config.endpoint:
@@ -333,6 +378,10 @@ class ClientSet:
     @property
     def trigger_service(self) -> TriggerService:
         return self._trigger_service
+
+    @property
+    def cluster_service(self) -> ClusterService:
+        return self._cluster_service
 
     @property
     def endpoint(self) -> str:

--- a/src/flyte/remote/_logs.py
+++ b/src/flyte/remote/_logs.py
@@ -6,8 +6,8 @@ from typing import AsyncGenerator, AsyncIterator
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from flyteidl2.common import identifier_pb2
+from flyteidl2.dataproxy import dataproxy_service_pb2
 from flyteidl2.logs.dataplane import payload_pb2
-from flyteidl2.workflow import run_logs_service_pb2
 from rich.console import Console
 from rich.live import Live
 from rich.panel import Panel
@@ -124,11 +124,12 @@ class Logs:
         :param attempt: The attempt number (default is 0).
         """
         ensure_client()
+        client = get_client()
         retries = 0
         while True:
             try:
-                resp = get_client().logs_service.tail_logs(
-                    run_logs_service_pb2.TailLogsRequest(action_id=action_id, attempt=attempt)
+                resp = client.dataproxy_service.tail_logs(
+                    dataproxy_service_pb2.TailLogsRequest(action_id=action_id, attempt=attempt)
                 )
                 async for log_set in resp:
                     if log_set.logs:

--- a/tests/flyte/remote/test_cluster_aware_dataproxy.py
+++ b/tests/flyte/remote/test_cluster_aware_dataproxy.py
@@ -28,6 +28,11 @@ def _make_wrapper(
         return_value=dataproxy_service_pb2.CreateUploadLocationResponse(signed_url="https://signed/")
     )
     default_client.upload_inputs = AsyncMock(return_value=dataproxy_service_pb2.UploadInputsResponse())
+
+    async def _stream_one(_request):
+        yield dataproxy_service_pb2.TailLogsResponse()
+
+    default_client.tail_logs = MagicMock(side_effect=_stream_one)
     return (
         ClusterAwareDataProxy(
             cluster_service=cluster_service,
@@ -201,3 +206,22 @@ async def test_failed_resolve_is_evicted_so_retries_can_succeed():
 
     assert cluster_service.select_cluster.await_count == 2
     assert default_client.create_upload_location.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_tail_logs_routes_by_action_id():
+    wrapper, cluster_service, default_client = _make_wrapper()
+    action_id = identifier_pb2.ActionIdentifier(
+        run=identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="r"),
+        name="a",
+    )
+    req = dataproxy_service_pb2.TailLogsRequest(action_id=action_id, attempt=1)
+
+    received = [resp async for resp in wrapper.tail_logs(req)]
+
+    assert len(received) == 1
+    sent = cluster_service.select_cluster.await_args[0][0]
+    assert sent.operation == cluster_payload_pb2.SelectClusterRequest.Operation.OPERATION_TAIL_LOGS
+    assert sent.WhichOneof("resource") == "action_id"
+    assert sent.action_id == action_id
+    default_client.tail_logs.assert_called_once_with(req)


### PR DESCRIPTION
1. Added tail_logs to ClusterAwareDataProxy (returns an AsyncIterator synchronously, matching the protocol)
2. SelectCluster: added a new _resolve_by_action cached resolver. Extracted the SelectCluster + client construction into a shared _select_and_build helper that both resolvers call.                                                                                                                                                                                                                                                                    

_Testing_
Ran the demo cluster locally. Tested with flyte-sdk and this script

```

@env.task
async def spew_logs(duration_sec: int = 300, interval_sec: int = 5) -> str:
    elapsed = 0
    iteration = 0
    while elapsed < duration_sec:
        iteration += 1
        print(f"[{elapsed:>4}s] iteration {iteration} - still running...", flush=True)
        await asyncio.sleep(interval_sec)
        elapsed += interval_sec
    print(f"Done after {elapsed}s ({iteration} iterations)", flush=True)
    return f"completed {iteration} iterations"


if __name__ == "__main__":
    import sys

    config_path = sys.argv[1] if len(sys.argv) > 1 else None
    if config_path:
        from flyte.config import Config

        flyte.init_from_config(Config.auto(config_path))
    else:
        flyte.init_from_config()
    run = flyte.run(spew_logs)
    print(f"Run: {run.name}")
    print(f"URL: {run.url}")
    print("Tailing logs...")
    run.action.show_logs(raw=True)
```

Verified output worked fine

```
 python examples/basics/long_running.py .flyte/config-oss-local.yaml
  > Bundling code...
  ✓ Code bundle: 1 files, 0.009765625 MB (compressed 0.0006895065307617188 MB)
  > Uploading code bundle...
Run: r8xqdw87c7l266b9j99x
URL: http://localhost:30080/v2/domain/development/project/flytesnacks/runs/r8xqdw87c7l266b9j99x
Tailing logs...
 [flyte] Flyte runtime started for action a0 with run name r8xqdw87c7l266b9j99x [   0s] iteration 1 - still running... [   5s] iteration 2 - still running... [  10s] iteration 3 - still running...
```