### PR TITLE
fix: accept common cache behavior aliases (enable/on/off/...)

### DIFF
--- a/src/flyte/_cache/cache.py
+++ b/src/flyte/_cache/cache.py
@@ -23,6 +23,21 @@ FuncOut = TypeVar("FuncOut")
 
 CacheBehavior = Literal["auto", "override", "disable"]
 
+# Common user-typed aliases mapped to their canonical CacheBehavior. Keeps
+# code like `cache="enable"` or `cache="off"` working instead of crashing
+# with a ValueError that ends up in Sentry as an SDK error.
+_CACHE_BEHAVIOR_ALIASES = {
+    "enable": "auto",
+    "enabled": "auto",
+    "on": "auto",
+    "true": "auto",
+    "yes": "auto",
+    "off": "disable",
+    "false": "disable",
+    "no": "disable",
+    "none": "disable",
+}
+
 
 @dataclass
 class VersionParameters(Generic[P, FuncOut]):
@@ -105,8 +120,16 @@ class Cache:
     policies: Optional[Union[List[CachePolicy], CachePolicy]] = None
 
     def __post_init__(self):
-        if self.behavior not in get_args(CacheBehavior):
-            raise ValueError(f"Invalid cache behavior: {self.behavior}. Must be one of ['auto', 'override', 'disable']")
+        valid = get_args(CacheBehavior)
+        if isinstance(self.behavior, str) and self.behavior not in valid:
+            aliased = _CACHE_BEHAVIOR_ALIASES.get(self.behavior.lower())
+            if aliased is not None:
+                self.behavior = aliased
+        if self.behavior not in valid:
+            raise ValueError(
+                f"Invalid cache behavior: {self.behavior!r}. Must be one of {list(valid)} "
+                f"(aliases accepted: {sorted(_CACHE_BEHAVIOR_ALIASES)})."
+            )
 
         # Still setup _ignore_inputs when cache is disabled to prevent _ignored_inputs attribute not found error
         if isinstance(self.ignored_inputs, str):

--- a/tests/user_api/test_cache.py
+++ b/tests/user_api/test_cache.py
@@ -48,7 +48,7 @@ def test_cache_behavior_aliases(alias, canonical):
 
 def test_cache_invalid_behavior_message_lists_aliases():
     with pytest.raises(ValueError, match="aliases accepted"):
-        Cache(behavior="enbale")
+        Cache(behavior="notarealvalue")
 
 
 def test_cache_version_override():

--- a/tests/user_api/test_cache.py
+++ b/tests/user_api/test_cache.py
@@ -27,6 +27,30 @@ def test_cache_invalid_behavior():
         Cache(behavior="invalid")
 
 
+@pytest.mark.parametrize(
+    "alias,canonical",
+    [
+        ("enable", "auto"),
+        ("enabled", "auto"),
+        ("on", "auto"),
+        ("True", "auto"),
+        ("YES", "auto"),
+        ("off", "disable"),
+        ("false", "disable"),
+        ("no", "disable"),
+        ("None", "disable"),
+    ],
+)
+def test_cache_behavior_aliases(alias, canonical):
+    cache = Cache(behavior=alias)
+    assert cache.behavior == canonical
+
+
+def test_cache_invalid_behavior_message_lists_aliases():
+    with pytest.raises(ValueError, match="aliases accepted"):
+        Cache(behavior="enbale")
+
+
 def test_cache_version_override():
     cache = Cache(behavior="auto", version_override="v1.0")
     assert cache.get_version() == "v1.0"


### PR DESCRIPTION
## Summary

`Cache(behavior=...)` (and thus `@env.task(cache=...)`, `task.override(cache=...)`, etc.) only accepted the three `CacheBehavior` literals `"auto"`, `"override"`, `"disable"`. Users very reasonably reach for `"enable"`, `"on"`, `"off"`, `"true"`, etc., and the resulting `ValueError: Invalid cache behavior: enable. Must be one of ['auto', 'override', 'disable']` lands in Sentry as if it were an SDK crash even though it's user-input validation.

Normalize a small list of common aliases (`enable`/`enabled`/`on`/`true`/`yes` → `auto`, `off`/`false`/`no`/`none` → `disable`) before validating, and include the alias list in the error message so users who type something else (e.g. `enbale`) can self-correct.

## Sentry issues

Fixes [FLYTE-SDK-37](https://unionai.sentry.io/issues/7490224960/) (`ValueError: Invalid cache behavior: enable. Must be one of ['auto', 'override', 'disable']`)

## Test plan

- [x] New parametrized test covers each accepted alias (`enable`/`enabled`/`on`/`True`/`YES`/`off`/`false`/`no`/`None`) and asserts it canonicalizes to the expected `CacheBehavior`.
- [x] New test asserts the updated error message lists the accepted aliases when the value is still invalid (e.g. typo `"enbale"`).
- [x] Existing `tests/user_api/test_cache.py` suite (26 tests) still passes.
- [x] `make fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)