### PR TITLE
fix: pin plugin wheel version via SETUPTOOLS_SCM_PRETEND_VERSION on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -202,6 +202,18 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         id: setup-uv
+      - name: Set version from tag (release only)
+        if: github.event_name == 'release'
+        run: |
+          VERSION=$(echo "$GITHUB_REF" | sed 's|refs/tags/v||')
+          # `uv run` triggers `uv sync`, which may re-resolve and rewrite the
+          # plugin's uv.lock (e.g. for plugins that pull `flyte` from PyPI rather
+          # than via `[tool.uv.sources]`). That dirties the working tree, which
+          # would cause setuptools_scm (root = "../../") to emit a PEP 440 local
+          # version like "2.3.0b1.dev0+g<sha>.d<date>" that PyPI rejects. Pinning
+          # the version explicitly bypasses git inspection entirely.
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "Pinned SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}"
       - name: Install dependencies
         working-directory: ${{ matrix.workdir }}
         run: |


### PR DESCRIPTION
## Summary

- The plugin-pypi release job was producing wheels with PEP 440 **local version identifiers** (e.g. `flyteplugins_papermill-2.3.0b1.dev0+gc32c0adb8.d20260513`) that PyPI rejects with a 400 error.
- Root cause: `uv run python -m build --wheel --installer uv` triggers `uv sync`, which re-resolves dependencies and rewrites the plugin's `uv.lock`. For plugins that pull `flyte` from PyPI (e.g. `mlflow`, `papermill`) the lockfile changes, dirtying the working tree. Plugins with `[tool.uv.sources] flyte = { path = "../../", editable = true }` (e.g. `ray`, `spark`) re-resolve to a byte-identical lock and stay clean — which is why those uploads succeeded.
- A dirty parent tree causes `setuptools_scm` (configured with `root = "../../"` in each plugin) to bump to the next dev version and append a local segment, which PyPI then refuses.
- Fix: on release events, export `SETUPTOOLS_SCM_PRETEND_VERSION=<tag-version>` so `setuptools_scm` returns the exact tag version regardless of working-tree state. This mirrors the `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FLYTE` fix already applied to the main `flyte` package in the prior PR.

## Test plan

- [ ] Push a pre-release tag (e.g. `v2.3.0b1`) and confirm `mlflow` and `papermill` wheels are built and uploaded to PyPI with the clean tag version.
- [ ] Verify all other plugin uploads still succeed.


Made with [Cursor](https://cursor.com)