### PR TITLE
fix: filter InitializationError from Sentry

### DIFF
--- a/src/flyte/_sentry.py
+++ b/src/flyte/_sentry.py
@@ -72,12 +72,14 @@ def _is_user_error(exc: BaseException) -> bool:
 
     # Errors raised by the deploy / image-build pipeline that always carry an
     # actionable, user-facing message (bad trigger config, image build failure
-    # from the remote builder, etc.). Treat them like ClickException so we
-    # don't flood Sentry with what is fundamentally user input feedback.
+    # from the remote builder, etc.). InitializationError means the user forgot
+    # to call flyte.init() / flyte.init_from_config() — also a user-facing
+    # message, not a crash. Treat them all like ClickException so we don't
+    # flood Sentry with what is fundamentally user input feedback.
     try:
-        from flyte.errors import DeploymentError, ImageBuildError
+        from flyte.errors import DeploymentError, ImageBuildError, InitializationError
 
-        if isinstance(exc, (DeploymentError, ImageBuildError)):
+        if isinstance(exc, (DeploymentError, ImageBuildError, InitializationError)):
             return True
     except ImportError:
         pass

--- a/tests/flyte/test_sentry.py
+++ b/tests/flyte/test_sentry.py
@@ -59,3 +59,12 @@ def test_capture_exception_skips_image_build_error():
     with mock.patch.object(_sentry, "init") as init_mock:
         _sentry.capture_exception(err)
     init_mock.assert_not_called()
+
+
+def test_capture_exception_skips_initialization_error():
+    from flyte.errors import InitializationError
+
+    err = InitializationError("NotInitialized", "user", "Client has not been initialized.")
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()


### PR DESCRIPTION
## Summary
- `InitializationError` is what the SDK raises when the user runs a CLI command (or calls `flyte.deploy` / `flyte.upload_file` / etc.) without having first called `flyte.init()` or `flyte.init_from_config()`. The exception's message is a clear, actionable instruction to the user — not a crash report worth paging on.
- Sentry has collected several of these reports already (see linked issues below). Add `InitializationError` to the existing user-error filter in `flyte._sentry` alongside `DeploymentError` and `ImageBuildError`.

## Sentry issues
Fixes [FLYTE-SDK-7](https://unionai.sentry.io/issues/7476258800/) (InitializationError on `flyte deploy`)
Fixes [FLYTE-SDK-8](https://unionai.sentry.io/issues/7476262632/) (InitializationError during `upload_file`)

## Test plan
- [x] New `test_capture_exception_skips_initialization_error` unit test
- [x] Full `tests/flyte/test_sentry.py` suite passes