### PR TITLE
fix default values handling in the CLI for pydantic and dataclasses

### DIFF
--- a/examples/cli/default_values_cli.py
+++ b/examples/cli/default_values_cli.py
@@ -1,0 +1,110 @@
+"""
+Example: tasks with default input values, exercised through the CLI.
+
+Covers the three default-shaping patterns that the SDK supports for a task
+input:
+
+    (1) Pydantic model with field defaults, passed as a default task input
+    (2) Frozen dataclass with field defaults, passed as a default task input
+    (3) Primitive task args with function-level defaults
+
+To exercise the deployed-task path end-to-end, deploy this file and then
+invoke each task via ``flyte run deployed-task`` with no arguments — relying
+entirely on the defaults:
+
+    flyte deploy examples/cli/default_values.py env
+    flyte run deployed-task default_values_cli.task_pydantic_default
+    flyte run deployed-task default_values_cli.task_dataclass_default
+    flyte run deployed-task default_values_cli.task_primitive_defaults
+
+``--help`` on any of these should render the actual default value (e.g.
+``[default: standard]``), not the ``_has_default`` sentinel class.
+
+You can also run locally (no backend required) with:
+
+    flyte run --local examples/cli/default_values_cli.py task_primitive_defaults
+    flyte run --local examples/cli/default_values_cli.py task_pydantic_default
+    flyte run --local examples/cli/default_values_cli.py task_dataclass_default
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Annotated
+
+import pydantic
+from pydantic import Field
+
+import flyte
+
+env = flyte.TaskEnvironment(name="default_values_cli")
+
+
+# ---------------------------------------------------------------------------
+# Case (1): Pydantic model with field defaults, given as the task arg default.
+# ---------------------------------------------------------------------------
+
+
+class PydanticInput(pydantic.BaseModel):
+    target_revision: Annotated[str, Field(default="head", description="git ref to inspect")] = "head"
+    repo: str = "flyteorg/flyte"
+
+
+@env.task
+def task_pydantic_default(inputs: PydanticInput = PydanticInput()) -> str:
+    msg = f"[pydantic] repo={inputs.repo} target_revision={inputs.target_revision}"
+    print(msg)
+    return msg
+
+
+# ---------------------------------------------------------------------------
+# Case (2): Frozen dataclass with field defaults, given as the task arg.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DataclassInput:
+    message: str = "hello"
+    font: str = "standard"
+
+
+@env.task
+def task_dataclass_default(inputs: DataclassInput = DataclassInput()) -> str:
+    msg = f"[dataclass] message={inputs.message} font={inputs.font}"
+    print(msg)
+    return msg
+
+
+# ---------------------------------------------------------------------------
+# Case (3): Primitive args with function-level defaults — the exact shape from
+# the customer's `hello_flyte_task` repro.
+# ---------------------------------------------------------------------------
+
+
+@env.task
+def task_primitive_defaults(message: str = "hello, flyte", font: str = "standard") -> str:
+    msg = f"[primitive] message={message} font={font}"
+    print(msg)
+    return msg
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+
+    print("Running task_pydantic_default")
+    run = flyte.run(task_pydantic_default)
+    print(run.url)
+    run.wait()
+    print(run.outputs())
+
+    print("Running task_dataclass_default")
+    run = flyte.run(task_dataclass_default)
+    print(run.url)
+    run.wait()
+    print(run.outputs())
+
+    print("Running task_primitive_defaults")
+    run = flyte.run(task_primitive_defaults)
+    print(run.url)
+    run.wait()
+    print(run.outputs())

--- a/examples/cli/default_values_cli.py
+++ b/examples/cli/default_values_cli.py
@@ -12,7 +12,7 @@ To exercise the deployed-task path end-to-end, deploy this file and then
 invoke each task via ``flyte run deployed-task`` with no arguments — relying
 entirely on the defaults:
 
-    flyte deploy examples/cli/default_values.py env
+    flyte deploy examples/cli/default_values_cli.py env
     flyte run deployed-task default_values_cli.task_pydantic_default
     flyte run deployed-task default_values_cli.task_dataclass_default
     flyte run deployed-task default_values_cli.task_primitive_defaults
@@ -22,9 +22,9 @@ entirely on the defaults:
 
 You can also run locally (no backend required) with:
 
-    flyte run --local examples/cli/default_values_cli.py task_primitive_defaults
-    flyte run --local examples/cli/default_values_cli.py task_pydantic_default
-    flyte run --local examples/cli/default_values_cli.py task_dataclass_default
+    flyte run examples/cli/default_values_cli.py task_primitive_defaults
+    flyte run examples/cli/default_values_cli.py task_pydantic_default
+    flyte run examples/cli/default_values_cli.py task_dataclass_default
 """
 
 from __future__ import annotations

