### PR TITLE
fix: raise actionable error when module file is outside root_dir

### DIFF
--- a/src/flyte/_utils/module_loader.py
+++ b/src/flyte/_utils/module_loader.py
@@ -5,10 +5,33 @@ from pathlib import Path
 from types import ModuleType
 from typing import List, Tuple
 
+import click
+
 import flyte.errors
 from flyte._code_bundle._ignore import GitIgnore, IgnoreGroup, StandardIgnore
 from flyte._constants import FLYTE_SYS_PATH
 from flyte._logging import logger
+
+
+def _relative_to_root(path: Path, root_dir: Path) -> Path:
+    """Resolve ``path`` relative to ``root_dir`` and translate ``ValueError`` into a clear ClickException.
+
+    ``pathlib.Path.relative_to`` raises ``ValueError`` with an unhelpful "is not in the subpath of"
+    message when a user runs ``flyte deploy`` against a file that lives outside of the configured
+    project root (commonly: a src-layout project where the file is under ``src/`` but the root was
+    inferred as the project itself, or vice versa). Surfacing this as a ``click.ClickException``
+    gives the user an actionable message and short-circuits Sentry's user-error filter.
+    """
+    try:
+        return path.resolve().relative_to(root_dir)
+    except ValueError as e:
+        raise click.ClickException(
+            f"Cannot load '{path}' because it is not inside the project root '{root_dir}'.\n"
+            "This usually happens when running `flyte deploy` from outside your source root, "
+            "or when your project uses a src/ layout but --root-dir was not set.\n"
+            "Try passing --root-dir <your source root> (e.g. --root-dir src) so the file lives "
+            "underneath it."
+        ) from e
 
 
 def load_python_modules(
@@ -28,7 +51,7 @@ def load_python_modules(
     failed_paths = []
 
     if path.is_file() and path.suffix == ".py":
-        rel_path = path.resolve().relative_to(root_dir)
+        rel_path = _relative_to_root(path, root_dir)
         mod = (".".join(rel_path.parts))[:-3]
         imported_module = importlib.import_module(mod)
         loaded_modules.append(imported_module)

--- a/tests/flyte/utils/test_module_loader.py
+++ b/tests/flyte/utils/test_module_loader.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import click
 import pytest
 
 from flyte._utils.module_loader import load_python_modules
@@ -119,3 +120,29 @@ def test_load_python_modules_skips_venv_with_relative_paths(temp_project):
     finally:
         os.chdir(old_cwd)
         sys.path.remove(str(temp_project))
+
+
+def test_load_python_modules_file_outside_root_raises_click_exception(tmp_path):
+    """When a single .py file is loaded but lives outside the configured root_dir, surface a
+    click.ClickException with an actionable message instead of letting pathlib's
+    ``ValueError: '...' is not in the subpath of '...'`` bubble up to Sentry as an SDK crash.
+
+    Reproduces FLYTE-SDK-2T: user ran `flyte deploy` on a file under
+    ``examples/basics/multi_status.py`` while the SDK had detected the root as
+    ``flyte-sdk/src``, so ``Path.resolve().relative_to(root)`` blew up.
+    """
+    root_dir = tmp_path / "src"
+    root_dir.mkdir()
+    outside_dir = tmp_path / "examples"
+    outside_dir.mkdir()
+    outside_file = outside_dir / "workflow.py"
+    outside_file.write_text("x = 1\n")
+
+    with pytest.raises(click.ClickException) as excinfo:
+        load_python_modules(outside_file, root_dir=root_dir, recursive=False)
+
+    msg = excinfo.value.message
+    assert "not inside the project root" in msg
+    assert "--root-dir" in msg
+    assert str(outside_file) in msg
+    assert str(root_dir) in msg


### PR DESCRIPTION
## Summary
- `load_python_modules` derives the dotted module name from a `.py` file path via `Path.resolve().relative_to(root_dir)`. If the user runs `flyte deploy path/to/file.py` on a file that lives **outside** the configured project root (commonly: src-layout projects where the SDK inferred `src/` but the file is elsewhere in the project), `pathlib` raises `ValueError: '...' is not in the subpath of '...'` and the raw stack lands in Sentry as an unhandled SDK crash.
- Wrap the `relative_to` call in a `_relative_to_root` helper that translates the `ValueError` into a `click.ClickException`. The user gets an actionable message pointing at the most common cause (forgot `--root-dir`), and the exception short-circuits the Sentry filter for click errors so we stop logging this as an SDK crash.

## Sentry issues
Fixes [FLYTE-SDK-2T](https://unionai.sentry.io/issues/7481668541/) (`ValueError: '/Users/.../examples/basics/multi_status.py' is not in the subpath of '/Users/.../flyte-sdk/src'`)

## Test plan
- [x] New regression test `test_load_python_modules_file_outside_root_raises_click_exception` reproduces the Sentry crash shape and asserts a `click.ClickException` with the actionable message is raised
- [x] Existing `tests/flyte/utils/test_module_loader.py` suite still passes
- [x] `make fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)