### PR TITLE
fix: wrap docker buildx CalledProcessError as ImageBuildError

### DIFF
--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -645,10 +645,18 @@ class DockerImageBuilder(ImageBuilder):
         logger.debug(f"Build command: {concat_command}")
         click.secho(f"Run command: {concat_command} ", fg="blue")
 
-        if wait:
-            await run_sync_with_loop(subprocess.run, command, cwd=str(cast(Path, image.dockerfile).cwd()), check=True)
-        else:
-            await run_sync_with_loop(subprocess.Popen, command, cwd=str(cast(Path, image.dockerfile).cwd()))
+        try:
+            if wait:
+                await run_sync_with_loop(
+                    subprocess.run, command, cwd=str(cast(Path, image.dockerfile).cwd()), check=True
+                )
+            else:
+                await run_sync_with_loop(subprocess.Popen, command, cwd=str(cast(Path, image.dockerfile).cwd()))
+        except subprocess.CalledProcessError as e:
+            from flyte.errors import ImageBuildError
+
+            logger.error(f"Failed to build image from dockerfile: {e}")
+            raise ImageBuildError(f"Failed to build image from {image.dockerfile}: {e}") from e
 
         return image.uri
 
@@ -803,7 +811,9 @@ class DockerImageBuilder(ImageBuilder):
                 else:
                     await run_sync_with_loop(subprocess.Popen, command)
             except subprocess.CalledProcessError as e:
+                from flyte.errors import ImageBuildError
+
                 logger.error(f"Failed to build image: {e}")
-                raise RuntimeError(f"Failed to build image: {e}")
+                raise ImageBuildError(f"Failed to build image: {e}") from e
 
             return image.uri

--- a/tests/flyte/imagebuild/test_docker_builder.py
+++ b/tests/flyte/imagebuild/test_docker_builder.py
@@ -57,6 +57,57 @@ async def test_doesnt_work_yet():
 
 
 @pytest.mark.asyncio
+async def test_build_from_dockerfile_wraps_calledprocesserror_as_image_build_error(tmp_path):
+    """
+    Regression: when `docker buildx build -f Dockerfile` fails (non-zero exit), the raw
+    `subprocess.CalledProcessError` previously bubbled out of `_build_from_dockerfile`
+    and surfaced in Sentry as an unhandled SDK crash (FLYTE-SDK-34). Wrap as
+    `ImageBuildError` so the error is filtered out of Sentry and presented as
+    user-facing image-build feedback.
+    """
+    from flyte.errors import ImageBuildError
+
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text("FROM scratch\n")
+
+    img = Image.from_dockerfile(file=dockerfile, registry="localhost:30000", name="bad_dockerfile")
+    builder = DockerImageBuilder()
+
+    def _raise_called_process(*args, **kwargs):
+        raise subprocess.CalledProcessError(returncode=1, cmd=args[0] if args else ["docker"])
+
+    with patch.object(DockerImageBuilder, "_resolve_builder_name", return_value="flytex"):
+        with patch("flyte._internal.imagebuild.docker_builder.subprocess.run", side_effect=_raise_called_process):
+            with pytest.raises(ImageBuildError, match="Failed to build image from"):
+                await builder._build_from_dockerfile(img, push=False, wait=True)
+
+
+@pytest.mark.asyncio
+async def test_build_image_wraps_calledprocesserror_as_image_build_error(monkeypatch, tmp_path):
+    """
+    Regression: when the generated buildx command fails, `_build_image` previously
+    wrapped the error as a plain `RuntimeError` (FLYTE-SDK-2R). `RuntimeError` is
+    not in the Sentry user-error filter set, so the crash leaked into Sentry as an
+    SDK bug. Wrap as `ImageBuildError` so it is filtered.
+    """
+    from flyte.errors import ImageBuildError
+
+    img = Image.from_debian_base(registry="localhost:30000", name="img_build_fails")
+    builder = DockerImageBuilder()
+
+    def _raise_called_process(*args, **kwargs):
+        raise subprocess.CalledProcessError(returncode=1, cmd=args[0] if args else ["docker"])
+
+    # Patch the subprocess.run used inside _build_image's try-block. _ensure_buildx_builder
+    # is also called via _resolve_builder_name, so stub it out so we don't trip its own
+    # subprocess.run patching with a CalledProcessError.
+    with patch.object(DockerImageBuilder, "_resolve_builder_name", return_value="flytex"):
+        with patch("flyte._internal.imagebuild.docker_builder.subprocess.run", side_effect=_raise_called_process):
+            with pytest.raises(ImageBuildError, match="Failed to build image"):
+                await builder._build_image(img, push=False, wait=True)
+
+
+@pytest.mark.asyncio
 async def test_ensure_buildx_builder_raises_image_build_error_when_docker_missing(monkeypatch):
     """
     Regression: when docker is not installed/in PATH, `subprocess.run(["docker", ...])`


### PR DESCRIPTION
## Summary

Two related fixes in `flyte/_internal/imagebuild/docker_builder.py`:

1. **`_build_from_dockerfile`** had no try/except around `subprocess.run(..., check=True)`, so a non-zero `docker buildx build -f Dockerfile` exit propagated the raw `subprocess.CalledProcessError` straight up to the caller — and into Sentry as an unhandled SDK crash.
2. **`_build_image`** already wrapped the same case, but raised a plain `RuntimeError("Failed to build image: ...")`. `RuntimeError` is not in `_is_user_error`'s filter set, so even though docker rejecting the user's Dockerfile/context is purely user-facing feedback, each occurrence landed in Sentry as a crash.

Both call sites now wrap the failure as `ImageBuildError`, which is already filtered from Sentry via `_is_user_error` (#1052). The chained `CalledProcessError` is preserved via `raise ... from e` so the diagnostic information remains available.

## Sentry issues
- Fixes [FLYTE-SDK-34](https://unionai.sentry.io/issues/7487857254/) (`CalledProcessError: Command '['docker', 'buildx', 'build', '-f', ...]' returned non-zero exit status 1.`) — escaped from `_build_from_dockerfile`
- Fixes [FLYTE-SDK-2R](https://unionai.sentry.io/issues/7481358912/) (`RuntimeError: Failed to build image: Command '['docker', 'buildx', 'build', '--tag', ...]' returned non-zero exit status 1.`) — escaped from `_build_image`

## Test plan
- [x] New `test_build_from_dockerfile_wraps_calledprocesserror_as_image_build_error` regression test
- [x] New `test_build_image_wraps_calledprocesserror_as_image_build_error` regression test
- [x] Existing `test_ensure_buildx_builder_raises_image_build_error_when_docker_missing` still passes
- [x] `make fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)