### PR TITLE
prewarm reusable env

### DIFF
--- a/examples/reuse/prewarm.py
+++ b/examples/reuse/prewarm.py
@@ -27,7 +27,6 @@ from kubernetes.client import V1Container, V1PodSpec
 
 import flyte
 
-
 # Seconds the init container will sleep. Stand-in for image pull / model
 # load / any first-pod startup cost. Tune to ≈ the driver's ``setup_seconds``
 # so the benefit of prewarm is clearly visible but not exaggerated.
@@ -111,7 +110,11 @@ async def with_prewarm(setup_seconds: int = 90) -> int:
     while we await other things.
     """
     print("scheduling prewarm() — pool warms in background")
-    asyncio.create_task(heavy_env.prewarm())
+    # Intentionally fire-and-forget. In a real codebase you'd want to retain a
+    # reference (see Python's background-tasks idiom) so the task can't be
+    # GC'd mid-execution; in this short driver the local frame is alive for
+    # the whole duration so it's safe to discard.
+    asyncio.create_task(heavy_env.prewarm())  # noqa: RUF006
 
     print(f"simulating {setup_seconds}s of pre-heavy work")
     await asyncio.sleep(setup_seconds)

--- a/examples/reuse/prewarm.py
+++ b/examples/reuse/prewarm.py
@@ -1,0 +1,138 @@
+"""Pre-warm a reusable env's worker pool before the first heavy task fires.
+
+Demonstrates the cold-start hide via `env.prewarm()`. Two driver tasks
+exercise the same reusable env:
+
+  * ``with_prewarm``    — schedules `heavy_env.prewarm()` with
+    ``asyncio.create_task``, does N seconds of unrelated async work, then
+    calls ``heavy_task``. The pool warms in parallel with the setup work
+    so the heavy task lands on HEALTHY workers.
+  * ``without_prewarm`` — same shape, no prewarm. ``heavy_task`` waits in
+    ``WaitingForResources`` until the first pod is HEALTHY.
+
+To make the cold-start cost visible, ``heavy_env`` attaches a pod template
+whose init container just sleeps. K8s blocks the primary container until
+init containers finish, so every first-time-on-this-node pod pays the
+``INIT_SLEEP_SECONDS`` cost. Once warm, the pool reuses those pods for
+free.
+
+Compare the two runs in the UI: the gap between ``submitted`` and
+``started`` on ``heavy_task`` is near-zero with prewarm and
+``~INIT_SLEEP_SECONDS`` without.
+"""
+
+import asyncio
+
+from kubernetes.client import V1Container, V1PodSpec
+
+import flyte
+
+
+# Seconds the init container will sleep. Stand-in for image pull / model
+# load / any first-pod startup cost. Tune to ≈ the driver's ``setup_seconds``
+# so the benefit of prewarm is clearly visible but not exaggerated.
+INIT_SLEEP_SECONDS = 60
+
+
+# If you're working against an unreleased SDK build, swap this image
+# definition for one that bakes the local wheel:
+#
+#   image = (
+#       flyte.Image.from_debian_base(install_flyte=False)
+#       .with_pip_packages("unionai-reuse", "kubernetes")
+#       .with_local_v2()
+#   )
+#
+# requires ``python -m build --wheel`` in the flyte-sdk repo so a wheel
+# exists in ``dist/``.
+image = flyte.Image.from_debian_base().with_pip_packages("unionai-reuse", "kubernetes")
+
+
+# Init container blocks the primary container until it finishes —
+# simulates a slow first-pod startup so prewarm has something meaningful
+# to hide.
+slow_startup_pod = flyte.PodTemplate(
+    primary_container_name="primary",
+    pod_spec=V1PodSpec(
+        containers=[V1Container(name="primary")],
+        init_containers=[
+            V1Container(
+                name="slow-startup-sim",
+                image="busybox:latest",
+                command=["sh", "-c", f"echo 'simulating slow startup'; sleep {INIT_SLEEP_SECONDS}"],
+            ),
+        ],
+    ),
+)
+
+
+heavy_env = flyte.TaskEnvironment(
+    name="prewarm_demo_heavy",
+    resources=flyte.Resources(cpu=1, memory="500Mi"),
+    image=image,
+    pod_template=slow_startup_pod,
+    reusable=flyte.ReusePolicy(
+        replicas=(2, 2),
+        # Sized to cover the driver's pre-heavy work plus a margin. The
+        # same idle_ttl also applies after the heavy task completes, so a
+        # longer value also delays scale-down.
+        idle_ttl=600,
+        scaledown_ttl=60,
+    ),
+)
+
+
+# driver_env is defined separately (not via clone_with) so it does NOT
+# inherit heavy_env's slow-startup pod_template — we only want the heavy
+# pods to pay the init-container cost.
+driver_env = flyte.TaskEnvironment(
+    name="prewarm_demo_driver",
+    resources=flyte.Resources(cpu=1, memory="500Mi"),
+    image=image,
+    depends_on=[heavy_env],
+)
+
+
+@heavy_env.task
+async def heavy_task(x: int) -> int:
+    # Cheap once a worker is alive; the interesting cost is reaching this
+    # point from a cold pool (pod schedule + init container + start).
+    print(f"heavy_task running with x={x}")
+    return x * 2
+
+
+@driver_env.task
+async def with_prewarm(setup_seconds: int = 90) -> int:
+    """Fire-and-forget prewarm via asyncio.create_task, then do unrelated work.
+
+    ``await heavy_env.prewarm()`` would block until the pool is HEALTHY,
+    defeating the parallelism. The Pythonic fire-and-forget pattern is
+    ``asyncio.create_task`` — schedule it on the event loop, let it run
+    while we await other things.
+    """
+    print("scheduling prewarm() — pool warms in background")
+    asyncio.create_task(heavy_env.prewarm())
+
+    print(f"simulating {setup_seconds}s of pre-heavy work")
+    await asyncio.sleep(setup_seconds)
+
+    print("now calling heavy_task — pool should already be HEALTHY")
+    return await heavy_task(21)
+
+
+@driver_env.task
+async def without_prewarm(setup_seconds: int = 90) -> int:
+    """Baseline: same shape, no prewarm. heavy_task hits a cold pool."""
+    print(f"simulating {setup_seconds}s of pre-heavy work (no prewarm)")
+    await asyncio.sleep(setup_seconds)
+
+    print("now calling heavy_task — pool is cold; pays init-container cost")
+    return await heavy_task(21)
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(with_prewarm, setup_seconds=90)
+    # run = flyte.run(without_prewarm, setup_seconds=90)
+    print("run url:", run.url)
+    run.wait()

--- a/src/flyte/_internal/resolvers/prewarm.py
+++ b/src/flyte/_internal/resolvers/prewarm.py
@@ -1,0 +1,69 @@
+"""Resolver for auto-synthesized prewarm tasks.
+
+A prewarm task is a hidden no-op that the SDK attaches to every reusable
+TaskEnvironment so that `env.prewarm()` can submit a cheap sub-action whose
+sole side-effect is to trigger `GetOrCreateEnvironment` on the backend
+(see `cloud/flyte/fasttask/plugin/plugin.go`). The dummy function lives in
+the SDK rather than in user code, so the worker needs a resolver that can
+materialize a task without importing the user's module.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from typing import List, Optional
+
+from flyte._internal.resolvers.common import Resolver
+from flyte._task import AsyncFunctionTaskTemplate, TaskTemplate
+from flyte.models import NativeInterface
+
+
+def prewarm_task_short_name(env_name: str) -> str:
+    """Per-env short name so the UI shows which env each prewarm belongs to.
+
+    Prefix-form (`prewarm_<env>`) makes prewarm tasks sort together when
+    listing a project's tasks alphabetically.
+    """
+    return f"prewarm_{env_name}"
+
+
+def prewarm_task_full_name(env_name: str) -> str:
+    return f"{env_name}.{prewarm_task_short_name(env_name)}"
+
+
+async def _prewarm_noop() -> int:
+    """No-op coroutine; serves only as a vehicle to spin up the actor pool."""
+    return 0
+
+
+class PrewarmTaskResolver(Resolver):
+    """Resolver that materializes a prewarm task from its env name alone.
+
+    The synthesized task carries no user code, so on the worker side we can
+    rebuild it from `["env_name", <env_name>]` without touching the code
+    bundle. The wire `TaskTemplate` proto carries the image, ReusePolicy,
+    secrets, env_vars, etc. — the worker only needs a callable to execute.
+    """
+
+    @property
+    def import_path(self) -> str:
+        return "flyte._internal.resolvers.prewarm.PrewarmTaskResolver"
+
+    def load_task(self, loader_args: List[str]) -> TaskTemplate:
+        # loader_args is ["env_name", <env_name>]
+        if len(loader_args) < 2 or loader_args[0] != "env_name":
+            raise ValueError(
+                f"PrewarmTaskResolver expected ['env_name', <name>], got {loader_args}"
+            )
+        env_name = loader_args[1]
+        return AsyncFunctionTaskTemplate(
+            func=_prewarm_noop,
+            name=prewarm_task_full_name(env_name),
+            short_name=prewarm_task_short_name(env_name),
+            interface=NativeInterface.from_callable(_prewarm_noop),
+            parent_env_name=env_name,
+            task_resolver=self,
+        )
+
+    def loader_args(self, task: TaskTemplate, root_dir: Optional[pathlib.Path] = None) -> List[str]:
+        return ["env_name", task.parent_env_name or ""]

