### PR TITLE
fix(genai): gate Flyte blob streaming on model_path for vLLM and SGLang apps

### DIFF
--- a/plugins/sglang/src/flyteplugins/sglang/_app_environment.py
+++ b/plugins/sglang/src/flyteplugins/sglang/_app_environment.py
@@ -62,9 +62,10 @@ class SGLangAppEnvironment(flyte.app.AppEnvironment):
     :param model_path: Remote path to model (e.g., s3://bucket/path/to/model).
     :param model_hf_path: Hugging Face path to model (e.g., Qwen/Qwen3-0.6B).
     :param model_id: Model id that is exposed by SGLang.
-    :param stream_model: Set to True to stream model from blob store to the GPU directly.
-        If False, the model will be downloaded to the local file system first and then loaded
-        into the GPU.
+    :param stream_model: When ``model_path`` is set, use True to stream weights from object
+        storage to the GPU (Flyte loader integration). Ignored for ``model_hf_path``-only apps,
+        which use SGLang's normal Hugging Face download path. If False with ``model_path``,
+        the model is downloaded to the local filesystem first, then loaded.
     """
 
     port: int | Port = 8080
@@ -123,8 +124,12 @@ class SGLangAppEnvironment(flyte.app.AppEnvironment):
         if self.parameters:
             raise ValueError("parameters cannot be set for SGLangAppEnvironment")
 
-        input_kwargs = {}
-        if self.stream_model:
+        # Flyte blob streaming requires ``model_path`` (remote / RunOutput). HF-only apps use
+        # SGLang's default loading regardless of ``stream_model``.
+        use_flyte_blob_streaming = bool(self.stream_model and self.model_path)
+
+        input_kwargs: dict[str, Any] = {}
+        if use_flyte_blob_streaming:
             self.env_vars["FLYTE_MODEL_LOADER_STREAM_SAFETENSORS"] = "true"
             input_kwargs["env_var"] = "FLYTE_MODEL_LOADER_REMOTE_MODEL_PATH"
             input_kwargs["download"] = False

--- a/plugins/sglang/tests/test_app_environment.py
+++ b/plugins/sglang/tests/test_app_environment.py
@@ -40,7 +40,10 @@ def test_basic_init_with_model_hf_path():
     assert app.model_id == "test-model"
     assert app.port.port == 8080
     assert app.type == "SGLang"
+    assert app.stream_model is True
     assert app.image == DEFAULT_SGLANG_IMAGE
+    # Hugging Face path: no Flyte blob streaming without model_path (matches sglang-fserve guards).
+    assert app.env_vars["FLYTE_MODEL_LOADER_STREAM_SAFETENSORS"] == "false"
     # When using model_hf_path, no parameters should be created
     assert app.parameters == []
     # The model mount path should be set to the HF path
@@ -181,6 +184,9 @@ def test_model_hf_path_no_inputs():
 
     # No parameters should be created for HF path
     assert app.parameters == []
+
+    # Streaming env off when there is no remote model_path
+    assert app.env_vars["FLYTE_MODEL_LOADER_STREAM_SAFETENSORS"] == "false"
 
     # Mount path should be set to the HF path
     assert app.env_vars["FLYTE_MODEL_LOADER_LOCAL_MODEL_PATH"] == "meta-llama/Llama-2-7b"

--- a/plugins/vllm/src/flyteplugins/vllm/_app_environment.py
+++ b/plugins/vllm/src/flyteplugins/vllm/_app_environment.py
@@ -51,9 +51,10 @@ class VLLMAppEnvironment(flyte.app.AppEnvironment):
     :param model_path: Remote path to model (e.g., s3://bucket/path/to/model).
     :param model_hf_path: Hugging Face path to model (e.g., Qwen/Qwen3-0.6B).
     :param model_id: Model id that is exposed by vllm.
-    :param stream_model: Set to True to stream model from blob store to the GPU directly.
-        If False, the model will be downloaded to the local file system first and then loaded
-        into the GPU.
+    :param stream_model: When ``model_path`` is set, use True to stream weights from object
+        storage to the GPU (Flyte custom loader). Ignored for ``model_hf_path``-only apps,
+        which always use vLLM's normal Hugging Face download path. If False with ``model_path``,
+        the model is downloaded to the local filesystem first, then loaded.
     """
 
     port: int | Port = 8080
@@ -98,8 +99,12 @@ class VLLMAppEnvironment(flyte.app.AppEnvironment):
         else:
             extra_args = self.extra_args
 
-        stream_model_args = []
-        if self.stream_model:
+        # Flyte streaming requires a remote ``model_path`` (and the model-loader env). HF-only
+        # apps must use vLLM's default loaders regardless of ``stream_model``.
+        use_flyte_blob_streaming = bool(self.stream_model and self.model_path)
+
+        stream_model_args: list[str] = []
+        if use_flyte_blob_streaming:
             stream_model_args.extend(["--load-format", "flyte-vllm-streaming"])
 
         self.args = [
@@ -117,8 +122,8 @@ class VLLMAppEnvironment(flyte.app.AppEnvironment):
         if self.parameters:
             raise ValueError("parameters cannot be set for VLLMAppEnvironment")
 
-        input_kwargs = {}
-        if self.stream_model:
+        input_kwargs: dict[str, Any] = {}
+        if use_flyte_blob_streaming:
             self.env_vars["FLYTE_MODEL_LOADER_STREAM_SAFETENSORS"] = "true"
             input_kwargs["env_var"] = "FLYTE_MODEL_LOADER_REMOTE_MODEL_PATH"
             input_kwargs["download"] = False

--- a/plugins/vllm/src/flyteplugins/vllm/_model_loader/shim.py
+++ b/plugins/vllm/src/flyteplugins/vllm/_model_loader/shim.py
@@ -38,7 +38,6 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-@register_model_loader("flyte-vllm-streaming")
 class FlyteModelLoader(DefaultModelLoader):
     """Custom model loader for streaming model weights from object storage."""
 
@@ -115,6 +114,10 @@ class FlyteModelLoader(DefaultModelLoader):
             return super().load_model(vllm_config, model_config)
 
 
+if REMOTE_MODEL_PATH and STREAM_SAFETENSORS:
+    register_model_loader("flyte-vllm-streaming")(FlyteModelLoader)
+
+
 async def _get_model_files():
     import flyte.storage as storage
 
@@ -137,7 +140,12 @@ def main():
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
 
-    # Prefetch the model
-    asyncio.run(_get_model_files())
+    logger.info("REMOTE_MODEL_PATH: %s", REMOTE_MODEL_PATH)
+    logger.info("LOCAL_MODEL_PATH: %s", LOCAL_MODEL_PATH)
+    logger.info("STREAM_SAFETENSORS: %s", STREAM_SAFETENSORS)
+
+    if REMOTE_MODEL_PATH:
+        logger.info("Prefetching model files from object storage...")
+        asyncio.run(_get_model_files())
 
     vllm.entrypoints.cli.main.main()

--- a/plugins/vllm/tests/test_app_environment.py
+++ b/plugins/vllm/tests/test_app_environment.py
@@ -40,7 +40,11 @@ def test_basic_init_with_model_hf_path():
     assert app.model_id == "test-model"
     assert app.port.port == 8080
     assert app.type == "vLLM"
+    assert app.stream_model is True
     assert app.image == DEFAULT_VLLM_IMAGE
+    # Hugging Face path uses vLLM's default loading (no Flyte blob streaming without model_path).
+    assert "--load-format" not in app.args
+    assert app.env_vars["FLYTE_MODEL_LOADER_STREAM_SAFETENSORS"] == "false"
     # When using model_hf_path, no parameters should be created
     assert app.parameters == []
     # The model mount path should be set to the HF path


### PR DESCRIPTION
This pull request refines the model loading logic and documentation for both SGLang and vLLM plugin environments, clarifying how streaming from object storage is handled when using remote model paths versus Hugging Face paths. It ensures that Flyte blob streaming is only enabled when a remote model path is provided, and updates tests to verify this behavior. Additionally, it improves logging and the registration logic for the vLLM custom model loader.

**Model loading and streaming logic improvements:**

* Updated the `stream_model` parameter documentation and logic in both `SGLangAppEnvironment` and `VLLMAppEnvironment` to clarify that Flyte blob streaming is only enabled when a remote `model_path` is provided, and is ignored for Hugging Face-only paths.
* Changed the internal logic to set streaming-related environment variables and arguments only when both `stream_model` is True and `model_path` is set, preventing accidental streaming activation for Hugging Face-only models. 

**Testing improvements:**

* Enhanced tests for both plugins to assert that streaming is disabled (`FLYTE_MODEL_LOADER_STREAM_SAFETENSORS == "false"`) when only a Hugging Face path is used, and that no streaming-specific arguments are present in such cases. 

**vLLM custom loader registration and logging:**

* Changed the registration of the `FlyteModelLoader` to occur only if both `REMOTE_MODEL_PATH` and `STREAM_SAFETENSORS` are set, preventing unnecessary loader registration.
* Improved logging in the vLLM loader shim to provide visibility into environment variable values and prefetching behavior.