### PR TITLE
Add vLLM + Claude Code integration example

### DIFF
--- a/examples/genai/vllm/vllm_claude.py
+++ b/examples/genai/vllm/vllm_claude.py
@@ -1,0 +1,84 @@
+"""
+Serve a model with vLLM and connect Claude Code to it.
+
+Based on the vLLM Claude Code integration guide:
+https://docs.vllm.ai/en/stable/serving/integrations/claude_code/
+
+Deploy
+------
+
+```
+flyte deploy examples/genai/vllm/vllm_claude.py vllm_app
+```
+
+Connect Claude Code
+-------------------
+
+Once deployed, point Claude Code at the app endpoint:
+
+```bash
+ANTHROPIC_BASE_URL=<your-app-endpoint> \
+ANTHROPIC_API_KEY=dummy \
+ANTHROPIC_AUTH_TOKEN=dummy \
+ANTHROPIC_DEFAULT_OPUS_MODEL=my-model \
+ANTHROPIC_DEFAULT_SONNET_MODEL=my-model \
+ANTHROPIC_DEFAULT_HAIKU_MODEL=my-model \
+claude
+```
+
+Optionally add `"CLAUDE_CODE_ATTRIBUTION_HEADER": "0"` to `~/.claude/settings.json`
+to preserve prefix caching performance.
+"""
+
+from flyteplugins.vllm import VLLMAppEnvironment
+
+import flyte
+import flyte.app
+
+vllm_app = VLLMAppEnvironment(
+    name="gpt-oss-claude-code",
+    model_hf_path="openai/gpt-oss-120b",
+    model_id="my-model",
+    resources=flyte.Resources(cpu="16", memory="200Gi", gpu="H100:4", disk="500Gi"),
+    image=(
+        flyte.Image.from_debian_base(
+            name="vllm-claude-image",
+            install_flyte=False,
+        )
+        .with_pip_packages("flashinfer-python", "flashinfer-cubin")
+        .with_pip_packages("flashinfer-jit-cache", index_url="https://flashinfer.ai/whl/cu129")
+        .with_pip_packages("vllm==0.11.0", "transformers==4.57.6")
+        .with_pip_packages("flyteplugins-vllm")
+    ),
+    stream_model=True,
+    scaling=flyte.app.Scaling(
+        replicas=(0, 1),
+        scaledown_after=300,
+    ),
+    requires_auth=False,
+    extra_args=[
+        "--served-model-name my-model",
+        "--enable-auto-tool-choice",
+        "--tool-call-parser openai",
+    ],
+)
+
+
+if __name__ == "__main__":
+    import flyte.prefetch
+    from flyte.remote import Run
+
+    flyte.init_from_config()
+
+    run: Run = flyte.prefetch.hf_model(repo="openai/gpt-oss-120b")
+    run.wait()
+    print(run.url)
+
+    app = flyte.serve(
+        vllm_app.clone_with(
+            name=vllm_app.name,
+            model_path=flyte.app.RunOutput(type="directory", run_name=run.name),
+            model_hf_path=None,
+        )
+    )
+    print(f"Deployed vLLM app: {app.url}")

