### PR TITLE
Update demo cluster image and progress labels

### DIFF
--- a/src/flyte/cli/_demo.py
+++ b/src/flyte/cli/_demo.py
@@ -195,10 +195,10 @@ def _merge_kubeconfig(kubeconfig_path: Path, container_name: str) -> None:
 _STEPS = [
     ("Pulling image", "pull"),
     ("Starting container", "start"),
-    ("Waiting for kubeconfig", "kubeconfig"),
+    ("Waiting for k3d cluster", "kubeconfig"),
     ("Merging kubeconfig", "merge"),
     ("Configuring kubectl context", "context"),
-    ("Waiting for cluster to be ready", "ready"),
+    ("Waiting for flyte cluster to be ready", "ready"),
 ]
 
 _STEPS_DEV = _STEPS[:-1]  # Dev mode skips the readiness check

--- a/src/flyte/cli/_start.py
+++ b/src/flyte/cli/_start.py
@@ -28,7 +28,7 @@ def tui():
 @start.command()
 @click.option(
     "--image",
-    default="ghcr.io/flyteorg/flyte-demo-v2:nightly",
+    default="ghcr.io/flyteorg/flyte-demo:nightly",
     show_default=True,
     help="Docker image to use for the demo cluster.",
 )

--- a/src/flyte/cli/_start.py
+++ b/src/flyte/cli/_start.py
@@ -28,7 +28,7 @@ def tui():
 @start.command()
 @click.option(
     "--image",
-    default="ghcr.io/flyteorg/flyte-sandbox-v2:nightly",
+    default="ghcr.io/flyteorg/flyte-demo-v2:nightly",
     show_default=True,
     help="Docker image to use for the demo cluster.",
 )


### PR DESCRIPTION
## Summary
- Switch default demo image from `flyte-sandbox-v2:nightly` to `flyte-demo-v2:nightly`.
- Clarify progress step labels in `flyte start demo` (k3d cluster, flyte cluster readiness).

## Test plan
- [x] Run `flyte start demo` and verify the new image pulls and progress labels display correctly.