### PR TITLE
forward api_key to per-cluster DataProxy session

### DIFF
--- a/src/flyte/remote/_client/auth/_session.py
+++ b/src/flyte/remote/_client/auth/_session.py
@@ -26,6 +26,7 @@ class SessionConfig:
     insecure_skip_verify: bool
     interceptors: tuple
     http_client: Any
+    api_key: typing.Optional[str] = None
 
     def connect_kwargs(self) -> dict[str, Any]:
         return {"address": self.endpoint, "interceptors": self.interceptors, "http_client": self.http_client}
@@ -259,4 +260,5 @@ async def create_session_config(
         insecure_skip_verify=insecure_skip_verify or False,
         interceptors=tuple(interceptors),
         http_client=http_client,
+        api_key=api_key,
     )

--- a/src/flyte/remote/_client/controlplane.py
+++ b/src/flyte/remote/_client/controlplane.py
@@ -302,6 +302,7 @@ class ClusterAwareDataProxy:
         try:
             new_cfg = await create_session_config(
                 endpoint,
+                self._session_config.api_key,
                 insecure=self._session_config.insecure,
                 insecure_skip_verify=self._session_config.insecure_skip_verify,
                 auth_endpoint=self._session_config.endpoint,


### PR DESCRIPTION
- Bug: `ClusterAwareDataProxy._select_and_build` creates a new `SessionConfig` for the per-cluster DataProxy endpoint but doesn't carry over the original session's auth credentials.
- Impact: All non-interactive auth (CI/CD using `FLYTE_API_KEY`) silently falls back to PKCE on image builder uploads → hangs waiting for browser. Works locally only because macOS Keychain caches a token from prior PKCE sessions.
- Repro: `FLYTE_API_KEY=...` `flyte deploy --copy-style none ...` on a Linux runner with no keyring backend.
- Fix: Persist the api_key on `SessionConfig` and forward it when creating a new session for a different endpoint.