### PR TITLE
make fixes to python script cli

### DIFF
--- a/src/flyte/_run_python_script.py
+++ b/src/flyte/_run_python_script.py
@@ -72,7 +72,7 @@ def _build_task(
         cmd = [sys.executable, "-u", script_name, *args]
         tail: "collections.deque[str]" = collections.deque(maxlen=80)
 
-        proc = subprocess.Popen(  # noqa: ASYNC221
+        proc = subprocess.Popen(  # noqa: ASYNC220
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,  # unified ordering with stdout
@@ -94,9 +94,7 @@ def _build_task(
         stdout_tail = "".join(tail)
 
         if proc.returncode != 0:
-            raise RuntimeError(
-                f"Script failed with exit code {proc.returncode}, last output: {stdout_tail}"
-            )
+            raise RuntimeError(f"Script failed with exit code {proc.returncode}, last output: {stdout_tail}")
 
         from flyte.io import Dir, EmptyDir
 

--- a/src/flyte/_run_python_script.py
+++ b/src/flyte/_run_python_script.py
@@ -62,33 +62,41 @@ def _build_task(
     @env.task(timeout=task_timeout, short_name=short_name, task_resolver=task_resolver)
     async def execute_script(args: list[str], task_timeout: int) -> PythonScriptOutput:
         """Execute a Python script on a remote machine."""
-        import os
+        import collections
         import subprocess
         import sys
-        import tempfile
 
-        tail_bytes = 1000
-        cmd = [sys.executable, script_name, *args]
+        # `-u` forces line-buffered Python so prints flush into the pipe
+        # immediately, giving us live streaming to the pod's stdout (and
+        # therefore the k8s log stream / Flyte UI logs tab).
+        cmd = [sys.executable, "-u", script_name, *args]
+        tail: "collections.deque[str]" = collections.deque(maxlen=80)
 
-        with tempfile.TemporaryFile(mode="w+") as out_f, tempfile.TemporaryFile(mode="w+") as err_f:
-            result = subprocess.run(  # noqa: ASYNC221
-                cmd,
-                stdout=out_f,
-                stderr=err_f,
-                check=False,
-                timeout=task_timeout - 60,
+        proc = subprocess.Popen(  # noqa: ASYNC221
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,  # unified ordering with stdout
+            text=True,
+            bufsize=1,
+        )
+        assert proc.stdout is not None
+        try:
+            for line in proc.stdout:
+                sys.stdout.write(line)
+                sys.stdout.flush()
+                tail.append(line)
+            proc.wait(timeout=task_timeout - 60)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+            raise
+
+        stdout_tail = "".join(tail)
+
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"Script failed with exit code {proc.returncode}, last output: {stdout_tail}"
             )
-
-            for f in (out_f, err_f):
-                f.seek(0, os.SEEK_END)
-                pos = f.tell()
-                f.seek(max(0, pos - tail_bytes))
-
-            stdout_tail = out_f.read()
-            stderr_tail = err_f.read()
-
-        if result.returncode != 0:
-            raise RuntimeError(f"Script failed with exit code {result.returncode}, stderr: {stderr_tail}")
 
         from flyte.io import Dir, EmptyDir
 
@@ -98,7 +106,7 @@ def _build_task(
             _dir = EmptyDir()
 
         return PythonScriptOutput(
-            exit_code=result.returncode,
+            exit_code=proc.returncode,
             stdout=stdout_tail,
             output_dir=_dir,
         )
@@ -217,7 +225,7 @@ async def run_python_script(
 
     # Create environment
     env_kwargs: Dict[str, Any] = {
-        "name": "python_script",
+        "name": f"python_script_{script.stem}",
         "image": img,
         "resources": resources,
     }
@@ -243,7 +251,7 @@ async def run_python_script(
         name=name,
         debug=debug,
         copy_style="custom",
-        _bundle_relative_paths=(script.name,),
+        _bundle_relative_paths=tuple(p.name for p in script.parent.glob("*.py")),
         _bundle_from_dir=script.parent,
     )
     run = await runner.run.aio(

--- a/src/flyte/_run_python_script.py
+++ b/src/flyte/_run_python_script.py
@@ -141,6 +141,7 @@ async def run_python_script(
     name: "Optional[str]" = None,
     debug: bool = False,
     output_dir: "Optional[str]" = None,
+    include_files: "Optional[List[str]]" = None,
 ) -> "Run":
     """Package and run a Python script on a remote Flyte cluster.
 
@@ -173,6 +174,10 @@ async def run_python_script(
     :param debug: If True, run the task as a VS Code debug task, starting a
         code-server in the container so you can connect via the UI to
         interactively debug/run the task.
+    :param include_files: Extra paths or glob patterns to bundle alongside
+        the script. Relative entries anchor at the script's directory;
+        absolute paths pass through unchanged. Example:
+        `["*.py", "configs/settings.yaml"]`.
     :return: A `flyte.remote.Run` handle for the remote execution.
 
     Example::
@@ -229,7 +234,13 @@ async def run_python_script(
     }
     if queue:
         env_kwargs["queue"] = queue
+    if include_files:
+        env_kwargs["include"] = tuple(include_files)
     env = flyte.TaskEnvironment(**env_kwargs)
+    # Anchor relative `include` entries at the script's directory. The default
+    # stack-walk in `_get_declaring_file` lands on CLI internals, which would
+    # resolve globs against the wrong anchor.
+    env._declaring_file = str(script)
 
     # Build task with the InternalTaskResolver so the runner knows how to
     # serialize and reload it without pickling.
@@ -249,7 +260,7 @@ async def run_python_script(
         name=name,
         debug=debug,
         copy_style="custom",
-        _bundle_relative_paths=tuple(p.name for p in script.parent.glob("*.py")),
+        _bundle_relative_paths=(script.name,),
         _bundle_from_dir=script.parent,
     )
     run = await runner.run.aio(

--- a/src/flyte/cli/_run_python_script.py
+++ b/src/flyte/cli/_run_python_script.py
@@ -65,6 +65,15 @@ class PythonScriptCommand(CommandBase):
     default=None,
     help="Directory path (inside the container) to upload as output after the script finishes.",
 )
+@click.option(
+    "--include-files",
+    "include_files",
+    type=str,
+    multiple=True,
+    help="Extra paths or glob patterns (relative to the script's directory) to bundle "
+    "alongside the script. Repeat the flag to pass multiple entries, "
+    "e.g. --include-files '*.py' --include-files 'configs/settings.yaml'.",
+)
 @click.pass_obj
 def python_script(
     cfg: common.CLIConfig,
@@ -79,6 +88,7 @@ def python_script(
     extra_args: str | None,
     queue: str | None,
     output_dir: str | None,
+    include_files: tuple[str, ...],
 ) -> None:
     """Run a Python script on a remote Flyte cluster.
 
@@ -163,6 +173,7 @@ def python_script(
         name=name,
         debug=debug,
         output_dir=output_dir,
+        include_files=list(include_files) if include_files else None,
     )
 
     url = run.url

--- a/src/flyte/cli/_run_python_script.py
+++ b/src/flyte/cli/_run_python_script.py
@@ -28,8 +28,8 @@ class PythonScriptCommand(CommandBase):
 
 @click.command("python-script", cls=PythonScriptCommand)
 @click.argument("script", type=click.Path(exists=True, dir_okay=False))
-@click.option("--cpu", type=int, default=4, show_default=True, help="Number of CPUs to request.")
-@click.option("--memory", type=str, default="16Gi", show_default=True, help="Memory to request (e.g. 16Gi, 64Gi).")
+@click.option("--cpu", type=int, default=1, show_default=True, help="Number of CPUs to request.")
+@click.option("--memory", type=str, default="2Gi", show_default=True, help="Memory to request (e.g. 16Gi, 64Gi).")
 @click.option("--gpu", type=int, default=0, show_default=True, help="Number of GPUs to request.")
 @click.option(
     "--gpu-type",
@@ -138,7 +138,10 @@ def python_script(
     # Build the image argument for the public API
     image_arg: flyte.Image | list[str] | None
     if image:
-        image_arg = flyte.Image.from_ref_name(image)
+        if "/" in image or ":" in image:
+            image_arg = flyte.Image.from_base(image)
+        else:
+            image_arg = flyte.Image.from_ref_name(image)
     elif packages:
         image_arg = [p.strip() for p in packages.split(",") if p.strip()]
     else:


### PR DESCRIPTION
## Summary
Testing `flyte run python-script` end-to-end against a Union Cloud tenant surfaced five independent issues. This PR fixes all five. None of the changes alter the public API surface; they are all internal CLI / task runner fixes.

## Changes

### 1. `--image <uri>` was unusable
`cli/_run_python_script.py` routed `--image` through `flyte.Image.from_ref_name(name)`, which only looks up named images registered in the config's image map. Passing a raw URI (the documented usage: `"Container image URI"`) raised `Image name '...' not found in config. Available: []`.

Fix: branch on whether the value looks like a URI (contains `/` or `:`) and use `Image.from_base(image_uri)` in that case, falling back to `from_ref_name` for bare names.

### 2. No way to bundle anything besides the script itself
`_run_python_script.py` called the runner with `_bundle_relative_paths=(script.name,)`. That's fine for self-contained scripts, but any script that imported a sibling helper or read a local config file failed in the pod (`ModuleNotFoundError`, `FileNotFoundError`) with no obvious escape hatch — `copy_style="custom"` was hard-coded and the user had no lever to widen the bundle.

Fix: expose the existing `Environment.include` mechanism on the python-script command as `--include-files` (repeatable, accepts paths or globs). Relative entries are anchored at the script's directory via `env._declaring_file = str(script)` (the default stack-walk lands on CLI internals, which would resolve globs against the wrong directory). Absolute paths pass through unchanged.

```bash
flyte run python-script train.py \
    --include-files "*.py" \
    --include-files "configs/settings.yaml"
```

Same param is available in the Python API as `include_files=[...]`. Default behavior is unchanged — still just the script — so this is purely additive.

### 3. Every script registered under the same task identity
The task name is computed as `env.name + "." + func.__name__` (`_task_environment.py:319`). Since the env name was hardcoded `"python_script"` and the function name is always `execute_script`, every script ended up registered as `python_script.execute_script`. In the UI this caused the same run IDs to appear under every script-stem grouping (the UI groups runs by `short_name`, but pulls the run list from the shared task identity).

Fix: make env name script-specific: `f"python_script_{script.stem}"`. Each script now has a distinct backend task, and the UI groups runs correctly per script.

### 4. Default resources too heavy for a "hello world"-positioned feature
Defaults were `--cpu 4 --memory 16Gi`, which do not fit on common smaller node shapes (e.g. t3a.xlarge) — users would see their first `flyte run python-script hello.py` sit in Pending indefinitely. Users who need more can still override.

Fix: `--cpu 1 --memory 2Gi`.

### 5. No live log streaming
The task used `subprocess.run(stdout=tempfile, stderr=tempfile)` inside the pod, capturing all output to tempfiles. Only the last 1000 bytes were returned as `PythonScriptOutput.stdout` after exit. Users could not observe a running script via the logs tab / `kubectl logs` — the script's output appeared nowhere until completion.

Fix: switch to `subprocess.Popen` with `stdout=PIPE, stderr=STDOUT`, iterate lines as they arrive, echo each to `sys.stdout` (which the pod emits to its stdout stream → k8s → UI logs tab), and keep a `collections.deque(maxlen=80)` tail for the structured output. Also pass `python -u` for unbuffered interpreter so `print()` flushes line-by-line.