### PR TITLE
Errors, exiting with 0, expects outputs

### DIFF
--- a/examples/sandbox/raise_error.py
+++ b/examples/sandbox/raise_error.py
@@ -1,0 +1,39 @@
+"""
+Sandbox — Code That Raises an Error
+===================================
+
+Minimal example: a sandbox whose code always raises. Run remotely to see
+the failure surface as a task error.
+"""
+
+from pathlib import Path
+
+import flyte
+import flyte.sandbox
+from flyte._image import PythonWheels
+from flyte.sandbox import sandbox_environment
+
+env = flyte.TaskEnvironment(
+    name="raise-error-demo",
+    depends_on=[sandbox_environment],
+)
+
+
+boom_sandbox = flyte.sandbox.create(
+    name="boom",
+    code='raise ValueError(f"boom: x={x}")',
+    inputs={"x": int},
+    outputs={"result": int},
+    cache="disable",
+)
+
+
+@env.task
+async def trigger_failure(x: int = 1) -> int:
+    return await boom_sandbox.run.aio(x=x)
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.with_runcontext(mode="remote").run(trigger_failure, x=42)
+    print("Run URL:", run.url)

--- a/examples/sandbox/raise_error.py
+++ b/examples/sandbox/raise_error.py
@@ -6,7 +6,6 @@ Minimal example: a sandbox whose code always raises. Run remotely to see
 the failure surface as a task error.
 """
 
-
 import flyte
 import flyte.sandbox
 from flyte.sandbox import sandbox_environment

--- a/examples/sandbox/raise_error.py
+++ b/examples/sandbox/raise_error.py
@@ -6,11 +6,9 @@ Minimal example: a sandbox whose code always raises. Run remotely to see
 the failure surface as a task error.
 """
 
-from pathlib import Path
 
 import flyte
 import flyte.sandbox
-from flyte._image import PythonWheels
 from flyte.sandbox import sandbox_environment
 
 env = flyte.TaskEnvironment(

--- a/src/flyte/sandbox/_code_sandbox.py
+++ b/src/flyte/sandbox/_code_sandbox.py
@@ -262,7 +262,7 @@ class _Sandbox:
                 "echo '--- script ---' && cat \"$1\" && "
                 "echo '--- running ---' && "
                 f"{python_cmd}; "
-                "_exit=$?; echo $_exit > /var/outputs/exit_code"
+                "_exit=$?; echo $_exit > /var/outputs/exit_code; exit $_exit"
             )
 
             return ContainerTask(


### PR DESCRIPTION
-> setting an error code so that we look for the failed error message 
-> We still need a follow up in the backend to ensure we treat this like a user error with co-pilot and only retry if retries are configured