### PR TITLE
fix publish CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,6 +115,11 @@ jobs:
           sed -i "s/flyte_controller_base>=2.0.0b0/flyte_controller_base==${VERSION}/" pyproject.toml
           echo "Pinned flyte_controller_base==${VERSION}"
           grep flyte_controller_base pyproject.toml
+          # Editing pyproject.toml above makes the git working tree dirty, which
+          # would cause setuptools_scm to produce a PEP 440 local version like
+          # "2.3.1.dev0+g<sha>.d<date>" that PyPI rejects. Pin the version
+          # explicitly to the release tag so the resulting wheel is uploadable.
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FLYTE=${VERSION}" >> $GITHUB_ENV
       - name: Build and publish
         run: |
           uv run python -m build --wheel --installer uv


### PR DESCRIPTION
This pull request makes a targeted improvement to the publishing workflow to ensure that Python package wheels are built with a valid version string for PyPI uploads. Specifically, it addresses an issue where modifying `pyproject.toml` could result in setuptools_scm generating a local version string that PyPI rejects. The workflow now explicitly pins the version using an environment variable.

**Publishing workflow improvements:**

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R118-R122): Added logic to set the `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FLYTE` environment variable to the release tag, ensuring that the wheel is built with a valid version string for PyPI, even when the git working tree is dirty after editing `pyproject.toml`.