### PR TITLE
fix: use cr.flyte.org registry for devbox images

### DIFF
--- a/src/flyte/cli/_start.py
+++ b/src/flyte/cli/_start.py
@@ -25,8 +25,8 @@ def tui():
     launch_tui_explore()
 
 
-_DEFAULT_DEVBOX_IMAGE = "ghcr.io/flyteorg/flyte-devbox:nightly"
-_DEFAULT_DEVBOX_GPU_IMAGE = "ghcr.io/flyteorg/flyte-devbox:gpu-nightly"
+_DEFAULT_DEVBOX_IMAGE = "cr.flyte.org/flyteorg/flyte-devbox:nightly"
+_DEFAULT_DEVBOX_GPU_IMAGE = "cr.flyte.org/flyteorg/flyte-devbox:gpu-nightly"
 
 
 @start.command()


### PR DESCRIPTION
## Summary
- Switch default devbox image registry from `ghcr.io/flyteorg` to `cr.flyte.org/flyteorg` for both CPU and GPU defaults in `src/flyte/cli/_start.py`.

## Test plan
- [x] `flyte start devbox` pulls the image from `cr.flyte.org/flyteorg/flyte-devbox:nightly`
- [x] GPU variant resolves to `cr.flyte.org/flyteorg/flyte-devbox:gpu-nightly`