### PR TITLE
Resolve --builder default from flytectl config

### DIFF
--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -347,7 +347,7 @@ async def init_from_config(
         root_dir=root_dir,
         log_level=log_level,
         log_format=log_format,
-        image_builder=image_builder or cfg.image.builder,
+        image_builder=image_builder or cfg.image.builder or "local",
         batch_size=batch_size,
         images=cfg.image.image_refs,
         storage=storage,

--- a/src/flyte/cli/main.py
+++ b/src/flyte/cli/main.py
@@ -103,8 +103,10 @@ def _verbosity_to_loglevel(verbosity: int) -> int | None:
     "--image-builder",
     "--builder",
     type=click.Choice(["local", "remote"]),
-    default="local",
-    help="Image builder to use for building images. Overrides the config file setting.",
+    default=None,
+    help="Image builder to use for building images. Overrides the config file setting."
+    " If not specified, the builder from the config file (image.builder) is used,"
+    " falling back to 'local'.",
     show_default=True,
     required=False,
 )

--- a/tests/user_api/test_initialize.py
+++ b/tests/user_api/test_initialize.py
@@ -329,6 +329,49 @@ task:
         assert call_kwargs["domain"] == mock_config.task.domain
 
 
+    @patch("flyte._initialize.init")
+    @patch("flyte.config.auto")
+    @pytest.mark.asyncio
+    async def test_image_builder_explicit_overrides_config(self, mock_config_auto, mock_init, mock_config):
+        """Explicit image_builder argument wins over cfg.image.builder."""
+        mock_config.image.builder = "remote"
+        mock_config_auto.return_value = mock_config
+        mock_init.aio = AsyncMock()
+
+        await init_from_config.aio(path_or_config=None, image_builder="local")
+
+        call_kwargs = mock_init.aio.call_args[1]
+        assert call_kwargs["image_builder"] == "local"
+
+    @patch("flyte._initialize.init")
+    @patch("flyte.config.auto")
+    @pytest.mark.asyncio
+    async def test_image_builder_from_config_when_unspecified(self, mock_config_auto, mock_init, mock_config):
+        """When no image_builder is passed, cfg.image.builder is used."""
+        mock_config.image.builder = "remote"
+        mock_config_auto.return_value = mock_config
+        mock_init.aio = AsyncMock()
+
+        await init_from_config.aio(path_or_config=None)
+
+        call_kwargs = mock_init.aio.call_args[1]
+        assert call_kwargs["image_builder"] == "remote"
+
+    @patch("flyte._initialize.init")
+    @patch("flyte.config.auto")
+    @pytest.mark.asyncio
+    async def test_image_builder_falls_back_to_local(self, mock_config_auto, mock_init, mock_config):
+        """With no image_builder and no cfg.image.builder, falls back to 'local'."""
+        mock_config.image.builder = None
+        mock_config_auto.return_value = mock_config
+        mock_init.aio = AsyncMock()
+
+        await init_from_config.aio(path_or_config=None)
+
+        call_kwargs = mock_init.aio.call_args[1]
+        assert call_kwargs["image_builder"] == "local"
+
+
 class TestInitialization:
     """Test cases for core initialization functions"""
 

--- a/tests/user_api/test_initialize.py
+++ b/tests/user_api/test_initialize.py
@@ -328,7 +328,6 @@ task:
         assert call_kwargs["project"] == mock_config.task.project
         assert call_kwargs["domain"] == mock_config.task.domain
 
-
     @patch("flyte._initialize.init")
     @patch("flyte.config.auto")
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `--image-builder` (`--builder`) previously defaulted to `"local"`, silently overriding any `image.builder` set in the flytectl config
- Change the CLI default to `None` so the config value is used when the flag is omitted
- `init_from_config` now falls back to `"local"` only when neither the flag nor `cfg.image.builder` is set

Precedence: explicit `--builder` > `cfg.image.builder` (from `--config` or auto-discovered) > `"local"`.

## Test plan
- [x] `uv run pytest tests/user_api/test_initialize.py -k image_builder` — 3 new tests pass
- [x] `flyte --help` still works
- [x] Manual: `flyte run ...` with `image.builder: remote` in config uses the remote builder
- [x] Manual: `flyte --builder local run ...` still forces local