### PR TITLE
fix: remove stale devbox container on restart

### DIFF
--- a/src/flyte/cli/_delete.py
+++ b/src/flyte/cli/_delete.py
@@ -80,9 +80,8 @@ def devbox(volume: bool):
     Stop and remove the local Flyte devbox cluster container.
     """
     console = common.get_console()
-    result = subprocess.run(["docker", "stop", "flyte-devbox"], capture_output=True, check=False)
+    result = subprocess.run(["docker", "rm", "-f", "flyte-devbox"], capture_output=True, check=False)
     if result.returncode == 0:
-        subprocess.run(["docker", "wait", "flyte-devbox"], capture_output=True, check=False)
         console.print("[green]Devbox cluster stopped.[/green]")
     else:
         console.print("[yellow]Devbox cluster is not running.[/yellow]")

--- a/src/flyte/cli/_devbox.py
+++ b/src/flyte/cli/_devbox.py
@@ -57,16 +57,6 @@ def _container_is_running(container_name: str) -> bool:
     return container_name in result.stdout
 
 
-def _container_exists(container_name: str) -> bool:
-    result = subprocess.run(
-        ["docker", "ps", "-a", "--filter", f"name=^{container_name}$", "--format", "{{.Names}}"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return container_name in result.stdout
-
-
 def _container_is_paused(container_name: str) -> bool:
     result = subprocess.run(
         [
@@ -264,9 +254,7 @@ def launch_devbox(image_name: str, is_dev_mode: bool, gpu: bool = False, log_for
         console.print("[yellow]Flyte devbox cluster is already running.[/yellow]")
         if not click.confirm("Do you want to delete the existing devbox cluster and start a new one?"):
             return
-        subprocess.run(["docker", "rm", "-f", _CONTAINER_NAME], check=True, capture_output=True)
-    elif _container_exists(_CONTAINER_NAME):
-        subprocess.run(["docker", "rm", "-f", _CONTAINER_NAME], check=True, capture_output=True)
+    subprocess.run(["docker", "rm", "-f", _CONTAINER_NAME], check=False, capture_output=True)
 
     _KUBE_DIR.mkdir(parents=True, exist_ok=True)
     # This step makes sure that we always used the latest k3s kubeconfig file

--- a/src/flyte/cli/_devbox.py
+++ b/src/flyte/cli/_devbox.py
@@ -57,6 +57,16 @@ def _container_is_running(container_name: str) -> bool:
     return container_name in result.stdout
 
 
+def _container_exists(container_name: str) -> bool:
+    result = subprocess.run(
+        ["docker", "ps", "-a", "--filter", f"name=^{container_name}$", "--format", "{{.Names}}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return container_name in result.stdout
+
+
 def _container_is_paused(container_name: str) -> bool:
     result = subprocess.run(
         [
@@ -254,7 +264,9 @@ def launch_devbox(image_name: str, is_dev_mode: bool, gpu: bool = False, log_for
         console.print("[yellow]Flyte devbox cluster is already running.[/yellow]")
         if not click.confirm("Do you want to delete the existing devbox cluster and start a new one?"):
             return
-        subprocess.run(["docker", "stop", _CONTAINER_NAME], check=True, capture_output=True)
+        subprocess.run(["docker", "rm", "-f", _CONTAINER_NAME], check=True, capture_output=True)
+    elif _container_exists(_CONTAINER_NAME):
+        subprocess.run(["docker", "rm", "-f", _CONTAINER_NAME], check=True, capture_output=True)
 
     _KUBE_DIR.mkdir(parents=True, exist_ok=True)
     # This step makes sure that we always used the latest k3s kubeconfig file


### PR DESCRIPTION
## Summary
<img width="780" height="323" alt="Screenshot 2026-05-07 at 10 37 54 AM" src="https://github.com/user-attachments/assets/db721c3a-3243-450f-98a1-27cf75f0c993" />


- Fix `container name "/flyte-devbox" is already in use` error when running `flyte start devbox` after the container exists in a stopped/exited state (e.g. after Docker Desktop or machine restart).
- `_container_is_running` only checks running containers via `docker ps`, so a stopped container would fall through to `docker run` and fail on the name conflict.
- Always run `docker rm -f flyte-devbox` (with `check=False`) before starting, so any leftover container — running or stopped — is cleared. The "already running" prompt is preserved.

## Test plan
- `flyte start devbox`, then restart Docker, then `flyte start devbox` again — should start cleanly instead of erroring.
- `flyte start devbox` while one is already running, answer `y` to the prompt — should remove and recreate.
- Fresh machine with no existing container — should start normally.