### PR TITLE
Check docker availability before launching devbox

### DIFF
--- a/plugins/huggingface/uv.lock
+++ b/plugins/huggingface/uv.lock
@@ -626,7 +626,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -682,7 +682,7 @@ requires-dist = [
     { name = "deltalake", marker = "extra == 'examples-test'" },
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
-    { name = "flyteidl2", specifier = "==2.0.12" },
+    { name = "flyteidl2", specifier = "==2.0.13" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -702,7 +702,7 @@ requires-dist = [
     { name = "protobuf", specifier = ">=6.30.1" },
     { name = "pyarrow", marker = "extra == 'examples-test'" },
     { name = "pydantic", specifier = ">=2.10.6" },
-    { name = "pydantic-monty", marker = "extra == 'sandbox'", specifier = ">=0.0.8" },
+    { name = "pydantic-monty", marker = "extra == 'sandbox'", specifier = "==0.0.17" },
     { name = "pyopenssl", specifier = ">=24.0.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "rich-click", specifier = "==1.8.9" },
@@ -728,7 +728,7 @@ dev = [
     { name = "orjson" },
     { name = "pandas" },
     { name = "pyarrow" },
-    { name = "pydantic-monty", specifier = ">=0.0.8" },
+    { name = "pydantic-monty", specifier = "==0.0.17" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
     { name = "pytest-benchmark", specifier = ">=5.1.0" },
@@ -743,7 +743,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.12"
+version = "2.0.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -752,7 +752,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/73/ebbeecbdb7cb80272e00d4b5a300b584848064123dafb12d33dee110eb43/flyteidl2-2.0.12-py3-none-any.whl", hash = "sha256:4e0d78fd4cf948699b02449f7c411368531464ac99032cf0cb8560fda9ce55b7", size = 339964, upload-time = "2026-04-16T16:22:18.744Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/39/39714f95709e042a5a34711cabdf77fe3e438a3079f4b9c8c6b330f58591/flyteidl2-2.0.13-py3-none-any.whl", hash = "sha256:4a280546a695d372f80bbc5989e3c0572e0f0cea69e9f8235aa2c449cefea927", size = 339889, upload-time = "2026-04-18T01:01:40.754Z" },
 ]
 
 [[package]]
@@ -2530,8 +2530,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "jeepney", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [

--- a/src/flyte/cli/_devbox.py
+++ b/src/flyte/cli/_devbox.py
@@ -24,6 +24,18 @@ _PORTS = ["6443:6443", "30000:30000", "30001:30001", "30002:30002", "30003:30003
 _CONSOLE_READYZ_URL = "http://localhost:30080/readyz"
 
 
+def _ensure_docker_available() -> None:
+    if shutil.which("docker") is None:
+        raise click.ClickException(
+            "Docker is not installed or not on PATH. Install Docker Desktop (or the Docker Engine) and try again."
+        )
+    result = subprocess.run(["docker", "info"], capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise click.ClickException(
+            f"Docker daemon is not running or not reachable. Start Docker and try again.\n{result.stderr.strip()}"
+        )
+
+
 def _ensure_volume(volume_name: str) -> None:
     result = subprocess.run(
         ["docker", "volume", "ls", "--filter", f"name=^{volume_name}$", "--format", "{{.Name}}"],
@@ -231,6 +243,7 @@ def stop_devbox() -> None:
 
 @_sentry.capture_errors
 def launch_devbox(image_name: str, is_dev_mode: bool, gpu: bool = False, log_format: str = "console") -> None:
+    _ensure_docker_available()
     _ensure_volume(_VOLUME_NAME)
     if _container_is_paused(_CONTAINER_NAME):
         console.print("[cyan]Resuming paused devbox cluster...[/cyan]")

--- a/src/flyte/cli/_start.py
+++ b/src/flyte/cli/_start.py
@@ -25,8 +25,8 @@ def tui():
     launch_tui_explore()
 
 
-_DEFAULT_DEVBOX_IMAGE = "cr.flyte.org/flyteorg/flyte-devbox:nightly"
-_DEFAULT_DEVBOX_GPU_IMAGE = "cr.flyte.org/flyteorg/flyte-devbox:gpu-nightly"
+_DEFAULT_DEVBOX_IMAGE = "cr.flyte.org/flyteorg/flyte-devbox:latest"
+_DEFAULT_DEVBOX_GPU_IMAGE = "cr.flyte.org/flyteorg/flyte-devbox:gpu-latest"
 
 
 @start.command()


### PR DESCRIPTION
## Summary
- Add `_ensure_docker_available()` to verify the `docker` CLI is on PATH and the daemon is reachable, called at the top of `launch_devbox` so users get a clear error before the pull step instead of a cryptic subprocess failure.
- Switch default devbox images from `:nightly` / `:gpu-nightly` to `:latest` / `:gpu-latest`.

## Test plan
- [ ] Run `flyte start devbox` with Docker not installed — expect a clear error
- [ ] Run `flyte start devbox` with Docker installed but daemon stopped — expect a clear error
- [ ] Run `flyte start devbox` with Docker running — expect normal launch