### PR TITLE
fix: show distinct sys.modules keys in duplicate-env error message

### DIFF
--- a/src/flyte/_deploy.py
+++ b/src/flyte/_deploy.py
@@ -533,23 +533,31 @@ async def apply(deployment_plan: DeploymentPlan, copy_style: CopyFiles, dryrun: 
 
 
 def _find_env_module(env: Environment):
-    """Scan sys.modules to find the module that contains this env as a top-level variable."""
-    for module in list(sys.modules.values()):
+    """Scan sys.modules to find the (sys.modules key, module) that contains this env as a top-level variable.
+
+    Iterates ``sys.modules.items()`` rather than ``.values()`` so callers can show the *import
+    name* (the sys.modules key, e.g. ``examples.basics.multi_status``) in error messages. When the
+    same file is loaded twice under different names, the two module objects may share the same
+    ``__name__`` attribute (because both were created via ``importlib.util.spec_from_file_location``
+    with the file stem), but their sys.modules keys differ — that's what the user actually needs to
+    see to fix their layout. Returns ``(None, None)`` if nothing matches.
+    """
+    for key, module in list(sys.modules.items()):
         if module is None:
             continue
         try:
             # search for at least one value inside this module that is the same object as env and return it
             if any(v is env for v in vars(module).values()):
-                return module
+                return key, module
         except TypeError:
             continue
-    return None
+    return None, None
 
 
 def _check_duplicate_env(existing_env: Environment, env: Environment) -> None:
     """Raise an appropriate error when the same environment name is encountered twice."""
-    existing_module = _find_env_module(existing_env)
-    new_module = _find_env_module(env)
+    existing_key, existing_module = _find_env_module(existing_env)
+    new_key, new_module = _find_env_module(env)
     existing_file = getattr(existing_module, "__file__", None)
     new_file = getattr(new_module, "__file__", None)
 
@@ -559,8 +567,8 @@ def _check_duplicate_env(existing_env: Environment, env: Environment) -> None:
         # `my_module.envs` and `src.my_module.envs`).
         raise ValueError(
             f"Environment '{env.name}' is defined in '{existing_file}' but was imported "
-            f"twice under different module names ('{existing_module.__name__}' and "
-            f"'{new_module.__name__}'). This is usually caused by running `flyte deploy` "
+            f"twice under different module names ('{existing_key}' and "
+            f"'{new_key}'). This is usually caused by running `flyte deploy` "
             f"from the project root of a src/ layout project without --root-dir. "
             f"Try adding --root-dir src (or your source root directory)."
         )

--- a/tests/flyte/test_deploy.py
+++ b/tests/flyte/test_deploy.py
@@ -279,6 +279,43 @@ def test_recursive_discover_dual_import_raises(dual_import_envs):
         _recursive_discover({"my_env": env1}, env2)
 
 
+def test_check_duplicate_env_dual_import_shows_distinct_sys_modules_keys():
+    """When both module objects share the same ``__name__`` (e.g. both were created via
+    ``importlib.util.spec_from_file_location`` with the file stem), the error message must still
+    show the *sys.modules keys*, which are the distinguishing import paths the user can act on.
+
+    Reproduces FLYTE-SDK-2S: the error message showed
+    ``imported twice under different module names ('multi_status' and 'multi_status')`` —
+    identical names — because the code was reading ``module.__name__`` instead of the
+    sys.modules dict key.
+    """
+    env1 = flyte.TaskEnvironment(name="multi_status_demo", image="python:3.10")
+    env2 = flyte.TaskEnvironment(name="multi_status_demo", image="python:3.10")
+
+    # Both module objects intentionally have ``__name__ == "multi_status"`` (the file stem).
+    # Their sys.modules keys are different — that's what the error should show.
+    mod1 = _make_module("multi_status", "/project/examples/basics/multi_status.py", env1)
+    mod2 = _make_module("multi_status", "/project/examples/basics/multi_status.py", env2)
+
+    modules = {
+        "multi_status": mod1,
+        "examples.basics.multi_status": mod2,
+    }
+
+    with (
+        patch.dict(sys.modules, modules),
+        patch("flyte._deploy.os.path.samefile", return_value=True),
+        pytest.raises(ValueError) as excinfo,
+    ):
+        _check_duplicate_env(env1, env2)
+
+    msg = str(excinfo.value)
+    assert "'multi_status'" in msg
+    assert "'examples.basics.multi_status'" in msg
+    # Guardrail against the regression: the two displayed import names must differ.
+    assert "('multi_status' and 'multi_status')" not in msg
+
+
 # ---------------------------------------------------------------------------
 # _build_image_bg and _build_images tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- When the same file gets loaded twice under different import paths (the classic src/ layout dual-import scenario), `_check_duplicate_env` told the user the env was *"imported twice under different module names ('multi_status' and 'multi_status')"* — the two displayed names were identical, defeating the entire purpose of the message.
- Root cause: `_find_env_module` returned the module object, and the error formatter read `module.__name__`. But when the SDK's path-based loader creates a module via `importlib.util.spec_from_file_location(file_path.stem, ...)`, both module objects end up with the *same* `__name__` (the file stem), even though they sit at different `sys.modules` keys.
- Switch `_find_env_module` to iterate `sys.modules.items()` and return the `(key, module)` tuple. The error message now uses the sys.modules keys — the distinguishing import paths the user can actually act on.

## Sentry issues
Fixes [FLYTE-SDK-2S](https://unionai.sentry.io/issues/7481668212/) (`ValueError: Environment 'multi_status_demo' ... imported twice under different module names ('multi_status' and 'multi_status')`)

## Test plan
- [x] New regression test `test_check_duplicate_env_dual_import_shows_distinct_sys_modules_keys` constructs two modules that intentionally share `__name__` but sit at different sys.modules keys (the exact shape from the Sentry crash) and asserts the error message shows both distinct keys
- [x] All existing `_check_duplicate_env` / dual-import tests still pass
- [x] `make fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)