### PR TITLE
fix: surface missing src path as ImageBuildError in copy_files_to_context

### DIFF
--- a/src/flyte/_internal/imagebuild/utils.py
+++ b/src/flyte/_internal/imagebuild/utils.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 from flyte._code_bundle._ignore import STANDARD_IGNORE_PATTERNS
 from flyte._image import DockerIgnore, Image
 from flyte._logging import logger
+from flyte.errors import ImageBuildError
 
 
 def copy_files_to_context(src: Path, context_path: Path, ignore_patterns: list[str] = STANDARD_IGNORE_PATTERNS) -> Path:
@@ -27,6 +28,18 @@ def copy_files_to_context(src: Path, context_path: Path, ignore_patterns: list[s
     :param ignore_patterns: A list of ignore patterns to apply when copying files. This is used to filter out files
         that should not be included in the Docker build context, such as those specified in a .dockerignore file.
     """
+    # Surface a user-actionable error if the user pointed an image layer at a path that doesn't
+    # exist on disk. Without this guard, ``shutil.copy`` raises ``FileNotFoundError`` from deep in
+    # the stack and the raw traceback ends up in Sentry as an unhandled SDK crash (see
+    # FLYTE-SDK-2X).
+    if not src.exists():
+        raise ImageBuildError(
+            f"Cannot copy '{src}' into the image build context: the path does not exist on disk. "
+            "Check that the file/directory you passed to your image layer "
+            "(e.g. with_requirements, with_source_folder, with_pyproject) is correct and "
+            "reachable from where you are running `flyte deploy`."
+        )
+
     if src.is_absolute() or ".." in str(src):
         rel_path = PurePath(*src.parts[1:])
         dst_path = context_path / "_flyte_abs_context" / rel_path
@@ -46,9 +59,18 @@ def copy_files_to_context(src: Path, context_path: Path, ignore_patterns: list[s
             # Create parent directory if needed
             dst_file.parent.mkdir(parents=True, exist_ok=True)
 
-            # Copy file (not directory)
+            # Copy file (not directory). Skip any entries that disappeared between
+            # ``pm.walk`` enumerating them and the copy (e.g. broken symlinks, transient venv
+            # files, or files removed mid-build) — surface a warning rather than aborting the
+            # entire image build.
             if src_file.is_file():
-                shutil.copy2(src_file, dst_file)
+                try:
+                    shutil.copy2(src_file, dst_file)
+                except FileNotFoundError:
+                    logger.warning(
+                        f"Skipping '{src_file}' while building image context: file disappeared "
+                        "between enumeration and copy."
+                    )
 
     else:
         # Single file

--- a/tests/flyte/imagebuild/test_utils.py
+++ b/tests/flyte/imagebuild/test_utils.py
@@ -199,3 +199,60 @@ def test_copy_files_to_context_basic():
 
         # --- .git/ should NOT be copied ---
         assert not (dst / ".git").exists(), ".git directory should be ignored"
+
+
+def test_copy_files_to_context_missing_src_raises_image_build_error():
+    """When the user points an image layer at a path that doesn't exist on disk,
+    ``copy_files_to_context`` should surface an actionable ``ImageBuildError`` instead of letting
+    ``shutil.copy``'s raw ``FileNotFoundError`` bubble up to Sentry.
+
+    Reproduces FLYTE-SDK-2X: user's image build crashed with
+    ``FileNotFoundError: [Errno 2] No such file or directory: '/Users/.../flyte-sdk/.venv/lib/python3.13/dist'``
+    from ``shutil.py:copyfile`` inside ``copy_files_to_context``.
+    """
+    import pytest
+
+    from flyte.errors import ImageBuildError
+
+    with tempfile.TemporaryDirectory() as tmp_context:
+        context_path = Path(tmp_context)
+        missing = context_path / "does_not_exist.txt"
+
+        with pytest.raises(ImageBuildError) as excinfo:
+            copy_files_to_context(missing, context_path)
+
+        msg = str(excinfo.value)
+        assert "does not exist" in msg
+        assert str(missing) in msg
+
+
+def test_copy_files_to_context_skips_files_that_vanish_mid_walk():
+    """If a file listed by the directory walker disappears before ``shutil.copy2`` runs (e.g. a
+    transient venv entry or a broken symlink), the build should warn and keep going rather than
+    aborting with ``FileNotFoundError``.
+    """
+    with tempfile.TemporaryDirectory() as src_root, tempfile.TemporaryDirectory() as ctx_root:
+        src = Path(src_root)
+        keep = src / "keep.txt"
+        keep.write_text("kept\n")
+        vanishing = src / "vanishing.txt"
+        vanishing.write_text("temp\n")
+
+        real_copy2 = shutil.copy2
+
+        def fragile_copy2(s, d, *args, **kwargs):
+            # Simulate the file disappearing between enumeration and copy.
+            if Path(s).name == "vanishing.txt":
+                raise FileNotFoundError(2, "No such file or directory", str(s))
+            return real_copy2(s, d, *args, **kwargs)
+
+        import shutil as _shutil_mod
+
+        with patch.object(_shutil_mod, "copy2", side_effect=fragile_copy2):
+            # Should not raise — vanishing file is logged and skipped, kept file is copied.
+            dst = copy_files_to_context(src, Path(ctx_root))
+
+        assert (dst / "keep.txt").exists()
+
+
+import shutil  # noqa: E402  (kept at bottom so the new tests own the import)


### PR DESCRIPTION
## Summary
- `copy_files_to_context` is called for every image layer that needs a file or directory inside the Docker build context (requirements files, pyproject/uv.lock, source folders, etc.). It used to delegate the existence check to `shutil.copy` / `shutil.copy2` and let `FileNotFoundError` bubble all the way up. When the user pointed a layer at a path that didn't exist, the raw traceback ended up in Sentry as an unhandled SDK crash even though it's purely a configuration mistake on the user side.

Two changes:
1. Guard the entrypoint with `src.exists()` and raise `ImageBuildError` with an actionable message naming the missing path and the most likely culprits (`with_requirements`, `with_source_folder`, `with_pyproject`). `ImageBuildError` is already filtered from Sentry via `_is_user_error` (#1052), so we stop logging this as an SDK crash.
2. Inside the directory branch, defensively catch `FileNotFoundError` from `shutil.copy2` so that a file that disappears between enumeration (`pm.walk`) and the copy (e.g. a transient venv entry, a broken symlink, or a file removed mid-build) only generates a warning rather than aborting the entire image build.

## Sentry issues
Fixes [FLYTE-SDK-2X](https://unionai.sentry.io/issues/7481752765/) (`FileNotFoundError: [Errno 2] No such file or directory: '/Users/.../flyte-sdk/.venv/lib/python3.13/dist'` from `shutil.copyfile` inside `copy_files_to_context`)

## Test plan
- [x] New regression test `test_copy_files_to_context_missing_src_raises_image_build_error` covers the missing-src branch
- [x] New regression test `test_copy_files_to_context_skips_files_that_vanish_mid_walk` covers the vanish-mid-walk branch
- [x] Existing `tests/flyte/imagebuild/test_utils.py` suite still passes
- [x] `make fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)