### PR TITLE
fix: retry upload on httpx.ReadError and other network errors

### DIFF
--- a/src/flyte/remote/_data.py
+++ b/src/flyte/remote/_data.py
@@ -118,7 +118,7 @@ async def _upload_with_retry(
                         )
         except RuntimeSystemError:
             raise
-        except (httpx.TimeoutException, httpx.ConnectError, OSError) as e:
+        except (httpx.TimeoutException, httpx.NetworkError, OSError) as e:
             last_error = e
             if retry_attempt >= max_retries:
                 raise RuntimeSystemError(

--- a/tests/flyte/remote/test_upload_retry.py
+++ b/tests/flyte/remote/test_upload_retry.py
@@ -93,6 +93,24 @@ async def test_upload_retries_on_connect_error(upload_file):
 
 
 @pytest.mark.asyncio
+async def test_upload_retries_on_read_error(upload_file):
+    with patch("flyte.remote._data.httpx.AsyncClient") as mock_cls:
+        client = AsyncMock()
+        client.put.side_effect = httpx.ReadError("connection reset by peer")
+        ctx = AsyncMock()
+        ctx.__aenter__.return_value = client
+        ctx.__aexit__.return_value = False
+        mock_cls.return_value = ctx
+
+        with pytest.raises(RuntimeSystemError, match="connection reset by peer"):
+            await _upload_with_retry(
+                upload_file, "https://signed.url/upload", {}, verify=True, max_retries=1, min_backoff_sec=0.01
+            )
+
+        assert client.put.call_count == 2
+
+
+@pytest.mark.asyncio
 async def test_upload_retries_on_server_error_then_succeeds(upload_file):
     with patch("flyte.remote._data.httpx.AsyncClient") as mock_cls:
         client = AsyncMock()


### PR DESCRIPTION
## Summary
- `_upload_with_retry` only catches `httpx.TimeoutException` and `httpx.ConnectError`. A transient `httpx.ReadError` (e.g. \"connection reset by peer\" mid-upload) bypasses the retry loop entirely and surfaces as an unhandled crash.
- Broaden the catch to `httpx.NetworkError`, which is the umbrella for `ConnectError`, `ReadError`, `WriteError`, and `CloseError` — all transient transport-level failures that deserve the same backoff/retry treatment timeouts already get.

## Sentry issues
Fixes [FLYTE-SDK-9](https://unionai.sentry.io/issues/7474616101/) (`ReadError` during signed-URL upload, no retry)

## Test plan
- [x] New `test_upload_retries_on_read_error` integration test
- [x] Existing `tests/flyte/remote/test_upload_retry.py` suite still passes