### PR TITLE
resolve CodeBundleLayer in flyte build

### DIFF
--- a/src/flyte/_deploy.py
+++ b/src/flyte/_deploy.py
@@ -615,13 +615,22 @@ async def deploy(
 
 
 @syncify
-async def build_images(envs: Environment) -> ImageCache:
+async def build_images(envs: Environment, copy_style: "CopyFiles" = "loaded_modules") -> ImageCache:
     """
-    Build the images for the given environments.
+    Build the images for the given environment.
     :param envs: Environment to build images for.
+    :param copy_style: Copy style that the eventual deploy will use. Must match the deploy's
+        ``--copy-style`` so the image content hashes — and therefore the registry tags — line
+        up, letting deploy reuse the pre-built image.
     :return: ImageCache containing the built images.
     """
+    from flyte._image import resolve_code_bundle_layer
+
     cfg = get_init_config()
     images = cfg.images if cfg else {}
     deployment = plan_deploy(envs)
-    return await _build_images(deployment[0], images)
+    plan = deployment[0]
+    for env_name, env in plan.envs.items():
+        if isinstance(env.image, Image):
+            env.image = resolve_code_bundle_layer(env.image, copy_style, pathlib.Path(cfg.root_dir))
+    return await _build_images(plan, images)

--- a/src/flyte/_deploy.py
+++ b/src/flyte/_deploy.py
@@ -368,16 +368,28 @@ async def _build_image_bg(env_name: str, image: Image) -> Tuple[str, str, Option
     return env_name, result.uri, run_id_data
 
 
-async def _build_images(deployment: DeploymentPlan, image_refs: Dict[str, str] | None = None) -> ImageCache:
+async def _build_images(
+    deployment: DeploymentPlan,
+    image_refs: Dict[str, str] | None = None,
+    copy_style: "CopyFiles" = "loaded_modules",
+) -> ImageCache:
     """
     Build the images for the given deployment plan and update the environment with the built image.
+
+    Resolves any ``CodeBundleLayer`` layers first so callers (apply, build_images, serve,
+    connectors, run) don't each need to duplicate that step.
     """
-    from flyte._image import _DEFAULT_IMAGE_REF_NAME
+    from flyte._image import _DEFAULT_IMAGE_REF_NAME, resolve_code_bundle_layer
 
     from ._internal.imagebuild.image_builder import ImageCache
 
     if image_refs is None:
         image_refs = {}
+
+    cfg = get_init_config()
+    for env_name, env in deployment.envs.items():
+        if isinstance(env.image, Image):
+            env.image = resolve_code_bundle_layer(env.image, copy_style, pathlib.Path(cfg.root_dir))
 
     images = []
     image_identifier_map: Dict[str, str] = {}
@@ -452,14 +464,7 @@ async def apply(deployment_plan: DeploymentPlan, copy_style: CopyFiles, dryrun: 
 
     cfg = get_init_config()
 
-    # Resolve any CodeBundleLayer layers before building images
-    from flyte._image import resolve_code_bundle_layer
-
-    for env_name, env in deployment_plan.envs.items():
-        if isinstance(env.image, Image):
-            env.image = resolve_code_bundle_layer(env.image, copy_style, pathlib.Path(cfg.root_dir))
-
-    image_cache = await _build_images(deployment_plan, cfg.images)
+    image_cache = await _build_images(deployment_plan, cfg.images, copy_style)
 
     # Collect all `Environment.include` files across envs in the plan. They are
     # resolved to absolute paths anchored at each env's declaring file and
@@ -624,13 +629,7 @@ async def build_images(envs: Environment, copy_style: "CopyFiles" = "loaded_modu
         up, letting deploy reuse the pre-built image.
     :return: ImageCache containing the built images.
     """
-    from flyte._image import resolve_code_bundle_layer
-
     cfg = get_init_config()
     images = cfg.images if cfg else {}
     deployment = plan_deploy(envs)
-    plan = deployment[0]
-    for env_name, env in plan.envs.items():
-        if isinstance(env.image, Image):
-            env.image = resolve_code_bundle_layer(env.image, copy_style, pathlib.Path(cfg.root_dir))
-    return await _build_images(plan, images)
+    return await _build_images(deployment[0], images, copy_style)

--- a/src/flyte/cli/_build.py
+++ b/src/flyte/cli/_build.py
@@ -1,11 +1,12 @@
 from dataclasses import dataclass, field, fields
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List, cast, get_args
 
 import rich_click as click
 
 import flyte
+from flyte._code_bundle._utils import CopyFiles
 
 from . import _common as common
 from ._common import CLIConfig
@@ -13,13 +14,25 @@ from ._common import CLIConfig
 
 @dataclass
 class BuildArguments:
-    noop: bool = field(
-        default=False,
+    copy_style: CopyFiles = field(
+        default="loaded_modules",
         metadata={
             "click.option": click.Option(
-                ["--noop"],
-                type=bool,
-                help="Dummy parameter, placeholder for future use. Does not affect the build process.",
+                ["--copy-style"],
+                type=click.Choice(get_args(CopyFiles)),
+                default="loaded_modules",
+                help="Copy style of the eventual deploy. Must match the deploy's --copy-style "
+                "so the image content hash — and therefore the registry tag — lines up.",
+            )
+        },
+    )
+    root_dir: str | None = field(
+        default=None,
+        metadata={
+            "click.option": click.Option(
+                ["--root-dir"],
+                type=str,
+                help="Override the root source directory, helpful when working with monorepos.",
             )
         },
     )
@@ -31,7 +44,7 @@ class BuildArguments:
     @classmethod
     def options(cls) -> List[click.Option]:
         """
-        Return the set of base parameters added to every flyte run workflow subcommand.
+        Return the set of base parameters added to every flyte build subcommand.
         """
         return [common.get_option_from_metadata(f.metadata) for f in fields(cls) if f.metadata]
 
@@ -48,9 +61,9 @@ class BuildEnvCommand(click.Command):
 
         obj: CLIConfig = ctx.obj
         status.step(f"Building environment: {self.obj_name}")
-        obj.init()
+        obj.init(root_dir=self.build_args.root_dir)
         with common.cli_status(obj.output_format, "Building...", spinner="dots"):
-            image_cache = flyte.build_images(self.obj)
+            image_cache = flyte.build_images(self.obj, copy_style=self.build_args.copy_style)
 
         status.success(f"Environment {self.obj_name} built")
         common.print_output(common.format("Images", image_cache.repr(), obj.output_format), obj.output_format)

--- a/tests/cli/test_build.py
+++ b/tests/cli/test_build.py
@@ -1,0 +1,34 @@
+import pathlib
+
+import pytest
+from click.testing import CliRunner
+
+from flyte.cli._build import build
+
+TEST_CODE_PATH = pathlib.Path(__file__).parent
+HELLO_WORLD_PY = TEST_CODE_PATH / "run_testdata" / "hello_world.py"
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_build_exposes_copy_style_and_root_dir(runner):
+    """flyte build must accept --copy-style and --root-dir so CI can split
+    image builds from deploys without hash drift."""
+    result = runner.invoke(build, ["--help"])
+    assert result.exit_code == 0, result.output
+    assert "--copy-style" in result.output
+    assert "--root-dir" in result.output
+
+
+def test_build_rejects_invalid_copy_style(runner):
+    """--copy-style is a Click.Choice constrained to the CopyFiles values;
+    unknown values must fail loudly (not silently build with the wrong hash)."""
+    result = runner.invoke(
+        build,
+        ["--copy-style", "bogus", str(HELLO_WORLD_PY), "hello_world"],
+    )
+    assert result.exit_code != 0
+    assert "bogus" in result.output.lower() or "invalid" in result.output.lower()

--- a/tests/flyte/test_deploy.py
+++ b/tests/flyte/test_deploy.py
@@ -18,6 +18,7 @@ from flyte._deploy import (
     _get_documentation_entity,
     _recursive_discover,
     _update_interface_inputs_and_outputs_docstring,
+    build_images,
     plan_deploy,
 )
 from flyte._docstring import Docstring
@@ -325,6 +326,7 @@ async def test_build_images_stores_build_run_urls_in_cache():
     """build_run_ids in ImageCache is populated when remote builder provides a run identifier."""
     from flyte._internal.imagebuild.image_builder import RunIdentifierData
 
+    flyte.init()
     image = flyte.Image.from_base("python:3.10")
     env = flyte.TaskEnvironment(name="my-env", image=image)
     plan = DeploymentPlan(envs={"my-env": env})
@@ -351,6 +353,7 @@ async def test_build_images_stores_build_run_urls_in_cache():
 @pytest.mark.asyncio
 async def test_build_images_no_build_run_urls_for_local_build():
     """build_run_ids in ImageCache is empty when local builder is used."""
+    flyte.init()
     image = flyte.Image.from_base("python:3.10")
     env = flyte.TaskEnvironment(name="my-env", image=image)
     plan = DeploymentPlan(envs={"my-env": env})
@@ -402,3 +405,49 @@ def test_resolve_covers_depends_on_envs():
     assert not any(isinstance(layer, CodeBundleLayer) for layer in env_dep.image._layers), (
         "depends_on env still has CodeBundleLayer after resolution — regression"
     )
+
+
+# ---------------------------------------------------------------------------
+# build_images resolves CodeBundleLayer (regression for flyte build CLI)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_images_resolves_code_bundle_layer_default_copy_style():
+    """`flyte build` would previously raise 'root_dir not set for CodeBundleLayer'
+    on any image that used `.with_code_bundle()`, because build_images did not
+    run resolve_code_bundle_layer the way apply() does. With the default
+    copy_style='loaded_modules', the bundle layer must be stripped before build.
+    """
+    flyte.init()
+
+    image = flyte.Image.from_base("python:3.10").clone(registry="r", name="img", extendable=True).with_code_bundle()
+    env = flyte.TaskEnvironment(name="e", image=image)
+
+    with patch("flyte._build.build") as mock_build:
+        mock_build.aio = AsyncMock(return_value=ImageBuild(uri="registry/img:abc", remote_run=None))
+        await build_images.aio(env)
+
+    assert not any(isinstance(layer, CodeBundleLayer) for layer in env.image._layers), (
+        "CodeBundleLayer not stripped at copy_style='loaded_modules'"
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_images_resolves_code_bundle_layer_copy_style_none():
+    """At copy_style='none', CodeBundleLayer is resolved in place (not stripped)
+    so the source gets baked into the image via a COPY instruction.
+    """
+    flyte.init()
+
+    image = flyte.Image.from_base("python:3.10").clone(registry="r", name="img", extendable=True).with_code_bundle()
+    env = flyte.TaskEnvironment(name="e", image=image)
+
+    with patch("flyte._build.build") as mock_build:
+        mock_build.aio = AsyncMock(return_value=ImageBuild(uri="registry/img:abc", remote_run=None))
+        await build_images.aio(env, copy_style="none")
+
+    # Layer should still be present (resolved, with root_dir populated), not stripped.
+    bundle_layers = [layer for layer in env.image._layers if isinstance(layer, CodeBundleLayer)]
+    assert len(bundle_layers) == 1, "CodeBundleLayer should remain (resolved) at copy_style='none'"
+    assert bundle_layers[0].root_dir is not None, "resolved CodeBundleLayer must have root_dir set"


### PR DESCRIPTION
## Problem
`flyte build` errors with `root_dir not set for CodeBundleLayer` for any image that uses `.with_code_bundle()`.

## Fix
`build_images()` now resolves `CodeBundleLayer` before building, mirroring what `apply()` already does on the deploy path. The CLI gains `--copy-style` and `--root-dir` (matching `flyte deploy`) so the resolution has the inputs it needs.

## Behavior
- Images without `.with_code_bundle()`: unchanged.
- Images with `.with_code_bundle()`: previously crashed, now build.
- Defaults match `flyte deploy`, so running `flyte build` then `flyte deploy` with no flags produces matching image hashes — deploy reuses the pre-built image instead of rebuilding.

## Why
Enables splitting image builds from deploys in CI, which is otherwise impossible today using .with_code_bundle()`.