### PR TITLE
block network access in the sandbox

### DIFF
--- a/examples/sandbox/code_sandbox.py
+++ b/examples/sandbox/code_sandbox.py
@@ -125,8 +125,37 @@ linecount_sandbox = flyte.sandbox.create(
     outputs={"line_count": str},
 )
 
+# Example 5 — block_network=True (default): no outbound network access
+#
+# Network access is blocked by default. The sandbox can only read its inputs
+# and write its outputs — any attempt to reach the network will fail.
 
-# Example 5 — as_task() + deploy: build a deployable sandbox task
+isolated_sandbox = flyte.sandbox.create(
+    name="isolated-compute",
+    code="""\
+import urllib.request
+with urllib.request.urlopen("https://example.com") as r:
+    status = str(r.status)
+""",
+    outputs={"status": str},
+    block_network=True,  # default — shown explicitly for clarity
+)
+
+# Example 6 — block_network=False: outbound network access allowed
+
+networked_sandbox = flyte.sandbox.create(
+    name="networked-fetch",
+    code="""\
+import urllib.request
+with urllib.request.urlopen("https://example.com") as r:
+    status = str(r.status)
+""",
+    outputs={"status": str},
+    block_network=False,
+)
+
+
+# Example 7 — as_task() + deploy: build a deployable sandbox task
 #
 # Use ``as_task()`` to get a ContainerTask with ``_script`` pre-filled as a
 # default.
@@ -197,6 +226,15 @@ async def run_pipeline() -> dict:
     data_file = await create_text_file()
     line_count = await linecount_sandbox.run.aio(data_file=data_file)
 
+    # Network-blocked sandbox: pure computation, no network
+    try:
+        isolated_result = await isolated_sandbox.run.aio(x=7)
+    except Exception as e:
+        isolated_result = f"Failed to access network: {e}"
+
+    # Network-allowed sandbox: fetch external URL
+    status = await networked_sandbox.run.aio()
+
     # Deploy a sandbox task
     deployment_summary = await deploy_sandbox_task()
 
@@ -207,6 +245,8 @@ async def run_pipeline() -> dict:
         "window_end": window_end.isoformat(),
         "etl_sum_1_to_10": etl_total,
         "line_count": line_count,
+        "isolated_result": isolated_result,
+        "networked_status": status,
         "deployment_summary": deployment_summary,
     }
 
@@ -224,6 +264,13 @@ def run_pipeline_sync() -> dict:
     etl_total = etl_sandbox.run(payload=payload)
     data_file = asyncio.run(create_text_file())
     line_count = linecount_sandbox.run(data_file=data_file)
+
+    try:
+        isolated_result = isolated_sandbox.run(x=7)
+    except Exception as e:
+        isolated_result = f"Failed to access network: {e}"
+
+    status = networked_sandbox.run()
     deployment_summary = asyncio.run(deploy_sandbox_task())
 
     return {
@@ -233,6 +280,8 @@ def run_pipeline_sync() -> dict:
         "window_end": window_end.isoformat(),
         "etl_sum_1_to_10": etl_total,
         "line_count": line_count,
+        "isolated_result": isolated_result,
+        "networked_status": status,
         "deployment_summary": deployment_summary,
     }
 

--- a/examples/sandbox/code_sandbox.py
+++ b/examples/sandbox/code_sandbox.py
@@ -125,7 +125,7 @@ linecount_sandbox = flyte.sandbox.create(
     outputs={"line_count": str},
 )
 
-# Example 5 — block_network=True (default): no outbound network access
+# Example 5 — block_network=True: no outbound network access
 #
 # Network access is blocked by default. The sandbox can only read its inputs
 # and write its outputs — any attempt to reach the network will fail.
@@ -138,10 +138,10 @@ with urllib.request.urlopen("https://example.com") as r:
     status = str(r.status)
 """,
     outputs={"status": str},
-    block_network=True,  # default — shown explicitly for clarity
+    block_network=True,
 )
 
-# Example 6 — block_network=False: outbound network access allowed
+# Example 6 — block_network=False (default): outbound network access allowed
 
 networked_sandbox = flyte.sandbox.create(
     name="networked-fetch",
@@ -151,7 +151,6 @@ with urllib.request.urlopen("https://example.com") as r:
     status = str(r.status)
 """,
     outputs={"status": str},
