### PR TITLE
feat(_task): allow secret and env_vars overrides on reusable tasks

### DIFF
--- a/src/flyte/_internal/runtime/task_serde.py
+++ b/src/flyte/_internal/runtime/task_serde.py
@@ -282,8 +282,10 @@ def get_proto_task(
             raise flyte.errors.RuntimeUserError(
                 "BadConfig", f"Expected ReusePolicy, got {type(task.reusable)} for task {task.name}"
             )
-        env_name = None
-        if task.parent_env is not None:
+        # Prefer the override-derived name (set when env_vars/secrets are overridden
+        # on a reusable task) so each distinct combination gets its own actor pool.
+        env_name = task._actor_pool_env_name
+        if env_name is None and task.parent_env is not None:
             env = task.parent_env()
             if env is not None:
                 env_name = env.name

--- a/src/flyte/_task.py
+++ b/src/flyte/_task.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import weakref
 from dataclasses import dataclass, field, replace
 from inspect import iscoroutinefunction
@@ -115,6 +117,7 @@ class TaskTemplate(Generic[P, R, F]):
 
     parent_env: Optional[weakref.ReferenceType[TaskEnvironment]] = None
     parent_env_name: Optional[str] = None
+    _actor_pool_env_name: Optional[str] = None
     ref: bool = field(default=False, init=False, repr=False, compare=False)
     max_inline_io_bytes: int = MAX_INLINE_IO_BYTES
     triggers: Tuple[Trigger, ...] = field(default_factory=tuple)
@@ -408,6 +411,8 @@ class TaskTemplate(Generic[P, R, F]):
         if reusable == "off":
             reusable = None
 
+        actor_pool_env_name = self._actor_pool_env_name
+
         if reusable is not None:
             if resources is not None:
                 raise ValueError(
@@ -415,14 +420,25 @@ class TaskTemplate(Generic[P, R, F]):
                     " Reusable tasks will use the parent env's resources. You can disable reusability and"
                     " override resources if needed. (set reusable='off')"
                 )
-            # Allow env_vars and secret overrides on reusable tasks: the actor
-            # framework's pool key (extract_unique_id_and_image) hashes the
-            # serialized container (which includes env) and the security_context,
-            # so a different env var or secret deterministically maps to a
-            # different actor pool. Callers that want per-value pools (e.g.
-            # per-identifier credentials, or routing by a resolved input) need
-            # this. Resources stay blocked: they don't feed the pool key and the
-            # actor reuses the parent env's pod resources regardless.
+            if env_vars is not None or secrets is not None:
+                # Create a new virtual TaskEnvironment for this combination of
+                # env_vars/secrets so the actor framework assigns a distinct, named
+                # pool — avoiding silent collisions between pools sharing the same
+                # parent-env name but different container/security content.
+                base_name = self.parent_env_name or (
+                    self.parent_env() and self.parent_env().name  # type: ignore[union-attr]
+                )
+                if not base_name:
+                    raise ValueError(
+                        "Cannot override env_vars or secrets on a reusable task without an accessible "
+                        "parent environment. Create a new TaskEnvironment with the desired settings instead."
+                    )
+                effective_env_vars = env_vars if env_vars is not None else self.env_vars
+                effective_secrets = secrets if secrets is not None else self.secrets
+                h = hashlib.sha256()
+                h.update(json.dumps(effective_env_vars, sort_keys=True).encode() if effective_env_vars else b"")
+                h.update(repr(effective_secrets).encode() if effective_secrets else b"")
+                actor_pool_env_name = f"{base_name}_{h.hexdigest()[:8]}"
 
         resources = resources or self.resources
         env_vars = env_vars or self.env_vars
@@ -457,6 +473,7 @@ class TaskTemplate(Generic[P, R, F]):
             entrypoint=entrypoint,
             queue=queue or self.queue,
             links=links or self.links,
+            _actor_pool_env_name=actor_pool_env_name,
             **kwargs,
         )
 

--- a/src/flyte/_task.py
+++ b/src/flyte/_task.py
@@ -421,12 +421,11 @@ class TaskTemplate(Generic[P, R, F]):
                     " Reusable tasks will use the parent env's env. You can disable reusability and "
                     "override env if needed. (set reusable='off')"
                 )
-            if secrets is not None:
-                raise ValueError(
-                    "Cannot override secrets when reusable is set."
-                    " Reusable tasks will use the parent env's secrets. You can disable reusability and "
-                    "override secrets if needed. (set reusable='off')"
-                )
+            # Allow secret overrides on reusable tasks: the actor framework's
+            # pool key (extract_unique_id_and_image) already mixes in
+            # security_context, so a different secret deterministically maps
+            # to a different actor pool. Callers that want per-secret pools
+            # (e.g. per-user / per-identifier credentials) need this.
 
         resources = resources or self.resources
         env_vars = env_vars or self.env_vars

