### PR TITLE
docs: enhance TaskEnvironment and Image.clone() docstrings

### DIFF
--- a/src/flyte/_environment.py
+++ b/src/flyte/_environment.py
@@ -31,16 +31,27 @@ def is_snake_or_kebab_with_numbers(s: str) -> bool:
 @dataclass(init=True, repr=True)
 class Environment:
     """
-    :param name: Name of the environment
-    :param image: Docker image to use for the environment. If set to "auto", will use the default image.
-    :param resources: Resources to allocate for the environment.
-    :param env_vars: Environment variables to set for the environment.
+    Base class for execution environments, shared by `TaskEnvironment` and
+    `AppEnvironment`. Defines common infrastructure settings such as container
+    image, compute resources, secrets, and deployment dependencies.
+
+    You typically don't instantiate `Environment` directly — use
+    `TaskEnvironment` for tasks or `AppEnvironment` for long-running apps.
+
+    :param name: Name of the environment (required). Must be snake_case or
+        kebab-case.
+    :param image: Docker image for the environment. Can be a string (image URI),
+        an `Image` object, or `"auto"` to use the default image.
+    :param resources: Compute resources (CPU, memory, GPU, disk) via a
+        `Resources` object.
+    :param env_vars: Environment variables as `dict[str, str]`.
     :param secrets: Secrets to inject into the environment.
-    :param pod_template: Pod template to use for the environment.
-    :param description: Description of the environment.
-    :param interruptible: Whether the environment is interruptible and can be scheduled on spot/preemptible instances
-    :param depends_on: Environment dependencies to hint, so when you deploy the environment, the dependencies are
-        also deployed. This is useful when you have a set of environments that depend on each other.
+    :param pod_template: Kubernetes pod template as a string reference to a
+        named template or a `PodTemplate` object.
+    :param description: Human-readable description (max 255 characters).
+    :param interruptible: Whether the environment can be scheduled on
+        spot/preemptible instances.
+    :param depends_on: List of other environments to deploy alongside this one.
     """
 
     name: str
@@ -81,7 +92,17 @@ class Environment:
 
     def add_dependency(self, *env: Environment):
         """
-        Add a dependency to the environment.
+        Add one or more environment dependencies so they are deployed together.
+
+        When you deploy this environment, any environments added via
+        `add_dependency` will also be deployed. This is an alternative to
+        passing `depends_on=[...]` at construction time, useful when the
+        dependency is defined after the environment is created.
+
+        Duplicate dependencies are silently ignored. An environment cannot
+        depend on itself.
+
+        :param env: One or more `Environment` instances to add as dependencies.
         """
         for e in env:
             if not isinstance(e, Environment):

