### PR TITLE
fix: surface actionable error when docker is missing for image build

### DIFF
--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -655,13 +655,21 @@ class DockerImageBuilder(ImageBuilder):
     @staticmethod
     async def _ensure_buildx_builder():
         """Ensure there is a docker buildx builder called flyte"""
+        from flyte.errors import ImageBuildError
+
         # Check if buildx is available
         try:
             await run_sync_with_loop(
                 subprocess.run, ["docker", "buildx", "version"], check=True, stdout=subprocess.DEVNULL
             )
+        except FileNotFoundError:
+            raise ImageBuildError(
+                "Docker is not installed or not available in PATH. "
+                "Install Docker (https://docs.docker.com/get-docker/) and ensure it is running, "
+                "or use the remote image builder by setting `image_builder='remote'` on your `flyte.Image`."
+            )
         except subprocess.CalledProcessError:
-            raise RuntimeError("Docker buildx is not available. Make sure BuildKit is installed and enabled.")
+            raise ImageBuildError("Docker buildx is not available. Make sure BuildKit is installed and enabled.")
 
         # List builders
         result = await run_sync_with_loop(

--- a/tests/flyte/imagebuild/test_docker_builder.py
+++ b/tests/flyte/imagebuild/test_docker_builder.py
@@ -57,6 +57,24 @@ async def test_doesnt_work_yet():
 
 
 @pytest.mark.asyncio
+async def test_ensure_buildx_builder_raises_image_build_error_when_docker_missing(monkeypatch):
+    """
+    Regression: when docker is not installed/in PATH, `subprocess.run(["docker", ...])`
+    raises `FileNotFoundError`, which previously bubbled up to Sentry as an unhandled
+    SDK crash. The user should instead get an actionable `ImageBuildError` telling
+    them docker isn't installed and pointing at the remote builder fallback.
+    """
+    from flyte.errors import ImageBuildError
+
+    def _raise_filenotfound(*args, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory", "docker")
+
+    with patch("flyte._internal.imagebuild.docker_builder.subprocess.run", side_effect=_raise_filenotfound):
+        with pytest.raises(ImageBuildError, match="Docker is not installed"):
+            await DockerImageBuilder._ensure_buildx_builder()
+
+
+@pytest.mark.asyncio
 @pytest.mark.integration
 async def test_image_with_secrets(monkeypatch):
     monkeypatch.setenv("FLYTE", "test-value")


### PR DESCRIPTION
## Summary
- `DockerImageBuilder._ensure_buildx_builder` shells out to `subprocess.run(["docker", "buildx", "version"])` and only catches `CalledProcessError`. If docker isn't installed at all, the call raises `FileNotFoundError: [Errno 2] No such file or directory: 'docker'`, which bubbles all the way up to Sentry as an unhandled SDK crash.
- Catch `FileNotFoundError` explicitly and raise `ImageBuildError` (the user-facing error type the CLI already special-cases) with a message that tells the user docker isn't on PATH, links the install instructions, and points at the remote builder as the no-local-docker escape hatch.

## Sentry issues
Fixes [FLYTE-SDK-2K](https://unionai.sentry.io/issues/7478609313/)

## Test plan
- [x] New regression test `test_ensure_buildx_builder_raises_image_build_error_when_docker_missing` monkey-patches `subprocess.run` to raise `FileNotFoundError` and asserts the new `ImageBuildError` is raised