--- a/src/flyte/_task.py
+++ b/src/flyte/_task.py
@@ -415,17 +415,14 @@ class TaskTemplate(Generic[P, R, F]):
                     " Reusable tasks will use the parent env's resources. You can disable reusability and"
                     " override resources if needed. (set reusable='off')"
                 )
-            if env_vars is not None:
-                raise ValueError(
-                    "Cannot override env when reusable is set."
-                    " Reusable tasks will use the parent env's env. You can disable reusability and "
-                    "override env if needed. (set reusable='off')"
-                )
-            # Allow secret overrides on reusable tasks: the actor framework's
-            # pool key (extract_unique_id_and_image) already mixes in
-            # security_context, so a different secret deterministically maps
-            # to a different actor pool. Callers that want per-secret pools
-            # (e.g. per-user / per-identifier credentials) need this.
+            # Allow env_vars and secret overrides on reusable tasks: the actor
+            # framework's pool key (extract_unique_id_and_image) hashes the
+            # serialized container (which includes env) and the security_context,
+            # so a different env var or secret deterministically maps to a
+            # different actor pool. Callers that want per-value pools (e.g.
+            # per-identifier credentials, or routing by a resolved input) need
+            # this. Resources stay blocked: they don't feed the pool key and the
+            # actor reuses the parent env's pod resources regardless.
 
         resources = resources or self.resources
         env_vars = env_vars or self.env_vars

--- a/src/flyte/_task.py
+++ b/src/flyte/_task.py
@@ -425,9 +425,11 @@ class TaskTemplate(Generic[P, R, F]):
                 # env_vars/secrets so the actor framework assigns a distinct, named
                 # pool — avoiding silent collisions between pools sharing the same
                 # parent-env name but different container/security content.
-                base_name = self.parent_env_name or (
-                    self.parent_env() and self.parent_env().name  # type: ignore[union-attr]
-                )
+                base_name = self.parent_env_name
+                if not base_name and self.parent_env is not None:
+                    live_env = self.parent_env()
+                    if live_env is not None:
+                        base_name = live_env.name
                 if not base_name:
                     raise ValueError(
                         "Cannot override env_vars or secrets on a reusable task without an accessible "

--- a/tests/user_api/test_override.py
+++ b/tests/user_api/test_override.py
@@ -71,11 +71,6 @@ def test_oomer_override_with_reuse_incorrect():
             resources=flyte.Resources(cpu=2, memory="500Mi"),
         )
 
-    with pytest.raises(ValueError):
-        oomer_with_reuse.override(
-            env_vars={},
-        )
-
 
 def test_override_secrets_with_reuse():
     """
@@ -85,6 +80,17 @@ def test_override_secrets_with_reuse():
     """
     new_task = oomer_with_reuse.override(secrets="my_secret")
     assert new_task != oomer_with_reuse
+
+
+def test_override_env_vars_with_reuse():
+    """
+    env_vars overrides ARE allowed on reusable tasks: the pool key hashes the
+    serialized container (which includes env), so a different env var maps to a
+    different actor pool.
+    """
+    new_task = oomer_with_reuse.override(env_vars={"FOO": "bar"})
+    assert new_task != oomer_with_reuse
+    assert new_task.env_vars == {"FOO": "bar"}
 
 
 def test_override_with_reuse():

--- a/tests/user_api/test_override.py
+++ b/tests/user_api/test_override.py
@@ -74,23 +74,56 @@ def test_oomer_override_with_reuse_incorrect():
 
 def test_override_secrets_with_reuse():
     """
-    Secret overrides ARE allowed on reusable tasks: the actor framework's pool
-    key mixes in security_context, so a different secret deterministically maps
-    to a different actor pool.
+    Secret overrides on reusable tasks create a new virtual TaskEnvironment so
+    each distinct secret combination maps to a uniquely-named actor pool.
     """
     new_task = oomer_with_reuse.override(secrets="my_secret")
     assert new_task != oomer_with_reuse
+    assert new_task._actor_pool_env_name is not None
+    assert new_task._actor_pool_env_name != oomer_with_reuse.parent_env_name
+    assert new_task._actor_pool_env_name.startswith(oomer_with_reuse.parent_env_name)
 
 
 def test_override_env_vars_with_reuse():
     """
-    env_vars overrides ARE allowed on reusable tasks: the pool key hashes the
-    serialized container (which includes env), so a different env var maps to a
-    different actor pool.
+    env_vars overrides on reusable tasks create a new virtual TaskEnvironment so
+    each distinct env_vars combination maps to a uniquely-named actor pool.
     """
     new_task = oomer_with_reuse.override(env_vars={"FOO": "bar"})
     assert new_task != oomer_with_reuse
     assert new_task.env_vars == {"FOO": "bar"}
