### PR TITLE
fix: raise InitializationError for missing project/domain

### DIFF
--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -744,17 +744,21 @@ def require_project_and_domain(func):
     def wrapper(*args, **kwargs):
         cfg = get_init_config()
         if cfg.project is None:
-            raise ValueError(
+            raise InitializationError(
+                "ProjectNotConfigured",
+                "user",
                 "Project must be provided to initialize the client. "
                 "Please set 'project' in the 'task' section of your config file, "
-                "or pass it directly to flyte.init(project='your-project-name')."
+                "or pass it directly to flyte.init(project='your-project-name').",
             )
 
         if cfg.domain is None:
-            raise ValueError(
+            raise InitializationError(
+                "DomainNotConfigured",
+                "user",
                 "Domain must be provided to initialize the client. "
                 "Please set 'domain' in the 'task' section of your config file, "
-                "or pass it directly to flyte.init(domain='your-domain-name')."
+                "or pass it directly to flyte.init(domain='your-domain-name').",
             )
 
         return func(*args, **kwargs)

--- a/tests/user_api/test_initialize.py
+++ b/tests/user_api/test_initialize.py
@@ -17,6 +17,7 @@ from flyte._initialize import (
     init_in_cluster,
     is_initialized,
     replace_client,
+    require_project_and_domain,
     requires_initialization,
     requires_storage,
 )
@@ -526,6 +527,42 @@ class TestDecorators:
             test_func()
 
         assert "test_func" in str(exc_info.value)
+
+    def test_require_project_and_domain_raises_initialization_error_when_project_missing(self):
+        """Missing project must raise InitializationError, not ValueError.
+
+        InitializationError is filtered from Sentry as a user-facing error; a raw
+        ValueError leaks into Sentry as an unhandled SDK crash (FLYTE-SDK-35).
+        """
+        test_config = _InitConfig(root_dir=Path("/test"), project=None, domain="dev")
+        init_module._init_config = test_config
+
+        @require_project_and_domain
+        def test_func():
+            return "success"
+
+        with pytest.raises(InitializationError) as exc_info:
+            test_func()
+
+        assert "Project must be provided" in str(exc_info.value)
+        assert exc_info.value.code == "ProjectNotConfigured"
+        assert exc_info.value.kind == "user"
+
+    def test_require_project_and_domain_raises_initialization_error_when_domain_missing(self):
+        """Missing domain must raise InitializationError, not ValueError."""
+        test_config = _InitConfig(root_dir=Path("/test"), project="my-project", domain=None)
+        init_module._init_config = test_config
+
+        @require_project_and_domain
+        def test_func():
+            return "success"
+
+        with pytest.raises(InitializationError) as exc_info:
+            test_func()
+
+        assert "Domain must be provided" in str(exc_info.value)
+        assert exc_info.value.code == "DomainNotConfigured"
+        assert exc_info.value.kind == "user"
 
 
 class TestInitFunction:


### PR DESCRIPTION
## Summary

`require_project_and_domain` raised a plain `ValueError` when `cfg.project` or `cfg.domain` was unset. The error message itself is already actionable (`"Project must be provided to initialize the client. Please set 'project' in the 'task' section of your config file, or pass it directly to flyte.init(project='your-project-name')."`), but `ValueError` is not in `_is_user_error`'s filter set, so every occurrence lands in Sentry as an unhandled SDK crash — purely user-config feedback being logged as if the SDK had bugged out.

Switch both raises to `InitializationError("ProjectNotConfigured" / "DomainNotConfigured", "user", ...)`. `InitializationError` is already filtered from Sentry via `_is_user_error` (#1056), so this stops logging these as crashes while preserving the existing user-facing message verbatim.

## Sentry issues
Fixes [FLYTE-SDK-35](https://unionai.sentry.io/issues/7487859623/) (`ValueError: Project must be provided to initialize the client.`)

## Test plan
- [x] New `test_require_project_and_domain_raises_initialization_error_when_project_missing` regression test
- [x] New `test_require_project_and_domain_raises_initialization_error_when_domain_missing` regression test
- [x] Existing `tests/user_api/test_initialize.py::TestDecorators` suite still passes (6/6)
- [x] `make fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)