### PR TITLE
fix: resolve AppEnvironment caller frame across __post_init__ chains

### DIFF
--- a/src/flyte/app/_app_environment.py
+++ b/src/flyte/app/_app_environment.py
@@ -129,14 +129,18 @@ class AppEnvironment(Environment):
         self._validate_name()
 
         # Capture the frame where this environment was instantiated
-        # This helps us find the module where the app variable is defined
+        # This helps us find the module where the app variable is defined.
+        # Walk up the stack past any frames inside this file (e.g. subclass
+        # __post_init__ chains) and the dataclass __init__ frame, until we
+        # reach the user's code.
         frame = inspect.currentframe()
-        if frame and frame.f_back:
-            # Go up the call stack to find the user's module
-            # Skip the dataclass __init__ frame
-            caller_frame = frame.f_back
-            if caller_frame and caller_frame.f_back:
-                self._caller_frame = inspect.getframeinfo(caller_frame.f_back)
+        f = frame.f_back if frame else None
+        # Skip __post_init__ frames (covers subclasses calling
+        # super().__post_init__()) and the synthesized dataclass __init__ frame.
+        while f is not None and f.f_code.co_name in ("__post_init__", "__init__"):
+            f = f.f_back
+        if f is not None:
+            self._caller_frame = inspect.getframeinfo(f)
 
     def container_args(self, serialize_context: SerializationContext) -> List[str]:
         if self.args is None:

--- a/tests/flyte/app/test_connector_environment.py
+++ b/tests/flyte/app/test_connector_environment.py
@@ -542,3 +542,61 @@ def test_connector_environment_empty_args_vs_none_args():
         args=[],
     )
     assert conn_empty.container_args(ctx) == []
+
+
+def test_connector_environment_caller_frame_points_to_user_code():
+    """
+    GOAL: Verify _caller_frame skips the subclass __post_init__ chain.
+
+    ConnectorEnvironment.__post_init__ calls super().__post_init__(), which
+    used to push _caller_frame onto the synthesized dataclass __init__ frame
+    instead of the user's module. That broke `flyte.deploy` for connectors
+    when the SDK was installed in editable mode, because the resolver fell
+    back to the class definition file as the module.
+    """
+    user_code = (
+        "import flyte\n"
+        "from flyte.app import ConnectorEnvironment\n"
+        "from flyte._image import Image\n"
+        "connector = ConnectorEnvironment(\n"
+        "    name='my-connector',\n"
+        "    image=Image.from_base('python:3.11'),\n"
+        "    include=['my_connector'],\n"
+        ")\n"
+    )
+    namespace = {"__file__": "/tmp/fake_user_app.py"}
+    exec(compile(user_code, "/tmp/fake_user_app.py", "exec"), namespace)
+    connector = namespace["connector"]
+
+    assert connector._caller_frame is not None
+    assert connector._caller_frame.filename == "/tmp/fake_user_app.py"
+    assert connector._caller_frame.function == "<module>"
+
+
+def test_connector_environment_caller_frame_with_custom_subclass():
+    """
+    GOAL: Verify _caller_frame works when a user adds another __post_init__
+    layer by subclassing ConnectorEnvironment, exercising the loop that
+    skips chained __post_init__/__init__ frames.
+    """
+    from dataclasses import dataclass
+
+    from flyte._image import Image
+    from flyte.app import ConnectorEnvironment
+
+    @dataclass
+    class MyConnector(ConnectorEnvironment):
+        def __post_init__(self):
+            super().__post_init__()
+
+    user_code = (
+        "def make(cls, Image):\n"
+        "    return cls(name='c', image=Image.from_base('python:3.11'))\n"
+    )
+    namespace = {"__file__": "/tmp/fake_user_subclass.py"}
+    exec(compile(user_code, "/tmp/fake_user_subclass.py", "exec"), namespace)
+    conn = namespace["make"](MyConnector, Image)
+
+    assert conn._caller_frame is not None
+    assert conn._caller_frame.filename == "/tmp/fake_user_subclass.py"
+    assert conn._caller_frame.function == "make"

--- a/tests/flyte/app/test_connector_environment.py
+++ b/tests/flyte/app/test_connector_environment.py
@@ -589,10 +589,7 @@ def test_connector_environment_caller_frame_with_custom_subclass():
         def __post_init__(self):
             super().__post_init__()
 
-    user_code = (
-        "def make(cls, Image):\n"
-        "    return cls(name='c', image=Image.from_base('python:3.11'))\n"
-    )
+    user_code = "def make(cls, Image):\n    return cls(name='c', image=Image.from_base('python:3.11'))\n"
     namespace = {"__file__": "/tmp/fake_user_subclass.py"}
     exec(compile(user_code, "/tmp/fake_user_subclass.py", "exec"), namespace)
     conn = namespace["make"](MyConnector, Image)


### PR DESCRIPTION
## Summary
- `ConnectorEnvironment.__post_init__` calls `super().__post_init__()`, adding an extra frame so `AppEnvironment` captured the dataclass `__init__` as `_caller_frame` instead of the user module. In editable installs this caused `flyte.deploy(connector)` to fail with `ValueError: ... module file .../src/flyte/app/_connector_environment.py is not relative to source directory ...`.
- Walk up the stack past any `__post_init__`/`__init__` frames so `_caller_frame` always points at user code, regardless of subclass depth.
- Add regression tests covering the connector and a custom subclass that adds another `__post_init__` layer.

## Test plan
- [x] `pytest tests/flyte/app/test_connector_environment.py` — 18 passed
- [x] `pytest tests/flyte/app/` — 199 passed
- [ ] Verify `flyte.deploy(connector)` from `examples/apps/custom_connector_app/app.py` works with an editable SDK install