### PR TITLE
Allow overriding buildx builder via FLYTE_DOCKER_BUILDKIT_BUILDER_NAME

### DIFF
--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
 _F_IMG_ID = "_F_IMG_ID"
 FLYTE_DOCKER_BUILDER_CACHE_FROM = "FLYTE_DOCKER_BUILDER_CACHE_FROM"
 FLYTE_DOCKER_BUILDER_CACHE_TO = "FLYTE_DOCKER_BUILDER_CACHE_TO"
+FLYTE_DOCKER_BUILDER_NAME = "FLYTE_DOCKER_BUILDER_NAME"
 
 UV_LOCK_WITHOUT_PROJECT_INSTALL_TEMPLATE = Template("""\
 RUN --mount=type=cache,sharing=locked,mode=0777,target=/root/.cache/uv,id=uv \
@@ -607,14 +608,17 @@ class DockerImageBuilder(ImageBuilder):
         Build the image from a provided Dockerfile.
         """
         assert image.dockerfile  # for mypy
-        await DockerImageBuilder._ensure_buildx_builder()
+        builder_name = os.getenv(FLYTE_DOCKER_BUILDER_NAME)
+        if not builder_name:
+            await DockerImageBuilder._ensure_buildx_builder()
+            builder_name = DockerImageBuilder._builder_name
 
         command = [
             "docker",
             "buildx",
             "build",
             "--builder",
-            DockerImageBuilder._builder_name,
+            builder_name,
             "-f",
             str(image.dockerfile),
             "--tag",
@@ -717,7 +721,10 @@ class DockerImageBuilder(ImageBuilder):
         # For testing, set `push=False` to just build the image locally and not push to
         # registry.
 
-        await DockerImageBuilder._ensure_buildx_builder()
+        builder_name = os.getenv(FLYTE_DOCKER_BUILDER_NAME)
+        if not builder_name:
+            await DockerImageBuilder._ensure_buildx_builder()
+            builder_name = DockerImageBuilder._builder_name
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             logger.warning(f"Temporary directory: {tmp_dir}")
@@ -745,7 +752,7 @@ class DockerImageBuilder(ImageBuilder):
                 "buildx",
                 "build",
                 "--builder",
-                DockerImageBuilder._builder_name,
+                builder_name,
                 "--tag",
                 f"{image.uri}",
                 "--platform",

--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
 _F_IMG_ID = "_F_IMG_ID"
 FLYTE_DOCKER_BUILDER_CACHE_FROM = "FLYTE_DOCKER_BUILDER_CACHE_FROM"
 FLYTE_DOCKER_BUILDER_CACHE_TO = "FLYTE_DOCKER_BUILDER_CACHE_TO"
-FLYTE_DOCKER_BUILDER_NAME = "FLYTE_DOCKER_BUILDER_NAME"
+FLYTE_DOCKER_BUILDKIT_BUILDER_NAME = "FLYTE_DOCKER_BUILDKIT_BUILDER_NAME"
 
 UV_LOCK_WITHOUT_PROJECT_INSTALL_TEMPLATE = Template("""\
 RUN --mount=type=cache,sharing=locked,mode=0777,target=/root/.cache/uv,id=uv \
@@ -606,7 +606,7 @@ class DockerImageBuilder(ImageBuilder):
     @staticmethod
     async def _resolve_builder_name() -> str:
         """Return the buildx builder to use, ensuring the default one exists if no override is set."""
-        builder_name = os.getenv(FLYTE_DOCKER_BUILDER_NAME)
+        builder_name = os.getenv(FLYTE_DOCKER_BUILDKIT_BUILDER_NAME)
         if builder_name:
             return builder_name
         await DockerImageBuilder._ensure_buildx_builder()

--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -603,15 +603,21 @@ class DockerImageBuilder(ImageBuilder):
         )
         return ImageBuild(uri=uri, remote_run=None)
 
+    @staticmethod
+    async def _resolve_builder_name() -> str:
+        """Return the buildx builder to use, ensuring the default one exists if no override is set."""
+        builder_name = os.getenv(FLYTE_DOCKER_BUILDER_NAME)
+        if builder_name:
+            return builder_name
+        await DockerImageBuilder._ensure_buildx_builder()
+        return DockerImageBuilder._builder_name
+
     async def _build_from_dockerfile(self, image: Image, push: bool, wait: bool = True) -> str:
         """
         Build the image from a provided Dockerfile.
         """
         assert image.dockerfile  # for mypy
-        builder_name = os.getenv(FLYTE_DOCKER_BUILDER_NAME)
-        if not builder_name:
-            await DockerImageBuilder._ensure_buildx_builder()
-            builder_name = DockerImageBuilder._builder_name
+        builder_name = await DockerImageBuilder._resolve_builder_name()
 
         command = [
             "docker",
@@ -721,10 +727,7 @@ class DockerImageBuilder(ImageBuilder):
         # For testing, set `push=False` to just build the image locally and not push to
         # registry.
 
-        builder_name = os.getenv(FLYTE_DOCKER_BUILDER_NAME)
-        if not builder_name:
-            await DockerImageBuilder._ensure_buildx_builder()
-            builder_name = DockerImageBuilder._builder_name
+        builder_name = await DockerImageBuilder._resolve_builder_name()
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             logger.warning(f"Temporary directory: {tmp_dir}")

--- a/tests/flyte/imagebuild/test_docker_builder.py
+++ b/tests/flyte/imagebuild/test_docker_builder.py
@@ -816,10 +816,10 @@ async def test_ensure_buildx_builder_recreates_when_network_host_missing():
 
 @pytest.mark.asyncio
 async def test_build_image_uses_custom_builder_from_env(monkeypatch):
-    """When FLYTE_DOCKER_BUILDER_NAME is set, _build_image should use it and skip _ensure_buildx_builder."""
+    """When FLYTE_DOCKER_BUILDKIT_BUILDER_NAME is set, _build_image should use it and skip _ensure_buildx_builder."""
     from flyte._internal.imagebuild import docker_builder as db
 
-    monkeypatch.setenv("FLYTE_DOCKER_BUILDER_NAME", "my-custom-builder")
+    monkeypatch.setenv("FLYTE_DOCKER_BUILDKIT_BUILDER_NAME", "my-custom-builder")
 
     calls = []
 
@@ -853,10 +853,10 @@ async def test_build_image_uses_custom_builder_from_env(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_build_image_uses_default_builder_when_env_unset(monkeypatch):
-    """When FLYTE_DOCKER_BUILDER_NAME is unset, _build_image should call _ensure_buildx_builder and use the default name."""
+    """When FLYTE_DOCKER_BUILDKIT_BUILDER_NAME is unset, _build_image should call _ensure_buildx_builder and use the default name."""
     from flyte._internal.imagebuild import docker_builder as db
 
-    monkeypatch.delenv("FLYTE_DOCKER_BUILDER_NAME", raising=False)
+    monkeypatch.delenv("FLYTE_DOCKER_BUILDKIT_BUILDER_NAME", raising=False)
 
     calls = []
 
@@ -890,10 +890,10 @@ async def test_build_image_uses_default_builder_when_env_unset(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_build_from_dockerfile_uses_custom_builder_from_env(monkeypatch):
-    """_build_from_dockerfile should respect FLYTE_DOCKER_BUILDER_NAME and skip ensure when set."""
+    """_build_from_dockerfile should respect FLYTE_DOCKER_BUILDKIT_BUILDER_NAME and skip ensure when set."""
     from flyte._internal.imagebuild import docker_builder as db
 
-    monkeypatch.setenv("FLYTE_DOCKER_BUILDER_NAME", "my-custom-builder")
+    monkeypatch.setenv("FLYTE_DOCKER_BUILDKIT_BUILDER_NAME", "my-custom-builder")
 
     calls = []
 

--- a/tests/flyte/imagebuild/test_docker_builder.py
+++ b/tests/flyte/imagebuild/test_docker_builder.py
@@ -853,7 +853,8 @@ async def test_build_image_uses_custom_builder_from_env(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_build_image_uses_default_builder_when_env_unset(monkeypatch):
-    """When FLYTE_DOCKER_BUILDKIT_BUILDER_NAME is unset, _build_image should call _ensure_buildx_builder and use the default name."""
+    # When FLYTE_DOCKER_BUILDKIT_BUILDER_NAME is unset, _build_image should
+    # call _ensure_buildx_builder and use the default name.
     from flyte._internal.imagebuild import docker_builder as db
 
     monkeypatch.delenv("FLYTE_DOCKER_BUILDKIT_BUILDER_NAME", raising=False)
@@ -911,9 +912,7 @@ async def test_build_from_dockerfile_uses_custom_builder_from_env(monkeypatch):
         dockerfile = Path(tmp_dir) / "Dockerfile"
         dockerfile.write_text("FROM python:3.12\n")
 
-        img = Image.from_dockerfile(
-            file=dockerfile, registry="localhost:30000", name="custom_dockerfile_test"
-        )
+        img = Image.from_dockerfile(file=dockerfile, registry="localhost:30000", name="custom_dockerfile_test")
 
         with patch.object(db.DockerImageBuilder, "_ensure_buildx_builder", side_effect=fake_ensure):
             with patch(

--- a/tests/flyte/imagebuild/test_docker_builder.py
+++ b/tests/flyte/imagebuild/test_docker_builder.py
@@ -814,6 +814,123 @@ async def test_ensure_buildx_builder_recreates_when_network_host_missing():
     assert "network=host" in create_cmds[0]
 
 
+@pytest.mark.asyncio
+async def test_build_image_uses_custom_builder_from_env(monkeypatch):
+    """When FLYTE_DOCKER_BUILDER_NAME is set, _build_image should use it and skip _ensure_buildx_builder."""
+    from flyte._internal.imagebuild import docker_builder as db
+
+    monkeypatch.setenv("FLYTE_DOCKER_BUILDER_NAME", "my-custom-builder")
+
+    calls = []
+
+    def mock_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    ensure_called = False
+
+    async def fake_ensure():
+        nonlocal ensure_called
+        ensure_called = True
+
+    img = Image.from_debian_base(registry="localhost:30000", name="custom_builder_test", install_flyte=False)
+
+    with patch.object(db.DockerImageBuilder, "_ensure_buildx_builder", side_effect=fake_ensure):
+        with patch(
+            "flyte._internal.imagebuild.docker_builder.run_sync_with_loop",
+            side_effect=lambda fn, *a, **kw: fn(*a, **kw),
+        ):
+            with patch("subprocess.run", side_effect=mock_run):
+                await db.DockerImageBuilder()._build_image(img, push=False, dry_run=False)
+
+    assert ensure_called is False
+    build_cmds = [c for c in calls if isinstance(c, list) and "build" in c and "buildx" in c]
+    assert build_cmds, "expected a buildx build command"
+    cmd = build_cmds[0]
+    builder_idx = cmd.index("--builder")
+    assert cmd[builder_idx + 1] == "my-custom-builder"
+
+
+@pytest.mark.asyncio
+async def test_build_image_uses_default_builder_when_env_unset(monkeypatch):
+    """When FLYTE_DOCKER_BUILDER_NAME is unset, _build_image should call _ensure_buildx_builder and use the default name."""
+    from flyte._internal.imagebuild import docker_builder as db
+
+    monkeypatch.delenv("FLYTE_DOCKER_BUILDER_NAME", raising=False)
+
+    calls = []
+
+    def mock_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    ensure_called = False
+
+    async def fake_ensure():
+        nonlocal ensure_called
+        ensure_called = True
+
+    img = Image.from_debian_base(registry="localhost:30000", name="default_builder_test", install_flyte=False)
+
+    with patch.object(db.DockerImageBuilder, "_ensure_buildx_builder", side_effect=fake_ensure):
+        with patch(
+            "flyte._internal.imagebuild.docker_builder.run_sync_with_loop",
+            side_effect=lambda fn, *a, **kw: fn(*a, **kw),
+        ):
+            with patch("subprocess.run", side_effect=mock_run):
+                await db.DockerImageBuilder()._build_image(img, push=False, dry_run=False)
+
+    assert ensure_called is True
+    build_cmds = [c for c in calls if isinstance(c, list) and "build" in c and "buildx" in c]
+    assert build_cmds
+    cmd = build_cmds[0]
+    builder_idx = cmd.index("--builder")
+    assert cmd[builder_idx + 1] == db.DockerImageBuilder._builder_name
+
+
+@pytest.mark.asyncio
+async def test_build_from_dockerfile_uses_custom_builder_from_env(monkeypatch):
+    """_build_from_dockerfile should respect FLYTE_DOCKER_BUILDER_NAME and skip ensure when set."""
+    from flyte._internal.imagebuild import docker_builder as db
+
+    monkeypatch.setenv("FLYTE_DOCKER_BUILDER_NAME", "my-custom-builder")
+
+    calls = []
+
+    def mock_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    ensure_called = False
+
+    async def fake_ensure():
+        nonlocal ensure_called
+        ensure_called = True
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        dockerfile = Path(tmp_dir) / "Dockerfile"
+        dockerfile.write_text("FROM python:3.12\n")
+
+        img = Image.from_dockerfile(
+            file=dockerfile, registry="localhost:30000", name="custom_dockerfile_test"
+        )
+
+        with patch.object(db.DockerImageBuilder, "_ensure_buildx_builder", side_effect=fake_ensure):
+            with patch(
+                "flyte._internal.imagebuild.docker_builder.run_sync_with_loop",
+                side_effect=lambda fn, *a, **kw: fn(*a, **kw),
+            ):
+                with patch("subprocess.run", side_effect=mock_run):
+                    await db.DockerImageBuilder()._build_from_dockerfile(img, push=False)
+
+    assert ensure_called is False
+    build_cmds = [c for c in calls if isinstance(c, list) and "build" in c and "buildx" in c]
+    assert build_cmds
+    cmd = build_cmds[0]
+    builder_idx = cmd.index("--builder")
+    assert cmd[builder_idx + 1] == "my-custom-builder"
+
+
 def test_dockerfile_footer_switches_to_flyte_user():
     """The footer should switch the runtime user to flyte and set the workdir to /home/flyte."""
     from flyte._internal.imagebuild.docker_builder import DOCKER_FILE_BASE_FOOTER


### PR DESCRIPTION
## Summary
- Adds a new `FLYTE_DOCKER_BUILDER_NAME` env var to let users override the auto-managed `flytex` buildx builder with their own buildkit builder (e.g. a remote/multi-arch builder).
- When set, both `_build_image` and `_build_from_dockerfile` use the provided builder name and skip `_ensure_buildx_builder()` so we don't try to recreate or manage a builder we don't own.
- When unset, behavior is unchanged.

## Test plan
- [x] `test_build_image_uses_custom_builder_from_env` — env var honored, ensure call skipped
- [x] `test_build_image_uses_default_builder_when_env_unset` — default `flytex` builder used, ensure call invoked
- [x] `test_build_from_dockerfile_uses_custom_builder_from_env` — env var honored on the dockerfile path