### PR TITLE
fix(controller): guard against None responses in informer watch loop

### DIFF
--- a/src/flyte/_internal/controllers/remote/_core.py
+++ b/src/flyte/_internal/controllers/remote/_core.py
@@ -335,9 +335,23 @@ class Controller:
             )
 
         logger.debug(f"{threading.current_thread().name} Waiting for completion of {action.name}")
-        # Wait for completion
+        # Wait for completion.  For trace actions apply a timeout so a
+        # transient watch failure (e.g. gRPC deserialization returning None)
+        # doesn't block the caller indefinitely.  Task actions may legitimately
+        # run for hours, so they wait without a timeout.
         wait_start = time.monotonic()
-        await informer.wait_for_action_completion(action.name)
+        if action.type == "trace":
+            _trace_timeout = float(os.getenv("_F_TRACE_COMPLETION_TIMEOUT", "60"))
+            try:
+                await asyncio.wait_for(informer.wait_for_action_completion(action.name), timeout=_trace_timeout)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    f"{threading.current_thread().name} Trace completion wait timed out after {_trace_timeout}s "
+                    f"for {action.name}, continuing anyway"
+                )
+                await informer.fire_completion_event(action.name)
+        else:
+            await informer.wait_for_action_completion(action.name)
         if trace_enabled:
             self._trace_log(
                 action.name,
@@ -350,7 +364,8 @@ class Controller:
         # Get final resource state and clean up
         final_resource = await informer.get(action.name)
         if final_resource is None:
-            raise ValueError(f"Action {action.name} not found")
+            logger.warning(f"Action {action.name} not found in cache after completion, returning action stub")
+            return action
         logger.debug(f"{threading.current_thread().name} Removed completion event for action {action.name}")
         await informer.remove(action.name)  # TODO we should not remove maybe, we should keep a record of completed?
         logger.debug(f"{threading.current_thread().name} Removed action {action.name}")

--- a/src/flyte/_internal/controllers/remote/_informer.py
+++ b/src/flyte/_internal/controllers/remote/_informer.py
@@ -255,6 +255,14 @@ class Informer:
                     )
                 async for resp in watcher:
                     retries = 0
+                    if resp is None:
+                        # gRPC deserialization failure: _transform() caught an
+                        # exception and returned None instead of raising.  Skip
+                        # the message so the watch loop stays alive and can
+                        # receive subsequent updates rather than crashing into
+                        # the retry/backoff path.
+                        logger.warning(f"Received None (deserialization failure) from watcher {self.name}, skipping")
+                        continue
                     if resp.control_message is not None and resp.control_message.sentinel:
                         logger.info(f"Received Sentinel, for run {self.name}")
                         await self._set_ready()


### PR DESCRIPTION
When gRPC deserialization fails, grpc._common._transform() logs the exception and returns None instead of raising.  In the informer's watch loop this caused an AttributeError on resp.control_message, which crashed the loop and triggered a retry/backoff cycle.  During that backoff window the trace-action completion event was never received, so wait_for_action_completion() blocked forever.

Two fixes:
1. _informer.py: skip None responses with a warning so the stream stays alive and can receive the real completion update on the next message.
2. _core.py: add a 60-second timeout on wait_for_action_completion() for trace actions only (task actions may run for hours).  On timeout we fire the completion event ourselves so the caller is unblocked even if the server update was genuinely missed.  The timeout is configurable via _F_TRACE_COMPLETION_TIMEOUT.