--- a/src/flyte/_internal/resolvers/prewarm.py
+++ b/src/flyte/_internal/resolvers/prewarm.py
@@ -52,9 +52,7 @@ class PrewarmTaskResolver(Resolver):
     def load_task(self, loader_args: List[str]) -> TaskTemplate:
         # loader_args is ["env_name", <env_name>]
         if len(loader_args) < 2 or loader_args[0] != "env_name":
-            raise ValueError(
-                f"PrewarmTaskResolver expected ['env_name', <name>], got {loader_args}"
-            )
+            raise ValueError(f"PrewarmTaskResolver expected ['env_name', <name>], got {loader_args}")
         env_name = loader_args[1]
         return AsyncFunctionTaskTemplate(
             func=_prewarm_noop,

--- a/src/flyte/_task_environment.py
+++ b/src/flyte/_task_environment.py
@@ -25,6 +25,7 @@ from ._doc import Documentation
 from ._environment import Environment
 from ._image import Image
 from ._link import Link
+from ._logging import logger
 from ._pod import PodTemplate
 from ._resources import Resources
 from ._retry import RetryStrategy
@@ -150,6 +151,12 @@ class TaskEnvironment(Environment):
             raise TypeError(f"Expected reusable to be of type ReusePolicy, got {type(self.reusable)}")
         if self.cache and not isinstance(self.cache, (str, Cache)):
             raise TypeError(f"Expected cache to be of type str or Cache, got {type(self.cache)}")
+
+        # Synthesize a hidden __prewarm__ task so env.prewarm() has something cheap to
+        # submit. The task must share the env's image / ReusePolicy / env_vars / secrets
+        # so its version hash matches the env's real tasks and lands on the same pool.
+        if self.reusable is not None:
+            self._register_prewarm_task()
 
     def clone_with(
         self,
@@ -388,6 +395,187 @@ class TaskEnvironment(Environment):
         Get all tasks defined in the environment.
         """
         return self._tasks
+
+    def _register_prewarm_task(self) -> None:
+        """Attach a hidden no-op task to this env to back env.prewarm().
+
+        Uses a SDK-provided resolver instead of the user-code resolver so the
+        worker can load the task without importing user modules.
+        """
+        from ._internal.resolvers.prewarm import (
+            PrewarmTaskResolver,
+            _prewarm_noop,
+            prewarm_task_full_name,
+            prewarm_task_short_name,
+        )
+
+        task_name = prewarm_task_full_name(self.name)
+        tmpl = AsyncFunctionTaskTemplate[Any, int, Callable[[], Any]](
+            func=_prewarm_noop,
+            name=task_name,
+            image=self.image,
+            resources=self.resources,
+            cache="disable",
+            reusable=self.reusable,
+            env_vars=self.env_vars,
+            secrets=self.secrets,
+            pod_template=self.pod_template,
+            parent_env=weakref.ref(self),
+            parent_env_name=self.name,
+            interface=NativeInterface.from_callable(_prewarm_noop),
+            short_name=prewarm_task_short_name(self.name),
+            interruptible=self.interruptible,
+            queue=self.queue,
+            task_resolver=PrewarmTaskResolver(),
+        )
+        self._tasks[task_name] = tmpl
+
+    def _resolve_prewarm_target(self) -> Optional[TaskTemplate]:
+        """Run the validation gauntlet for prewarm{,_sync}().
+
+        Returns the prewarm `TaskTemplate` if we should fire it, otherwise
+        `None` (after logging the reason). Centralizes the warn-and-return
+        cases shared by the async and sync entry points.
+        """
+        if self.reusable is None:
+            logger.warning(
+                f"prewarm() called on TaskEnvironment '{self.name}' which is not reusable — no-op."
+            )
+            return None
+
+        from ._context import internal_ctx
+
+        ctx = internal_ctx()
+        if not ctx.is_task_context():
+            logger.warning(
+                f"prewarm() called on '{self.name}' outside a task context — no-op. "
+                "Call this from inside a @env.task function."
+            )
+            return None
+
+        try:
+            from ._internal.controllers import get_controller
+            from ._internal.controllers._local_controller import LocalController
+        except Exception:
+            logger.warning(f"prewarm() on '{self.name}': controller machinery unavailable — no-op.")
+            return None
+
+        try:
+            controller = get_controller()
+        except Exception:
+            logger.warning(f"prewarm() on '{self.name}': no controller initialized — no-op.")
+            return None
+
+        if isinstance(controller, LocalController):
+            # In local execution there is no remote replica pool to warm.
+            return None
+
+        from ._internal.resolvers.prewarm import prewarm_task_full_name
+
+        task_name = prewarm_task_full_name(self.name)
+        prewarm_task = self._tasks.get(task_name)
+        if prewarm_task is None:
+            # Defensive: should not happen since __post_init__ registers it for reusable envs.
+            logger.warning(f"prewarm() on '{self.name}': hidden task missing — no-op.")
+            return None
+
+        # Surface the idle_ttl window so the user sees how long the pool stays
+        # warm after this prewarm completes. If their setup work exceeds this,
+        # the pool will scale down before the heavy task arrives.
+        idle_ttl_seconds = int(self.reusable.idle_ttl.total_seconds())
+        logger.info(
+            f"prewarm: warming env '{self.name}' (idle_ttl={idle_ttl_seconds}s — "
+            f"pool will stay alive ~{idle_ttl_seconds}s after each task completes)"
+        )
+        return prewarm_task
+
+    async def prewarm(self) -> None:
+        """Pre-warm this reusable env's worker pool by submitting a hidden no-op.
+
+        The backend's first task submission to an `actor` pool triggers
+        `GetOrCreateEnvironment`, which spawns up to `min_replica_count`
+        workers. Subsequent tasks on the same env land on the warm pool
+        with no cold-start cost.
+
+        **Awaiting waits for completion.** `await env.prewarm()` blocks until
+        the no-op sub-action terminates — i.e., the pool has reached HEALTHY
+        and the no-op has actually executed on a worker. On return, the pool
+        is guaranteed to be ready.
+
+        **For fire-and-forget**, use the standard Python pattern:
+
+        ```python
+        asyncio.create_task(env.prewarm())   # schedule, do not wait
+        await asyncio.sleep(setup_seconds)   # other work runs in parallel
+        await heavy_task(...)                # pool is warm by now
+        ```
+
+        In sync tasks, use :meth:`prewarm_sync` instead.
+
+        **Warm window.** A single prewarm only stays useful for roughly
+        `ReusePolicy.idle_ttl - pod_startup_time`. If your driver does
+        long work before invoking the heavy task, increase `idle_ttl`.
+        Note that the same `idle_ttl` also applies *after* the heavy task
+        completes, so a longer value also delays scale-down.
+
+        **No-op cases:**
+
+        - Called on a non-reusable environment → logs a warning and returns.
+        - Running in local execution mode → silent no-op.
+        - Called outside a task / run context (no controller) → warns and returns.
+
+        Example (fire-and-forget, the common case):
+
+        ```python
+        heavy_env = flyte.TaskEnvironment(
+            name="heavy",
+            reusable=flyte.ReusePolicy(replicas=(2, 4), idle_ttl=600),
+        )
+
+        @heavy_env.task
+        async def big_inference(x: str) -> str: ...
+
+        driver_env = heavy_env.clone_with("driver", reusable=None, depends_on=[heavy_env])
+
+        @driver_env.task
+        async def main():
+            asyncio.create_task(heavy_env.prewarm())   # kick off pool startup
+            await asyncio.sleep(60)                    # other async setup work
+            return await big_inference("...")          # pool already HEALTHY
+        ```
+        """
+        prewarm_task = self._resolve_prewarm_target()
+        if prewarm_task is None:
+            return
+        await prewarm_task.aio()  # type: ignore[misc]
+
+    def prewarm_sync(self) -> None:
+        """Synchronous companion to :meth:`prewarm` for use in sync `@env.task` functions.
+
+        Blocks until the no-op sub-action terminates. On return the pool is
+        guaranteed HEALTHY. Matches the SDK convention used by
+        `File.download_sync`, `Checkpoint.load_sync`, etc.
+
+        For fire-and-forget in sync code, wrap with a thread:
+
+        ```python
+        import threading
+        threading.Thread(target=heavy_env.prewarm_sync, daemon=True).start()
+        do_setup()                # warms in background
+        return heavy_task(...)    # pool may or may not be ready
+        ```
+
+        Same no-op cases as :meth:`prewarm` (non-reusable, local mode,
+        outside task context).
+        """
+        prewarm_task = self._resolve_prewarm_target()
+        if prewarm_task is None:
+            return
+        from ._internal.controllers import get_controller
+
+        controller = get_controller()
+        fut = controller.submit_sync(prewarm_task)
+        fut.result()  # block until terminal
 
     @classmethod
     def from_task(

--- a/src/flyte/_task_environment.py
+++ b/src/flyte/_task_environment.py
@@ -438,9 +438,7 @@ class TaskEnvironment(Environment):
         cases shared by the async and sync entry points.
         """
         if self.reusable is None:
-            logger.warning(
-                f"prewarm() called on TaskEnvironment '{self.name}' which is not reusable — no-op."
-            )
+            logger.warning(f"prewarm() called on TaskEnvironment '{self.name}' which is not reusable — no-op.")
             return None
 
         from ._context import internal_ctx
@@ -482,7 +480,9 @@ class TaskEnvironment(Environment):
         # Surface the idle_ttl window so the user sees how long the pool stays
         # warm after this prewarm completes. If their setup work exceeds this,
         # the pool will scale down before the heavy task arrives.
-        idle_ttl_seconds = int(self.reusable.idle_ttl.total_seconds())
+        # ReusePolicy.__post_init__ normalizes idle_ttl to a timedelta, but the
+        # declared type is `int | timedelta` — narrow it for the type checker.
+        idle_ttl_seconds = int(self.reusable.idle_ttl.total_seconds())  # type: ignore[union-attr]
         logger.info(
             f"prewarm: warming env '{self.name}' (idle_ttl={idle_ttl_seconds}s — "
             f"pool will stay alive ~{idle_ttl_seconds}s after each task completes)"

--- a/tests/user_api/test_prewarm.py
+++ b/tests/user_api/test_prewarm.py
@@ -1,0 +1,160 @@
+"""Tests for the imperative prewarm() method on reusable TaskEnvironments.
+
+Design context: SE-760. The prewarm task is auto-synthesized on every reusable
+env; env.prewarm() submits it fire-and-forget so the backend's
+`GetOrCreateEnvironment` spins up the actor pool ahead of the first heavy task.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+import flyte
+from flyte._internal.resolvers.prewarm import (
+    PrewarmTaskResolver,
+    prewarm_task_full_name,
+    prewarm_task_short_name,
+)
+from flyte._internal.runtime.task_serde import translate_task_to_wire
+from flyte.models import SerializationContext
+
+
+def test_reusable_env_synthesizes_prewarm_task():
+    env = flyte.TaskEnvironment(
+        name="warm_env",
+        reusable=flyte.ReusePolicy(replicas=2, idle_ttl=60),
+    )
+    expected = prewarm_task_full_name("warm_env")
+    assert expected == "warm_env.prewarm_warm_env"  # documents the naming convention
+    assert expected in env.tasks
+    t = env.tasks[expected]
+    assert t.parent_env_name == "warm_env"
+    assert t.short_name == prewarm_task_short_name("warm_env")
+    assert t.short_name == "prewarm_warm_env"
+    assert t.reusable == env.reusable
+    assert isinstance(t.task_resolver, PrewarmTaskResolver)
+
+
+def test_non_reusable_env_skips_prewarm_synthesis():
+    env = flyte.TaskEnvironment(name="cold_env")
+    assert env.tasks == {}
+
+
+def test_prewarm_task_shares_actor_version_with_real_task():
+    """The prewarm task must hash to the same actor `version` as the env's real
+    tasks, otherwise the backend treats them as different pools and the warm-up
+    accomplishes nothing."""
+    env = flyte.TaskEnvironment(
+        name="shared_pool_env",
+        reusable=flyte.ReusePolicy(replicas=(1, 3), idle_ttl=120),
+    )
+
+    @env.task
+    async def heavy(x: int) -> int:
+        return x
+
+    # root_dir must be an ancestor of the test file (DefaultTaskResolver requirement).
+    repo_root = Path(__file__).resolve().parents[2]
+    sctx = SerializationContext(
+        project="p", domain="d", org="o",
+        root_dir=repo_root, code_bundle=None, version="v1",
+    )
+    heavy_wire = translate_task_to_wire(env.tasks["shared_pool_env.heavy"], sctx)
+    prewarm_wire = translate_task_to_wire(
+        env.tasks[prewarm_task_full_name("shared_pool_env")], sctx
+    )
+    assert (
+        heavy_wire.task_template.custom["version"]
+        == prewarm_wire.task_template.custom["version"]
+    ), "prewarm version diverged — prewarm would target a different pool"
+    assert prewarm_wire.task_template.custom["type"] == "actor"
+    assert prewarm_wire.task_template.custom["name"] == "shared_pool_env"
+
+
+def test_prewarm_resolver_roundtrip():
+    env = flyte.TaskEnvironment(
+        name="rt_env",
+        reusable=flyte.ReusePolicy(replicas=1, idle_ttl=60),
+    )
+    task = env.tasks[prewarm_task_full_name("rt_env")]
+    resolver = PrewarmTaskResolver()
+    args = resolver.loader_args(task)
+    assert args == ["env_name", "rt_env"]
+    reloaded = resolver.load_task(args)
+    assert reloaded.name == prewarm_task_full_name("rt_env")
+    assert reloaded.short_name == "prewarm_rt_env"
+    assert reloaded.parent_env_name == "rt_env"
+    assert reloaded.interface.outputs == {"o0": int}
+    assert reloaded.interface.inputs == {}
+
+
+def test_prewarm_resolver_rejects_malformed_args():
+    resolver = PrewarmTaskResolver()
+    with pytest.raises(ValueError):
+        resolver.load_task(["wrong"])
+    with pytest.raises(ValueError):
+        resolver.load_task(["foo", "bar"])
+
+
+class _ListHandler(logging.Handler):
+    """Capture log records from the propagate=False flyte logger."""
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+@pytest.fixture
+def flyte_log_capture():
+    flyte_logger = logging.getLogger("flyte")
+    handler = _ListHandler()
+    flyte_logger.addHandler(handler)
+    try:
+        yield handler
+    finally:
+        flyte_logger.removeHandler(handler)
+
+
+@pytest.mark.asyncio
+async def test_prewarm_on_non_reusable_env_warns_and_returns(flyte_log_capture):
+    env = flyte.TaskEnvironment(name="cold_env_warn")
+    await env.prewarm()
+    msgs = [r.getMessage() for r in flyte_log_capture.records]
+    assert any("not reusable" in m for m in msgs), msgs
+
+
+@pytest.mark.asyncio
+async def test_prewarm_outside_task_context_warns_and_returns(flyte_log_capture):
+    """Calling prewarm() from a bare async function (no TaskContext) is a no-op
+    plus warning — there is no controller to submit through."""
+    env = flyte.TaskEnvironment(
+        name="ctxless_env",
+        reusable=flyte.ReusePolicy(replicas=1, idle_ttl=60),
+    )
+    await env.prewarm()
+    msgs = [r.getMessage() for r in flyte_log_capture.records]
+    assert any("outside a task context" in m for m in msgs), msgs
+
+
+def test_prewarm_sync_on_non_reusable_env_warns_and_returns(flyte_log_capture):
+    """Sync companion: same warn-and-noop behavior as the async variant."""
+    env = flyte.TaskEnvironment(name="cold_env_sync_warn")
+    env.prewarm_sync()
+    msgs = [r.getMessage() for r in flyte_log_capture.records]
+    assert any("not reusable" in m for m in msgs), msgs
+
+
+def test_prewarm_sync_outside_task_context_warns_and_returns(flyte_log_capture):
+    """Sync companion outside a TaskContext also warn-and-noops without raising."""
+    env = flyte.TaskEnvironment(
+        name="ctxless_sync_env",
+        reusable=flyte.ReusePolicy(replicas=1, idle_ttl=60),
+    )
+    env.prewarm_sync()
+    msgs = [r.getMessage() for r in flyte_log_capture.records]
+    assert any("outside a task context" in m for m in msgs), msgs

--- a/tests/user_api/test_prewarm.py
+++ b/tests/user_api/test_prewarm.py
@@ -4,6 +4,7 @@ Design context: SE-760. The prewarm task is auto-synthesized on every reusable
 env; env.prewarm() submits it fire-and-forget so the backend's
 `GetOrCreateEnvironment` spins up the actor pool ahead of the first heavy task.
 """
+
 from __future__ import annotations
 
 import logging
@@ -58,17 +59,18 @@ def test_prewarm_task_shares_actor_version_with_real_task():
     # root_dir must be an ancestor of the test file (DefaultTaskResolver requirement).
     repo_root = Path(__file__).resolve().parents[2]
     sctx = SerializationContext(
-        project="p", domain="d", org="o",
-        root_dir=repo_root, code_bundle=None, version="v1",
+        project="p",
+        domain="d",
+        org="o",
+        root_dir=repo_root,
+        code_bundle=None,
+        version="v1",
     )
     heavy_wire = translate_task_to_wire(env.tasks["shared_pool_env.heavy"], sctx)
-    prewarm_wire = translate_task_to_wire(
-        env.tasks[prewarm_task_full_name("shared_pool_env")], sctx
+    prewarm_wire = translate_task_to_wire(env.tasks[prewarm_task_full_name("shared_pool_env")], sctx)
+    assert heavy_wire.task_template.custom["version"] == prewarm_wire.task_template.custom["version"], (
+        "prewarm version diverged — prewarm would target a different pool"
     )
-    assert (
-        heavy_wire.task_template.custom["version"]
-        == prewarm_wire.task_template.custom["version"]
-    ), "prewarm version diverged — prewarm would target a different pool"
     assert prewarm_wire.task_template.custom["type"] == "actor"
     assert prewarm_wire.task_template.custom["name"] == "shared_pool_env"
 


### PR DESCRIPTION
## Motivation
When a reusable `TaskEnvironment` is first invoked, the backend lazily spawns its actor pool — pulling images, running init containers, starting workers. Subsequent tasks land on the warm pool, but the first one pays the full cold start. Users who know they'll hit a reusable env later in a workflow have no way to ask the SDK to start that pool earlier; today they have to author a hand-rolled dummy task and fire it from the driver. SE-760 adds a first-class API for it.

## Summary
Adds `TaskEnvironment.prewarm()` (async) and `TaskEnvironment.prewarm_sync()` (matching `download_sync` / `load_sync` convention). Calling either submits a hidden no-op sub-action on the reusable env, which triggers `GetOrCreateEnvironment` on the backend and spins up `min_replica_count` workers. The heavy task — invoked later in the driver — lands on the warm pool instead of paying the cold start.
- `await env.prewarm()` blocks until the noo HEALTHY on return) — standard Python async semantics.
- `asyncio.create_task(env.prewarm())` is the pool warms concurrently with whatever async work the driver does next.
- `env.prewarm_sync()` blocks until completiions.

The synthesized no-op is a real task registen time (`__post_init__` calls `_register_prewarm_task` when `reusable is not None`). It shares the env's image, `ReusePolicy`, env_ve so its actor `version` hash matches the env's real tasks — without this match, the warm-up would land on a different pool a `PrewarmTaskResolver` materializes the task on the worker without touching user code, so the no-op is loadable even when thee bundle that doesn't define it explicitly.

Per-env naming (`<env>.prewarm_<env>`, prefix form) makes prewarm sub-actions sort together in the UI. `prewarm()` logs thfired so users can see the warm window they're operating in.

No-op cases (all warn and return):
- `prewarm()` on a non-reusable env
- Running in local execution mode
- Called outside a task / run context

## Example Executions
Without Prewarm: https://union-internal.hosted.unionai.cloud/v2/domain/development/project/flytesnacks/runs/ux2bz5jljgkhlrxqt9st

With Prewarm: https://union-internal.hosted.unionai.cloud/v2/domain/development/project/flytesnacks/runs/uff6qnnx59wjzvx5f6kz