### PR TITLE
fix: raise clear error when flyte.TriggerTime is used as a task default

### DIFF
--- a/src/flyte/_internal/runtime/convert.py
+++ b/src/flyte/_internal/runtime/convert.py
@@ -77,10 +77,21 @@ async def convert_upload_default_inputs(
     if not interface.inputs:
         return []
 
+    # flyte.TriggerTime is a sentinel that gets bound at trigger fire time, not a
+    # serializable default. Importing lazily avoids a circular import at module load.
+    from flyte._trigger import _trigger_time
+
     vars = []
     literal_coros = []
     for input_name, (input_type, default_value) in interface.inputs.items():
         if default_value is not None and default_value is not inspect.Parameter.empty:
+            if isinstance(default_value, _trigger_time):
+                raise ValueError(
+                    f"Input '{input_name}' uses flyte.TriggerTime as its default value. "
+                    "flyte.TriggerTime is only valid as a value in `flyte.Trigger(inputs=...)` — "
+                    "it cannot be used as a regular task default. Remove the default from the "
+                    "task signature and pass it through the Trigger inputs instead."
+                )
             lt = TypeEngine.to_literal_type(input_type)
             literal_coros.append(TypeEngine.to_literal(default_value, input_type, lt))
             vars.append((input_name, lt))

--- a/tests/flyte/internal/runtime/test_convert.py
+++ b/tests/flyte/internal/runtime/test_convert.py
@@ -1411,6 +1411,25 @@ async def test_convert_upload_default_inputs_with_falsy_defaults():
 
 
 @pytest.mark.asyncio
+async def test_convert_upload_default_inputs_rejects_trigger_time():
+    """
+    convert_upload_default_inputs must raise a clear ValueError when flyte.TriggerTime
+    is used as a default value for a regular task input. Previously this produced an
+    opaque TypeTransformerFailedError because TriggerTime is a sentinel, not a datetime.
+    """
+    from datetime import datetime
+
+    import flyte
+
+    interface = NativeInterface.from_types(
+        {"trigger_time": (datetime, flyte.TriggerTime)},
+        {},
+    )
+    with pytest.raises(ValueError, match=r"flyte\.TriggerTime"):
+        await convert.convert_upload_default_inputs(interface)
+
+
+@pytest.mark.asyncio
 async def test_convert_upload_default_inputs_remote_interface():
     """
     convert_upload_default_inputs should handle remote interfaces correctly.


### PR DESCRIPTION
## Summary

When a user declares a task with `flyte.TriggerTime` as the default value for a regular parameter:

```python
@env.task
async def my_task(t: datetime = flyte.TriggerTime):
    ...
```

deploy fails with an opaque `TypeTransformerFailedError`:

> Expected value of type `<class 'datetime.datetime'>` but got `<flyte._trigger._trigger_time object at …>`

That happened because `convert_upload_default_inputs` passed the `flyte.TriggerTime` sentinel through to the datetime literal transformer.

`flyte.TriggerTime` is only valid as a *value* inside `flyte.Trigger(inputs=...)` — it cannot be used as a regular task default. This PR detects the sentinel in `convert_upload_default_inputs` and raises a clear `ValueError` explaining the supported pattern, so users get an actionable error at deploy time instead of a transformer crash.

## Sentry

Fixes [FLYTE-SDK-2Q](https://unionai.sentry.io/issues/7480549137/)

## Test plan
- [x] Added regression test `test_convert_upload_default_inputs_rejects_trigger_time`
- [x] `make fmt`
- [x] Existing convert / trigger_serde / triggers test suites pass (132 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)