--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -785,7 +785,11 @@ class Image:
         extendable: Optional[bool] = None,
     ) -> Image:
         """
-        Use this method to clone the current image and change the registry and name
+        Clone an existing image, optionally with a new name or registry.
+
+        All `with_*` methods already produce a new immutable `Image`; use
+        `clone()` when you need an independent copy with a different name,
+        registry, or other base properties.
 
         :param registry: Registry to use for the image
         :param registry_secret: Secret to use to pull/push the private image.

--- a/src/flyte/_task_environment.py
+++ b/src/flyte/_task_environment.py
@@ -68,8 +68,40 @@ class TaskEnvironment(Environment):
         pass
     ```
 
+    **Parameter interaction across configuration levels:**
+
+    | Parameter | `TaskEnvironment` | `@env.task` | `task.override()` |
+    |-----------|:-----------------:|:-----------:|:-----------------:|
+    | `name` | Yes (required) | — | — |
+    | `image` | Yes | — | — |
+    | `depends_on` | Yes | — | — |
+    | `description` | Yes | — | — |
+    | `plugin_config` | Yes | — | — |
+    | `resources` | Yes | — | Yes* |
+    | `env_vars` | Yes | — | Yes* |
+    | `secrets` | Yes | — | Yes* |
+    | `cache` | Yes | Yes | Yes |
+    | `pod_template` | Yes | Yes | Yes |
+    | `reusable` | Yes | — | Yes |
+    | `interruptible` | Yes | Yes | Yes |
+    | `queue` | Yes | Yes | Yes |
+    | `short_name` | — | Yes | Yes |
+    | `retries` | — | Yes | Yes |
+    | `timeout` | — | Yes | Yes |
+    | `max_inline_io_bytes` | — | Yes | Yes |
+    | `links` | — | Yes | Yes |
+    | `report` | — | Yes | — |
+    | `triggers` | — | Yes | — |
+    | `docs` | — | Yes | — |
+
+    *When `reusable` is set, `resources`, `env_vars`, and `secrets` can only
+    be overridden via `task.override()` with `reusable="off"` in the same call.
+
     :param name: Name of the environment (required). Must be snake_case or kebab-case.
-        TaskEnvironment level only.
+        TaskEnvironment level only. The fully-qualified name of each task is
+        `<env_name>.<function_name>` (e.g., environment `"my_env"` containing
+        function `my_task` produces FQN `"my_env.my_task"`). Neither component
+        is overridable.
     :param image: Docker image for the environment. Can be a string (image URI),
         an `Image` object, or `"auto"` to use the default image.
         TaskEnvironment level only.
@@ -88,8 +120,15 @@ class TaskEnvironment(Environment):
     :param cache: Cache policy — `"auto"`, `"override"`, `"disable"`, or a `Cache` object.
         Also settable in `@env.task(cache=...)` and `task.override(cache=...)`.
     :param reusable: `ReusePolicy` for container reuse. Also overridable via
-        `task.override(reusable=...)`.
-    :param queue: Queue name for scheduling. Also settable in `@env.task` and `task.override`.
+        `task.override(reusable=...)`. Note: when `reusable` is set on the
+        environment, overriding `resources`, `env_vars`, or `secrets` in
+        `task.override()` requires passing `reusable="off"` in the same call.
+        Additionally, `secrets` cannot be overridden at the `@env.task`
+        decorator level when the environment has `reusable` set.
+    :param queue: Queue name for scheduling. Queues identify specific partitions
+        of your compute infrastructure (e.g., a particular cluster in a
+        multi-cluster deployment) and are configured as part of your Flyte/Union
+        deployment. Also settable in `@env.task` and `task.override`.
     :param pod_template: Kubernetes pod template for advanced configuration (sidecars,
         volumes, etc.). Also settable in `@env.task` and `task.override`.
     :param interruptible: Whether tasks can run on spot/preemptible instances. Also
@@ -125,24 +164,37 @@ class TaskEnvironment(Environment):
         **kwargs: Any,
     ) -> TaskEnvironment:
         """
-        Clone the TaskEnvironment with new parameters.
+        Create a new `TaskEnvironment` that shares most settings with this one
+        but differs in name and selected overrides.
 
-        Besides the base environment parameters, you can override kwargs like `cache`, `reusable`, etc.
+        Use `clone_with` when you need several environments that share a common
+        base configuration (image, resources, secrets, etc.) but vary in one or
+        two settings, avoiding repetition.
 
