### PR TITLE
fix: filter DeploymentError/ImageBuildError from Sentry

### DIFF
--- a/src/flyte/_sentry.py
+++ b/src/flyte/_sentry.py
@@ -69,6 +69,19 @@ def _is_user_error(exc: BaseException) -> bool:
             return True
     except ImportError:
         pass
+
+    # Errors raised by the deploy / image-build pipeline that always carry an
+    # actionable, user-facing message (bad trigger config, image build failure
+    # from the remote builder, etc.). Treat them like ClickException so we
+    # don't flood Sentry with what is fundamentally user input feedback.
+    try:
+        from flyte.errors import DeploymentError, ImageBuildError
+
+        if isinstance(exc, (DeploymentError, ImageBuildError)):
+            return True
+    except ImportError:
+        pass
+
     return False
 
 

--- a/tests/flyte/test_sentry.py
+++ b/tests/flyte/test_sentry.py
@@ -41,3 +41,21 @@ def test_capture_errors_decorator_filters_click_abort():
         with pytest.raises(click.Abort):
             fn()
     init_mock.assert_not_called()
+
+
+def test_capture_exception_skips_deployment_error():
+    from flyte.errors import DeploymentError
+
+    err = DeploymentError("bad trigger config")
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()
+
+
+def test_capture_exception_skips_image_build_error():
+    from flyte.errors import ImageBuildError
+
+    err = ImageBuildError("build failed")
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()


### PR DESCRIPTION
## Summary

`DeploymentError` and `ImageBuildError` are both defined as
`RuntimeUserError` subclasses in `flyte/errors.py`: they are raised at
deploy / build time to feed an actionable, user-facing message back
through the CLI (bad trigger schema, image push permission denied,
remote image build failure, etc.). They are not SDK crashes -- but the
Sentry filter added in #1039 only short-circuited click exceptions, so
every such user error still showed up in Sentry with the user's stack
trace.

Extend `_is_user_error` to also skip these two classes. Other
`RuntimeUserError` subclasses (OOM, retries exhausted, image pull
backoff, etc.) are deliberately left in so runtime telemetry is
unaffected.

## Closes

- [FLYTE-SDK-P](https://unionai.sentry.io/issues/FLYTE-SDK-P) -- `ImageBuildError: Build failed` from remote image builder
- [FLYTE-SDK-1P](https://unionai.sentry.io/issues/FLYTE-SDK-1P) -- `DeploymentError`: TriggerTime input missing from task
- [FLYTE-SDK-20](https://unionai.sentry.io/issues/FLYTE-SDK-20) -- `DeploymentError` for scheduled trigger configuration
- [FLYTE-SDK-A](https://unionai.sentry.io/issues/FLYTE-SDK-A) -- `DeploymentError`: build-image task deploy failure
- [FLYTE-SDK-9](https://unionai.sentry.io/issues/FLYTE-SDK-9) -- `DeploymentError`: build-image task deploy failure
- [FLYTE-SDK-8](https://unionai.sentry.io/issues/FLYTE-SDK-8) -- `DeploymentError`: build-image task deploy failure
- [FLYTE-SDK-7](https://unionai.sentry.io/issues/FLYTE-SDK-7) -- `DeploymentError`: build-image task deploy failure
- [FLYTE-SDK-6](https://unionai.sentry.io/issues/FLYTE-SDK-6) -- `DeploymentError`: build-image task deploy failure

`fixes https://github.com/flyteorg/flyte-sdk/issues/FLYTE-SDK-P`
`fixes https://github.com/flyteorg/flyte-sdk/issues/FLYTE-SDK-1P`
`fixes https://github.com/flyteorg/flyte-sdk/issues/FLYTE-SDK-20`

## Test plan

- [x] New unit tests in `tests/flyte/test_sentry.py` cover the two new filtered types.
- [x] Existing click filter tests still pass.
- [x] `make fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)