### PR TITLE
fix: filter ConnectError(Unauthenticated/PermissionDenied/FailedPrecondition) from Sentry

### DIFF
--- a/src/flyte/_sentry.py
+++ b/src/flyte/_sentry.py
@@ -77,6 +77,37 @@ def _iter_cause_chain(exc: BaseException):
         depth += 1
 
 
+_USER_ACTIONABLE_CONNECT_CODES: frozenset[str] = frozenset(
+    {
+        "UNAUTHENTICATED",
+        "PERMISSION_DENIED",
+        "FAILED_PRECONDITION",
+        "INVALID_ARGUMENT",
+        "NOT_FOUND",
+        "ALREADY_EXISTS",
+    }
+)
+
+
+def _is_user_actionable_connect_error(exc: BaseException) -> bool:
+    """ConnectError responses the backend uses to tell the user their request was wrong.
+
+    The CLI's InvokeBaseMixin (flyte/cli/_common.py) already maps these same codes
+    to ClickException — they are user/config problems, not SDK crashes. But code
+    paths outside the CLI (capture_exception in _run.py, capture_errors on deploy)
+    surface RuntimeSystemError wrappers whose cause chain still terminates in a
+    ConnectError, and those leak into Sentry as if they were SDK bugs.
+    """
+    try:
+        from connectrpc.errors import ConnectError
+    except ImportError:
+        return False
+    if not isinstance(exc, ConnectError):
+        return False
+    code = getattr(exc, "code", None)
+    return getattr(code, "name", None) in _USER_ACTIONABLE_CONNECT_CODES
+
+
 def _is_user_error(exc: BaseException) -> bool:
     """Errors raised intentionally as user-facing messages — not crash reports."""
     try:
@@ -109,11 +140,11 @@ def _is_user_error(exc: BaseException) -> bool:
         auth_user_exc = ()
 
     user_excs = click_user_exc + flyte_user_exc + auth_user_exc
-    if not user_excs:
-        return False
 
     for cause in _iter_cause_chain(exc):
-        if isinstance(cause, user_excs):
+        if user_excs and isinstance(cause, user_excs):
+            return True
+        if _is_user_actionable_connect_error(cause):
             return True
     return False
 

--- a/tests/flyte/test_sentry.py
+++ b/tests/flyte/test_sentry.py
@@ -200,3 +200,87 @@ def test_capture_exception_skips_wrapped_module_load_error_via_cause_chain():
     with mock.patch.object(_sentry, "init") as init_mock:
         _sentry.capture_exception(err)
     init_mock.assert_not_called()
+
+
+def test_capture_exception_skips_connect_error_unauthenticated():
+    """FLYTE-SDK-33: ConnectError(Unauthenticated) from auth interceptor is a user
+    credentials issue (expired token, IDP policy denial), not an SDK crash."""
+    from connectrpc.code import Code
+    from connectrpc.errors import ConnectError
+
+    err = ConnectError(
+        Code.UNAUTHENTICATED,
+        'transport: per-RPC creds failed due to error: failed to get new token: oauth2: "access_denied"',
+    )
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()
+
+
+def test_capture_exception_skips_connect_error_permission_denied_wrapped_as_system_error():
+    """FLYTE-SDK-40: cross-org call rejected with PermissionDenied is wrapped as
+    RuntimeError("SelectCluster failed...") -> RuntimeSystemError("Failed to get signed url").
+    The outer types are SDK errors, but the cause chain reveals a user config mistake."""
+    from connectrpc.code import Code
+    from connectrpc.errors import ConnectError
+
+    from flyte.errors import RuntimeSystemError
+
+    try:
+        try:
+            try:
+                raise ConnectError(
+                    Code.PERMISSION_DENIED,
+                    "cross org calls are not allowed for organization [demo] on behalf of [default]",
+                )
+            except ConnectError as ce:
+                raise RuntimeError(f"SelectCluster failed for operation=1: {ce}") from ce
+        except RuntimeError:
+            raise RuntimeSystemError("RuntimeError", "Failed to get signed url for /tmp/x.tar.gz.")
+    except RuntimeSystemError as e:
+        err = e
+
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()
+
+
+def test_capture_exception_skips_connect_error_failed_precondition_wrapped_as_system_error():
+    """FLYTE-SDK-3S: backend returns FailedPrecondition ('no enabled clusters for org X')
+    which surfaces as RuntimeSystemError('Failed to create run: ...'). Org config problem,
+    not an SDK bug."""
+    from connectrpc.code import Code
+    from connectrpc.errors import ConnectError
+
+    from flyte.errors import RuntimeSystemError
+
+    try:
+        try:
+            raise ConnectError(Code.FAILED_PRECONDITION, "no enabled clusters found for org union-nav")
+        except ConnectError:
+            raise RuntimeSystemError(
+                "RuntimeError", "Failed to create run: no enabled clusters found for org union-nav"
+            )
+    except RuntimeSystemError as e:
+        err = e
+
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()
+
+
+def test_capture_exception_still_reports_connect_error_internal():
+    """ConnectError with Internal/Unavailable/Unknown is NOT user-actionable — those
+    indicate backend bugs or outages and should still be reported to Sentry."""
+    from connectrpc.code import Code
+    from connectrpc.errors import ConnectError
+
+    err = ConnectError(Code.INTERNAL, "backend panicked")
+    with (
+        mock.patch.object(_sentry, "init"),
+        mock.patch("sentry_sdk.is_initialized", return_value=True),
+        mock.patch("sentry_sdk.capture_exception") as capture_mock,
+        mock.patch("sentry_sdk.flush"),
+    ):
+        _sentry.capture_exception(err)
+    capture_mock.assert_called_once_with(err)


