### PR TITLE
Add auth endpoint to create_session_config

### DIFF
--- a/src/flyte/remote/_client/auth/_session.py
+++ b/src/flyte/remote/_client/auth/_session.py
@@ -163,6 +163,7 @@ async def create_session_config(
     ca_cert_file_path: typing.Optional[str] = None,
     proxy_command: typing.List[str] | None = None,
     rpc_retries: typing.Optional[int] = None,
+    auth_endpoint: typing.Optional[str] = None,
     **kwargs,
 ) -> SessionConfig:
     """
@@ -178,6 +179,9 @@ async def create_session_config(
     :param ca_cert_file_path: Path to CA certificate file for SSL verification
     :param proxy_command: List of strings for proxy command configuration
     :param rpc_retries: Number of times to retry RPCs. None means do not install the retry interceptor.
+    :param auth_endpoint: Endpoint for auth/OAuth discovery. Defaults to ``endpoint`` when not set.
+        When creating sessions for per-cluster DataProxy clients, pass the
+        control-plane endpoint so auth tokens are obtained from the right server.
     :param kwargs: Additional arguments passed to authenticator factories
     :return: SessionConfig with endpoint, interceptors, and http_client
     """
@@ -232,7 +236,7 @@ async def create_session_config(
     # local dev). This matches the old gRPC create_channel() behavior.
     if not insecure:
         auth_interceptors = create_auth_interceptors(
-            endpoint=endpoint,
+            endpoint=auth_endpoint or endpoint,
             http_client=http_client,
             insecure=insecure,
             insecure_skip_verify=insecure_skip_verify,

--- a/src/flyte/remote/_client/controlplane.py
+++ b/src/flyte/remote/_client/controlplane.py
@@ -304,6 +304,7 @@ class ClusterAwareDataProxy:
                 endpoint,
                 insecure=self._session_config.insecure,
                 insecure_skip_verify=self._session_config.insecure_skip_verify,
+                auth_endpoint=self._session_config.endpoint,
             )
         except Exception as e:
             raise RuntimeError(f"Failed to create session for cluster endpoint '{endpoint}': {e}") from e


### PR DESCRIPTION
Follow-up to https://github.com/flyteorg/flyte-sdk/pull/959

When we use the ClusterAwareDataProxy, we still need to pass the control plane endpoint to auth middleware because auth still needs to happen against the control plane even if the request is ultimately served by a separate dataplane.

Tested in a deployment where SelectCluster returned a direct dataplane URL and verified I could launch executions

Before
```
╭─────────────────────────────────────────────────────────────────────────────── Exception ───────────────────────────────────────────────────────────────────────────────╮
│ ✕ Execution failed: Failed to get signed url for /var/folders/1h/dgljffnn1q1clj5qb12ypw0c0000gn/T/tmpnk1yd25_/fastf3fae0b4949b45165d6191395c1f76c8.tar.gz: Unauthorized │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

After

```
18:21:22.475607 DEBUG    controlplane.py:312 -  Created DataProxy client for cluster endpoint: https://foo...                                                                                                                                   
╭────────────────────────────────────────────────── Remote Run ───────────────────────────────────────────────────╮
│ Created Run: rf2xrlq5sbssl7zpvpdz                                                                               │
│ URL: https://foo/v2/domain/development/project/flytesnacks/runs/rf2xrlq5sbssl7zpvpdz │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```