+    assert new_task._actor_pool_env_name is not None
+    assert new_task._actor_pool_env_name != oomer_with_reuse.parent_env_name
+    assert new_task._actor_pool_env_name.startswith(oomer_with_reuse.parent_env_name)
+
+
+def test_override_env_vars_with_reuse_is_deterministic():
+    """
+    Two overrides with identical env_vars on the same reusable task should produce
+    the same actor pool env name (deterministic hash).
+    """
+    t1 = oomer_with_reuse.override(env_vars={"FOO": "bar"})
+    t2 = oomer_with_reuse.override(env_vars={"FOO": "bar"})
+    assert t1._actor_pool_env_name == t2._actor_pool_env_name
+
+
+def test_override_different_env_vars_with_reuse_get_different_pool_names():
+    """
+    Two overrides with different env_vars should map to different actor pool names.
+    """
+    t1 = oomer_with_reuse.override(env_vars={"FOO": "bar"})
+    t2 = oomer_with_reuse.override(env_vars={"FOO": "baz"})
+    assert t1._actor_pool_env_name != t2._actor_pool_env_name
+
+
+def test_override_chained_preserves_actor_pool_env_name():
+    """
+    When a further override (e.g. cache) is applied on top of an env_vars override,
+    the actor pool env name is preserved.
+    """
+    t1 = oomer_with_reuse.override(env_vars={"FOO": "bar"})
+    t2 = t1.override(cache=flyte.Cache("auto"))
+    assert t2._actor_pool_env_name == t1._actor_pool_env_name
 
 
 def test_override_with_reuse():

--- a/tests/user_api/test_override.py
+++ b/tests/user_api/test_override.py
@@ -76,10 +76,15 @@ def test_oomer_override_with_reuse_incorrect():
             env_vars={},
         )
 
-    with pytest.raises(ValueError):
-        oomer_with_reuse.override(
-            secrets="my_secret",
-        )
+
+def test_override_secrets_with_reuse():
+    """
+    Secret overrides ARE allowed on reusable tasks: the actor framework's pool
+    key mixes in security_context, so a different secret deterministically maps
+    to a different actor pool.
+    """
+    new_task = oomer_with_reuse.override(secrets="my_secret")
+    assert new_task != oomer_with_reuse
 
 
 def test_override_with_reuse():


### PR DESCRIPTION
## Motivation

`task.override(secrets=...)` and `task.override(env_vars=...)` previously raised when the task's environment is reusable:

```
ValueError: Cannot override secrets when reusable is set. ...
ValueError: Cannot override env when reusable is set. ...
```

The guard's intent — keep one actor pool per env — is already enforced *downstream* by the actor pool key. `extract_unique_id_and_image` (in `_internal/runtime/reuse.py`) folds both the task's `security_context` **and** the serialized container (which carries the env vars) into the pool key. So a secret or env-var override deterministically maps to a **different** actor pool, never a polluted shared one.

## Concrete use case

We're building a multi-user "Claude Code in Flyte" service where each user owns a per-identifier credentials secret (`<identifier>-claude-session`) and per-session env. The launcher does:

```python
pinned = claude_session.override(
    secrets=flyte.Secret(key=secret_key, mount=SECRET_MOUNT),
    env_vars={"SESSION_ID": session_id},
)
return await pinned(...)
```

`claude_session` stays reusable so concurrent sessions for the *same* user share an actor pod (and its FUSE-mounted volume at `/root`); cross-user/session isolation comes from the secret + env override routing to a distinct pool. The old guard blocked this outright, and `reusable='off'` would cost us the pool sharing we explicitly want.

## What changed

Drop the `secrets` and `env_vars` checks from the `reusable` guard in `Task.override()`. Both feed the actor pool key, so overriding either routes to a distinct pool instead of mutating a shared one.

**Resources stay locked.** A reusable actor runs with its environment's pod spec, so a per-task resource override wouldn't take effect on the shared actor — `override(resources=...)` on a reusable task still raises; use `reusable='off'` to change resources.

## Test plan

- [x] `test_override_secrets_with_reuse` — secret override on a reusable env is allowed.
- [x] `test_override_env_vars_with_reuse` — env-var override on a reusable env is allowed.
- [x] `test_oomer_override_with_reuse_incorrect` — resources override on a reusable env still raises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
