### PR TITLE
build: tag default image with local flyte version

### DIFF
--- a/maint_tools/build_default_image.py
+++ b/maint_tools/build_default_image.py
@@ -21,7 +21,7 @@ async def build_flyte_image(registry: str | None = None, name: str | None = None
     from flyte._version import __version__
 
     default_image = Image.from_debian_base(registry=registry, name=name, install_flyte=False).with_local_v2()
-    suffix = __version__.replace("+", "-")
+    suffix = __version__ if __version__.startswith("v") else f"v{__version__}".replace("+", "-")
     python_version = _detect_python_version()
     tag = f"py{python_version[0]}.{python_version[1]}-{suffix}"
     object.__setattr__(default_image, "_tag", tag)
@@ -74,7 +74,7 @@ async def build_flyte_connector_image(
         default_image = Image.from_debian_base(registry=registry, name=name).with_pip_packages(
             "flyteplugins-bigquery", "flyteplugins-snowflake", "flyteplugins-databricks", pre=True
         )
-    suffix = __version__.replace("+", "-")
+    suffix = __version__ if __version__.startswith("v") else f"v{__version__}".replace("+", "-")
     python_version = _detect_python_version()
     tag = f"py{python_version[0]}.{python_version[1]}-{suffix}"
     object.__setattr__(default_image, "_tag", tag)

--- a/maint_tools/build_default_image.py
+++ b/maint_tools/build_default_image.py
@@ -17,8 +17,8 @@ async def build_flyte_image(registry: str | None = None, name: str | None = None
         name:     e.g. "my-flyte-image".
         builder:  e.g. "local" or "remote".
     """
-    from flyte._version import __version__
     from flyte._image import _detect_python_version
+    from flyte._version import __version__
 
     default_image = Image.from_debian_base(registry=registry, name=name, install_flyte=False).with_local_v2()
     suffix = __version__.replace("+", "-")

--- a/maint_tools/build_default_image.py
+++ b/maint_tools/build_default_image.py
@@ -17,7 +17,14 @@ async def build_flyte_image(registry: str | None = None, name: str | None = None
         name:     e.g. "my-flyte-image".
         builder:  e.g. "local" or "remote".
     """
-    default_image = Image.from_debian_base(registry=registry, name=name)
+    from flyte._version import __version__
+    from flyte._image import _detect_python_version
+
+    default_image = Image.from_debian_base(registry=registry, name=name, install_flyte=False).with_local_v2()
+    suffix = __version__.replace("+", "-")
+    python_version = _detect_python_version()
+    tag = f"py{python_version[0]}.{python_version[1]}-{suffix}"
+    object.__setattr__(default_image, "_tag", tag)
     await ImageBuildEngine.build(default_image, builder=builder)
 
 


### PR DESCRIPTION
## Summary
- Build the default image from local flyte source via `with_local_v2()` (skipping the pip install of flyte inside the base).
- Tag the resulting image as `py{X.Y}-{version}` so images are identifiable by their Python and flyte version.

## Test plan
- [x] Run `python maint_tools/build_default_image.py` locally and confirm the image tag matches `py{X.Y}-{version}`.
- [x] Verify the built image contains the local flyte source (not a pip-installed version).
- [x] Confirm `ImageBuildEngine.build` succeeds with both `local` and `remote` builders.