### PR TITLE
fix: include underlying cause in upload signed-url error message

### DIFF
--- a/src/flyte/remote/_data.py
+++ b/src/flyte/remote/_data.py
@@ -185,7 +185,7 @@ async def _upload_single_file(
         else:
             raise RuntimeSystemError(e.code.value, f"Failed to get signed url for {fp}: {e.message}")
     except Exception as e:
-        raise RuntimeSystemError(type(e).__name__, f"Failed to get signed url for {fp}.") from e
+        raise RuntimeSystemError(type(e).__name__, f"Failed to get signed url for {fp}: {e}") from e
     logger.debug(f"Uploading to [link={resp.signed_url}]signed url[/link] for [link=file://{fp}]{fp}[/link]")
     extra_headers = get_extra_headers_for_protocol(resp.native_url)
     extra_headers.update(resp.headers)

--- a/tests/flyte/remote/test_data_errors.py
+++ b/tests/flyte/remote/test_data_errors.py
@@ -51,3 +51,32 @@ async def test_upload_connect_error_translation(code, expected_error, expected_c
 
         if expected_code:
             assert exc_info.value.code == expected_code
+
+
+@pytest.mark.asyncio
+async def test_upload_generic_exception_includes_cause_message(tmp_path):
+    """Non-ConnectError exceptions surface the underlying cause's message to the user.
+
+    Regression test for FLYTE-SDK-2H: the prior wrapper dropped the cause message,
+    leaving users with only "Failed to get signed url for ..." and no hint that the
+    real problem was e.g. missing 'org' config rejected by server validation.
+    """
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("hello")
+
+    cfg = _make_cfg()
+    underlying = RuntimeError(
+        "SelectCluster failed for operation=1: validation error:\n"
+        " - project_id.organization: value length must be at least 1 characters [string.min_len]"
+    )
+    mock_client = _make_mock_client(underlying)
+
+    with (
+        patch("flyte._initialize._get_init_config", return_value=cfg),
+        patch("flyte.remote._data.get_client", return_value=mock_client),
+    ):
+        with pytest.raises(RuntimeSystemError) as exc_info:
+            await _upload_single_file(cfg, test_file, basedir="")
+
+        assert "project_id.organization" in str(exc_info.value)
+        assert exc_info.value.__cause__ is underlying


### PR DESCRIPTION
## Summary

`_upload_single_file`'s generic `except Exception` branch wrapped the underlying error with a static message — `f"Failed to get signed url for {fp}."` — and dropped the cause's text. The chained `__cause__` was still attached, but the surfaced message gave users zero hint about what actually went wrong.

For [FLYTE-SDK-2H](https://unionai.sentry.io/issues/7477614204/), the chained cause is:

```
RuntimeError: SelectCluster failed for operation=1: validation error:
 - project_id.organization: value length must be at least 1 characters [string.min_len]
```

i.e. the user's `org` config is empty and the server rejects it. With this PR, the user sees that text instead of a vague "Failed to get signed url" with no actionable info.

This is a one-line change to `src/flyte/remote/_data.py`:

```diff
-        raise RuntimeSystemError(type(e).__name__, f"Failed to get signed url for {fp}.") from e
+        raise RuntimeSystemError(type(e).__name__, f"Failed to get signed url for {fp}: {e}") from e
```

The typed `ConnectError` branches above (`NOT_FOUND` / `PERMISSION_DENIED` / `UNAVAILABLE` / generic) already include `{e.message}`, so this just brings the catch-all branch in line.

## Sentry issues

- [FLYTE-SDK-2H](https://unionai.sentry.io/issues/7477614204/) — primary target. Cause: server-side `project_id.organization` validation failure (empty org).

Fixes FLYTE-SDK-2H

## Test plan

- [x] New regression test in `tests/flyte/remote/test_data_errors.py` covering the empty-org RuntimeError shape from FLYTE-SDK-2H, asserting the surfaced message includes the underlying validation text and `__cause__` is preserved.
- [x] Existing parametrized `ConnectError` tests still pass.
- [x] `make fmt` clean.
- [x] Commit signed (`-s`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)