### PR TITLE
feat: add disable_keyring config option to skip token caching

### DIFF
--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -71,6 +71,7 @@ async def _initialize_client(
     client_credentials_secret: str | None = None,
     rpc_retries: int = 3,
     http_proxy_url: str | None = None,
+    disable_keyring: bool = False,
 ) -> ClientSet:
     """
     Initialize the client based on the execution mode.
@@ -93,6 +94,7 @@ async def _initialize_client(
             client_config=client_config,
             rpc_retries=rpc_retries,
             http_proxy_url=http_proxy_url,
+            disable_keyring=disable_keyring,
         )
     elif api_key:
         return await ClientSet.for_api_key(
@@ -109,6 +111,7 @@ async def _initialize_client(
             client_config=client_config,
             rpc_retries=rpc_retries,
             http_proxy_url=http_proxy_url,
+            disable_keyring=disable_keyring,
         )
 
     raise InitializationError(
@@ -145,6 +148,7 @@ async def init(
     auth_client_config: ClientConfig | None = None,
     rpc_retries: int = 3,
     http_proxy_url: str | None = None,
+    disable_keyring: bool = False,
     storage: Storage | None = None,
     batch_size: int = 1000,
     image_builder: ImageBuildEngine.ImageBuilderType = "local",
@@ -227,6 +231,7 @@ async def init(
                 client_config=auth_client_config,
                 rpc_retries=rpc_retries,
                 http_proxy_url=http_proxy_url,
+                disable_keyring=disable_keyring,
             )
 
         if not root_dir:
@@ -332,6 +337,7 @@ async def init_from_config(
         proxy_command=cfg.platform.proxy_command,
         client_id=cfg.platform.client_id,
         client_credentials_secret=cfg.platform.client_credentials_secret,
+        disable_keyring=cfg.platform.disable_keyring,
         root_dir=root_dir,
         log_level=log_level,
         log_format=log_format,

--- a/src/flyte/config/_config.py
+++ b/src/flyte/config/_config.py
@@ -40,6 +40,7 @@ class PlatformConfig(object):
     :param auth_mode: The OAuth mode to use. Defaults to pkce flow
     :param ca_cert_file_path: [optional] str Root Cert to be loaded and used to verify admin
     :param http_proxy_url: [optional] HTTP Proxy to be used for OAuth requests
+    :param disable_keyring: If True, disables storing/retrieving/deleting tokens from the system keyring
     """
 
     endpoint: str | None = None
@@ -56,6 +57,7 @@ class PlatformConfig(object):
     audience: typing.Optional[str] = None
     rpc_retries: int = 3
     http_proxy_url: typing.Optional[str] = None
+    disable_keyring: bool = False
 
     @classmethod
     def auto(cls, config_file: typing.Optional[typing.Union[str, ConfigFile]] = None) -> "PlatformConfig":
@@ -105,6 +107,7 @@ class PlatformConfig(object):
         kwargs = set_if_exists(kwargs, "console_endpoint", _internal.Platform.CONSOLE_ENDPOINT.read(config_file))
 
         kwargs = set_if_exists(kwargs, "http_proxy_url", _internal.Platform.HTTP_PROXY_URL.read(config_file))
+        kwargs = set_if_exists(kwargs, "disable_keyring", _internal.Platform.DISABLE_KEYRING.read(config_file))
         return PlatformConfig(**kwargs)
 
     def replace(self, **kwargs: typing.Any) -> "PlatformConfig":

--- a/src/flyte/config/_internal.py
+++ b/src/flyte/config/_internal.py
@@ -8,6 +8,7 @@ class Platform(object):
     CONSOLE_ENDPOINT = ConfigEntry(YamlConfigEntry("console.endpoint"))
     CA_CERT_FILE_PATH = ConfigEntry(YamlConfigEntry("admin.caCertFilePath"))
     HTTP_PROXY_URL = ConfigEntry(YamlConfigEntry("admin.httpProxyURL"))
+    DISABLE_KEYRING = ConfigEntry(YamlConfigEntry("admin.disableKeyring", bool))
 
 
 class Credentials(object):

--- a/src/flyte/remote/_client/auth/_authenticators/base.py
+++ b/src/flyte/remote/_client/auth/_authenticators/base.py
@@ -34,6 +34,7 @@ class Authenticator(object):
         verify: bool = True,
         ca_cert_path: typing.Optional[str] = None,
         default_header_key: str = "authorization",
+        disable_keyring: bool = False,
         **kwargs,
     ):
         """
@@ -67,7 +68,8 @@ class Authenticator(object):
             - app: ASGI application to handle requests
         """
         self._endpoint = endpoint
-        self._creds = credentials or KeyringStore.retrieve(endpoint)
+        self._disable_keyring = disable_keyring
+        self._creds = credentials or KeyringStore.retrieve(endpoint, disable=disable_keyring)
         self._http_proxy_url = http_proxy_url
         self._verify = verify
         self._ca_cert_path = ca_cert_path
@@ -177,9 +179,9 @@ class Authenticator(object):
             # Perform the actual credential refresh
             try:
                 self._creds = await self._do_refresh_credentials()
-                KeyringStore.store(self._creds)
+                KeyringStore.store(self._creds, disable=self._disable_keyring)
             except Exception:
-                KeyringStore.delete(self._endpoint)
+                KeyringStore.delete(self._endpoint, disable=self._disable_keyring)
                 raise
 
             # Update the timestamp to indicate credentials have been refreshed

--- a/src/flyte/remote/_client/auth/_keyring.py
+++ b/src/flyte/remote/_client/auth/_keyring.py
@@ -56,7 +56,7 @@ class KeyringStore:
     _refresh_token_key = "refresh_token"
 
     @staticmethod
