### PR TITLE
feat(convert): expose current output name to type transformers

### DIFF
--- a/src/flyte/_internal/runtime/convert.py
+++ b/src/flyte/_internal/runtime/convert.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextvars
 import hashlib
 import inspect
 from dataclasses import dataclass
 from types import NoneType
-from typing import Any, Dict, List, Tuple, Union, get_args
+from typing import Any, Dict, List, Optional, Tuple, Union, get_args
 
 from flyteidl2.core import execution_pb2, interface_pb2, literals_pb2
 from flyteidl2.task import common_pb2, task_definition_pb2
@@ -16,6 +17,23 @@ import flyte.storage as storage
 from flyte._context import ctx
 from flyte.models import ActionID, NativeInterface, TaskContext
 from flyte.types import TypeEngine, TypeTransformerFailedError
+
+# Name of the output slot currently being serialized (e.g. "o0"), scoped to
+# a single ``TypeEngine.to_literal`` call by ``convert_from_native_to_outputs``.
+# Lets a TypeTransformer attribute a value to the output it's being returned
+# as — without threading the name through ``to_literal``'s signature (which
+# every transformer would have to adopt). ``None`` outside output conversion
+# (e.g. on the input path), so readers must treat absence as "unknown".
+_output_name_var: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "flyte_current_output_name", default=None
+)
+
+
+def current_output_name() -> Optional[str]:
+    """The output slot name being converted right now (e.g. ``"o0"``), or
+    ``None`` when not inside output conversion. See :data:`_output_name_var`.
+    """
+    return _output_name_var.get()
 
 
 @dataclass(frozen=True)
@@ -256,11 +274,16 @@ async def convert_from_native_to_outputs(o: Any, interface: NativeInterface, tas
         )
     named = []
     for (output_name, python_type), v in zip(interface.outputs.items(), o):
+        # Expose the output slot name to transformers for the duration of this
+        # single conversion (see ``current_output_name``), then always clear it.
+        tok = _output_name_var.set(output_name)
         try:
             lit = await TypeEngine.to_literal(v, python_type, TypeEngine.to_literal_type(python_type))
             named.append(common_pb2.NamedLiteral(name=output_name, value=lit))
         except TypeTransformerFailedError as e:
             raise flyte.errors.RuntimeDataValidationError(output_name, e, task_name)
+        finally:
+            _output_name_var.reset(tok)
 
     return Outputs(proto_outputs=common_pb2.Outputs(literals=named))
 

--- a/tests/flyte/internal/runtime/test_convert.py
+++ b/tests/flyte/internal/runtime/test_convert.py
@@ -1460,6 +1460,7 @@ async def test_convert_upload_default_inputs_remote_interface():
 # current_output_name
 # ---------------------------------------------------------------------------
 
+
 def test_current_output_name_is_none_outside_conversion():
     """Outside of output conversion the slot name should be absent."""
     assert current_output_name() is None

--- a/tests/flyte/internal/runtime/test_convert.py
+++ b/tests/flyte/internal/runtime/test_convert.py
@@ -27,7 +27,7 @@ from flyteidl2.task import common_pb2 as _task_common_pb2
 from flyteidl2.task import common_pb2 as run_definition_pb2
 
 import flyte._internal.runtime.convert as convert
-from flyte._internal.runtime.convert import Inputs, generate_sub_action_id_and_output_path
+from flyte._internal.runtime.convert import Inputs, current_output_name, generate_sub_action_id_and_output_path
 from flyte._internal.runtime.types_serde import transform_native_to_typed_interface
 from flyte.models import ActionID, NativeInterface, RawDataPath, TaskContext
 from flyte.report import Report
@@ -1454,3 +1454,70 @@ async def test_convert_upload_default_inputs_remote_interface():
             value=await TypeEngine.to_literal("hello", str, TypeEngine.to_literal_type(str)),
         ),
     ]
+
+
+# ---------------------------------------------------------------------------
+# current_output_name
+# ---------------------------------------------------------------------------
+
+def test_current_output_name_is_none_outside_conversion():
+    """Outside of output conversion the slot name should be absent."""
+    assert current_output_name() is None
+
+
+def test_current_output_name_reflects_contextvar():
+    """current_output_name() is a thin wrapper over the ContextVar."""
+    from flyte._internal.runtime.convert import _output_name_var
+
+    assert current_output_name() is None
+    tok = _output_name_var.set("o0")
+    try:
+        assert current_output_name() == "o0"
+    finally:
+        _output_name_var.reset(tok)
+    assert current_output_name() is None
+
+
+@pytest.mark.asyncio
+async def test_current_output_name_set_during_output_conversion():
+    """current_output_name() returns each output slot name while its value is
+    being converted, and is None again both before and after."""
+    observed: list[str | None] = []
+    original_to_literal = convert.TypeEngine.to_literal
+
+    async def _capturing_to_literal(value, python_type, expected_literal_type):
+        observed.append(current_output_name())
+        return await original_to_literal(value, python_type, expected_literal_type)
+
+    # int is natively supported — no pickle fallback.
+    interface = NativeInterface.from_types({}, {"slot_a": int, "slot_b": int})
+
+    assert current_output_name() is None
+    convert.TypeEngine.to_literal = _capturing_to_literal
+    try:
+        await convert.convert_from_native_to_outputs((1, 2), interface, "test_task")
+    finally:
+        convert.TypeEngine.to_literal = original_to_literal
+
+    assert observed == ["slot_a", "slot_b"]
+    assert current_output_name() is None
+
+
+@pytest.mark.asyncio
+async def test_current_output_name_cleared_on_transformer_error():
+    """Even when a transformer raises, the slot name is cleared."""
+    original_to_literal = convert.TypeEngine.to_literal
+
+    async def _failing_to_literal(value, python_type, expected_literal_type):
+        raise convert.TypeTransformerFailedError("boom")
+
+    interface = NativeInterface.from_types({}, {"out": int})
+
+    convert.TypeEngine.to_literal = _failing_to_literal
+    try:
+        with pytest.raises(Exception):
+            await convert.convert_from_native_to_outputs((42,), interface, "test_task")
+    finally:
+        convert.TypeEngine.to_literal = original_to_literal
+
+    assert current_output_name() is None


### PR DESCRIPTION
## What

Adds a contextvar that exposes the **name of the output slot** currently being serialized (e.g. `o0`) to type transformers, plus a `current_output_name()` accessor.

`convert_from_native_to_outputs` sets the contextvar around each `TypeEngine.to_literal` call (and clears it in a `finally`), so a transformer can attribute a returned value to the specific output it's being serialized as — without threading the name through `to_literal`'s signature, which every transformer would otherwise have to adopt.

- `None` on the input path and outside output conversion; readers treat absence as "unknown".
- Scoped per-conversion via `set`/`reset`, so it never leaks across outputs.

## Why

The `flyteplugins-union` Volume lineage work needs to record which task output a `Volume` was returned as (so `flyte volume explore` can deep-link to a specific output and stamp `produced_by.output_name`). That information only exists at output-conversion time. This is the minimal, generic hook that surfaces it; the plugin reads it defensively and degrades to `None` against an SDK without this change.

## Scope

~24 lines in `convert.py`, behind the existing output loop. No behavior change for existing transformers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)