### PR TITLE
fix: cap snowflake-connector-python <5 in snowflake plugin

### DIFF
--- a/maint_tools/build_default_image.py
+++ b/maint_tools/build_default_image.py
@@ -72,7 +72,7 @@ async def build_flyte_connector_image(
         )
     else:
         default_image = Image.from_debian_base(registry=registry, name=name).with_pip_packages(
-            "flyteplugins-bigquery", "flyteplugins-snowflake", "flyteplugins-databricks", pre=True
+            "flyteplugins-bigquery", "flyteplugins-snowflake", "flyteplugins-databricks"
         )
     suffix = __version__ if __version__.startswith("v") else f"v{__version__}".replace("+", "-")
     python_version = _detect_python_version()

--- a/plugins/snowflake/pyproject.toml
+++ b/plugins/snowflake/pyproject.toml
@@ -7,7 +7,7 @@ authors = [{ name = "Kevin Su", email = "pingsutw@users.noreply.github.com" }]
 requires-python = ">=3.10"
 dependencies = [
     "flyte[connector]",
-    "snowflake-connector-python[pandas]",
+    "snowflake-connector-python[pandas]<5",
     "cryptography",
 ]
 

--- a/plugins/snowflake/uv.lock
+++ b/plugins/snowflake/uv.lock
@@ -595,7 +595,7 @@ dev = [
 requires-dist = [
     { name = "cryptography" },
     { name = "flyte", extras = ["connector"], editable = "../../" },
-    { name = "snowflake-connector-python", extras = ["pandas"] },
+    { name = "snowflake-connector-python", extras = ["pandas"], specifier = "<5" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

- The connector image build in `.github/workflows/publish.yml` installs `flyteplugins-snowflake`/`-bigquery`/`-databricks` with `--pre`, which lets uv pick up the prerelease `snowflake-connector-python==5.0.0b1` (a Rust rewrite that needs `cargo` to build from source). The base connector image has no Rust toolchain, so the build fails with `FileNotFoundError: [Errno 2] No such file or directory: 'cargo'`.
- This has broken the last three publish runs (v2.3.0, v2.3.1, v2.3.2) at the connector image step. Failing job: https://github.com/flyteorg/flyte-sdk/actions/runs/25925272795/job/76206538880
- Fix: cap `snowflake-connector-python[pandas]<5` in `plugins/snowflake/pyproject.toml`. `--pre` still resolves the flyteplugins prereleases, but uv honors the upper bound and picks the latest 4.x for snowflake-connector-python.
- Regenerated `plugins/snowflake/uv.lock`.

Note: the fix only takes effect once a new `flyteplugins-snowflake` wheel is published from this repo (the bound is baked into the wheel's metadata). A new release tag will be needed after merge.

## Test plan

- [x] `uv pip compile --pre` with the new constraint resolves to `snowflake-connector-python==4.5.0` locally.
- [x] `uv lock` succeeds in `plugins/snowflake/` with no other drift.
- [ ] After merge + new release tag, confirm the `Build and push the connector image` step succeeds for all Python versions.