### PR TITLE
fix(app): resolve _caller_frame to user code in subclasses and factories

### DIFF
--- a/src/flyte/ai/chat/app.py
+++ b/src/flyte/ai/chat/app.py
@@ -287,7 +287,6 @@ class AgentChatAppEnvironment(flyte.app.AppEnvironment):
     passthrough_auth_excluded_paths: frozenset[str] | None = None
     task_entrypoint: Any | None = None
     type: str = "AgentChat"
-    _caller_frame: inspect.FrameInfo | None = None
 
     def __post_init__(self):
         if self.agent is None:
@@ -305,12 +304,6 @@ class AgentChatAppEnvironment(flyte.app.AppEnvironment):
 
         super().__post_init__()
         self._server = self._fastapi_server
-
-        frame = inspect.currentframe()
-        if frame and frame.f_back:
-            caller_frame = frame.f_back
-            if caller_frame and caller_frame.f_back:
-                self._caller_frame = inspect.getframeinfo(caller_frame.f_back)
 
     def build_fastapi_app(self) -> Any:
         """Construct the FastAPI application (routes, HTML shell, optional auth).

--- a/src/flyte/ai/mcp/_mcp_app.py
+++ b/src/flyte/ai/mcp/_mcp_app.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import inspect
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
@@ -43,7 +42,6 @@ class MCPAppEnvironment(flyte.app.AppEnvironment):
     uvicorn_config: uvicorn.Config | None = None
 
     _starlette_app: Starlette | None = field(init=False, default=None)
-    _caller_frame: inspect.FrameInfo | None = field(init=False, default=None)
 
     def __post_init__(self):
         if getattr(self, "image", None) in (None, "auto"):
@@ -58,12 +56,6 @@ class MCPAppEnvironment(flyte.app.AppEnvironment):
 
         if not isinstance(self.mcp_mount_path, str) or not self.mcp_mount_path.startswith("/"):
             raise ValueError("mcp_mount_path must be an absolute path starting with '/'.")
-
-        frame = inspect.currentframe()
-        if frame and frame.f_back:
-            caller_frame = frame.f_back
-            if caller_frame and caller_frame.f_back:
-                self._caller_frame = inspect.getframeinfo(caller_frame.f_back)
 
         self._starlette_app = self._create_starlette_app()
 

--- a/src/flyte/app/_app_environment.py
+++ b/src/flyte/app/_app_environment.py
@@ -18,6 +18,70 @@ APP_NAME_RE = re.compile(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[
 INVALID_APP_PORTS = [8012, 8022, 8112, 9090, 9091]
 INTERNAL_APP_ENDPOINT_PATTERN_ENV_VAR = "INTERNAL_APP_ENDPOINT_PATTERN"
 
+# Root of the flyte SDK source tree (the directory that contains ``flyte/``).
+# Used by ``_find_user_caller_frame`` to skip every frame whose source file
+# lives inside the SDK, so that subclass ``__post_init__`` chains, helper
+# methods, and the synthesized dataclass ``__init__`` never get reported as
+# the user's caller.
+_SDK_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Filenames that ``inspect.getframeinfo`` may report for synthesized frames
+# (e.g. dataclass-generated ``__init__`` is compiled with ``"<string>"``) that
+# can't possibly belong to user code.
+_SYNTHESIZED_FILENAME_PREFIXES = ("<",)
+
+
+def _is_sdk_frame(filename: str) -> bool:
+    """Return True if ``filename`` lives inside the flyte SDK source tree."""
+    if not filename or filename.startswith(_SYNTHESIZED_FILENAME_PREFIXES):
+        return True
+    try:
+        abs_filename = os.path.abspath(filename)
+    except (OSError, ValueError):
+        return False
+    try:
+        return os.path.commonpath([_SDK_ROOT, abs_filename]) == _SDK_ROOT
+    except ValueError:
+        # commonpath raises on mixed drives / unrelated roots.
+        return False
+
+
+def _find_user_caller_frame() -> inspect.Traceback | None:
+    """Walk up the call stack to the first user-code frame outside the SDK.
+
+    Returns an :class:`inspect.Traceback` pointing at whatever line of user
+    code triggered the construction of an :class:`AppEnvironment`. The walker
+    skips:
+
+    * frames whose source file lives inside the SDK source tree (covers every
+      ``AppEnvironment``/subclass ``__post_init__`` plus helper methods),
+    * synthesized frames whose ``co_filename`` is angle-bracketed
+      (``"<string>"``, ``"<frozen ...>"``, etc. — produced by the dataclass-
+      generated ``__init__``, ``exec``-compiled modules, frozen importers),
+    * user-authored ``__post_init__`` / ``__init__`` frames so that a user
+      subclass calling ``super().__post_init__()`` still resolves to the
+      caller that actually instantiated the env (factory helper, module
+      scope, …).
+
+    Whatever the first remaining frame is — module scope, factory helper, or
+    any other regular function — that's what we report.
+    """
+    f = inspect.currentframe()
+    f = f.f_back if f is not None else None
+    while f is not None:
+        co_filename = f.f_code.co_filename
+        if _is_sdk_frame(co_filename):
+            f = f.f_back
+            continue
+        if f.f_code.co_name in ("__post_init__", "__init__"):
+            # User-defined subclass init frame chaining super().__post_init__().
+            f = f.f_back
+            continue
+        break
+    if f is None:
+        return None
+    return inspect.getframeinfo(f)
+
 
 @rich.repr.auto
 @dataclass(init=True, repr=True)
@@ -89,6 +153,11 @@ class AppEnvironment(Environment):
     _server: Callable[[], None] | None = field(init=False, default=None)
     _on_startup: Callable[[], None] | None = field(init=False, default=None)
     _on_shutdown: Callable[[], None] | None = field(init=False, default=None)
+    # Frame of the user code that instantiated this environment. Used by
+    # ``flyte._internal.resolvers.app_env.AppEnvResolver`` to locate the module
+    # that holds the module-level ``app_env`` binding the deployed container
+    # needs to import.
+    _caller_frame: inspect.Traceback | None = field(init=False, default=None, repr=False, compare=False)
 
     def _validate_name(self):
         if not APP_NAME_RE.fullmatch(self.name):
@@ -128,19 +197,14 @@ class AppEnvironment(Environment):
 
         self._validate_name()
 
-        # Capture the frame where this environment was instantiated
-        # This helps us find the module where the app variable is defined.
-        # Walk up the stack past any frames inside this file (e.g. subclass
-        # __post_init__ chains) and the dataclass __init__ frame, until we
-        # reach the user's code.
-        frame = inspect.currentframe()
-        f = frame.f_back if frame else None
-        # Skip __post_init__ frames (covers subclasses calling
-        # super().__post_init__()) and the synthesized dataclass __init__ frame.
-        while f is not None and f.f_code.co_name in ("__post_init__", "__init__"):
-            f = f.f_back
-        if f is not None:
-            self._caller_frame = inspect.getframeinfo(f)
+        # Capture the frame where this environment was instantiated. The Flyte
+        # ``AppEnvResolver`` uses ``self._caller_frame.filename`` to locate the
+        # module that holds the module-level ``app_env`` binding the container
+        # must import. We walk up past every SDK / dataclass-machinery frame
+        # so that we land on actual user code regardless of whether the env
+        # was created inline at module scope, inside a subclass with a custom
+        # ``__post_init__``, or via a user-provided factory helper.
+        self._caller_frame = _find_user_caller_frame()
 
     def container_args(self, serialize_context: SerializationContext) -> List[str]:
         if self.args is None:

--- a/src/flyte/app/extras/_fastapi.py
+++ b/src/flyte/app/extras/_fastapi.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import inspect
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -20,7 +19,6 @@ class FastAPIAppEnvironment(flyte.app.AppEnvironment):
     app: fastapi.FastAPI
     type: str = "FastAPI"
     uvicorn_config: uvicorn.Config | None = None
-    _caller_frame: inspect.FrameInfo | None = None
 
     def __post_init__(self):
         try:
@@ -62,16 +60,6 @@ class FastAPIAppEnvironment(flyte.app.AppEnvironment):
 
         self.links = [flyte.app.Link(path="/docs", title="FastAPI OpenAPI Docs", is_relative=True), *self.links]
         self._server = self._fastapi_app_server
-
-        # Capture the frame where this environment was instantiated
-        # This helps us find the module where the app variable is defined
-        frame = inspect.currentframe()
-        if frame and frame.f_back:
-            # Go up the call stack to find the user's module
-            # Skip the dataclass __init__ frame
-            caller_frame = frame.f_back
-            if caller_frame and caller_frame.f_back:
-                self._caller_frame = inspect.getframeinfo(caller_frame.f_back)
 
     async def _fastapi_app_server(self):
         try:

--- a/src/flyte/app/extras/_webhook_app.py
+++ b/src/flyte/app/extras/_webhook_app.py
@@ -88,7 +88,6 @@ Example:
 
 from __future__ import annotations
 
-import inspect
 import logging
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
@@ -1489,7 +1488,6 @@ class FlyteWebhookAppEnvironment(FastAPIAppEnvironment):
     task_allowlist: list[str] | None = None
     app_allowlist: list[str] | None = None
     trigger_allowlist: list[str] | None = None
-    _caller_frame: inspect.FrameInfo | None = None
 
     def __post_init__(self):
         if self.endpoints is not None and self.endpoint_groups is not None:
@@ -1497,16 +1495,6 @@ class FlyteWebhookAppEnvironment(FastAPIAppEnvironment):
 
         self.app = _create_webhook_app(self)
         super().__post_init__()
-
-        # Capture the frame where this environment was instantiated
-        # This helps us find the module where the app variable is defined
-        frame = inspect.currentframe()
-        if frame and frame.f_back:
-            # Go up the call stack to find the user's module
-            # Skip the dataclass __init__ frame
-            caller_frame = frame.f_back
-            if caller_frame and caller_frame.f_back:
-                self._caller_frame = inspect.getframeinfo(caller_frame.f_back)
 
     async def _fastapi_app_server(self):
         try:

--- a/tests/flyte/app/test_caller_frame_resolution.py
+++ b/tests/flyte/app/test_caller_frame_resolution.py
@@ -1,0 +1,222 @@
+"""Tests for ``AppEnvironment._caller_frame`` discovery.
+
+The Flyte ``AppEnvResolver`` uses ``app_env._caller_frame.filename`` to figure
+out which module to import in the deployed container so it can rebind the
+``app_env`` variable for ``fserve``. If that filename ends up pointing at
+SDK source (or worse, at the dataclass-synthesised ``__init__`` whose
+filename is ``"<string>"``), the resolver-args are silently dropped from the
+container command and ``fserve`` crashes with
+``ValueError: No command provided to execute`` at boot.
+
+This module locks in:
+
+1. The parent ``AppEnvironment``'s walker always lands on a user-code frame
+   (never inside the SDK, never on a synthesised ``"<string>"`` frame).
+2. The same property holds when an env is built through a factory helper
+   (single level *or* nested).
+3. Every subclass that previously shipped a buggy 2-level override
+   (MCP / FastAPI / Webhook / AgentChat) now inherits the correct walker.
+4. The resolver's ``loader_args`` round-trips to ``"<module>:<varname>"`` so
+   ``fserve`` can re-import the binding.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from flyte._internal.resolvers.app_env import AppEnvResolver
+from flyte.app import AppEnvironment
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+THIS_FILE = pathlib.Path(__file__).resolve()
+THIS_DIR = THIS_FILE.parent
+
+
+# A module-level binding so the round-trip resolver test below can locate an
+# AppEnvironment when it imports this test module. Without this binding, the
+# resolver (which only sees module globals) would have nothing to match
+# against and would raise.
+MODULE_LEVEL_ENV = AppEnvironment(name="caller-frame-module-level-env")
+
+
+def _make_inline_env() -> AppEnvironment:
+    """Module-equivalent inline factory; same file, single frame above ctor."""
+    return AppEnvironment(name="caller-frame-factory")
+
+
+def _make_outer_env() -> AppEnvironment:
+    """Nested factory: deliberately wraps another factory call."""
+    return _make_inline_env()
+
+
+def _make_subclass_factory(env_cls, **kwargs) -> AppEnvironment:
+    """Subclass factory used by parametrised subclass tests."""
+    return env_cls(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Parent AppEnvironment
+# ---------------------------------------------------------------------------
+
+
+def test_caller_frame_module_level_landing():
+    """A direct call at module scope lands on the test file's <module>-equivalent frame."""
+    env = AppEnvironment(name="caller-frame-direct")
+    assert env._caller_frame is not None
+    assert env._caller_frame.filename == str(THIS_FILE)
+    # Inside a pytest test function the immediate caller is the test, not <module>.
+    assert env._caller_frame.function == "test_caller_frame_module_level_landing"
+
+
+def test_caller_frame_factory_lands_in_user_module():
+    """A factory helper still resolves to the user file (not into the SDK)."""
+    env = _make_inline_env()
+    assert env._caller_frame is not None
+    assert env._caller_frame.filename == str(THIS_FILE)
+    assert env._caller_frame.function == "_make_inline_env"
+
+
+def test_caller_frame_nested_factory_lands_in_user_module():
+    """Nested factories still resolve to the innermost user frame, never to '<string>'."""
+    env = _make_outer_env()
+    assert env._caller_frame is not None
+    assert env._caller_frame.filename == str(THIS_FILE)
+    # The inner call wins because that frame is closer to AppEnvironment.__post_init__.
+    assert env._caller_frame.function == "_make_inline_env"
+
+
+def test_caller_frame_filename_never_synthesised():
+    """Regression guard: filename must never be ``<string>`` / ``<frozen>`` / empty."""
+    env = AppEnvironment(name="caller-frame-synthesised-check")
+    assert env._caller_frame is not None
+    assert not env._caller_frame.filename.startswith("<")
+
+
+def test_caller_frame_filename_outside_sdk_tree():
+    """The walker must skip every SDK-internal frame so the resolver works."""
+    env = AppEnvironment(name="caller-frame-sdk-skip")
+    assert env._caller_frame is not None
+    # The walker reports an absolute path; just check it isn't inside flyte's source.
+    assert "/site-packages/flyte/" not in env._caller_frame.filename
+    assert "/src/flyte/" not in env._caller_frame.filename
+
+
+def test_resolver_loader_args_round_trip():
+    """End-to-end: resolver produces ``<module>:<varname>`` for module-level binding."""
+    loader_args = AppEnvResolver().loader_args(MODULE_LEVEL_ENV, THIS_DIR)
+    module_name, var_name = loader_args.split(":")
+    assert module_name == THIS_FILE.stem
+    assert var_name == "MODULE_LEVEL_ENV"
+
+
+# ---------------------------------------------------------------------------
+# Subclasses that previously clobbered _caller_frame
+# ---------------------------------------------------------------------------
+
+
+def _import_or_skip(qualified_name: str):
+    """Import a class lazily; skip the test if the optional extra isn't installed."""
+    import importlib
+
+    module_path, _, class_name = qualified_name.rpartition(".")
+    try:
+        mod = importlib.import_module(module_path)
+    except ModuleNotFoundError as e:
+        pytest.skip(f"optional dependency missing for {qualified_name}: {e}")
+    return getattr(mod, class_name)
+
+
+def _subclass_kwargs(env_cls):
+    """Minimal constructor kwargs per subclass."""
+    name_only = {"name": "caller-frame-subclass"}
+    if env_cls.__name__ == "FastAPIAppEnvironment":
+        import fastapi
+
+        return {**name_only, "app": fastapi.FastAPI()}
+    if env_cls.__name__ == "AgentChatAppEnvironment":
+
+        class _StubAgent:  # implements the Agent protocol minimally
+            tool_descriptions = ()
+
+            async def run(self, *_a, **_kw):  # pragma: no cover - never invoked in this test
+                yield ""
+
+        return {**name_only, "agent": _StubAgent()}
+    return name_only
+
+
+@pytest.mark.parametrize(
+    "qualified_name",
+    [
+        "flyte.ai.mcp.FlyteMCPAppEnvironment",
+        "flyte.app.extras.FastAPIAppEnvironment",
+        "flyte.app.extras._webhook_app.FlyteWebhookAppEnvironment",
+        "flyte.ai.chat.AgentChatAppEnvironment",
+    ],
+)
+def test_subclasses_caller_frame_lands_in_user_code(qualified_name):
+    """All subclasses that previously had a buggy override now inherit the fix."""
+    env_cls = _import_or_skip(qualified_name)
+    env = env_cls(**_subclass_kwargs(env_cls))
+    assert env._caller_frame is not None
+    assert env._caller_frame.filename == str(THIS_FILE), (
+        f"{qualified_name} reported filename {env._caller_frame.filename!r}; expected the test file (i.e. user code)."
+    )
+    assert not env._caller_frame.filename.startswith("<")
+
+
+@pytest.mark.parametrize(
+    "qualified_name",
+    [
+        "flyte.ai.mcp.FlyteMCPAppEnvironment",
+        "flyte.app.extras.FastAPIAppEnvironment",
+        "flyte.app.extras._webhook_app.FlyteWebhookAppEnvironment",
+        "flyte.ai.chat.AgentChatAppEnvironment",
+    ],
+)
+def test_subclasses_caller_frame_factory_pattern(qualified_name):
+    """Subclasses keep the user-code landing even when built via a helper."""
+    env_cls = _import_or_skip(qualified_name)
+    env = _make_subclass_factory(env_cls, **_subclass_kwargs(env_cls))
+    assert env._caller_frame is not None
+    assert env._caller_frame.filename == str(THIS_FILE)
+    assert env._caller_frame.function == "_make_subclass_factory"
+
+
+# ---------------------------------------------------------------------------
+# container_command must include resolver-args now that _caller_frame is correct
+# ---------------------------------------------------------------------------
+
+
+def test_container_cmd_includes_resolver_args_for_module_level_env():
+    """``container_cmd`` must add ``--resolver`` / ``--resolver-args``.
+
+    Without those flags, ``fserve`` can't import ``app_env`` and crashes at
+    boot. This is the precise failure mode the underlying bug produced.
+    """
+    from flyte._internal.imagebuild.image_builder import ImageCache
+    from flyte.models import CodeBundle, SerializationContext
+
+    ctx = SerializationContext(
+        org="org",
+        project="proj",
+        domain="dev",
+        version="v0",
+        root_dir=THIS_DIR,
+        code_bundle=CodeBundle(tgz="bundle.tgz", computed_version="v0", destination="/code"),
+        image_cache=ImageCache(image_lookup={}),
+    )
+    cmd = MODULE_LEVEL_ENV.container_cmd(ctx)
+    assert "--resolver" in cmd, f"expected --resolver in {cmd}"
+    assert "--resolver-args" in cmd, f"expected --resolver-args in {cmd}"
+    args_index = cmd.index("--resolver-args")
+    loader_args = cmd[args_index + 1]
+    module_name, var_name = loader_args.split(":")
+    assert module_name == THIS_FILE.stem
+    assert var_name == "MODULE_LEVEL_ENV"


### PR DESCRIPTION
AppEnvResolver uses ``AppEnvironment._caller_frame.filename`` to locate the module that holds the module-level ``app_env`` binding the deployed ``fserve`` container must import. Four subclasses
(``MCPAppEnvironment``, ``FastAPIAppEnvironment``, ``FlyteWebhookAppEnvironment``, ``AgentChatAppEnvironment``) were overwriting the parent class's correctly-computed ``_caller_frame`` with a 2-level ``frame.f_back.f_back`` walk that landed on the synthesized dataclass ``__init__`` whose ``co_filename`` is ``"<string>"``. The resolver then raised ``RuntimeError``, ``container_cmd`` silently dropped ``--resolver-args`` from the command line, and the deployed container crashed at boot with ``ValueError: No command provided to execute``.

This change:

* Declares ``_caller_frame`` once on the parent ``AppEnvironment`` (``field(init=False, default=None, repr=False, compare=False)``).
* Extracts a robust walker ``_find_user_caller_frame()`` that skips every frame whose source file lives inside the SDK source tree or has an angle-bracketed ``co_filename`` (``<string>``, ``<frozen ...>``), plus any ``__post_init__`` / ``__init__`` frames so a user subclass that chains ``super().__post_init__()`` still resolves to its caller.
* Deletes the broken 2-level overrides in the four subclasses.

Adds ``tests/flyte/app/test_caller_frame_resolution.py`` covering:

* Direct module-level instantiation lands on the user file.
* Factory helpers (single-level and nested) still land on the user file.
* Synthesized filenames are never reported.
* Every formerly-broken subclass now inherits the correct walker.
* ``container_cmd`` emits ``--resolver-args module:varname`` end-to-end.

All 378 existing ``tests/flyte/app/`` + ``tests/flyte/ai/`` tests pass.