### PR TITLE
fix(config): escape bracket in read_file_if_exists debug log

### DIFF
--- a/src/flyte/config/_reader.py
+++ b/src/flyte/config/_reader.py
@@ -221,5 +221,5 @@ def read_file_if_exists(filename: typing.Optional[str], encoding=None) -> typing
         return None
 
     file = pathlib.Path(filename)
-    logger.debug(f"Reading file contents from [{file}] with current directory [{os.getcwd()}].")
+    logger.debug(f"Reading file contents from \\[{file}] with current directory \\[{os.getcwd()}].")
     return file.read_text(encoding=encoding)

--- a/tests/flyte/config/test_reader.py
+++ b/tests/flyte/config/test_reader.py
@@ -1,0 +1,42 @@
+import io
+import logging
+import pathlib
+
+from rich.console import Console
+from rich.logging import RichHandler
+
+from flyte._logging import logger
+from flyte.config._reader import read_file_if_exists
+
+
+def test_read_file_if_exists_debug_log_renders_under_rich_markup(tmp_path: pathlib.Path) -> None:
+    """Regression: the debug log embeds the file path inside square brackets. Under
+    rich>=15 the markup parser strictly rejects `[/path]` as a closing tag with no
+    matching opener, raising MarkupError and crashing the caller. The call site
+    must escape the surrounding brackets so the message renders cleanly when a
+    RichHandler with markup=True is installed (matches flyte._logging setup).
+    """
+    buf = io.StringIO()
+    handler = RichHandler(
+        console=Console(file=buf, force_terminal=False, width=400, color_system=None),
+        markup=True,
+        show_time=False,
+        show_path=False,
+        show_level=False,
+    )
+    prior_level = logger.level
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
+    try:
+        target = tmp_path / "secret"
+        target.write_text("dummy")
+
+        # Would raise rich.errors.MarkupError if the path's leading `/` made
+        # the bracketed segment look like a closing tag.
+        assert read_file_if_exists(str(target)) == "dummy"
+
+        output = buf.getvalue()
+        assert f"[{target}]" in output
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(prior_level)


### PR DESCRIPTION
The debug log embedded the file path inside square brackets. Under rich>=15 the markup parser strictly rejects `[/path]` as a closing tag with no matching opener (RichHandler is configured with markup=True in flyte._logging), so any debug-level CLI run that read a config file crashed with MarkupError. Escape the opening `\[` so Rich renders the brackets literally while non-rich handlers stay readable.

Add a regression test that installs a RichHandler against the flyte logger and asserts read_file_if_exists logs cleanly with the brackets preserved in the rendered output.