### PR TITLE
fix: make module-level syncify wrappers cloudpickleable

### DIFF
--- a/src/flyte/syncify/_api.py
+++ b/src/flyte/syncify/_api.py
@@ -4,6 +4,7 @@ import asyncio
 import atexit
 import concurrent.futures
 import functools
+import importlib
 import inspect
 import logging
 import threading
@@ -245,6 +246,14 @@ class _BackgroundLoop:
             raise e
 
 
+def _resolve_sync_wrapper_by_name(module: str, qualname: str) -> Any:
+    """Reconstructor used by ``_SyncWrapper.__reduce__`` to re-import a module-level wrapper."""
+    obj: Any = importlib.import_module(module)
+    for part in qualname.split("."):
+        obj = getattr(obj, part)
+    return obj
+
+
 class _SyncWrapper:
     """
     A wrapper class that the Syncify decorator uses to convert asynchronous functions or methods into synchronous ones.
@@ -259,6 +268,24 @@ class _SyncWrapper:
         self.fn = fn
         self._bg_loop = bg_loop
         self._underlying_obj = underlying_obj
+
+    def __reduce__(self) -> Any:
+        # cloudpickle pulls captured globals by value when serializing a function. If a user
+        # function closes over a module-level syncify-wrapped helper (for example
+        # ``flyte._trace._fetch_action_outputs``), the default reducer tries to serialize the
+        # _BackgroundLoop, whose asyncio loop holds a ThreadPoolExecutor backed by a
+        # SimpleQueue — and SimpleQueue is unpicklable. When the wrapper is importable at its
+        # original module path, pickle it by reference so the consumer just re-imports.
+        module = getattr(self, "__module__", None) or getattr(self.fn, "__module__", None)
+        qualname = getattr(self, "__qualname__", None) or getattr(self.fn, "__qualname__", None)
+        if module and qualname and "<locals>" not in qualname and "<lambda>" not in qualname:
+            try:
+                resolved = _resolve_sync_wrapper_by_name(module, qualname)
+            except (ImportError, AttributeError):
+                resolved = None
+            if resolved is self:
+                return (_resolve_sync_wrapper_by_name, (module, qualname))
+        return super().__reduce__()
 
     def __get__(self, instance: Any, owner: Any) -> Any:
         """

--- a/src/flyte/syncify/_api.py
+++ b/src/flyte/syncify/_api.py
@@ -4,6 +4,7 @@ import asyncio
 import atexit
 import concurrent.futures
 import functools
+import importlib
 import inspect
 import logging
 import threading
@@ -247,6 +248,14 @@ class _BackgroundLoop:
             raise e
 
 
+def _resolve_sync_wrapper_by_name(module: str, qualname: str) -> Any:
+    """Reconstructor used by ``_SyncWrapper.__reduce__`` to re-import a module-level wrapper."""
+    obj: Any = importlib.import_module(module)
+    for part in qualname.split("."):
+        obj = getattr(obj, part)
+    return obj
+
+
 class _SyncWrapper:
     """
     A wrapper class that the Syncify decorator uses to convert asynchronous functions or methods into synchronous ones.
@@ -261,6 +270,24 @@ class _SyncWrapper:
         self.fn = fn
         self._bg_loop = bg_loop
         self._underlying_obj = underlying_obj
+
+    def __reduce__(self) -> Any:
+        # cloudpickle pulls captured globals by value when serializing a function. If a user
+        # function closes over a module-level syncify-wrapped helper (for example
+        # ``flyte._trace._fetch_action_outputs``), the default reducer tries to serialize the
+        # _BackgroundLoop, whose asyncio loop holds a ThreadPoolExecutor backed by a
+        # SimpleQueue — and SimpleQueue is unpicklable. When the wrapper is importable at its
+        # original module path, pickle it by reference so the consumer just re-imports.
+        module = getattr(self, "__module__", None) or getattr(self.fn, "__module__", None)
+        qualname = getattr(self, "__qualname__", None) or getattr(self.fn, "__qualname__", None)
+        if module and qualname and "<locals>" not in qualname and "<lambda>" not in qualname:
+            try:
+                resolved = _resolve_sync_wrapper_by_name(module, qualname)
+            except (ImportError, AttributeError):
+                resolved = None
+            if resolved is self:
+                return (_resolve_sync_wrapper_by_name, (module, qualname))
+        return super().__reduce__()
 
     def __get__(self, instance: Any, owner: Any) -> Any:
         """