-    block_network=False,
 )
 
 

--- a/examples/sandbox/code_sandbox.py
+++ b/examples/sandbox/code_sandbox.py
@@ -16,7 +16,6 @@ Three modes:
 - **Verbatim mode** (``code=``, ``auto_io=False``): run a complete Python script as-is.
   CLI args are forwarded but the script handles all I/O itself.
 - **Command mode** (``command=``): run any shell command (pytest, binary, non-Python code, etc.).
-
 """
 
 import asyncio
@@ -227,7 +226,7 @@ async def run_pipeline() -> dict:
 
     # Network-blocked sandbox: pure computation, no network
     try:
-        isolated_result = await isolated_sandbox.run.aio(x=7)
+        isolated_result = await isolated_sandbox.run.aio()
     except Exception as e:
         isolated_result = f"Failed to access network: {e}"
 
@@ -265,7 +264,7 @@ def run_pipeline_sync() -> dict:
     line_count = linecount_sandbox.run(data_file=data_file)
 
     try:
-        isolated_result = isolated_sandbox.run(x=7)
+        isolated_result = isolated_sandbox.run()
     except Exception as e:
         isolated_result = f"Failed to access network: {e}"
 

--- a/plugins/codegen/README.md
+++ b/plugins/codegen/README.md
@@ -164,6 +164,7 @@ result = await agent.generate.aio(prompt="...")
 | `cache`               | `str`             | `"auto"`       | CacheRequest for sandboxes: `"auto"`, `"override"`, or `"disable"` |
 | `backend`             | `str`             | `"litellm"`    | Execution backend: `"litellm"` or `"claude"`               |
 | `agent_max_turns`     | `int`             | `50`           | Max turns when `backend="claude"`                          |
+| `block_network`       | `bool`            | `True`         | Block all outbound network access in sandboxes. Set to `False` to allow network access. |
 
 **`generate()` parameters (per-call):**
 

--- a/plugins/codegen/README.md
+++ b/plugins/codegen/README.md
@@ -164,7 +164,7 @@ result = await agent.generate.aio(prompt="...")
 | `cache`               | `str`             | `"auto"`       | CacheRequest for sandboxes: `"auto"`, `"override"`, or `"disable"` |
 | `backend`             | `str`             | `"litellm"`    | Execution backend: `"litellm"` or `"claude"`               |
 | `agent_max_turns`     | `int`             | `50`           | Max turns when `backend="claude"`                          |
-| `block_network`       | `bool`            | `True`         | Block all outbound network access in sandboxes. Set to `False` to allow network access. |
+| `block_network`       | `bool`            | `False`        | Block all outbound network access in sandboxes. Set to `True` to block network access. |
 
 **`generate()` parameters (per-call):**
 

--- a/plugins/codegen/src/flyteplugins/codegen/auto_coder_agent.py
+++ b/plugins/codegen/src/flyteplugins/codegen/auto_coder_agent.py
@@ -73,7 +73,7 @@ class AutoCoderAgent:
         cache: CacheRequest for sandboxes: "auto", "override", or "disable". Defaults to "auto".
         backend: Execution backend: "litellm" (default) or "claude".
         agent_max_turns: Maximum agent turns when backend="claude". Defaults to 50.
-        block_network: Block all outbound network access in sandboxes. Defaults to True.
+        block_network: Block all outbound network access in sandboxes. Defaults to False.
 
     Example::
 
@@ -120,7 +120,7 @@ class AutoCoderAgent:
     cache: str = "auto"
     backend: Literal["litellm", "claude"] = "litellm"
     agent_max_turns: int = 50
-    block_network: bool = True
+    block_network: bool = False
 
     @syncify
     async def generate(

--- a/plugins/codegen/src/flyteplugins/codegen/auto_coder_agent.py
+++ b/plugins/codegen/src/flyteplugins/codegen/auto_coder_agent.py
@@ -73,6 +73,7 @@ class AutoCoderAgent:
         cache: CacheRequest for sandboxes: "auto", "override", or "disable". Defaults to "auto".
         backend: Execution backend: "litellm" (default) or "claude".
         agent_max_turns: Maximum agent turns when backend="claude". Defaults to 50.
+        block_network: Block all outbound network access in sandboxes. Defaults to True.
 
     Example::
 
@@ -119,6 +120,7 @@ class AutoCoderAgent:
     cache: str = "auto"
     backend: Literal["litellm", "claude"] = "litellm"
     agent_max_turns: int = 50
+    block_network: bool = True
 
     @syncify
     async def generate(
@@ -271,6 +273,7 @@ class AutoCoderAgent:
                 env_vars=self.env_vars,
                 secrets=self.secrets,
                 cache=self.cache,
+                block_network=self.block_network,
                 max_turns=self.agent_max_turns,
             )
 
@@ -386,6 +389,7 @@ class _CodeGenSession:
         self.env_vars = agent.env_vars
         self.secrets = agent.secrets
         self.cache = agent.cache
+        self.block_network = agent.block_network
         self.image_config = agent.image_config
         self.litellm_params = agent.litellm_params
 
@@ -606,6 +610,7 @@ class _CodeGenSession:
             env_vars=self.env_vars,
             secrets=self.secrets,
             cache=self.cache,
+            block_network=self.block_network,
             _attempt=attempt,
         )
 

--- a/plugins/codegen/src/flyteplugins/codegen/execution/agent.py
+++ b/plugins/codegen/src/flyteplugins/codegen/execution/agent.py
@@ -77,6 +77,7 @@ async def code_gen_eval_agent(
     env_vars: Optional[dict[str, str]] = None,
     secrets: Optional[list] = None,
     cache: str = "auto",
+    block_network: bool = True,
     max_turns: int = 50,
     language: str = "python",
 ) -> CodeGenEvalResult:
@@ -104,6 +105,7 @@ async def code_gen_eval_agent(
         env_vars: Optional environment variables to set in the sandbox
         secrets: Optional secrets to make available in the sandbox
         cache: Caching behavior for sandbox execution ("auto", "override", "disable")
+        block_network: Block all outbound network access in sandboxes. Defaults to True.
         max_turns: Maximum number of agent turns before stopping (default: 50)
         language: Programming language for code generation (default: "python")
 
@@ -189,6 +191,7 @@ async def code_gen_eval_agent(
             env_vars=env_vars,
             secrets=secrets,
             cache=cache,
+            block_network=block_network,
             _attempt=_exec_state["test_count"],
         )
 

--- a/plugins/codegen/src/flyteplugins/codegen/execution/agent.py
+++ b/plugins/codegen/src/flyteplugins/codegen/execution/agent.py
@@ -77,7 +77,7 @@ async def code_gen_eval_agent(
     env_vars: Optional[dict[str, str]] = None,
     secrets: Optional[list] = None,
     cache: str = "auto",
-    block_network: bool = True,
+    block_network: bool = False,
     max_turns: int = 50,
     language: str = "python",
 ) -> CodeGenEvalResult:
@@ -105,7 +105,7 @@ async def code_gen_eval_agent(
         env_vars: Optional environment variables to set in the sandbox
         secrets: Optional secrets to make available in the sandbox
         cache: Caching behavior for sandbox execution ("auto", "override", "disable")
-        block_network: Block all outbound network access in sandboxes. Defaults to True.
+        block_network: Block all outbound network access in sandboxes. Defaults to False.
         max_turns: Maximum number of agent turns before stopping (default: 50)
         language: Programming language for code generation (default: "python")
 

--- a/plugins/codegen/src/flyteplugins/codegen/execution/docker.py
+++ b/plugins/codegen/src/flyteplugins/codegen/execution/docker.py
@@ -140,6 +140,7 @@ async def run_tests(
     env_vars: Optional[dict[str, str]] = None,
     secrets: Optional[list] = None,
     cache: str = "auto",
+    block_network: bool = True,
     _attempt: int = 1,
 ) -> RunResult:
     """Run pytest tests against code in an isolated container.