### PR DESCRIPTION
## Summary

Three live Sentry issues are user-config or user-credentials problems that nonetheless slip past the existing `_is_user_error` filter and surface in `flyte-sdk` as if they were SDK crashes:

- **FLYTE-SDK-33** — `ConnectError: code = Unauthenticated, transport: per-RPC creds failed (oauth2 access_denied)` — IDP policy denial / expired token, raised from `flyte/remote/_client/auth/_interceptors/auth.py`.
- **FLYTE-SDK-3S** — `RuntimeSystemError: Failed to create run: no enabled clusters found for org union-nav` — backend returns `FailedPrecondition`, surfaced from `_run.py` via `capture_exception(e)` for any `RuntimeSystemError`.
- **FLYTE-SDK-40** — `RuntimeSystemError: Failed to get signed url for /var/folders/.../fast….tar.gz` whose cause chain terminates in `ConnectError: code = PermissionDenied desc = cross org calls are not allowed for organization [demo] on behalf of [default]`. The user pointed the SDK at the wrong org.

The CLI's `InvokeBaseMixin` (`flyte/cli/_common.py`) already maps the same set of `connectrpc.code.Code` values to `ClickException` and treats them as user-actionable — that mapping just doesn't cover the non-CLI capture paths.

This change extends `flyte/_sentry.py:_is_user_error` to inspect every link of the `__cause__`/`__context__` chain for a `ConnectError` with one of:

```
UNAUTHENTICATED, PERMISSION_DENIED, FAILED_PRECONDITION,
INVALID_ARGUMENT, NOT_FOUND, ALREADY_EXISTS
```

`INTERNAL`, `UNAVAILABLE`, and `UNKNOWN` are deliberately excluded — those indicate backend bugs or outages and should still reach Sentry. `connectrpc` is imported lazily, so the filter still degrades gracefully if it isn't installed.

## Closes

- [FLYTE-SDK-33](https://unionai.sentry.io/issues/FLYTE-SDK-33/)
- [FLYTE-SDK-3S](https://unionai.sentry.io/issues/FLYTE-SDK-3S/)
- [FLYTE-SDK-40](https://unionai.sentry.io/issues/FLYTE-SDK-40/)

`fixes FLYTE-SDK-33`
`fixes FLYTE-SDK-3S`
`fixes FLYTE-SDK-40`

## Test plan

- [x] `test_capture_exception_skips_connect_error_unauthenticated` — bare `ConnectError(Unauthenticated)` is filtered.
- [x] `test_capture_exception_skips_connect_error_permission_denied_wrapped_as_system_error` — reproduces the FLYTE-SDK-40 chain shape (`ConnectError -> RuntimeError -> RuntimeSystemError`) and verifies it is filtered.
- [x] `test_capture_exception_skips_connect_error_failed_precondition_wrapped_as_system_error` — reproduces the FLYTE-SDK-3S chain shape.
- [x] `test_capture_exception_still_reports_connect_error_internal` — `ConnectError(Internal)` is NOT filtered (regression guard against over-broad suppression).
- [x] All 20 tests in `tests/flyte/test_sentry.py` pass.
- [x] `ruff format` + `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)