### PR TITLE
examples(genai): add Concentrate AI gateway example

### DIFF
--- a/examples/genai/concentrate_agent.py
+++ b/examples/genai/concentrate_agent.py
@@ -1,0 +1,140 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#     "flyte>=2.0.0",
+#     "flyteplugins-openai>=2.0.0",
+#     "openai-agents>=0.11.1",
+# ]
+# ///
+
+
+import asyncio
+import os
+from typing import Optional
+
+from agents import Agent, Runner, set_default_openai_client, set_tracing_disabled
+from flyteplugins.openai.agents import function_tool
+from openai import AsyncOpenAI
+
+import flyte
+
+CONCENTRATE_BASE_URL = "https://api.concentrate.ai/v1"
+# Concentrate routes 120+ models. Use a specific slug like "gpt-5.4" for
+# deterministic behavior, "openai/gpt-5.4" to provider-pin, or "auto" to
+# let Concentrate pick the cheapest provider that satisfies your policy.
+MODEL = "gpt-5.4"
+
+agent_env = flyte.TaskEnvironment(
+    "concentrate-agent",
+    resources=flyte.Resources(cpu=1),
+    secrets=[flyte.Secret(key="concentrate_api_key", as_env_var="CONCENTRATE_API_KEY")],
+    image=flyte.Image.from_uv_script(__file__, name="concentrate-agent"),
+)
+
+
+def _configure_concentrate_client() -> None:
+    """Point `openai-agents` at the Concentrate gateway."""
+    set_default_openai_client(
+        AsyncOpenAI(
+            base_url=CONCENTRATE_BASE_URL,
+            api_key=os.environ["CONCENTRATE_API_KEY"],
+        )
+    )
+    # The default tracing exporter ships traces to OpenAI's tracing endpoint,
+    # which rejects Concentrate keys. Concentrate emits its own traces in the
+    # dashboard, so we disable the OpenAI exporter here.
+    set_tracing_disabled(True)
+
+
+@function_tool
+@agent_env.task
+async def get_bread() -> str:
+    await asyncio.sleep(1)
+    return "bread"
+
+
+@function_tool
+@agent_env.task
+async def get_peanut_butter() -> str:
+    await asyncio.sleep(1)
+    return "peanut butter"
+
+
+@function_tool
+@agent_env.task
+async def get_jelly() -> str:
+    await asyncio.sleep(1)
+    return "jelly"
+
+
+@function_tool
+@agent_env.task
+async def spread_peanut_butter(bread: str, peanut_butter: str) -> str:
+    await asyncio.sleep(1)
+    return f"{bread} with {peanut_butter}"
+
+
+@function_tool
+@agent_env.task
+async def spread_jelly(bread: str, jelly: str) -> str:
+    await asyncio.sleep(1)
+    return f"{bread} with {jelly}"
+
+
+@function_tool
+@agent_env.task
+async def assemble_sandwich(pb_bread: Optional[str] = None, j_bread: Optional[str] = None) -> str:
+    await asyncio.sleep(1)
+    return f"{pb_bread} and {j_bread} combined"
+
+
+@function_tool
+@agent_env.task
+async def eat_sandwich(sandwich: str) -> str:
+    await asyncio.sleep(1)
+    return f"Ate: {sandwich} 😋"
+
+
+@agent_env.task
+async def agent(goals: list[str]) -> list[str]:
+    _configure_concentrate_client()
+
+    async def run_agent(goal: str, index: int) -> str:
+        with flyte.group(f"sandwich-maker-{index}"):
+            result = await Runner.run(
+                Agent(
+                    name="sandwich_maker",
+                    model=MODEL,
+                    instructions="You are a sandwich-making assistant.",
+                    tools=[
+                        get_bread,
+                        get_peanut_butter,
+                        get_jelly,
+                        spread_peanut_butter,
+                        spread_jelly,
+                        assemble_sandwich,
+                        eat_sandwich,
+                    ],
+                ),
+                input=goal,
+            )
+            return result.final_output
+
+    tasks = [run_agent(goal, idx) for idx, goal in enumerate(goals, start=1)]
+    results = await asyncio.gather(*tasks)
+    return results
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(
+        agent,
+        [
+            "Make a plain peanut butter sandwich.",
+            "Make a peanut butter and jelly sandwich.",
+            "Make a jelly sandwich with no peanut butter.",
+            "You have one slice with peanut butter and one with jelly. Just assemble them into a sandwich.",
+            "Make one peanut butter sandwich and one jelly sandwich.",
+        ],
+    )
+    print(run.url)


### PR DESCRIPTION
## Summary

Adds `examples/genai/concentrate_agent.py`, a near-identical mirror of the existing [`examples/genai/openai_agent.py`](https://github.com/flyteorg/flyte-sdk/blob/main/examples/genai/openai_agent.py) that routes every LLM call through the [Concentrate AI](https://concentrate.ai) gateway.

The diff vs. `openai_agent.py` is intentionally tight:

- Override `base_url` on `AsyncOpenAI` to `https://api.concentrate.ai/v1`
- Swap the Flyte `Secret` from `OPENAI_API_KEY` to `CONCENTRATE_API_KEY`
- Pin a Concentrate model slug (`"gpt-5.4"`; users can swap in `"auto"` for least-cost routing or `"openai/gpt-5.4"` to provider-pin)
- Disable the `openai-agents` default tracing exporter (it ships traces to OpenAI's tracing endpoint, which rejects Concentrate keys)

Tool calling, agent orchestration, and Flyte task wrapping are unchanged because Concentrate exposes the same `/v1/responses` surface that `openai-agents` uses by default. Governance, failover, spend visibility, and guardrails are configured per API key in the Concentrate dashboard, so no extra code is required in the example to demo them; once traffic flows through the gateway it picks up the policy.

## Context

Coordinated with @samhita-alla (see thread on the Union/Concentrate test accounts) — Samhita suggested contributing an example here as the starting point for the partnership and offered to amplify once merged. Happy to pair with a blog post on our end too.

## Test plan

- [x] `ruff format` + `ruff check` pass
- [x] Verified Concentrate `/v1/responses` works end-to-end with `gpt-5.4` via `AsyncOpenAI(base_url=...)` outside Flyte
- [x] Verified the full `openai-agents` Runner path (`set_default_openai_client` + `set_tracing_disabled` + `Agent(model="gpt-5.4", tools=[...])`) executes a tool-call loop end-to-end against Concentrate
- [ ] Reviewer can run the full Flyte workflow against a cluster with a `concentrate_api_key` secret

Made with [Cursor](https://cursor.com)