--- a/src/flyte/syncify/_api.py
+++ b/src/flyte/syncify/_api.py
@@ -4,7 +4,6 @@ import asyncio
 import atexit
 import concurrent.futures
 import functools
-import importlib
 import inspect
 import logging
 import threading
@@ -248,6 +247,8 @@ class _BackgroundLoop:
 
 def _resolve_sync_wrapper_by_name(module: str, qualname: str) -> Any:
     """Reconstructor used by ``_SyncWrapper.__reduce__`` to re-import a module-level wrapper."""
+    import importlib
+
     obj: Any = importlib.import_module(module)
     for part in qualname.split("."):
         obj = getattr(obj, part)

--- a/tests/flyte/syncify/test_syncify.py
+++ b/tests/flyte/syncify/test_syncify.py
@@ -417,3 +417,34 @@ async def test_syncify_generator_exception():
         assert len(tb_list) == 3, (
             f"traceback should contain two frames: one for the exception and one for the function, got {tb_list}"
         )
+
+
+def test_module_level_sync_wrapper_is_cloudpickleable():
+    """
+    Regression test for FLYTE-SDK-38: cloudpickle could not serialize functions that
+    captured a module-level syncify-wrapped helper because the helper transitively held
+    an asyncio loop / SimpleQueue. Pickling by reference avoids that.
+    """
+    import cloudpickle
+
+    from flyte._trace import _fetch_action_outputs
+
+    payload = cloudpickle.dumps(_fetch_action_outputs)
+    restored = cloudpickle.loads(payload)
+    assert restored is _fetch_action_outputs
+
+
+def test_module_level_sync_wrapper_pickleable_via_closure():
+    """
+    Functions that close over a module-level syncify wrapper should also pickle cleanly.
+    """
+    import cloudpickle
+
+    from flyte._trace import _fetch_action_outputs
+
+    def closes_over_wrapper():
+        return _fetch_action_outputs
+
+    payload = cloudpickle.dumps(closes_over_wrapper)
+    restored = cloudpickle.loads(payload)
+    assert restored() is _fetch_action_outputs


### PR DESCRIPTION
## Summary

`_SyncWrapper` transitively references a `_BackgroundLoop` whose asyncio loop owns a `ThreadPoolExecutor` backed by a `_queue.SimpleQueue`. When cloudpickle serializes a user function that captures a module-level syncify-wrapped helper — notably `flyte._trace._fetch_action_outputs` — the default reducer walks into the loop's state and dies with:

```
TypeError: cannot pickle '_queue.SimpleQueue' object
when serializing dict item '_work_queue'
when serializing concurrent.futures.thread.ThreadPoolExecutor state
...
when serializing flyte.syncify._api._BackgroundLoop object
when serializing dict item '_bg_loop'
when serializing flyte.syncify._api._SyncWrapper state
...
```

This shows up in user-facing `flyte.deploy(...)` flows whenever the user has any `@trace`-decorated task — `wrapper_sync`'s globals capture `_fetch_action_outputs` (a `_SyncWrapper`), and that captures `_bg_loop`.

PR #1051 added a generic `try/except` around the deploy-time pickle that converts this into a `ClickException` and points the user at `version=...`, but the underlying SDK object is unpicklable for legitimate reasons we control — the proper fix is to make it serialize.

## Fix

Add a `__reduce__` to `_SyncWrapper` that pickles by reference (module + qualname) whenever the wrapper is importable at its original module path. The consumer just re-imports it on load, which is the only sane contract anyway — the bg loop in the producer is meaningless in the consumer process.

Falls back to the default reducer for unnamed (closure-local) wrappers so behavior outside the regression is unchanged.

## Closes

- [FLYTE-SDK-38](https://unionai.sentry.io/issues/FLYTE-SDK-38/) — `TypeError: cannot pickle '_queue.SimpleQueue' object` from `cloudpickle.dump` during `flyte deploy`

`fixes FLYTE-SDK-38`

## Test plan

- [x] Added `test_module_level_sync_wrapper_is_cloudpickleable` — direct round-trip of `flyte._trace._fetch_action_outputs`.
- [x] Added `test_module_level_sync_wrapper_pickleable_via_closure` — round-trip of a function that closes over the wrapper.
- [x] Manual repro: `cloudpickle.dumps(TaskEnvironment(...))` with a `@trace`-decorated task now succeeds (was raising `TypeError`).
- [x] Full `tests/flyte/syncify/` suite green (34 passed).
- [x] `make fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)