### PR TITLE
fix: skip symlinks pointing outside source when bundling code

### DIFF
--- a/src/flyte/_code_bundle/_packaging.py
+++ b/src/flyte/_code_bundle/_packaging.py
@@ -147,14 +147,23 @@ def create_bundle(
     # Compute where the archive should be written
     archive_fname = output_dir / f"{FAST_PREFIX}{ls_digest}{FAST_FILEENDING}"
     tar_path = output_dir / "tmp.tar"
-    resolved_source = source.resolve()
+    abs_source = os.path.abspath(str(source))
     with tarfile.open(str(tar_path), "w", dereference=deref_symlinks) as tar:
         for ws_file in ls:
-            # Resolve both paths to normalize any ".." components before computing
-            # the arcname — un-normalized paths produce tar member names containing
-            # ".." which GNU tar refuses to extract (and some tools create a literal
-            # ".." directory instead).  Also ensures forward slashes on all platforms.
-            rel_path = pathlib.Path(ws_file).resolve().relative_to(resolved_source).as_posix()
+            # Compute the arcname relative to source using os.path.relpath, which
+            # normalizes ".." components. We deliberately use os.path.abspath rather
+            # than Path.resolve() on both sides — resolve() follows symlinks, so a
+            # symlink inside source that points outside source (e.g.
+            # .venv/bin/python -> /usr/bin/python3.10) would crash relative_to with
+            # "<target> is not in the subpath of <source>".
+            abs_ws = os.path.abspath(ws_file)
+            rel_path = pathlib.PurePath(os.path.relpath(abs_ws, abs_source)).as_posix()
+            if rel_path.startswith(".."):
+                # Defensive: skip files that land outside the source root after
+                # normalization. Callers should have filtered these, but a stray
+                # entry shouldn't abort the entire bundle.
+                logger.warning(f"Skipping {ws_file}: resolves outside source root {abs_source}")
+                continue
             tar.add(
                 os.path.join(source, ws_file),
                 recursive=False,

--- a/src/flyte/_code_bundle/_utils.py
+++ b/src/flyte/_code_bundle/_utils.py
@@ -197,12 +197,15 @@ def ls_relative_files(relative_paths: list[str], source_path: pathlib.Path) -> t
                 raise ValueError(f"File {path} is not a valid file, directory, or glob pattern")
 
     all_files.sort()
-    resolved_source = source_path.resolve()
+    abs_source = os.path.abspath(str(source_path))
     for p in all_files:
         _filehash_update(p, hasher)
-        # Resolve before relative_to to normalize any ".." in the path — un-normalized
-        # paths would produce inconsistent hashes across equivalent paths.
-        rel_path = pathlib.Path(p).resolve().relative_to(resolved_source).as_posix()
+        # Normalize ".." components via os.path.relpath without following symlinks.
+        # Using os.path.abspath rather than Path.resolve(): resolve() would follow
+        # symlinks, so a symlink in source pointing outside source (e.g.
+        # .venv/bin/python -> /usr/bin/python3.10) would crash with
+        # "<target> is not in the subpath of <source>".
+        rel_path = pathlib.PurePath(os.path.relpath(os.path.abspath(p), abs_source)).as_posix()
         _pathhash_update(rel_path, hasher)
 
     digest = hasher.hexdigest()

--- a/tests/flyte/code_bundle/test_code_bundle.py
+++ b/tests/flyte/code_bundle/test_code_bundle.py
@@ -585,6 +585,55 @@ def test_ls_relative_files_dotdot_path_does_not_produce_dotdot_tar_entry():
         assert "sibling/module.py" in member_names
 
 
+def test_create_bundle_skips_symlinks_pointing_outside_source():
+    """
+    Regression: a symlink inside `source` that resolves to a path *outside* `source`
+    (e.g. `.venv/bin/python` -> `/usr/bin/python3.10`) previously crashed
+    `create_bundle` with `ValueError: '/usr/bin/python3.10' is not in the subpath of
+    '<source>'` because the arcname was computed via `Path.resolve().relative_to()`.
+
+    The arcname must reflect the file's position *within* `source`, regardless of where
+    the symlink target lives — `os.path.relpath` gives us that without following links.
+    For symlinks that already fall outside `source` after normalization, we now skip
+    them defensively rather than abort the whole bundle.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        outside = pathlib.Path(tmpdir) / "outside"
+        outside.mkdir()
+        # Target lives outside `source` — simulates /usr/bin/python3.10.
+        outside_target = outside / "python3.10"
+        outside_target.write_text("# fake interpreter")
+
+        source = pathlib.Path(tmpdir) / "source"
+        source.mkdir()
+        (source / "main.py").write_text("print('hello')")
+
+        # The symlink inside source that points outside source — the exact pattern
+        # that crashed Sentry issue FLYTE-SDK-2E.
+        symlink_path = source / "python_bin"
+        try:
+            os.symlink(str(outside_target), str(symlink_path))
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported on this filesystem")
+
+        output_dir = pathlib.Path(tmpdir) / "output"
+        output_dir.mkdir()
+
+        # Include both the regular file and the dangling-outside symlink.
+        files = [str(source / "main.py"), str(symlink_path)]
+
+        # Previously raised ValueError; should now succeed and include `main.py`
+        # plus the symlink (preserved as a link since deref_symlinks defaults False).
+        archive_path, _, _ = create_bundle(source, output_dir, files, "test_digest")
+
+        with tarfile.open(archive_path, "r:gz") as tar:
+            member_names = tar.getnames()
+
+        assert "main.py" in member_names
+        # The symlink itself is preserved under its source-relative arcname.
+        assert "python_bin" in member_names
+
+
 def test_list_all_files_returns_strings():
     """Test that list_all_files returns string paths (not pathlib.Path objects)."""
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- `create_bundle` and `ls_relative_files` computed the arcname / hash path via `Path(ws_file).resolve().relative_to(source.resolve())`. `resolve()` follows symlinks, so a symlink inside the source dir that points outside the source dir (e.g. `.venv/bin/python` -> `/usr/bin/python3.10`) crashes with `ValueError: '/usr/bin/python3.10' is not in the subpath of '<source>'`, aborting the entire deploy at code-bundle time.
- Switch both call sites to `os.path.relpath` against the **absolute** (non-resolved) source path. `abspath` still normalizes ".." components (the property the original `resolve()` was added to preserve, per the comment) but doesn't follow symlinks, so the arcname reflects the file's position inside `source` rather than the symlink target's location.
- As a defensive fallback, `create_bundle` now skips and logs a warning for any path that still lands outside `source` after normalization, rather than letting one stray entry abort the whole bundle.

## Sentry issues
Fixes [FLYTE-SDK-2E](https://unionai.sentry.io/issues/7476727356/)

## Test plan
- [x] New regression test `test_create_bundle_skips_symlinks_pointing_outside_source` constructs the exact symlink-outside-source shape from the Sentry crash and asserts the bundle succeeds
- [x] Existing `test_create_bundle_*` and `test_ls_relative_files_*` tests still pass