### PR TITLE
fix: wrap uv export failures as ImageBuildError with stderr context

### DIFF
--- a/src/flyte/_internal/imagebuild/utils.py
+++ b/src/flyte/_internal/imagebuild/utils.py
@@ -125,9 +125,24 @@ def get_and_list_dockerignore(image: Image) -> List[str]:
 
 def _extract_editables_from_uv_export(project_root: Path) -> list[str]:
     """Extracts editable dependencies from a uv export output."""
-    uv_export = subprocess.run(
-        ["uv", "export", "--no-emit-project"], cwd=project_root, capture_output=True, text=True, check=True
-    )
+    cmd = ["uv", "export", "--no-emit-project"]
+    try:
+        uv_export = subprocess.run(cmd, cwd=project_root, capture_output=True, text=True, check=True)
+    except FileNotFoundError as e:
+        raise ImageBuildError(
+            f"`uv` was not found on PATH while inspecting editable dependencies in {project_root}. "
+            "Install uv (https://docs.astral.sh/uv/) or ensure it is on PATH before running image build."
+        ) from e
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or "").strip()
+        stdout = (e.stdout or "").strip()
+        detail = stderr or stdout or "(no output from uv)"
+        raise ImageBuildError(
+            f"`{' '.join(cmd)}` failed in {project_root} with exit code {e.returncode} "
+            f"while resolving editable dependencies for image build:\n{detail}\n\n"
+            "Fix the uv project (e.g. resolve the failing lock or dependency conflict, "
+            "or run `uv lock` locally) and retry."
+        ) from e
     matches = []
     for line in uv_export.stdout.splitlines():
         if match := re.search(r"-e\s+([^\s]+)", line):

--- a/tests/flyte/imagebuild/test_utils.py
+++ b/tests/flyte/imagebuild/test_utils.py
@@ -256,3 +256,48 @@ def test_copy_files_to_context_skips_files_that_vanish_mid_walk():
 
 
 import shutil  # noqa: E402  (kept at bottom so the new tests own the import)
+
+
+def test_extract_editables_surfaces_uv_export_failure():
+    """
+    Regression test for FLYTE-SDK-3F: `uv export` failures used to bubble up as
+    raw CalledProcessError with no stderr context. The SDK should wrap them in
+    ImageBuildError so the user sees what uv complained about.
+    """
+    import subprocess
+
+    import pytest
+
+    from flyte._internal.imagebuild.utils import _extract_editables_from_uv_export
+    from flyte.errors import ImageBuildError
+
+    err = subprocess.CalledProcessError(
+        returncode=2,
+        cmd=["uv", "export", "--no-emit-project"],
+        output="",
+        stderr="error: Failed to parse `pyproject.toml`\n  caused by: missing field `name`",
+    )
+    with patch("flyte._internal.imagebuild.utils.subprocess.run", side_effect=err):
+        with pytest.raises(ImageBuildError) as exc_info:
+            _extract_editables_from_uv_export(Path("/tmp/fake-root"))
+
+    msg = str(exc_info.value)
+    assert "uv export" in msg
+    assert "exit code 2" in msg
+    assert "missing field `name`" in msg
+
+
+def test_extract_editables_surfaces_missing_uv_binary():
+    """If uv isn't installed at all, point the user to install it instead of leaking
+    FileNotFoundError."""
+    import pytest
+
+    from flyte._internal.imagebuild.utils import _extract_editables_from_uv_export
+    from flyte.errors import ImageBuildError
+
+    with patch("flyte._internal.imagebuild.utils.subprocess.run", side_effect=FileNotFoundError("uv")):
+        with pytest.raises(ImageBuildError) as exc_info:
+            _extract_editables_from_uv_export(Path("/tmp/fake-root"))
+
+    assert "uv" in str(exc_info.value).lower()
+    assert "not found" in str(exc_info.value).lower()


### PR DESCRIPTION
## Summary

`_extract_editables_from_uv_export` runs `uv export --no-emit-project` with `check=True` and lets `CalledProcessError` bubble up unmodified during image build. The default message — `Command '['uv', 'export', '--no-emit-project']' returned non-zero exit status 2.` — drops the captured stderr, which is the only useful piece of information for the user (broken pyproject, lock conflict, etc.).

This change catches `CalledProcessError`, includes the stderr/stdout the subprocess emitted, and raises it as `ImageBuildError` so the existing Sentry user-error filter and ClickException handler treat it as user-actionable. Also handles the `uv`-not-installed case with a pointer to install it instead of leaking `FileNotFoundError`.

## Closes

- [FLYTE-SDK-3F](https://unionai.sentry.io/issues/FLYTE-SDK-3F/) — `CalledProcessError: Command '['uv', 'export', '--no-emit-project']' returned non-zero exit status 2.` from `_extract_editables_from_uv_export`

`fixes FLYTE-SDK-3F`

## Test plan

- [x] `test_extract_editables_surfaces_uv_export_failure` — non-zero exit surfaces stderr inside an `ImageBuildError`.
- [x] `test_extract_editables_surfaces_missing_uv_binary` — `FileNotFoundError` becomes an `ImageBuildError` pointing at install docs.
- [x] Existing `test_get_uv_lock_editable_dependencies_resolves_paths` still passes (12 tests total).
- [x] `make fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)