--- a/src/flyte/_internal/runtime/convert.py
+++ b/src/flyte/_internal/runtime/convert.py
@@ -122,6 +122,19 @@ async def convert_from_native_to_inputs(
     return await _convert_from_native_to_inputs_impl(interface, args, custom_context, kwargs)
 
 
+def _is_has_default_sentinel(value: Any) -> bool:
+    """
+    Return True if `value` is the `_has_default` sentinel (the class itself or an instance).
+
+    The class is intended purely as a *marker* on `NativeInterface.inputs[name][1]` to indicate
+    "this remote task input has a default value stored on the spec". It must never be treated as a
+    real input value. We check both forms because the CLI's click integration used to coerce the
+    class into an instance (click instantiates callable defaults), so either shape can leak through
+    into kwargs.
+    """
+    return value is NativeInterface.has_default or isinstance(value, NativeInterface.has_default)
+
+
 async def _convert_from_native_to_inputs_impl(
     interface: NativeInterface,
     args: Tuple[Any, ...],
@@ -129,6 +142,10 @@ async def _convert_from_native_to_inputs_impl(
     kwargs: Dict[str, Any],
 ) -> Inputs:
     kwargs = interface.convert_to_kwargs(*args, **kwargs)
+
+    # Drop any sentinel values from kwargs so the loop below falls through to the `_remote_defaults`
+    # branch and substitutes the literal default instead of attempting to serialize the sentinel.
+    kwargs = {k: v for k, v in kwargs.items() if not _is_has_default_sentinel(v)}
 
     missing = [key for key in interface.required_inputs() if key not in kwargs]
     if missing:

--- a/src/flyte/cli/_params.py
+++ b/src/flyte/cli/_params.py
@@ -740,9 +740,20 @@ def to_click_option(
     """
     from flyteidl2.core.types_pb2 import SimpleType
 
+    from flyte.models import NativeInterface
+
     if input_name != input_name.lower():
         # Click does not support uppercase option names: https://github.com/pallets/click/issues/837
         raise ValueError(f"Workflow input name must be lowercase: {input_name!r}")
+
+    # Guard against the `_has_default` sentinel class ever reaching click. Click treats callable
+    # defaults as factories and will silently instantiate `_has_default()`, then string-format the
+    # resulting instance — producing a corrupted default that surfaces both in `--help` and as a
+    # real input value sent to the remote pod. Callers are expected to resolve the sentinel into
+    # the real default via `NativeInterface._remote_defaults` before getting here; this is a
+    # defense-in-depth fallback that drops the bogus default rather than poisoning the option.
+    if default_val is NativeInterface.has_default or isinstance(default_val, NativeInterface.has_default):
+        default_val = None
 
     literal_converter = FlyteLiteralConverter(
         literal_type=literal_var.type,

--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -15,6 +15,7 @@ from .._code_bundle._utils import CopyFiles
 from .._sentry import capture_exception, count
 from .._task import TaskTemplate
 from ..errors import RuntimeSystemError
+from ..models import NativeInterface
 from ..remote import Run
 from ..syncify import syncify
 from . import _common as common
@@ -65,6 +66,37 @@ def _list_tasks(
 
     common.initialize_config(ctx, project, domain)
     return [task.name for task in flyte.remote.Task.listall(by_task_name=by_task_name, by_task_env=by_task_env)]
+
+
+def _resolve_default_val(interface: NativeInterface, name: str, default_marker: Any, python_type: Any) -> Any:
+    """
+    Resolve the click default for an input on a (possibly remote) task interface.
+
+    Local task interfaces (built via `NativeInterface.from_callable`) carry the real Python default
+    directly in ``default_marker``. Remote/deployed task interfaces are reconstructed by
+    `flyte.types.guess_interface`, which uses `NativeInterface.has_default` as a sentinel marker
+    while stashing the actual literal default in ``interface._remote_defaults``. In the remote case
+    we materialize the literal back into a Python value so click can render it in ``--help`` and use
+    it as the option default — instead of leaking the `_has_default` class itself, which click would
+    silently instantiate and string-format into a corrupted default value.
+    """
+    if default_marker is inspect.Parameter.empty:
+        return None
+    if default_marker is not NativeInterface.has_default:
+        return default_marker
+
+    remote_defaults = interface._remote_defaults or {}
+    literal = remote_defaults.get(name)
+    if literal is None:
+        return None
+    try:
+        from ..types import TypeEngine
+
+        return asyncio.run(TypeEngine.to_python_value(literal, python_type))
+    except Exception:
+        # Fall back to no default rather than poisoning the option; the runtime path
+        # will still fill the missing kwarg from `_remote_defaults`.
+        return None
 
 
 @dataclass
@@ -348,7 +380,7 @@ Missing required parameter(s): {", ".join(f"--{p[0]} (type: {p[1]})" for p in mi
         if config.output_format in ("json", "table-simple"):
             content = f"Completed Local Run\nPath: {result.url}\nOutputs: {result.outputs()}"
         else:
-            content = f"[green]Completed Local Run[/green]\nPath: {result.url}\n➡️ Outputs: {result.outputs()}"
+            content = f"[green]Completed Local Run[/green]\nPath: {result.url}\n➡️  Outputs: {result.outputs()}"
         console.print(common.get_panel("Local Success", content, config.output_format))
 
     async def _render_remote_success(self, console, result, config):
@@ -429,10 +461,9 @@ Missing required parameter(s): {", ".join(f"--{p[0]} (type: {p[1]})" for p in mi
         params: List[click.Parameter] = []
         for entry in interface.inputs.variables:
             name, var = entry.key, entry.value
-            default_val = None
-            if inputs_interface[name][1] is not inspect._empty:
-                default_val = inputs_interface[name][1]
-            params.append(to_click_option(name, var, inputs_interface[name][0], default_val))
+            python_type, default_marker = inputs_interface[name]
+            default_val = _resolve_default_val(task.native_interface, name, default_marker, python_type)
+            params.append(to_click_option(name, var, python_type, default_val))
 
         self.params = params
         return super().get_params(ctx)
@@ -568,7 +599,7 @@ Missing required parameter(s): {", ".join(f"--{p[0]} (type: {p[1]})" for p in mi
         if config.output_format in ("json", "table-simple"):
             content = f"Completed Local Run\nPath: {result.url}\nOutputs: {result.outputs()}"
         else:
-            content = f"[green]Completed Local Run[/green]\nPath: {result.url}\n➡️ Outputs: {result.outputs()}"
+            content = f"[green]Completed Local Run[/green]\nPath: {result.url}\n➡️  Outputs: {result.outputs()}"
         console.print(common.get_panel("Local Success", content, config.output_format))
 
     async def _render_remote_success(self, console, result, config):
@@ -634,10 +665,9 @@ Missing required parameter(s): {", ".join(f"--{p[0]} (type: {p[1]})" for p in mi
         params: List[click.Parameter] = []
         for entry in interface.inputs.variables:
             name, var = entry.key, entry.value
-            default_val = None
-            if inputs_interface[name][1] is not inspect._empty:
-                default_val = inputs_interface[name][1]
-            params.append(to_click_option(name, var, inputs_interface[name][0], default_val))
+            python_type, default_marker = inputs_interface[name]
+            default_val = _resolve_default_val(task_details.interface, name, default_marker, python_type)
+            params.append(to_click_option(name, var, python_type, default_val))
 
         self.params = params
         return super().get_params(ctx)

--- a/tests/cli/test_run_remote_defaults.py
+++ b/tests/cli/test_run_remote_defaults.py
@@ -1,0 +1,245 @@
+"""
+Reproduction tests for the `_has_default` regression on `flyte run deployed-task`.
+
+When a deployed task has default input values, the SDK reconstructs the remote
+`NativeInterface` using `NativeInterface.has_default` (the `_has_default` class)
+as a sentinel marker — with the actual literal default value stored in
+`NativeInterface._remote_defaults`.
+
+The CLI's `get_params` used to pass this sentinel *class* straight through to
+`click.Option(default=...)`. Click treats callable defaults as factories, so it
+would instantiate `_has_default()` and convert the resulting instance with
+`STRING.convert`, producing a literal string like
+``"<flyte.models._has_default object at 0x...>"``. That garbage string then
+- showed up in ``--help`` as the rendered default, and
+- was shipped over the wire as the actual input value, causing the deployed
+  pod to fail with confusing errors like ``FontNotFound: <flyte.models._has_default object at 0x...>``.
+
+These tests pin both the CLI rendering and the runtime materialization paths so
+the regression cannot return.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+import flyte.remote
+from flyte.cli._params import to_click_option
+from flyte.cli._run import RunArguments, RunRemoteTaskCommand, run
+from flyte.models import NativeInterface
+from flyte.types import TypeEngine
+
+# ---------------------------------------------------------------------------
+# Helpers to build a fake remote `TaskDetails`-like object with real defaults
+# ---------------------------------------------------------------------------
+
+
+def _build_remote_interface(
+    defaults: dict[str, tuple[type, Any]],
+    required: dict[str, type] | None = None,
+) -> NativeInterface:
+    """
+    Build a `NativeInterface` mimicking what `guess_interface` produces for a
+    deployed task: defaults are encoded as the `_has_default` sentinel with the
+    actual literal values living in `_remote_defaults`.
+    """
+    required = required or {}
+
+    async def _build():
+        remote_defaults = {}
+        for name, (py_type, value) in defaults.items():
+            remote_defaults[name] = await TypeEngine.to_literal(value, py_type, TypeEngine.to_literal_type(py_type))
+
+        inputs: dict[str, tuple[type, Any]] = {}
+        for name, py_type in required.items():
+            inputs[name] = (py_type, inspect.Parameter.empty)
+        for name, (py_type, _value) in defaults.items():
+            inputs[name] = (py_type, NativeInterface.has_default)
+
+        return NativeInterface.from_types(inputs, {}, remote_defaults)
+
+    return asyncio.run(_build())
+
+
+class _FakeTaskDetails:
+    """Stand-in for `flyte.remote.TaskDetails` with a real `NativeInterface`."""
+
+    def __init__(self, interface: NativeInterface):
+        self._interface = interface
+
+    @property
+    def interface(self) -> NativeInterface:
+        return self._interface
+
+
+class _FakeLazyEntity:
+    """Stand-in for `flyte.remote.LazyEntity`; returns our fake details."""
+
+    def __init__(self, details: _FakeTaskDetails):
+        self._details = details
+
+    def fetch(self) -> _FakeTaskDetails:
+        return self._details
+
+
+def _patched_task_get(details: _FakeTaskDetails):
+    return patch.object(flyte.remote.Task, "get", return_value=_FakeLazyEntity(details))
+
+
+# ---------------------------------------------------------------------------
+# Tests targeting `to_click_option`: this is the lowest-level guard. The CLI
+# must never end up handing the `_has_default` sentinel class to click as a
+# default value, because click will instantiate it.
+# ---------------------------------------------------------------------------
+
+
+def test_to_click_option_rejects_has_default_sentinel_class():
+    """
+    Regression: `to_click_option` must not propagate `NativeInterface.has_default`
+    (a callable class) into `click.Option(default=...)`. If it does, click
+    silently calls `_has_default()` and string-formats the resulting *instance*.
+
+    The option's default must therefore be either ``None`` or a properly
+    resolved Python value — never the sentinel class itself.
+    """
+    from flyteidl2.core.interface_pb2 import Variable
+    from flyteidl2.core.types_pb2 import LiteralType, SimpleType
+
+    literal_var = Variable(type=LiteralType(simple=SimpleType.STRING), description="font")
+
+    option = to_click_option(
+        input_name="font",
+        literal_var=literal_var,
+        python_type=str,
+        default_val=NativeInterface.has_default,
+    )
+
+    # The sentinel must not leak through as the click default — neither as the
+    # class itself nor as a stringified instance/class of `_has_default`.
+    assert option.default is not NativeInterface.has_default
+    rendered_default = repr(option.default)
+    assert "_has_default" not in rendered_default, (
+        f"`_has_default` sentinel leaked into click default: {rendered_default!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests targeting `RunRemoteTaskCommand.get_params`: ensures the synthesized
+# click options use the *real* remote default values from `_remote_defaults`.
+# ---------------------------------------------------------------------------
+
+
+def _make_remote_command(task_name: str = "fake.task") -> RunRemoteTaskCommand:
+    return RunRemoteTaskCommand(
+        task_name=task_name,
+        run_args=RunArguments(project="p", domain="d"),
+        version=None,
+        name=task_name,
+    )
+
+
+@pytest.mark.parametrize(
+    "py_type,default_value",
+    [
+        (str, "head"),
+        (str, "hello, flyte"),
+        (int, 42),
+        (bool, True),
+    ],
+)
+def test_get_params_resolves_primitive_remote_defaults(py_type, default_value):
+    """
+    For a deployed task with primitive defaults, `RunRemoteTaskCommand.get_params`
+    must resolve the literal stored in `_remote_defaults` into a concrete Python
+    value and hand that to click as the option default. The result must never be
+    the `_has_default` sentinel.
+    """
+    interface = _build_remote_interface(defaults={"x": (py_type, default_value)})
+    details = _FakeTaskDetails(interface)
+    cmd = _make_remote_command()
+
+    with _patched_task_get(details), patch("flyte.cli._common.initialize_config"):
+        import click as _click
+
+        ctx = _click.Context(cmd)
+        params = cmd.get_params(ctx)
+
+    by_name = {p.name: p for p in params if isinstance(p, _click.Option)}
+    assert "x" in by_name, f"Expected --x option in {list(by_name)}"
+    opt = by_name["x"]
+    assert opt.default == default_value, f"--x default should resolve to {default_value!r}, got {opt.default!r}"
+    assert "_has_default" not in repr(opt.default)
+
+
+def test_help_output_shows_real_default_not_has_default_class():
+    """
+    End-to-end check: `flyte run deployed-task <name> --help` must render the
+    actual default value (e.g. ``standard``), never
+    ``<class 'flyte.models._has_default'>`` or ``<flyte.models._has_default object ...>``.
+    """
+    interface = _build_remote_interface(
+        defaults={
+            "message": (str, "hello, flyte"),
+            "font": (str, "standard"),
+        }
+    )
+    details = _FakeTaskDetails(interface)
+
+    runner = CliRunner()
+    with _patched_task_get(details), patch("flyte.cli._common.initialize_config"):
+        result = runner.invoke(
+            run,
+            ["deployed-task", "hello_flyte.hello_flyte_task", "--help"],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "_has_default" not in result.output, f"`_has_default` sentinel leaked into --help output:\n{result.output}"
+    # Sanity: the actual resolved defaults should be visible somewhere in --help.
+    assert "standard" in result.output
+    assert "hello, flyte" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Defense-in-depth: even if a caller manages to pass the `_has_default`
+# sentinel (class *or* instance) through to `convert_from_native_to_inputs`,
+# the runtime must fall back to the `_remote_defaults` literal instead of
+# trying to serialize the sentinel as if it were a real user value.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "sentinel",
+    [
+        NativeInterface.has_default,  # the class itself
+        NativeInterface.has_default(),  # an instance, as click would produce
+    ],
+    ids=["class", "instance"],
+)
+async def test_convert_from_native_to_inputs_handles_sentinel_in_kwargs(sentinel):
+    """
+    If the `_has_default` sentinel (class or instance) shows up as a value in
+    `kwargs`, `convert_from_native_to_inputs` must transparently substitute the
+    matching literal from `interface._remote_defaults` rather than attempting
+    to serialize the sentinel itself.
+    """
+    from flyte._internal.runtime.convert import convert_from_native_to_inputs
+
+    default_literal = await TypeEngine.to_literal("standard", str, TypeEngine.to_literal_type(str))
+    interface = NativeInterface.from_types(
+        {"font": (str, NativeInterface.has_default)},
+        {},
+        {"font": default_literal},
+    )
+
+    result = await convert_from_native_to_inputs(interface, font=sentinel)
+    literals = {lit.name: lit.value for lit in result.proto_inputs.literals}
+    assert "font" in literals
+    assert literals["font"].scalar.primitive.string_value == "standard"


### PR DESCRIPTION
This pull request addresses a regression in the handling of default input values for deployed tasks in the Flyte CLI, specifically ensuring that the `_has_default` sentinel marker is never propagated as an actual input value or rendered in CLI help output. The changes ensure that the real default values are correctly resolved and displayed, and that the sentinel is safely handled in both the CLI and runtime paths. Extensive regression tests are also added to prevent future occurrences of this issue.

**Fixes and improvements to default value handling:**

* The CLI now properly resolves default values for deployed tasks, ensuring that the `_has_default` sentinel is replaced with the actual default value from `NativeInterface._remote_defaults` before passing to click options or runtime serialization. [[1]](diffhunk://#diff-db6fcfb5640e750d38d2804766e92759199a666731872af457a4d7133fa59afdR71-R101) [[2]](diffhunk://#diff-db6fcfb5640e750d38d2804766e92759199a666731872af457a4d7133fa59afdL432-R466) [[3]](diffhunk://#diff-db6fcfb5640e750d38d2804766e92759199a666731872af457a4d7133fa59afdL637-R670) [[4]](diffhunk://#diff-55d849b75cb68188430758dc4d7d15239e201b7a6fcdfd8b46bbc9cdb66cc3b1R125-R137) [[5]](diffhunk://#diff-55d849b75cb68188430758dc4d7d15239e201b7a6fcdfd8b46bbc9cdb66cc3b1R146-R149) [[6]](diffhunk://#diff-3cae73d7a4cb3ac070d177ce108d2e0d7cdf9e8f01d64435f572969003a9479fR743-R757)
* Defense-in-depth: The runtime path drops any `_has_default` sentinel values from kwargs, ensuring only valid defaults are serialized and sent to remote pods. [[1]](diffhunk://#diff-55d849b75cb68188430758dc4d7d15239e201b7a6fcdfd8b46bbc9cdb66cc3b1R125-R137) [[2]](diffhunk://#diff-55d849b75cb68188430758dc4d7d15239e201b7a6fcdfd8b46bbc9cdb66cc3b1R146-R149)

**Testing and regression coverage:**

* New tests are added to reproduce the original regression and to pin correct behavior for both CLI rendering and runtime materialization of default values, including cases where the sentinel class or instance might leak through.

**Documentation and examples:**

* An example script (`examples/cli/default_values_cli.py`) is added, demonstrating the three supported patterns for task input defaults (Pydantic model, frozen dataclass, and primitive function defaults), and instructions for running and testing these via the CLI.

These changes ensure that Flyte CLI users see correct default values in help output and that deployed tasks receive proper input values, eliminating confusing errors caused by the sentinel marker.