@@ -155,6 +156,7 @@ async def run_tests(
         env_vars: Environment variables available inside the container.
         secrets: Flyte secrets to mount.
         cache: Cache behaviour — `"auto"`, `"override"`, or `"disable"`.
+        block_network: Block all outbound network access. Defaults to True.
         _attempt: Differentiates repeated calls with the same base name.
 
     Returns:
@@ -180,6 +182,7 @@ async def run_tests(
         env_vars=env_vars,
         secrets=secrets,
         cache=cache,
+        block_network=block_network,
     )
 
     try:

--- a/plugins/codegen/src/flyteplugins/codegen/execution/docker.py
+++ b/plugins/codegen/src/flyteplugins/codegen/execution/docker.py
@@ -140,7 +140,7 @@ async def run_tests(
     env_vars: Optional[dict[str, str]] = None,
     secrets: Optional[list] = None,
     cache: str = "auto",
-    block_network: bool = True,
+    block_network: bool = False,
     _attempt: int = 1,
 ) -> RunResult:
     """Run pytest tests against code in an isolated container.
@@ -156,7 +156,7 @@ async def run_tests(
         env_vars: Environment variables available inside the container.
         secrets: Flyte secrets to mount.
         cache: Cache behaviour — `"auto"`, `"override"`, or `"disable"`.
-        block_network: Block all outbound network access. Defaults to True.
+        block_network: Block all outbound network access. Defaults to False.
         _attempt: Differentiates repeated calls with the same base name.
 
     Returns:

--- a/plugins/codegen/tests/test_agent.py
+++ b/plugins/codegen/tests/test_agent.py
@@ -31,6 +31,15 @@ class TestAutoCoderAgentConstruction:
         assert agent.secrets is None
         assert agent.cache == "auto"
         assert agent.backend == "litellm"
+        assert agent.block_network is True
+
+    def test_block_network_default_is_true(self):
+        agent = AutoCoderAgent(model="gpt-4.1")
+        assert agent.block_network is True
+
+    def test_block_network_can_be_disabled(self):
+        agent = AutoCoderAgent(model="gpt-4.1", block_network=False)
+        assert agent.block_network is False
 
     def test_max_iterations_default(self):
         agent = AutoCoderAgent(model="test")

--- a/plugins/codegen/tests/test_agent.py
+++ b/plugins/codegen/tests/test_agent.py
@@ -31,15 +31,15 @@ class TestAutoCoderAgentConstruction:
         assert agent.secrets is None
         assert agent.cache == "auto"
         assert agent.backend == "litellm"
-        assert agent.block_network is True
-
-    def test_block_network_default_is_true(self):
-        agent = AutoCoderAgent(model="gpt-4.1")
-        assert agent.block_network is True
-
-    def test_block_network_can_be_disabled(self):
-        agent = AutoCoderAgent(model="gpt-4.1", block_network=False)
         assert agent.block_network is False
+
+    def test_block_network_default_is_false(self):
+        agent = AutoCoderAgent(model="gpt-4.1")
+        assert agent.block_network is False
+
+    def test_block_network_can_be_enabled(self):
+        agent = AutoCoderAgent(model="gpt-4.1", block_network=True)
+        assert agent.block_network is True
 
     def test_max_iterations_default(self):
         agent = AutoCoderAgent(model="test")

--- a/src/flyte/extras/_container.py
+++ b/src/flyte/extras/_container.py
@@ -52,9 +52,9 @@ class ContainerTask(TaskTemplate):
     :param output_data_dir: The directory where the output data is stored. This is a string or a Path object.
     :param metadata_format: The format of the output file. This can be "JSON", "YAML", or "PROTO".
     :param local_logs: If True, logs will be printed to the console in the local execution.
-    :param block_network: If True (default), blocks all outbound network access. Locally this
+    :param block_network: If True, blocks all outbound network access. Locally this
         sets Docker ``network_mode=none``. On-cluster it applies the pod template
-        ``sandboxed-pod-template``. Set to False to allow network access.
+        ``sandboxed-pod-template``. Defaults to False.
     """
 
     MetadataFormat = Literal["JSON", "YAML", "PROTO"]
@@ -71,7 +71,7 @@ class ContainerTask(TaskTemplate):
         output_data_dir: str | pathlib.Path = "/var/outputs",
         metadata_format: MetadataFormat = "JSON",
         local_logs: bool = True,
-        block_network: bool = True,
+        block_network: bool = False,
         **kwargs,
     ):
         if block_network:

--- a/src/flyte/extras/_container.py
+++ b/src/flyte/extras/_container.py
@@ -68,8 +68,22 @@ class ContainerTask(TaskTemplate):
         output_data_dir: str | pathlib.Path = "/var/outputs",
         metadata_format: MetadataFormat = "JSON",
         local_logs: bool = True,
+        block_network: bool = True,
         **kwargs,
     ):
+        if block_network:
+            existing = kwargs.get("pod_template")
+            if existing is None:
+                kwargs["pod_template"] = "sandboxed-pod-template"
+            elif isinstance(existing, str):
+                raise ValueError(
+                    "block_network=True cannot be combined with a string pod_template reference. "
+                    "Use a PodTemplate object instead so the 'sandboxed: true' label can be merged in, "
+                    "or ensure the referenced cluster template already includes that label."
+                )
+            else:
+                existing.labels = {**(existing.labels or {}), "sandboxed": "true"}
+
         super().__init__(
             task_type="raw-container",
             name=name,

--- a/src/flyte/extras/_container.py
+++ b/src/flyte/extras/_container.py
@@ -52,6 +52,9 @@ class ContainerTask(TaskTemplate):
     :param output_data_dir: The directory where the output data is stored. This is a string or a Path object.
     :param metadata_format: The format of the output file. This can be "JSON", "YAML", or "PROTO".
     :param local_logs: If True, logs will be printed to the console in the local execution.
+    :param block_network: If True (default), blocks all outbound network access. Locally this
+        sets Docker ``network_mode=none``. On-cluster it applies the pod template
+        ``sandboxed-pod-template``. Set to False to allow network access.
     """
 
     MetadataFormat = Literal["JSON", "YAML", "PROTO"]
@@ -105,6 +108,7 @@ class ContainerTask(TaskTemplate):
             raise ValueError("All elements in the command list must be strings.")
         if arguments and any(not isinstance(a, str) for a in arguments):
             raise ValueError("All elements in the arguments list must be strings.")
+        self._block_network = block_network
         self._cmd = command
         self._args = arguments
         self._input_data_dir = input_data_dir
@@ -289,6 +293,8 @@ class ContainerTask(TaskTemplate):
             "volumes": volume_bindings,
             "detach": True,
         }
+        if self._block_network:
+            run_kwargs["network_mode"] = "none"
 
         container = client.containers.run(uri, command=commands, **run_kwargs)
 

--- a/src/flyte/sandbox/__init__.py
+++ b/src/flyte/sandbox/__init__.py
@@ -46,6 +46,10 @@ Warning: Experimental feature: alpha — APIs may change without notice.
     - Verbatim mode — run a script that manages its own I/O via /var/inputs and /var/outputs.
     - Command mode — execute an arbitrary command or entrypoint.
 
+    Network access is blocked by default (`block_network=True`). This applies both locally
+    (Docker `network_mode=none`) and on-cluster (via a `NetworkPolicy`).
+    Pass `block_network=False` to allow outbound network access.
+
     Examples
     --------
 

--- a/src/flyte/sandbox/__init__.py
+++ b/src/flyte/sandbox/__init__.py
@@ -46,9 +46,9 @@ Warning: Experimental feature: alpha — APIs may change without notice.
     - Verbatim mode — run a script that manages its own I/O via /var/inputs and /var/outputs.
     - Command mode — execute an arbitrary command or entrypoint.
 
-    Network access is blocked by default (`block_network=True`). This applies both locally
-    (Docker `network_mode=none`) and on-cluster (via a `NetworkPolicy`).
-    Pass `block_network=False` to allow outbound network access.
+    Network access is allowed by default. Pass `block_network=True` to block all
+    outbound access — locally via Docker `network_mode=none`, on-cluster via a
+    `NetworkPolicy`.
 
     Examples
     --------

--- a/src/flyte/sandbox/_code_sandbox.py
+++ b/src/flyte/sandbox/_code_sandbox.py
@@ -357,12 +357,15 @@ class _Sandbox:
         return await task(**kwargs)
 
     def _default_image_name(self) -> str:
+        config = self.image_config or ImageConfig()
         spec = {
             "packages": sorted(self.packages),
             "system_packages": sorted(self.system_packages),
+            "additional_commands": self.additional_commands,
+            "python_version": list(config.python_version) if config.python_version else None,
         }
         config_hash = hashlib.sha256(json.dumps(spec, sort_keys=True).encode()).hexdigest()[:12]
-        return f"{self.name or 'sandbox'}-{config_hash}"
+        return f"sandbox-{config_hash}"
 
 
 def create(

--- a/src/flyte/sandbox/_code_sandbox.py
+++ b/src/flyte/sandbox/_code_sandbox.py
@@ -70,6 +70,7 @@ class _Sandbox:
     env_vars: Optional[dict[str, str]] = None
     secrets: Optional[list] = None
     cache: str = "auto"
+    block_network: bool = True
 
     def _task_name(self) -> str:
         if self.name:
@@ -276,6 +277,7 @@ class _Sandbox:
                 resources=resources,
                 retries=self.retries,
                 cache=self.cache,
+                block_network=self.block_network,
                 **extra_kwargs,
             )
         else:
@@ -292,6 +294,7 @@ class _Sandbox:
                 resources=resources,
                 retries=self.retries,
                 cache=self.cache,
+                block_network=self.block_network,
                 **extra_kwargs,
             )
 
@@ -383,6 +386,7 @@ def create(
     env_vars: Optional[dict[str, str]] = None,
     secrets: Optional[list] = None,
     cache: str = "auto",
+    block_network: bool = True,
 ) -> _Sandbox:
     """Create a stateless Python code sandbox.
 
@@ -477,6 +481,14 @@ def create(
         env_vars: Environment variables available inside the container.
         secrets: Flyte `flyte.Secret` objects to mount.
         cache: Cache behaviour — `"auto"`, `"override"`, or `"disable"`.
+        block_network: When `True` (default), the task pod is labeled
+            `sandboxed: "true"`, which triggers a cluster-level
+            `NetworkPolicy` that blocks all egress. Requires the
+            `deny-all-egress-sandboxed` NetworkPolicy and
+            `sandboxed-pod-template` PodTemplate to be provisioned in
+            the namespace (done automatically via cluster resource
+            templates on BYOC clusters). Set to `False` to allow
+            outbound network access from the container.
 
     Returns:
         Configured sandbox ready to `.run()`.
@@ -514,4 +526,5 @@ def create(
         env_vars=env_vars,
         secrets=secrets,
         cache=cache,
+        block_network=block_network,
     )

--- a/src/flyte/sandbox/_code_sandbox.py
+++ b/src/flyte/sandbox/_code_sandbox.py
@@ -481,14 +481,8 @@ def create(
         env_vars: Environment variables available inside the container.
         secrets: Flyte `flyte.Secret` objects to mount.
         cache: Cache behaviour — `"auto"`, `"override"`, or `"disable"`.
-        block_network: When `True` (default), the task pod is labeled
-            `sandboxed: "true"`, which triggers a cluster-level
-            `NetworkPolicy` that blocks all egress. Requires the
-            `deny-all-egress-sandboxed` NetworkPolicy and
-            `sandboxed-pod-template` PodTemplate to be provisioned in
-            the namespace (done automatically via cluster resource
-            templates on BYOC clusters). Set to `False` to allow
-            outbound network access from the container.
+        block_network: When `True` (default), the container will not have
+            access to the network. Set to `False` to allow network access.
 
     Returns:
         Configured sandbox ready to `.run()`.

--- a/src/flyte/sandbox/_code_sandbox.py
+++ b/src/flyte/sandbox/_code_sandbox.py
@@ -70,7 +70,7 @@ class _Sandbox:
     env_vars: Optional[dict[str, str]] = None
     secrets: Optional[list] = None
     cache: str = "auto"
-    block_network: bool = True
+    block_network: bool = False
 
     def _task_name(self) -> str:
         if self.name:
@@ -386,7 +386,7 @@ def create(
     env_vars: Optional[dict[str, str]] = None,
     secrets: Optional[list] = None,
     cache: str = "auto",
-    block_network: bool = True,
+    block_network: bool = False,
 ) -> _Sandbox:
     """Create a stateless Python code sandbox.
 
@@ -481,8 +481,9 @@ def create(
         env_vars: Environment variables available inside the container.
         secrets: Flyte `flyte.Secret` objects to mount.
         cache: Cache behaviour — `"auto"`, `"override"`, or `"disable"`.
-        block_network: When `True` (default), the container will not have
-            access to the network. Set to `False` to allow network access.
+        block_network: When `True`, blocks all outbound network access — locally
+            via Docker ``network_mode=none``, on-cluster via a NetworkPolicy.
+            Defaults to `False`.
 
     Returns:
         Configured sandbox ready to `.run()`.

--- a/tests/flyte/extras/test_container_task.py
+++ b/tests/flyte/extras/test_container_task.py
@@ -28,25 +28,25 @@ def test_bad_incorrect_type_in_command():
         )
 
 
-def test_block_network_default_sets_pod_template():
+def test_block_network_default_is_false():
     task = ContainerTask(
         name="test",
         image="alpine:latest",
         command=["echo", "hi"],
-    )
-    assert task.pod_template == "sandboxed-pod-template"
-    assert task._block_network is True
-
-
-def test_block_network_false_no_pod_template():
-    task = ContainerTask(
-        name="test",
-        image="alpine:latest",
-        command=["echo", "hi"],
-        block_network=False,
     )
     assert task.pod_template is None
     assert task._block_network is False
+
+
+def test_block_network_true_sets_pod_template():
+    task = ContainerTask(
+        name="test",
+        image="alpine:latest",
+        command=["echo", "hi"],
+        block_network=True,
+    )
+    assert task.pod_template == "sandboxed-pod-template"
+    assert task._block_network is True
 
 
 def test_block_network_merges_label_into_pod_template():

--- a/tests/flyte/extras/test_container_task.py
+++ b/tests/flyte/extras/test_container_task.py
@@ -56,6 +56,7 @@ def test_block_network_merges_label_into_pod_template():
         image="alpine:latest",
         command=["echo", "hi"],
         pod_template=pt,
+        block_network=True,
     )
     assert task.pod_template.labels == {"existing": "label", "sandboxed": "true"}
 
@@ -67,6 +68,7 @@ def test_block_network_with_string_pod_template_raises():
             image="alpine:latest",
             command=["echo", "hi"],
             pod_template="my-custom-template",
+            block_network=True,
         )
 
 

--- a/tests/flyte/extras/test_container_task.py
+++ b/tests/flyte/extras/test_container_task.py
@@ -1,5 +1,6 @@
 import pytest
 
+from flyte._pod import PodTemplate
 from flyte.extras import ContainerTask
 
 
@@ -24,6 +25,48 @@ def test_bad_incorrect_type_in_command():
                 "--hyperparams-base64",
                 hyperparams_str,
             ],
+        )
+
+
+def test_block_network_default_sets_pod_template():
+    task = ContainerTask(
+        name="test",
+        image="alpine:latest",
+        command=["echo", "hi"],
+    )
+    assert task.pod_template == "sandboxed-pod-template"
+    assert task._block_network is True
+
+
+def test_block_network_false_no_pod_template():
+    task = ContainerTask(
+        name="test",
+        image="alpine:latest",
+        command=["echo", "hi"],
+        block_network=False,
+    )
+    assert task.pod_template is None
+    assert task._block_network is False
+
+
+def test_block_network_merges_label_into_pod_template():
+    pt = PodTemplate(labels={"existing": "label"})
+    task = ContainerTask(
+        name="test",
+        image="alpine:latest",
+        command=["echo", "hi"],
+        pod_template=pt,
+    )
+    assert task.pod_template.labels == {"existing": "label", "sandboxed": "true"}
+
+
+def test_block_network_with_string_pod_template_raises():
+    with pytest.raises(ValueError, match="block_network=True cannot be combined"):
+        ContainerTask(
+            name="test",
+            image="alpine:latest",
+            command=["echo", "hi"],
+            pod_template="my-custom-template",
         )
 
 


### PR DESCRIPTION
* `block_network` is set to `False` by default in `ContainerTask`. 
* This param is also now available in the codegen plugin.
* Updates sandbox image hash to account for commands and python version.