### PR TITLE
Remote builder support package name

### DIFF
--- a/plugins/anthropic/uv.lock
+++ b/plugins/anthropic/uv.lock
@@ -381,7 +381,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -448,7 +448,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -457,7 +457,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]

--- a/plugins/bigquery/uv.lock
+++ b/plugins/bigquery/uv.lock
@@ -451,7 +451,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -518,7 +518,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -527,7 +527,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]

--- a/plugins/codegen/uv.lock
+++ b/plugins/codegen/uv.lock
@@ -736,7 +736,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -803,7 +803,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -812,7 +812,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]

--- a/plugins/dask/uv.lock
+++ b/plugins/dask/uv.lock
@@ -607,7 +607,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -674,7 +674,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -683,7 +683,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]

--- a/plugins/databricks/uv.lock
+++ b/plugins/databricks/uv.lock
@@ -619,7 +619,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -686,7 +686,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -695,7 +695,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]

--- a/plugins/echo/uv.lock
+++ b/plugins/echo/uv.lock
@@ -344,7 +344,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -411,7 +411,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -420,7 +420,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]

--- a/plugins/gemini/uv.lock
+++ b/plugins/gemini/uv.lock
@@ -467,7 +467,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -534,7 +534,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -543,7 +543,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]

--- a/plugins/hitl/uv.lock
+++ b/plugins/hitl/uv.lock
@@ -377,7 +377,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -444,7 +444,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -453,7 +453,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]

--- a/plugins/huggingface/uv.lock
+++ b/plugins/huggingface/uv.lock
@@ -683,7 +683,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -750,7 +750,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -759,7 +759,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]

--- a/plugins/hydra/uv.lock
+++ b/plugins/hydra/uv.lock
@@ -473,7 +473,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -540,7 +540,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -549,7 +549,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]

--- a/plugins/jsonl/uv.lock
+++ b/plugins/jsonl/uv.lock
@@ -353,7 +353,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -420,7 +420,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -429,7 +429,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]

--- a/plugins/omegaconf/uv.lock
+++ b/plugins/omegaconf/uv.lock
@@ -359,7 +359,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -426,7 +426,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -435,7 +435,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]

--- a/plugins/openai/uv.lock
+++ b/plugins/openai/uv.lock
@@ -460,7 +460,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -527,7 +527,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -536,7 +536,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]

--- a/plugins/pandera/uv.lock
+++ b/plugins/pandera/uv.lock
@@ -573,7 +573,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -640,7 +640,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -649,7 +649,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]

--- a/plugins/polars/uv.lock
+++ b/plugins/polars/uv.lock
@@ -354,7 +354,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -421,7 +421,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -430,7 +430,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]

--- a/plugins/pytorch/uv.lock
+++ b/plugins/pytorch/uv.lock
@@ -388,7 +388,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -455,7 +455,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -464,7 +464,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]

--- a/plugins/ray/uv.lock
+++ b/plugins/ray/uv.lock
@@ -510,7 +510,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -577,7 +577,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -586,7 +586,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]

--- a/plugins/sglang/uv.lock
+++ b/plugins/sglang/uv.lock
@@ -353,7 +353,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -420,7 +420,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -429,7 +429,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]

--- a/plugins/snowflake/uv.lock
+++ b/plugins/snowflake/uv.lock
@@ -497,7 +497,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -564,7 +564,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -573,7 +573,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]

--- a/plugins/spark/uv.lock
+++ b/plugins/spark/uv.lock
@@ -451,7 +451,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -518,7 +518,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -527,7 +527,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]

--- a/plugins/vllm/uv.lock
+++ b/plugins/vllm/uv.lock
@@ -353,7 +353,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -420,7 +420,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -429,7 +429,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]

--- a/plugins/wandb/uv.lock
+++ b/plugins/wandb/uv.lock
@@ -447,7 +447,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -514,7 +514,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -523,7 +523,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "async-lru>=2.0.5",
     "mashumaro",
     "aiolimiter>=1.2.1",
-    "flyteidl2==2.0.16",
+    "flyteidl2==2.0.17",
     "packaging",
     "sentry-sdk>=2.0",
     "pyOpenSSL>=24.0.0",

--- a/rs_controller/Cargo.toml
+++ b/rs_controller/Cargo.toml
@@ -34,7 +34,7 @@ async-trait = "0.1"
 thiserror = "1.0"
 # Uncomment this if you need to use local flyteidl2
 #flyteidl2 = { path = "/Users/ytong/go/src/github.com/flyteorg/flyte/gen/rust" }
-flyteidl2 = "=2.0.16"
+flyteidl2 = "=2.0.17"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/rs_controller/pyproject.toml
+++ b/rs_controller/pyproject.toml
@@ -9,7 +9,7 @@ description = "Rust controller for Union"
 requires-python = ">=3.10"
 classifiers = ["Programming Language :: Python", "Programming Language :: Rust"]
 dependencies = [
-    "flyteidl2==2.0.16",
+    "flyteidl2==2.0.17",
 ]
 [tool.maturin]
 module-name = "flyte_controller_base"

--- a/src/flyte/_internal/imagebuild/remote_builder.py
+++ b/src/flyte/_internal/imagebuild/remote_builder.py
@@ -261,6 +261,7 @@ def _get_layers_proto(image: Image, context_path: Path) -> "image_definition_pb2
             wheel_layer = image_definition_pb2.Layer(
                 python_wheels=image_definition_pb2.PythonWheels(
                     dir=str(dst_path.relative_to(context_path)),
+                    package_name=layer.package_name,
                     options=pip_options,
                     secret_mounts=secret_mounts,
                 ),

--- a/uv.lock
+++ b/uv.lock
@@ -1191,7 +1191,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.16" },
+    { name = "flyteidl2", specifier = "==2.0.17" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -1265,11 +1265,11 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "flyteidl2", specifier = "==2.0.16" }]
+requires-dist = [{ name = "flyteidl2", specifier = "==2.0.17" }]
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.16"
+version = "2.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -1278,7 +1278,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/a2/be9c8d06506c0bc2cef9481334acf84012d2f98db23f8fd4f47ff0609dda/flyteidl2-2.0.16-py3-none-any.whl", hash = "sha256:92d5a788ab8d08af20d5967303e929a4f5947c1eabf1ecc51ebe07ba3a1e97c0", size = 340232, upload-time = "2026-05-14T06:35:06.524Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/457cf86d71fa80c557e7658d6c448102a2676bf2ce151f026c29407332a9/flyteidl2-2.0.17-py3-none-any.whl", hash = "sha256:60e10fae4946ae10b513ec91d65e3a2f5e3537471c6f6bb3b6e8bd28bbdbcda5", size = 340324, upload-time = "2026-05-21T06:07:03.11Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Pass `package_name` to remote image builder so that it can build image with Rust controller correctly