### PR TITLE
fix: coerce CopyConfig.src to Path in __post_init__

### DIFF
--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -364,6 +364,8 @@ class CopyConfig(Layer):
     def __post_init__(self):
         if self.path_type not in (0, 1):
             raise ValueError(f"Invalid path_type {self.path_type}, must be 0 (file) or 1 (directory)")
+        if not isinstance(self.src, Path):
+            object.__setattr__(self, "src", Path(self.src))
 
     def validate(self):
         if not self.src.exists():

--- a/tests/flyte/test_image.py
+++ b/tests/flyte/test_image.py
@@ -399,6 +399,22 @@ def test_uv_project_optional_uvlock():
         assert hash1 != hash2
 
 
+def test_copy_config_coerces_string_src_to_path(tmp_path):
+    """CopyConfig accepts a str src and coerces it to Path so update_hash/validate work."""
+    import hashlib
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.txt").write_text("hello")
+
+    cc = CopyConfig(path_type=1, src=str(src), dst="/app")
+    assert isinstance(cc.src, Path)
+    assert cc.src == src
+
+    h = hashlib.md5()
+    cc.update_hash(h)
+
+
 def test_copy_config_update_hash_respects_dockerignore(tmp_path):
     """CopyConfig.update_hash must exclude files matched by .dockerignore."""
     import hashlib


### PR DESCRIPTION
## Summary
- `CopyConfig` is a frozen dataclass with `src: Path`, but is constructed with `str` from some call sites (and via deserialization). At runtime `update_hash()` calls `self.src.is_dir()` and crashes with `AttributeError: 'str' object has no attribute 'is_dir'`.
- Coerce `src` to `Path` inside `__post_init__` (using `object.__setattr__` because the dataclass is frozen, matching existing patterns in this file).

## Closes
- [FLYTE-SDK-11](https://unionai.sentry.io/issues/FLYTE-SDK-11) — `AttributeError: 'str' object has no attribute 'is_dir'` in `flyte._image.update_hash`

## Test plan
- [x] New unit test in `tests/flyte/test_image.py` constructs `CopyConfig` with a string `src` and asserts both the coerced type and that `update_hash` runs.
- [x] Existing `CopyConfig` tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)