### PR TITLE
fix: don't report click.Abort/ClickException to Sentry

### DIFF
--- a/src/flyte/_sentry.py
+++ b/src/flyte/_sentry.py
@@ -60,8 +60,22 @@ def init() -> None:
         logger.debug("Failed to initialize Sentry", exc_info=True)
 
 
+def _is_user_error(exc: BaseException) -> bool:
+    """Errors raised intentionally as user-facing messages — not crash reports."""
+    try:
+        import click
+
+        if isinstance(exc, (click.Abort, click.exceptions.Exit, click.ClickException)):
+            return True
+    except ImportError:
+        pass
+    return False
+
+
 def capture_exception(exc: BaseException) -> None:
     """Capture an exception and send it to Sentry."""
+    if _is_user_error(exc):
+        return
     try:
         init()
         import sentry_sdk

--- a/tests/flyte/test_sentry.py
+++ b/tests/flyte/test_sentry.py
@@ -1,0 +1,43 @@
+from unittest import mock
+
+import click
+import pytest
+
+from flyte import _sentry
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        click.Abort(),
+        click.exceptions.Exit(1),
+        click.ClickException("docker daemon not running"),
+    ],
+)
+def test_capture_exception_skips_user_errors(exc):
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(exc)
+    init_mock.assert_not_called()
+
+
+def test_capture_exception_reports_real_errors():
+    with (
+        mock.patch.object(_sentry, "init"),
+        mock.patch("sentry_sdk.is_initialized", return_value=True),
+        mock.patch("sentry_sdk.capture_exception") as capture_mock,
+        mock.patch("sentry_sdk.flush"),
+    ):
+        err = RuntimeError("boom")
+        _sentry.capture_exception(err)
+    capture_mock.assert_called_once_with(err)
+
+
+def test_capture_errors_decorator_filters_click_abort():
+    @_sentry.capture_errors
+    def fn():
+        raise click.Abort
+
+    with mock.patch.object(_sentry, "init") as init_mock:
+        with pytest.raises(click.Abort):
+            fn()
+    init_mock.assert_not_called()


### PR DESCRIPTION
## Summary
- `click.Abort`, `click.exceptions.Exit`, and `click.ClickException` are raised on purpose to display user-facing messages (Ctrl+C, declined prompts, missing dependencies, etc.). They are not crashes and shouldn't generate Sentry issues.
- This PR adds a small `_is_user_error` filter at the top of `capture_exception` so they short-circuit before any Sentry init/flush.

## Closes
- [FLYTE-SDK-H](https://unionai.sentry.io/issues/FLYTE-SDK-H) — `Abort` from `click.confirm`
- [FLYTE-SDK-G](https://unionai.sentry.io/issues/FLYTE-SDK-G) — Docker daemon not reachable
- [FLYTE-SDK-J](https://unionai.sentry.io/issues/FLYTE-SDK-J) — Timed out waiting for Flyte cluster
- [FLYTE-SDK-W](https://unionai.sentry.io/issues/FLYTE-SDK-W) — Timed out waiting for kubeconfig
- [FLYTE-SDK-Q](https://unionai.sentry.io/issues/FLYTE-SDK-Q) — Failed to pull image
- [FLYTE-SDK-5](https://unionai.sentry.io/issues/FLYTE-SDK-5) — Failed to start container

## Test plan
- [x] New unit tests in tests/flyte/test_sentry.py cover the filter (Abort/Exit/ClickException) and verify real errors still report.
- [ ] Smoke test \`flyte start devbox\` locally with no docker running — should print the friendly message and not bump Sentry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)