### PR TITLE
fix: fall back to ASCII spinner when stdout can't encode unicode

### DIFF
--- a/src/flyte/cli/_abort.py
+++ b/src/flyte/cli/_abort.py
@@ -24,7 +24,7 @@ def run(cfg: common.CLIConfig, run_name: str, reason: str, project: str | None =
     r = remote.Run.get(name=run_name)
     if r:
         console = common.get_console()
-        with console.status(f"Aborting run '{run_name}'...", spinner="dots"):
+        with console.status(f"Aborting run '{run_name}'...", spinner=common.safe_spinner("dots")):
             r.abort(reason=reason)
         console.print(f"Run '{run_name}' has been aborted.")
 
@@ -51,6 +51,8 @@ def action(
     a = remote.Action.get(run_name=run_name, name=action_name)
     if a:
         console = common.get_console()
-        with console.status(f"Aborting action '{action_name}' for run '{run_name}'...", spinner="dots"):
+        with console.status(
+            f"Aborting action '{action_name}' for run '{run_name}'...", spinner=common.safe_spinner("dots")
+        ):
             a.abort(reason=reason)
         console.print(f"Action '{action_name}' for run '{run_name}' has been aborted.")

--- a/src/flyte/cli/_common.py
+++ b/src/flyte/cli/_common.py
@@ -474,6 +474,26 @@ def get_console() -> Console:
     return Console(color_system="auto", force_terminal=True)
 
 
+def safe_spinner(spinner: str = "dots") -> str:
+    """
+    Pick an ASCII-safe spinner when stdout encoding can't represent the requested
+    spinner's characters (e.g. legacy Windows cp1252 consoles can't encode the
+    braille characters used by Rich's default "dots" spinner, which crashes
+    mid-render with UnicodeEncodeError).
+    """
+    import sys
+
+    encoding = getattr(sys.stdout, "encoding", None) or ""
+    if encoding.lower().replace("-", "") in ("utf8", "utf16", "utf32"):
+        return spinner
+    try:
+        # Probe with a representative non-ASCII char from the "dots" spinner.
+        "⠙".encode(encoding)
+    except (UnicodeEncodeError, LookupError):
+        return "line"
+    return spinner
+
+
 def cli_status(output_format: OutputFormat, message: str, spinner: str = "dots"):
     """
     Return a context manager for status display.
@@ -483,7 +503,7 @@ def cli_status(output_format: OutputFormat, message: str, spinner: str = "dots")
 
     if output_format in ("json", "table-simple", "json-raw"):
         return nullcontext()
-    return get_console().status(message, spinner=spinner)
+    return get_console().status(message, spinner=safe_spinner(spinner))
 
 
 def print_output(renderable: Any, output_format: OutputFormat) -> None:

--- a/tests/flyte/cli/test_safe_spinner.py
+++ b/tests/flyte/cli/test_safe_spinner.py
@@ -1,0 +1,34 @@
+"""Tests for ASCII-safe spinner fallback on non-UTF stdout encodings."""
+
+import io
+from unittest import mock
+
+from flyte.cli._common import safe_spinner
+
+
+def _stdout_with_encoding(encoding: str) -> io.TextIOWrapper:
+    return io.TextIOWrapper(io.BytesIO(), encoding=encoding)
+
+
+def test_safe_spinner_keeps_dots_on_utf8():
+    with mock.patch("sys.stdout", _stdout_with_encoding("utf-8")):
+        assert safe_spinner("dots") == "dots"
+
+
+def test_safe_spinner_falls_back_on_cp1252():
+    with mock.patch("sys.stdout", _stdout_with_encoding("cp1252")):
+        assert safe_spinner("dots") == "line"
+
+
+def test_safe_spinner_falls_back_on_ascii():
+    with mock.patch("sys.stdout", _stdout_with_encoding("ascii")):
+        assert safe_spinner("dots") == "line"
+
+
+def test_safe_spinner_handles_missing_encoding():
+    class _NoEncoding:
+        encoding = None
+
+    with mock.patch("sys.stdout", _NoEncoding()):
+        # No encoding info → fall back conservatively to ASCII.
+        assert safe_spinner("dots") == "line"


### PR DESCRIPTION
## Summary
- Rich's default \"dots\" spinner uses braille pattern characters (e.g. `'⠙'`). On legacy Windows consoles where `sys.stdout.encoding` is cp1252, writing those characters crashes the CLI with `UnicodeEncodeError` mid-render — Sentry has observed this taking down `flyte deploy` before any real work happens.
- Add a `safe_spinner()` helper in `flyte.cli._common` that probes `sys.stdout.encoding` and falls back to Rich's ASCII-only `\"line\"` spinner when the requested spinner's characters can't be encoded. Apply it in `cli_status` and at the direct `console.status(...)` callsites that explicitly request `\"dots\"`.

## Sentry issues
Fixes [FLYTE-SDK-A](https://unionai.sentry.io/issues/7476377068/) (`UnicodeEncodeError: 'charmap' codec can't encode character '⠙'`)

## Test plan
- [x] New `tests/flyte/cli/test_safe_spinner.py` covers utf-8 (keeps \"dots\"), cp1252 / ascii / missing encoding (falls back to \"line\")
- [x] `make fmt` clean