-    def store(credentials: Credentials) -> Credentials:
+    def store(credentials: Credentials, disable: bool = False) -> Credentials:
         """
         Stores the provided credentials in the system keyring.
 
@@ -64,9 +64,13 @@ class KeyringStore:
         in the system keyring, using the endpoint as the service name and specific key names for each token type.
 
         :param credentials: The credentials object containing tokens to store
+        :param disable: If True, skip storing tokens in the keyring
         :return: The same credentials object that was passed in
         :raises: Logs but does not raise NoKeyringError if the system keyring is not available
         """
+        if disable:
+            logger.debug("Keyring is disabled, skipping token store.")
+            return credentials
         try:
             if credentials.refresh_token:
                 keyring.set_password(
@@ -86,7 +90,7 @@ class KeyringStore:
         return credentials
 
     @staticmethod
-    def retrieve(for_endpoint: str) -> typing.Optional[Credentials]:
+    def retrieve(for_endpoint: str, disable: bool = False) -> typing.Optional[Credentials]:
         """
         Retrieves stored credentials from the system keyring for the specified endpoint.
 
@@ -94,9 +98,13 @@ class KeyringStore:
         using the endpoint as the service name. The endpoint URL scheme is stripped before lookup.
 
         :param for_endpoint: The endpoint URL to retrieve credentials for
+        :param disable: If True, skip retrieving tokens from the keyring
         :return: A Credentials object containing the retrieved tokens, or None if no tokens were found
                  or if the system keyring is not available
         """
+        if disable:
+            logger.debug("Keyring is disabled, skipping token retrieve.")
+            return None
         for_endpoint = strip_scheme(for_endpoint)
         access_token: str | None = None
         try:
@@ -124,7 +132,7 @@ class KeyringStore:
         )
 
     @staticmethod
-    def delete(for_endpoint: str):
+    def delete(for_endpoint: str, disable: bool = False):
         """
         Deletes all stored credentials for the specified endpoint from the system keyring.
 
@@ -132,7 +140,11 @@ class KeyringStore:
         using the endpoint as the service name. The endpoint URL scheme is stripped before lookup.
 
         :param for_endpoint: The endpoint URL to delete credentials for
+        :param disable: If True, skip deleting tokens from the keyring
         """
+        if disable:
+            logger.debug("Keyring is disabled, skipping token delete.")
+            return
         for_endpoint = strip_scheme(for_endpoint)
 
         def _delete_key(key):

--- a/tests/flyte/keyring/test_keyring_store.py
+++ b/tests/flyte/keyring/test_keyring_store.py
@@ -1,0 +1,43 @@
+from unittest.mock import patch
+
+from flyte.remote._client.auth._keyring import Credentials, KeyringStore
+
+
+def test_store_skips_when_disabled():
+    creds = Credentials(access_token="tok", for_endpoint="foo")
+    with patch("flyte.remote._client.auth._keyring.keyring.set_password") as mock_set:
+        result = KeyringStore.store(creds, disable=True)
+        mock_set.assert_not_called()
+        assert result is creds
+
+
+def test_store_writes_when_not_disabled():
+    creds = Credentials(access_token="tok", for_endpoint="foo", refresh_token="rtok")
+    with patch("flyte.remote._client.auth._keyring.keyring.set_password") as mock_set:
+        KeyringStore.store(creds, disable=False)
+        assert mock_set.call_count == 2
+
+
+def test_retrieve_skips_when_disabled():
+    with patch("flyte.remote._client.auth._keyring.keyring.get_password") as mock_get:
+        result = KeyringStore.retrieve("foo", disable=True)
+        mock_get.assert_not_called()
+        assert result is None
+
+
+def test_retrieve_reads_when_not_disabled():
+    with patch("flyte.remote._client.auth._keyring.keyring.get_password", return_value=None) as mock_get:
+        KeyringStore.retrieve("foo", disable=False)
+        assert mock_get.called
+
+
+def test_delete_skips_when_disabled():
+    with patch("flyte.remote._client.auth._keyring.keyring.delete_password") as mock_del:
+        KeyringStore.delete("foo", disable=True)
+        mock_del.assert_not_called()
+
+
+def test_delete_calls_when_not_disabled():
+    with patch("flyte.remote._client.auth._keyring.keyring.delete_password") as mock_del:
+        KeyringStore.delete("foo", disable=False)
+        assert mock_del.called


### PR DESCRIPTION
## Summary
- Adds `admin.disableKeyring` YAML config option (and corresponding `FLYTE_ADMIN_DISABLEKEYRING` env var) to disable system keyring use for auth tokens
- Plumbs the flag through `PlatformConfig` → `init_from_config` → `init` → `_initialize_client` → `ClientSet` → `Authenticator` → `KeyringStore.retrieve/store/delete`
- When disabled, `KeyringStore` skips all store/retrieve/delete operations so tokens are never persisted to the system keyring

## Why
Useful for environments where the system keyring is unavailable (headless/CI), misconfigured, or undesirable for security reasons. Users can now opt out of token caching via config or env var without having to rely on side-channel hacks.

## Usage
YAML config:
```yaml
admin:
  endpoint: dns:///your-endpoint
  authType: Pkce
  disableKeyring: true
```

Env var:
```
export FLYTE_ADMIN_DISABLEKEYRING=true
```

## Test plan
- [x] Added unit tests in `tests/flyte/keyring/test_keyring_store.py` covering `store`/`retrieve`/`delete` with `disable=True` and `disable=False`
- [x] Existing keyring tests still pass
- [ ] Manually verify with a real endpoint that no tokens are written to the keyring when `disableKeyring: true` is set