### PR TITLE
Add exclude-newer option to uv: delay new dependency releases by 5 days

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "flyte"
 dynamic = ["version"]
 description = "Add your description here"
 readme = "README.md"
-authors = [{ name = "Ketan Umare", email = "kumare3@users.noreply.github.com" }]
+authors = [{ name = "Flyte Contributors", email = "admin@flyte.org" }]
 requires-python = ">=3.10"
 dependencies = [
     "aiofiles>=24.1.0",
@@ -190,6 +190,9 @@ ignore = ["PGH003", "PLC0415", "ASYNC210", "ASYNC240", "FURB122"]
 [tool.mypy]
 disable_error_code = ["import-untyped"]
 ignore_missing_imports = true
+
+[tool.uv]
+exclude-newer = "5 days"
 
 [tool.uv.sources]
 flyte_controller_base = { path = "rs_controller" }


### PR DESCRIPTION
To give us a 5-day grace period to ignore new packages in the case of supply chain attacks