--- a/examples/genai/vllm/vllm_claude.py
+++ b/examples/genai/vllm/vllm_claude.py
@@ -1,8 +1,10 @@
 """
 Serve a model with vLLM and connect Claude Code to it.
 
-Based on the vLLM Claude Code integration guide:
-https://docs.vllm.ai/en/stable/serving/integrations/claude_code/
+vLLM exposes an OpenAI-compatible API (``/v1/chat/completions``), but Claude
+Code speaks the Anthropic API (``/v1/messages``). To bridge them we run
+``claude-code-router`` (``ccr``) locally — it translates Anthropic ↔ OpenAI
+and injects the ``ANTHROPIC_*`` env vars before launching ``claude``.
 
 Deploy
 ------
@@ -11,35 +13,81 @@ Deploy
 flyte deploy examples/genai/vllm/vllm_claude.py vllm_app
 ```
 
+The deploy prints the app URL, e.g.
+``https://<app-name>.apps.<your-domain>``. Use this URL below.
+
+Install the router
+------------------
+
+```bash
+npm install -g @musistudio/claude-code-router
+```
+
+Configure the router
+--------------------
+
+Create ``~/.claude-code-router/config.json``:
+
+```json
+{
+  "Providers": [
+    {
+      "name": "vllm",
+      "api_base_url": "https://<app-name>.apps.<your-domain>/v1/chat/completions",
+      "api_key": "dummy",
+      "models": ["my-model"]
+    }
+  ],
+  "Router": {
+    "default": "vllm,my-model",
+    "background": "vllm,my-model",
+    "think": "vllm,my-model",
+    "longContext": "vllm,my-model",
+    "longContextThreshold": 120000,
+    "webSearch": "vllm,my-model"
+  }
+}
+```
+
 Connect Claude Code
 -------------------
 
-Once deployed, point Claude Code at the app endpoint:
-
 ```bash
-ANTHROPIC_BASE_URL=<your-app-endpoint> \
-ANTHROPIC_API_KEY=dummy \
-ANTHROPIC_AUTH_TOKEN=dummy \
-ANTHROPIC_DEFAULT_OPUS_MODEL=my-model \
-ANTHROPIC_DEFAULT_SONNET_MODEL=my-model \
-ANTHROPIC_DEFAULT_HAIKU_MODEL=my-model \
-claude
+# Make sure no ANTHROPIC_* env vars are set — ccr injects its own.
+unset ANTHROPIC_BASE_URL ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN \
+      ANTHROPIC_DEFAULT_OPUS_MODEL ANTHROPIC_DEFAULT_SONNET_MODEL \
+      ANTHROPIC_DEFAULT_HAIKU_MODEL
+
+ccr code
 ```
 
-Optionally add `"CLAUDE_CODE_ATTRIBUTION_HEADER": "0"` to `~/.claude/settings.json`
-to preserve prefix caching performance.
+``ccr code`` starts a local proxy on ``127.0.0.1:3456``, points Claude Code
+at it, and forwards traffic to the vLLM app. Use ``ccr stop`` / ``ccr start``
+to manage the proxy; logs live at ``~/.claude-code-router/claude-code-router.log``.
+
+Optionally add ``"CLAUDE_CODE_ATTRIBUTION_HEADER": "0"`` to
+``~/.claude/settings.json`` to preserve prefix caching performance.
+
+Notes
+-----
+
+* ``--max-model-len 131072`` matches Claude Code's large system prompt; smaller
+  values cause ``max_tokens must be at least 1`` errors when the prompt
+  approaches the context limit.
+* ``gpt-oss-20b`` ships in MXFP4 quantization which requires GPU compute
+  capability ≥ 8.0 (Ampere+). T4 (sm_7.5) is not supported; L4, L40S, A10G,
+  A100, and H100 all work.
 """
 
 from flyteplugins.vllm import VLLMAppEnvironment
 
