### PR TITLE
fix: surface user-module load errors as ClickException

### DIFF
--- a/src/flyte/cli/_common.py
+++ b/src/flyte/cli/_common.py
@@ -328,7 +328,12 @@ class ObjectsPerFileGroup(GroupBase):
         sys.modules[module_name] = module
 
         sys.path.append(module_path)
-        spec.loader.exec_module(module)
+        try:
+            spec.loader.exec_module(module)
+        except click.ClickException:
+            raise
+        except (ImportError, SyntaxError, NameError, AttributeError, TypeError, ValueError) as e:
+            raise click.ClickException(f"Failed to load {self.filename}: {type(e).__name__}: {e}") from e
 
         self._objs = self._filter_objects(module)
         if not self._objs:

--- a/tests/flyte/cli/test_user_module_load.py
+++ b/tests/flyte/cli/test_user_module_load.py
@@ -1,0 +1,68 @@
+"""Tests for converting user-module exec errors into click.ClickException."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Dict
+
+import click
+import pytest
+
+from flyte.cli._common import ObjectsPerFileGroup
+
+
+class _DummyGroup(ObjectsPerFileGroup):
+    def _filter_objects(self, module: ModuleType) -> Dict[str, Any]:
+        return {k: v for k, v in vars(module).items() if not k.startswith("_")}
+
+    def _get_command_for_obj(self, ctx, obj_name, obj):  # pragma: no cover - unused
+        raise NotImplementedError
+
+
+def _make_group(tmp_path: Path, body: str) -> _DummyGroup:
+    p = tmp_path / "user_mod.py"
+    p.write_text(body)
+    return _DummyGroup(filename=p, name="dummy")
+
+
+def test_import_error_in_user_module_becomes_click_exception(tmp_path):
+    grp = _make_group(tmp_path, "from definitely_not_a_module import nope\n")
+    with pytest.raises(click.ClickException) as excinfo:
+        _ = grp.objs
+    assert "Failed to load" in excinfo.value.message
+    assert "ModuleNotFoundError" in excinfo.value.message or "ImportError" in excinfo.value.message
+
+
+def test_value_error_in_user_module_becomes_click_exception(tmp_path):
+    grp = _make_group(tmp_path, "raise ValueError('bad user config')\n")
+    with pytest.raises(click.ClickException) as excinfo:
+        _ = grp.objs
+    assert "Failed to load" in excinfo.value.message
+    assert "ValueError" in excinfo.value.message
+    assert "bad user config" in excinfo.value.message
+
+
+def test_syntax_error_in_user_module_becomes_click_exception(tmp_path):
+    grp = _make_group(tmp_path, "def broken(:\n")
+    with pytest.raises(click.ClickException) as excinfo:
+        _ = grp.objs
+    assert "Failed to load" in excinfo.value.message
+    assert "SyntaxError" in excinfo.value.message
+
+
+def test_click_exception_in_user_module_is_passed_through(tmp_path):
+    grp = _make_group(
+        tmp_path,
+        "import rich_click as click\nraise click.ClickException('explicit user-facing error')\n",
+    )
+    with pytest.raises(click.ClickException) as excinfo:
+        _ = grp.objs
+    # The original ClickException is preserved, not wrapped.
+    assert excinfo.value.message == "explicit user-facing error"
+
+
+def test_unexpected_exception_is_not_swallowed(tmp_path):
+    grp = _make_group(tmp_path, "raise RuntimeError('genuinely unexpected')\n")
+    with pytest.raises(RuntimeError):
+        _ = grp.objs


### PR DESCRIPTION
## Summary

When `flyte deploy` / `flyte run` loads a user's Python module via
`ObjectsPerFileGroup.objs`, exceptions raised at import time were
propagating up unchanged. The CLI's Sentry wrapper then treated these
user-code bugs (missing imports, broken modules, bad SDK call patterns
at module top-level) as SDK crashes.

This change converts the common user-side import/eval errors --
`ImportError`, `SyntaxError`, `NameError`, `AttributeError`,
`TypeError`, `ValueError` -- into `click.ClickException`. These
short-circuit the Sentry filter added in #1039 and give the user an
actionable message instead of a stack trace. Other unexpected
exceptions (e.g. `RuntimeError`) still propagate so real SDK bugs
continue to be reported.

## Closes

- [FLYTE-SDK-22](https://unionai.sentry.io/issues/FLYTE-SDK-22) -- `ValueError: Cannot add additional layers to a non-extendable image` raised from user's `env.py` calling `with_pip_packages()`
- [FLYTE-SDK-23](https://unionai.sentry.io/issues/FLYTE-SDK-23) -- `ImportError: cannot import name 'SAMPLING_IMAGE'` from user module
- [FLYTE-SDK-24](https://unionai.sentry.io/issues/FLYTE-SDK-24) -- `ImportError: cannot import name 'find_or_fetch_pdb'` from user module
- [FLYTE-SDK-26](https://unionai.sentry.io/issues/FLYTE-SDK-26) -- `ModuleNotFoundError: No module named 'flytelib.cache'` from user module

`fixes https://github.com/flyteorg/flyte-sdk/issues/FLYTE-SDK-22`
`fixes https://github.com/flyteorg/flyte-sdk/issues/FLYTE-SDK-23`
`fixes https://github.com/flyteorg/flyte-sdk/issues/FLYTE-SDK-24`
`fixes https://github.com/flyteorg/flyte-sdk/issues/FLYTE-SDK-26`

## Test plan

- [x] New unit tests in `tests/flyte/cli/test_user_module_load.py` cover ImportError, ValueError, SyntaxError pass-through of explicit `ClickException`, and that unrelated `RuntimeError` still propagates.
- [x] `make fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)