-        :param name: The name of the environment.
-        :param image: The image to use for the environment.
-        :param resources: The resources to allocate for the environment.
-        :param env_vars: The environment variables to set for the environment.
-        :param secrets: The secrets to inject into the environment.
-        :param depends_on: The environment dependencies to hint, so when you deploy the environment,
-            the dependencies are also deployed. This is useful when you have a set of environments
-            that depend on each other.
-        :param queue: The queue name to use for tasks in this environment.
-        :param pod_template: The pod template to use for tasks in this environment.
-        :param description: The description of the environment.
-        :param interruptible: Whether the environment is interruptible and can be scheduled on spot/preemptible
-            instances.
-        :param kwargs: Additional parameters to override the environment (e.g., cache, reusable, plugin_config).
+        ```python
+        gpu_env = flyte.TaskEnvironment(
+            name="gpu_env",
+            image=my_image,
+            resources=flyte.Resources(gpu="A100:1", memory="16Gi"),
+        )
+
+        # Same image and resources, different name and cache policy
+        gpu_env_cached = gpu_env.clone_with("gpu_env_cached", cache="auto")
+        ```
+
+        Any parameter not explicitly passed inherits the value from the
+        original environment.
+
+        :param name: Name for the new environment (required).
+        :param image: Override the container image.
+        :param resources: Override compute resources.
+        :param env_vars: Override environment variables.
+        :param secrets: Override secrets.
+        :param depends_on: Override deployment dependencies.
+        :param description: Override the description.
+        :param interruptible: Override the interruptible setting.
+        :param kwargs: Additional `TaskEnvironment`-specific overrides
+            (e.g., `cache`, `reusable`, `plugin_config`).
         """
         cache = kwargs.pop("cache", None)
         reusable = None
@@ -226,17 +278,22 @@ class TaskEnvironment(Environment):
 
         :param _func: Optional The function to decorate. If not provided, the decorator will return a callable that
         accepts a function to be decorated.
-        :param short_name: Optional A friendly name for the task (defaults to the function name)
+        :param short_name: Optional friendly name for the task or action, used in
+            parts of the UI (defaults to the function name). Overriding `short_name`
+            does not change the task's fully-qualified name.
         :param cache: Optional The cache policy for the task, defaults to auto, which will cache the results of the
         task.
-        :param retries: Optional The number of retries for the task, defaults to 0, which means no retries.
+        :param retries: Number of retries (`int`) or a `RetryStrategy` object that
+            defines retry behavior. Defaults to `0` (no retries).
         :param docs: Optional The documentation for the task, if not provided the function docstring will be used.
-        :param timeout: Optional The timeout for the task.
+        :param timeout: Task timeout, as a `timedelta` object or an integer number
+            of seconds. `0` means no timeout.
         :param pod_template: Optional The pod template for the task, if not provided the default pod template will be
         used.
         :param report: Optional Whether to generate the html report for the task, defaults to False.
-        :param max_inline_io_bytes: Maximum allowed size (in bytes) for all inputs and outputs passed directly to the
-         task (e.g., primitives, strings, dicts). Does not apply to files, directories, or dataframes.
+        :param max_inline_io_bytes: Maximum allowed size (in bytes) for all inputs and
+            outputs passed directly to the task (e.g., primitives, strings, dicts).
+            Does not apply to files, directories, or dataframes. Default is 10 MiB.
         :param triggers: Optional A tuple of triggers to associate with the task. This allows the task to be run on a
          schedule or in response to events. Triggers can be defined using the `flyte.trigger` module.
         :param links: Optional A tuple of links to associate with the task. Links can be used to provide


### PR DESCRIPTION
## Summary

Follow-up to #810. Restores information that was lost when user-guide reference content was trimmed in [unionai/unionai-docs#854](https://github.com/unionai/unionai-docs/pull/854).

**TaskEnvironment class docstring** (`_task_environment.py`):
- `name`: add fully-qualified name composition explanation (`<env_name>.<function_name>`)
- `reusable`: document the override interaction — overriding `resources`/`env_vars`/`secrets` in `task.override()` requires `reusable="off"` in the same call
- `queue`: explain that queues identify compute infrastructure partitions

**`task()` method docstring** (`_task_environment.py`):
- `short_name`: note that overriding it doesn't change the task's FQN
- `retries`: document `RetryStrategy` alternative to `int`
- `timeout`: document `timedelta`/`int` alternatives and `0` = no timeout
- `max_inline_io_bytes`: add 10 MiB default value

**`Image.clone()`** (`_image.py`):
- Clarify purpose vs `with_*` methods (all `with_*` methods already produce new immutable images)

## Context

An audit of PR #810 + unionai-docs #854 found that the `TaskEnvironment` class was the only class (out of 12 enhanced) where the docstring migration was incomplete. The `task()` method docstring was not touched at all by #810, leaving decorator-only parameters with sparse one-liners.

## Test plan

- [ ] `uv run python -c "import flyte; help(flyte.TaskEnvironment)"` renders correctly
- [ ] Regenerate API docs and verify enhanced content appears in the Parameters table

🤖 Generated with [Claude Code](https://claude.com/claude-code)