-import flyte
 import flyte.app
 
 vllm_app = VLLMAppEnvironment(
     name="gpt-oss-claude-code",
-    model_hf_path="openai/gpt-oss-120b",
+    model_hf_path="openai/gpt-oss-20b",
     model_id="my-model",
-    resources=flyte.Resources(cpu="16", memory="200Gi", gpu="H100:4", disk="500Gi"),
+    resources=flyte.Resources(cpu="8", memory="64Gi", gpu="L40s:1", disk="200Gi"),
     image=(
         flyte.Image.from_debian_base(
             name="vllm-claude-image",
@@ -53,13 +101,15 @@ vllm_app = VLLMAppEnvironment(
     stream_model=True,
     scaling=flyte.app.Scaling(
         replicas=(0, 1),
-        scaledown_after=300,
+        scaledown_after=60,
     ),
     requires_auth=False,
     extra_args=[
         "--served-model-name my-model",
         "--enable-auto-tool-choice",
         "--tool-call-parser openai",
+        "--max-model-len 131072",
+        "--gpu-memory-utilization 0.92"
     ],
 )
 
@@ -70,7 +120,7 @@ if __name__ == "__main__":
 
     flyte.init_from_config()
 
-    run: Run = flyte.prefetch.hf_model(repo="openai/gpt-oss-120b")
+    run: Run = flyte.prefetch.hf_model(repo="openai/gpt-oss-20b", force=1)
     run.wait()
     print(run.url)
 

--- a/examples/genai/vllm/vllm_gpt_oss_claude.py
+++ b/examples/genai/vllm/vllm_gpt_oss_claude.py
@@ -1,5 +1,5 @@
 """
-Serve a model with vLLM and connect Claude Code to it.
+Serve openai/gpt-oss-20b with vLLM and connect Claude Code to it.
 
 vLLM exposes an OpenAI-compatible API (``/v1/chat/completions``), but Claude
 Code speaks the Anthropic API (``/v1/messages``). To bridge them we run
@@ -10,7 +10,7 @@ Deploy
 ------
 
 ```
-flyte deploy examples/genai/vllm/vllm_claude.py vllm_app
+flyte deploy examples/genai/vllm/vllm_gpt_oss_claude.py vllm_app
 ```
 
 The deploy prints the app URL, e.g.
@@ -35,16 +35,16 @@ Create ``~/.claude-code-router/config.json``:
       "name": "vllm",
       "api_base_url": "https://<app-name>.apps.<your-domain>/v1/chat/completions",
       "api_key": "dummy",
-      "models": ["my-model"]
+      "models": ["gpt-oss-20b"]
     }
   ],
   "Router": {
-    "default": "vllm,my-model",
-    "background": "vllm,my-model",
-    "think": "vllm,my-model",
-    "longContext": "vllm,my-model",
+    "default": "vllm,gpt-oss-20b",
+    "background": "vllm,gpt-oss-20b",
+    "think": "vllm,gpt-oss-20b",
+    "longContext": "vllm,gpt-oss-20b",
     "longContextThreshold": 120000,
-    "webSearch": "vllm,my-model"
+    "webSearch": "vllm,gpt-oss-20b"
   }
 }
 ```
@@ -59,6 +59,7 @@ unset ANTHROPIC_BASE_URL ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN \
       ANTHROPIC_DEFAULT_HAIKU_MODEL
 
 ccr code
+/model vllm,gpt-oss-20b
 ```
 
 ``ccr code`` starts a local proxy on ``127.0.0.1:3456``, points Claude Code
@@ -86,7 +87,7 @@ import flyte.app
 vllm_app = VLLMAppEnvironment(
     name="gpt-oss-claude-code",
     model_hf_path="openai/gpt-oss-20b",
-    model_id="my-model",
+    model_id="gpt-oss-20b",
     resources=flyte.Resources(cpu="8", memory="64Gi", gpu="L40s:1", disk="200Gi"),
     image=(
         flyte.Image.from_debian_base(
@@ -101,11 +102,11 @@ vllm_app = VLLMAppEnvironment(
     stream_model=True,
     scaling=flyte.app.Scaling(
         replicas=(0, 1),
-        scaledown_after=60,
+        scaledown_after=3600,
     ),
     requires_auth=False,
     extra_args=[
-        "--served-model-name my-model",
+        "--served-model-name gpt-oss-20b",
         "--enable-auto-tool-choice",
         "--tool-call-parser openai",
         "--max-model-len 131072",

--- a/examples/genai/vllm/vllm_gpt_oss_claude.py
+++ b/examples/genai/vllm/vllm_gpt_oss_claude.py
@@ -110,7 +110,7 @@ vllm_app = VLLMAppEnvironment(
         "--enable-auto-tool-choice",
         "--tool-call-parser openai",
         "--max-model-len 131072",
-        "--gpu-memory-utilization 0.92"
+        "--gpu-memory-utilization 0.92",
     ],
 )
 

--- a/examples/genai/vllm/vllm_gpt_oss_claude.py
+++ b/examples/genai/vllm/vllm_gpt_oss_claude.py
@@ -88,7 +88,7 @@ vllm_app = VLLMAppEnvironment(
     name="gpt-oss-claude-code",
     model_hf_path="openai/gpt-oss-20b",
     model_id="gpt-oss-20b",
-    resources=flyte.Resources(cpu="8", memory="64Gi", gpu="L40s:1", disk="200Gi"),
+    resources=flyte.Resources(cpu="6", memory="24Gi", gpu="A10G:1", disk="200Gi"),
     image=(
         flyte.Image.from_debian_base(
             name="vllm-claude-image",


### PR DESCRIPTION
## Summary

<img width="793" height="282" alt="Screenshot 2026-04-28 at 11 15 05 PM" src="https://github.com/user-attachments/assets/a2080792-ffe2-4cda-b617-a4e5c90b6825" />
<img width="1140" height="406" alt="Screenshot 2026-04-28 at 11 14 42 PM" src="https://github.com/user-attachments/assets/76bc9037-18f9-4c74-a5d2-5647099e59d8" />

Adds two end-to-end examples that serve OSS models via `VLLMAppEnvironment` and connect Claude Code to them:

- `examples/genai/vllm/vllm_gpt_oss_claude.py` — `openai/gpt-oss-20b` on `L40s:1`, 131k context
- `examples/genai/vllm/vllm_qwen_claude.py` — `Qwen/Qwen2.5-7B-Instruct` on `L4:1`, 32k context (lighter-weight option)

### What the examples do
- Prefetch the model from HuggingFace into remote storage via `flyte.prefetch.hf_model`.
- Serve the model with `VLLMAppEnvironment`, with the flags Claude Code needs:
  - `--enable-auto-tool-choice`
  - `--tool-call-parser openai` (gpt-oss) / `hermes` (Qwen)
  - `--served-model-name my-model`
  - `--max-model-len` sized for Claude Code's system prompt
  - `--gpu-memory-utilization 0.92`
- Scale to zero when idle (`replicas=(0, 1)`, `scaledown_after=300`).

### Connecting Claude Code

vLLM 0.11 only exposes the OpenAI-compatible API (`/v1/chat/completions`); Claude Code speaks the Anthropic API (`/v1/messages`). The docstrings document using [`claude-code-router`](https://github.com/musistudio/claude-code-router) (`ccr`) as a local translator:

```bash
npm install -g @musistudio/claude-code-router
# configure ~/.claude-code-router/config.json with the deployed app URL
ccr code
```

`ccr` runs a local proxy on `127.0.0.1:3456`, translates Anthropic ↔ OpenAI, and launches Claude Code pointed at it.

### Notes
- `gpt-oss-20b` ships in MXFP4 quantization which requires GPU compute capability ≥ 8.0 (Ampere+). T4 (sm_7.5) is not supported; L4, L40S, A10G, A100, H100 all work.
- For the Qwen example's smaller 32k window, run `/compact` inside Claude Code on long sessions to keep the prompt under the limit.
- Reference: https://docs.vllm.ai/en/stable/serving/integrations/claude_code/

## Test plan
- [x] `flyte deploy examples/genai/vllm/vllm_gpt_oss_claude.py vllm_app` succeeds and the Knative revision becomes Ready
- [x] `flyte.prefetch.hf_model(repo="openai/gpt-oss-20b")` completes and the served model loads from remote storage
- [x] vLLM `/v1/models` returns `my-model` with `max_model_len=131072`
- [x] `ccr code` launches Claude Code; messages are routed through the proxy and answered by `my-model` (verified via `vllm:request_success_total` metrics)
- [x] Tool-using prompt round-trips successfully through Claude Code → ccr → vLLM
- [ ] Repeat the above for `vllm_qwen_claude.py`