### PR TITLE
fix: surface unpicklable deployments as ClickException

### DIFF
--- a/src/flyte/_deploy.py
+++ b/src/flyte/_deploy.py
@@ -488,10 +488,24 @@ async def apply(deployment_plan: DeploymentPlan, copy_style: CopyFiles, dryrun: 
         if deployment_plan.version:
             version = deployment_plan.version
         else:
+            import pickle as _pickle
+
+            import click
+
             h = hashlib.md5()
-            h.update(cloudpickle.dumps(deployment_plan.envs))
-            h.update(code_bundle.computed_version.encode("utf-8"))
-            h.update(cloudpickle.dumps(image_cache))
+            try:
+                h.update(cloudpickle.dumps(deployment_plan.envs))
+                h.update(code_bundle.computed_version.encode("utf-8"))
+                h.update(cloudpickle.dumps(image_cache))
+            except (_pickle.PicklingError, TypeError) as e:
+                raise click.ClickException(
+                    "Failed to compute deployment version: your task or environment captures an "
+                    f"unpicklable object ({type(e).__name__}: {e}). This is usually caused by closing "
+                    "over `sys.stdin` / `sys.stdout` / `sys.stderr`, an open file handle, a thread, "
+                    "or a lock from module-level code. Move the captured value inside the task "
+                    "function, or pass an explicit `version=...` to `flyte.deploy(...)` to skip "
+                    "version derivation."
+                ) from e
             version = h.hexdigest()
 
     sc = SerializationContext(

--- a/tests/flyte/test_deploy.py
+++ b/tests/flyte/test_deploy.py
@@ -451,3 +451,41 @@ async def test_build_images_resolves_code_bundle_layer_copy_style_none():
     bundle_layers = [layer for layer in env.image._layers if isinstance(layer, CodeBundleLayer)]
     assert len(bundle_layers) == 1, "CodeBundleLayer should remain (resolved) at copy_style='none'"
     assert bundle_layers[0].root_dir is not None, "resolved CodeBundleLayer must have root_dir set"
+
+
+@pytest.mark.asyncio
+async def test_apply_unpicklable_env_raises_click_exception():
+    """If the user's envs cannot be serialized, apply() should surface a friendly ClickException."""
+    import pathlib
+
+    import click
+
+    from flyte._deploy import apply
+
+    class _Unserializable:
+        def __reduce__(self):
+            raise TypeError("Cannot serialize objects that map to tty handles")
+
+    plan = DeploymentPlan(envs={"e": _Unserializable()}, version=None)  # type: ignore[dict-item]
+
+    fake_bundle = Mock()
+    fake_bundle.computed_version = "test-bundle-version"
+
+    fake_cfg = Mock()
+    fake_cfg.root_dir = pathlib.Path("/tmp")
+    fake_cfg.images = {}
+    fake_cfg.project = "p"
+    fake_cfg.domain = "d"
+    fake_cfg.org = "o"
+
+    with (
+        patch("flyte._initialize.is_initialized", return_value=True),
+        patch("flyte._deploy.get_init_config", return_value=fake_cfg),
+        patch("flyte._deploy._build_images", new=AsyncMock(return_value={})),
+        patch("flyte._code_bundle._includes.collect_env_include_files", return_value=[]),
+        patch("flyte._code_bundle.build_code_bundle", new=AsyncMock(return_value=fake_bundle)),
+    ):
+        with pytest.raises(click.ClickException) as excinfo:
+            await apply(plan, copy_style="loaded_modules", dryrun=True)
+    assert "unpicklable" in excinfo.value.message
+    assert "version=" in excinfo.value.message


### PR DESCRIPTION
## Summary

`apply()` derives the deployment version by piping the user's envs and
image cache through `cloudpickle.dumps`. If anything in the user's
task or environment is unpicklable (e.g. a captured
`sys.stdin`/`stdout` tty handle, an open file, a thread, or a lock),
cloudpickle raises `PicklingError`/`TypeError` and the raw stack ends
up in Sentry.

This change wraps the version-hash computation and translates those
pickle failures into a `click.ClickException` that names the most
common cause and points the user at the `version=` escape hatch. The
new ClickException short-circuits the Sentry filter added in #1039 so
we stop logging user-side closure mistakes as SDK crashes.

## Closes

- [FLYTE-SDK-21](https://unionai.sentry.io/issues/FLYTE-SDK-21) -- `PicklingError: Cannot pickle files that map to tty objects` from `cloudpickle._file_reduce`

`fixes https://github.com/flyteorg/flyte-sdk/issues/FLYTE-SDK-21`

## Test plan

- [x] New unit test in `tests/flyte/test_deploy.py` covers the unpicklable-envs path.
- [x] `make fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)