### PR TITLE
add support for Union types with Field annotation in pydantic types

### DIFF
--- a/examples/basics/types/pydantic_union_types.py
+++ b/examples/basics/types/pydantic_union_types.py
@@ -3,11 +3,24 @@
 ``Annotated[Union[A, B], Field(discriminator=...)]`` is a common Pydantic v2
 pattern that emits a JSON schema using ``oneOf`` plus a top-level
 ``discriminator`` object (no top-level ``type`` and no ``anyOf``). This
-example exercises that pattern end-to-end through ``flyte.run`` so the
-type engine has to roundtrip the union through serialization and reconstruct
-the right variant on the receiving side.
+example exercises that pattern end-to-end through ``flyte.run`` so the type
+engine has to roundtrip the union through serialization and reconstruct the
+right variant on the receiving side.
+
+It deliberately covers the three flavors of discriminated unions that the
+type engine needs to handle correctly:
+
+1. ``Shape`` -- a "classic" string-``Literal`` discriminator with variants
+   that have *non-overlapping* fields (``Circle.radius`` vs ``Rectangle.width``).
+2. ``Event`` -- an ``Enum``-typed discriminator where the variants have
+   *overlapping* field sets. Without a discriminator the type engine would
+   not be able to unambiguously pick the right variant from a dict, so this
+   exercises the schema-declared ``discriminator.mapping`` dispatch.
+3. ``Payment`` -- the same enum-discriminator pattern but used inside a
+   ``list[...]`` field, so the type engine has to dispatch per-element.
 """
 
+from enum import Enum
 from typing import Annotated, Literal, Union
 
 from pydantic import BaseModel, Field
@@ -18,6 +31,9 @@ env = flyte.TaskEnvironment(
     name="inputs_pydantic_union_types",
     image=flyte.Image.from_debian_base(),
 )
+
+
+# ---- Case 1: classic string-Literal discriminator, non-overlapping fields ----
 
 
 class Circle(BaseModel):
@@ -46,6 +62,86 @@ class ShapeReport(BaseModel):
     area: float
 
 
+# ---- Case 2: Enum-typed discriminator with overlapping fields ---------------
+
+
+class EventKind(str, Enum):
+    """An enum-typed discriminator value.
+
+    Note: subclassing ``str`` keeps the JSON-serialized form a plain string
+    (``"login"`` rather than ``"EventKind.LOGIN"``). The type engine also
+    handles non-``str`` ``Enum``s, but ``str``-enums are by far the most
+    common pattern in real-world Pydantic models.
+    """
+
+    LOGIN = "login"
+    LOGOUT = "logout"
+
+
+class LoginEvent(BaseModel):
+    # Variants share the ``user_id`` and ``timestamp`` fields. The
+    # discriminator is the *only* way to distinguish them from a raw dict --
+    # this is the case AdilFayyaz called out in the PR review.
+    kind: Literal[EventKind.LOGIN] = EventKind.LOGIN
+    user_id: str
+    timestamp: float
+    source_ip: str = ""
+
+
+class LogoutEvent(BaseModel):
+    kind: Literal[EventKind.LOGOUT] = EventKind.LOGOUT
+    user_id: str
+    timestamp: float
+    session_duration_s: float = 0.0
+
+
+Event = Annotated[Union[LoginEvent, LogoutEvent], Field(discriminator="kind")]
+
+
+class EventEnvelope(BaseModel):
+    event: Event
+
+
+class EventSummary(BaseModel):
+    kind: str
+    user_id: str
+
+
+# ---- Case 3: List of enum-discriminated unions ------------------------------
+
+
+class PaymentMethod(str, Enum):
+    CARD = "card"
+    BANK_TRANSFER = "bank_transfer"
+
+
+class CardPayment(BaseModel):
+    method: Literal[PaymentMethod.CARD] = PaymentMethod.CARD
+    amount: float
+    last4: str = ""
+
+
+class BankTransferPayment(BaseModel):
+    method: Literal[PaymentMethod.BANK_TRANSFER] = PaymentMethod.BANK_TRANSFER
+    amount: float
+    account_id: str = ""
+
+
+Payment = Annotated[Union[CardPayment, BankTransferPayment], Field(discriminator="method")]
+
+
+class PaymentBatch(BaseModel):
+    payments: list[Payment] = Field(default_factory=list)
+
+
+class PaymentTotals(BaseModel):
+    total: float
+    by_method: dict[str, float]
+
+
+# ---- Tasks -----------------------------------------------------------------
+
+
 @env.task
 def describe_shape(props: Properties) -> ShapeReport:
     """Receive a Pydantic model whose field is a discriminated union."""
@@ -58,23 +154,59 @@ def describe_shape(props: Properties) -> ShapeReport:
 
 
 @env.task
-def main(props: Properties = Properties(shape=Rectangle(color="blue", width=4.0, height=2.5))) -> ShapeReport:
-    return describe_shape(props=props)
+def summarize_event(envelope: EventEnvelope) -> EventSummary:
+    """Dispatch on an enum-typed discriminator with overlapping-field variants."""
+    event = envelope.event
+    return EventSummary(kind=event.kind.value, user_id=event.user_id)
+
+
+@env.task
+def total_payments(batch: PaymentBatch) -> PaymentTotals:
+    """Iterate a list of enum-discriminated variants and aggregate amounts."""
+    by_method: dict[str, float] = {}
+    for payment in batch.payments:
+        by_method[payment.method.value] = by_method.get(payment.method.value, 0.0) + payment.amount
+    return PaymentTotals(total=sum(by_method.values()), by_method=by_method)
+
+
+@env.task
+def main(
+    props: Properties = Properties(shape=Rectangle(color="blue", width=4.0, height=2.5)),
+    envelope: EventEnvelope = EventEnvelope(event=LoginEvent(user_id="u-1", timestamp=0.0)),
+    batch: PaymentBatch = PaymentBatch(
+        payments=[
+            CardPayment(amount=12.50, last4="4242"),
+            BankTransferPayment(amount=100.00, account_id="acct-7"),
+        ],
+    ),
+) -> tuple[ShapeReport, EventSummary, PaymentTotals]:
+    return (
+        describe_shape(props=props),
+        summarize_event(envelope=envelope),
+        total_payments(batch=batch),
+    )
 
 
 if __name__ == "__main__":
     flyte.init_from_config()
 
-    # Run with the default (Rectangle) shape.
-    print("Testing with Rectangle:")
+    # Run with all defaults: Rectangle shape + LoginEvent + a mixed payment batch.
+    print("Testing with defaults (Rectangle / LoginEvent / mixed payments):")
     r1 = flyte.run(main)
     print(r1.name)
     print(r1.url)
     r1.wait()
 
-    # Run with a Circle to exercise the other variant of the discriminated union.
-    print("\nTesting with Circle:")
-    r2 = flyte.run(main, props=Properties(shape=Circle(color="red", radius=2.0)))
+    # Exercise the other variant of each discriminated union.
+    print("\nTesting with Circle / LogoutEvent / single CardPayment:")
+    r2 = flyte.run(
+        main,
+        props=Properties(shape=Circle(color="red", radius=2.0)),
+        envelope=EventEnvelope(
+            event=LogoutEvent(user_id="u-1", timestamp=10.0, session_duration_s=10.0),
+        ),
+        batch=PaymentBatch(payments=[CardPayment(amount=42.00, last4="1234")]),
+    )
     print(r2.name)
     print(r2.url)
     r2.wait()

--- a/examples/basics/types/pydantic_union_types.py
+++ b/examples/basics/types/pydantic_union_types.py
@@ -1,0 +1,80 @@
+"""Pydantic v2 discriminated (tagged) unions as task inputs.
+
+``Annotated[Union[A, B], Field(discriminator=...)]`` is a common Pydantic v2
+pattern that emits a JSON schema using ``oneOf`` plus a top-level
+``discriminator`` object (no top-level ``type`` and no ``anyOf``). This
+example exercises that pattern end-to-end through ``flyte.run`` so the
+type engine has to roundtrip the union through serialization and reconstruct
+the right variant on the receiving side.
+"""
+
+from typing import Annotated, Literal, Union
+
+from pydantic import BaseModel, Field
+
+import flyte
+
+env = flyte.TaskEnvironment(
+    name="inputs_pydantic_union_types",
+    image=flyte.Image.from_debian_base(),
+)
+
+
+class Circle(BaseModel):
+    kind: Literal["circle"] = "circle"
+    color: str = ""
+    radius: float = 0.0
+
+
+class Rectangle(BaseModel):
+    kind: Literal["rectangle"] = "rectangle"
+    color: str = ""
+    width: float = 0.0
+    height: float = 0.0
+
+
+Shape = Annotated[Union[Circle, Rectangle], Field(discriminator="kind")]
+
+
+class Properties(BaseModel):
+    shape: Shape
+
+
+class ShapeReport(BaseModel):
+    kind: str
+    color: str
+    area: float
+
+
+@env.task
+def describe_shape(props: Properties) -> ShapeReport:
+    """Receive a Pydantic model whose field is a discriminated union."""
+    shape = props.shape
+    if isinstance(shape, Circle):
+        area = 3.141592653589793 * shape.radius * shape.radius
+    else:
+        area = shape.width * shape.height
+    return ShapeReport(kind=shape.kind, color=shape.color, area=area)
+
+
+@env.task
+def main(props: Properties = Properties(shape=Rectangle(color="blue", width=4.0, height=2.5))) -> ShapeReport:
+    return describe_shape(props=props)
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+
+    # Run with the default (Rectangle) shape.
+    print("Testing with Rectangle:")
+    r1 = flyte.run(main)
+    print(r1.name)
+    print(r1.url)
+    r1.wait()
+
+    # Run with a Circle to exercise the other variant of the discriminated union.
+    print("\nTesting with Circle:")
+    r2 = flyte.run(main, props=Properties(shape=Circle(color="red", radius=2.0)))
+    print(r2.name)
+    print(r2.url)
+    r2.wait()

--- a/src/flyte/types/_type_engine.py
+++ b/src/flyte/types/_type_engine.py
@@ -1194,13 +1194,46 @@ class _DiscriminatedUnion:
     """
 
     discriminator_property: typing.Optional[str]
-    mapping: typing.Mapping[str, type]
+    mapping: typing.Mapping[typing.Any, type]
     variants: typing.Tuple[type, ...]
 
 
+def _normalize_discriminator_value(value: typing.Any) -> typing.Any:
+    """Normalize a discriminator value for mapping lookup.
+
+    Pydantic v2 emits the schema-level ``discriminator.mapping`` keys as JSON
+    primitives (strings/ints/bools), but at runtime the corresponding model
+    field value can be an ``Enum`` member (e.g. when the discriminator field
+    is typed as a non-``str`` ``Enum``). Unwrap such values to their underlying
+    primitive so the lookup keys match.
+    """
+    if isinstance(value, enum.Enum):
+        return value.value
+    return value
+
+
+def _select_unambiguous_variant(variants: typing.Sequence[type], value: dict[str, Any]) -> type | None:
+    """Return the single variant whose dataclass fields accept ``value`` keys.
+
+    Used as a safe fallback when a ``oneOf`` schema lacks a usable discriminator.
+    Returns ``None`` if zero or more than one variant matches so the caller can
+    raise a clear ambiguity error instead of silently picking the first match.
+    """
+    value_keys = set(value.keys())
+    matches: list[type] = []
+    for variant_cls in variants:
+        try:
+            variant_fields = {f.name for f in dataclasses.fields(variant_cls)}
+        except TypeError:
+            continue
+        if value_keys.issubset(variant_fields):
+            matches.append(variant_cls)
+    return matches[0] if len(matches) == 1 else None
+
+
 def _mutable_schema_default_factory(
-    default: list[typing.Any] | dict[typing.Any, typing.Any],
-) -> typing.Callable[[], list[typing.Any] | dict[typing.Any, typing.Any]]:
+    default: list[Any] | dict[Any, Any],
+) -> typing.Callable[[], list[Any] | dict[Any, Any]]:
     """Return a no-arg factory for dataclass fields with mutable JSON-schema defaults."""
     snapshot = copy.deepcopy(default)
 
@@ -1211,11 +1244,11 @@ def _mutable_schema_default_factory(
 
 
 def _append_schema_field(
-    attribute_list: typing.List[typing.Tuple[Any, ...]],
+    attribute_list: list[tuple[Any, ...]],
     property_key: str,
-    field_type: typing.Any,
-    property_val: typing.Dict[str, typing.Any],
-    schema: typing.Dict[str, typing.Any],
+    field_type: Any,
+    property_val: dict[str, Any],
+    schema: dict[str, Any],
 ) -> None:
     """Append a dataclass field tuple, honoring JSON-schema ``default`` and ``required``."""
     required_set = set(schema.get("required") or ())
@@ -1360,11 +1393,33 @@ def generate_attribute_list_from_dataclass_json_mixin(schema: dict, schema_name:
                 discriminator_property = discriminator.get("propertyName")
                 mapping_from_schema = discriminator.get("mapping") or {}
                 # Map discriminator values to the runtime classes via the $ref name
-                discriminator_mapping: typing.Dict[str, type] = {}
+                discriminator_mapping: typing.Dict[typing.Any, type] = {}
                 for disc_value, ref_path in mapping_from_schema.items():
                     ref_name = ref_path.split("/")[-1] if isinstance(ref_path, str) else None
                     if ref_name is not None and ref_name in ref_name_to_class:
                         discriminator_mapping[disc_value] = ref_name_to_class[ref_name]
+                # If the schema didn't supply an explicit mapping (it's optional per the
+                # JSON Schema/OpenAPI specs), or it's incomplete, derive entries from the
+                # variants' own schemas by looking at the discriminator field's ``const``
+                # / single-element ``enum`` value. This is also what makes enum-typed
+                # discriminator fields work without any explicit mapping.
+                if discriminator_property is not None:
+                    defs = schema.get("$defs", schema.get("definitions", {}))
+                    mapped_classes = set(discriminator_mapping.values())
+                    for ref_name, variant_cls in ref_name_to_class.items():
+                        if variant_cls in mapped_classes:
+                            continue
+                        variant_schema = defs.get(ref_name, {})
+                        disc_field = (variant_schema.get("properties") or {}).get(discriminator_property)
+                        if not isinstance(disc_field, dict):
+                            continue
+                        const_val: typing.Any = disc_field.get("const")
+                        if const_val is None:
+                            enum_vals = disc_field.get("enum")
+                            if isinstance(enum_vals, list) and len(enum_vals) == 1:
+                                const_val = enum_vals[0]
+                        if const_val is not None:
+                            discriminator_mapping[const_val] = variant_cls
                 nested_types[property_key] = _DiscriminatedUnion(
                     discriminator_property=discriminator_property,
                     mapping=discriminator_mapping,
@@ -2489,23 +2544,41 @@ def convert_mashumaro_json_schema_to_python_class(schema: dict, schema_name: typ
                 if not isinstance(value, dict):
                     continue
                 if isinstance(descriptor, _DiscriminatedUnion):
-                    target_cls = None
                     disc_property = descriptor.discriminator_property
-                    if disc_property is not None:
-                        disc_value = value.get(disc_property)
-                        if disc_value is not None:
-                            target_cls = descriptor.mapping.get(disc_value)
-                    if target_cls is None:
-                        # Best effort: try each variant constructor until one succeeds. This is the
-                        # fallback path when no discriminator is specified or it does not match.
-                        for variant_cls in descriptor.variants:
-                            try:
-                                kwargs[field_name] = variant_cls(**value)
-                                break
-                            except TypeError:
-                                continue
-                    else:
+                    # Preferred path: dispatch using the schema-declared discriminator.
+                    # This is unambiguous even when two variants share fields.
+                    if disc_property is not None and descriptor.mapping:
+                        if disc_property not in value:
+                            raise ValueError(
+                                f"Cannot construct field {field_name!r} from discriminated union: "
+                                f"input is missing the discriminator property {disc_property!r}. "
+                                f"Expected one of {sorted(descriptor.mapping.keys())!r}."
+                            )
+                        raw_disc_value = value[disc_property]
+                        lookup_value = _normalize_discriminator_value(raw_disc_value)
+                        target_cls = descriptor.mapping.get(lookup_value)
+                        if target_cls is None:
+                            raise ValueError(
+                                f"Cannot construct field {field_name!r} from discriminated union: "
+                                f"discriminator value {raw_disc_value!r} for property {disc_property!r} "
+                                f"does not match any known variant. Expected one of "
+                                f"{sorted(descriptor.mapping.keys())!r}."
+                            )
                         kwargs[field_name] = target_cls(**value)
+                    else:
+                        # No usable discriminator: only dispatch when exactly one variant's
+                        # fields accept the input dict, so we never silently pick the wrong
+                        # variant for two models that share fields.
+                        matched_cls = _select_unambiguous_variant(descriptor.variants, value)
+                        if matched_cls is None:
+                            variant_names = [c.__name__ for c in descriptor.variants]
+                            raise ValueError(
+                                f"Cannot construct field {field_name!r} from union: input dict is "
+                                f"ambiguous (or matches no variant) across {variant_names!r} and no "
+                                f"discriminator is available. Provide a discriminator field or pass "
+                                f"the variant instance directly."
+                            )
+                        kwargs[field_name] = matched_cls(**value)
                 else:
                     kwargs[field_name] = descriptor(**value)
             original_init(self, *args, **kwargs)

--- a/src/flyte/types/_type_engine.py
+++ b/src/flyte/types/_type_engine.py
@@ -679,6 +679,17 @@ def _get_pydantic_element_type(
             return typing.Optional[inner_type] if has_null else inner_type  # type: ignore
         return type(None)
 
+    # Discriminated unions in Pydantic v2 produce oneOf rather than anyOf
+    if element_property.get("oneOf"):
+        variants = element_property["oneOf"]
+        non_null = [v for v in variants if v.get("type") != "null"]
+        has_null = len(non_null) < len(variants)
+        if non_null:
+            variant_types = tuple(_get_pydantic_element_type(v, schema) for v in non_null)
+            inner_type = variant_types[0] if len(variant_types) == 1 else typing.Union[variant_types]  # type: ignore
+            return typing.Optional[inner_type] if has_null else inner_type  # type: ignore
+        return type(None)
+
     element_type = element_property.get("type")
     if element_type == "object":
         if element_property.get("additionalProperties"):
@@ -713,7 +724,7 @@ def _create_pydantic_model_from_schema(schema: dict) -> Type:
         if "default" in prop:
             fields[name] = (field_type, prop["default"])
         elif schema_declares_required and name not in required_set:
-            if prop.get("anyOf"):
+            if prop.get("anyOf") or prop.get("oneOf"):
                 fields[name] = (typing.Optional[field_type], None)
             else:
                 fields[name] = (field_type, ...)
@@ -1173,6 +1184,20 @@ def _match_registered_type_from_schema(schema: dict) -> typing.Optional[type]:
     return None
 
 
+@dataclasses.dataclass(frozen=True)
+class _DiscriminatedUnion:
+    """Descriptor for a Pydantic v2 discriminated union field.
+
+    Captures the discriminator property name and a mapping of discriminator
+    values to the resolved Python classes so dict-to-object conversion in the
+    generated dataclass's ``__init__`` can pick the right variant.
+    """
+
+    discriminator_property: typing.Optional[str]
+    mapping: typing.Mapping[str, type]
+    variants: typing.Tuple[type, ...]
+
+
 def _mutable_schema_default_factory(
     default: list[typing.Any] | dict[typing.Any, typing.Any],
 ) -> typing.Callable[[], list[typing.Any] | dict[typing.Any, typing.Any]]:
@@ -1210,7 +1235,7 @@ def _append_schema_field(
             attribute_list.append((property_key, field_type, default))
         return
     if schema_declares_required and property_key not in required_set:
-        if property_val.get("anyOf"):
+        if property_val.get("anyOf") or property_val.get("oneOf"):
             attribute_list.append((property_key, typing.Optional[field_type], None))
         else:
             attribute_list.append((property_key, field_type))
@@ -1218,10 +1243,56 @@ def _append_schema_field(
     attribute_list.append((property_key, field_type))
 
 
+def _resolve_oneof_variants(
+    variants: typing.Sequence[typing.Dict[str, typing.Any]],
+    schema: typing.Dict[str, typing.Any],
+) -> typing.Tuple[typing.List[Any], typing.List[type], typing.Dict[str, type]]:
+    """Resolve the ``oneOf`` variants of a JSON schema property to Python types.
+
+    Returns a tuple of:
+      - ``variant_types``: list of resolved Python types (for building Union)
+      - ``variant_classes``: list of dynamically generated classes (for dict->object conversion)
+      - ``ref_name_to_class``: mapping from ``$ref`` name to the generated class
+        (used to wire up the discriminator's ``mapping`` to runtime classes)
+    """
+    variant_types: typing.List[Any] = []
+    variant_classes: typing.List[type] = []
+    ref_name_to_class: typing.Dict[str, type] = {}
+    defs = schema.get("$defs", schema.get("definitions", {}))
+
+    for variant in variants:
+        if not isinstance(variant, dict):
+            variant_types.append(_get_element_type(variant, schema))
+            continue
+        if variant.get("$ref"):
+            ref_name = variant["$ref"].split("/")[-1]
+            if ref_name in defs:
+                ref_schema = defs[ref_name].copy()
+                if ref_schema.get("enum"):
+                    variant_types.append(str)
+                    continue
+                matched = _match_registered_type_from_schema(ref_schema)
+                if matched is not None:
+                    variant_types.append(matched)
+                    continue
+                if "$defs" not in ref_schema and defs:
+                    ref_schema["$defs"] = defs
+                nested_class: type = convert_mashumaro_json_schema_to_python_class(ref_schema, ref_name)
+                variant_types.append(nested_class)
+                variant_classes.append(nested_class)
+                ref_name_to_class[ref_name] = nested_class
+                continue
+        variant_types.append(_get_element_type(variant, schema))
+
+    return variant_types, variant_classes, ref_name_to_class
+
+
 def generate_attribute_list_from_dataclass_json_mixin(schema: dict, schema_name: typing.Any):
 
     attribute_list: typing.List[typing.Tuple[Any, Any]] = []
-    nested_types: typing.Dict[str, type] = {}  # Track nested model types for conversion
+    # Tracks nested model types for dict-to-object conversion. Values are either a single class
+    # (for $ref / anyOf single-variant fields) or a _DiscriminatedUnion (for oneOf fields).
+    nested_types: typing.Dict[str, typing.Any] = {}
 
     # Use 'required' field to preserve property order, as protobuf Struct doesn't preserve dict order
     properties = schema["properties"]
@@ -1260,12 +1331,74 @@ def generate_attribute_list_from_dataclass_json_mixin(schema: dict, schema_name:
                 nested_types[property_key] = nested_class
             continue
 
+        # Handle oneOf -- Pydantic v2 emits this for discriminated unions
+        # (e.g. Annotated[Union[A, B], Field(discriminator="kind")]). The property has no
+        # top-level "type"; instead it has "oneOf" with the variant schemas.
+        if property_val.get("oneOf"):
+            variants = property_val["oneOf"]
+            non_null_variants = [v for v in variants if not (isinstance(v, dict) and v.get("type") == "null")]
+            has_null = len(non_null_variants) < len(variants)
+
+            variant_types, variant_classes, ref_name_to_class = _resolve_oneof_variants(non_null_variants, schema)
+
+            if not variant_types:
+                field_type: Any = type(None)
+            elif len(variant_types) == 1:
+                field_type = variant_types[0]
+            else:
+                field_type = typing.Union[tuple(variant_types)]  # type: ignore
+
+            if has_null:
+                field_type = typing.Optional[field_type]  # type: ignore
+
+            _append_schema_field(
+                attribute_list, property_key, typing.cast(GenericAlias, field_type), property_val, schema
+            )
+
+            if variant_classes:
+                discriminator = property_val.get("discriminator") or {}
+                discriminator_property = discriminator.get("propertyName")
+                mapping_from_schema = discriminator.get("mapping") or {}
+                # Map discriminator values to the runtime classes via the $ref name
+                discriminator_mapping: typing.Dict[str, type] = {}
+                for disc_value, ref_path in mapping_from_schema.items():
+                    ref_name = ref_path.split("/")[-1] if isinstance(ref_path, str) else None
+                    if ref_name is not None and ref_name in ref_name_to_class:
+                        discriminator_mapping[disc_value] = ref_name_to_class[ref_name]
+                nested_types[property_key] = _DiscriminatedUnion(
+                    discriminator_property=discriminator_property,
+                    mapping=discriminator_mapping,
+                    variants=tuple(variant_classes),
+                )
+            continue
+
         if property_val.get("anyOf"):
-            property_type = property_val["anyOf"][0]["type"]
+            # Resolve the first variant's "type" carefully -- anyOf variants may be
+            # $refs (e.g. Optional[Dataclass]) and not have a top-level "type" key.
+            anyof_variants = property_val["anyOf"]
+            non_null_anyof = [v for v in anyof_variants if not (isinstance(v, dict) and v.get("type") == "null")]
+            first_variant = non_null_anyof[0] if non_null_anyof else (anyof_variants[0] if anyof_variants else {})
+            if isinstance(first_variant, dict) and "type" in first_variant:
+                property_type = first_variant["type"]
+            elif isinstance(first_variant, dict) and "$ref" in first_variant:
+                # Treat $ref variant as a nested object (existing object branch handles it)
+                property_type = "object"
+            else:
+                # Fall through to general element resolution
+                _append_schema_field(
+                    attribute_list, property_key, _get_element_type(property_val, schema), property_val, schema
+                )
+                continue
         elif property_val.get("enum"):
             property_type = "enum"
-        else:
+        elif "type" in property_val:
             property_type = property_val["type"]
+        else:
+            # Unknown/exotic schema shape -- fall back to best-effort element type resolution
+            _append_schema_field(
+                attribute_list, property_key, _get_element_type(property_val, schema), property_val, schema
+            )
+            continue
         # Handle list
         if property_type == "array":
             _append_schema_field(
@@ -2349,11 +2482,32 @@ def convert_mashumaro_json_schema_to_python_class(schema: dict, schema_name: typ
 
         def __init__(self, *args, **kwargs):  # type: ignore[misc]
             # Convert dict values to nested types before calling original __init__
-            for field_name, field_type in nested_types.items():
-                if field_name in kwargs:
-                    value = kwargs[field_name]
-                    if isinstance(value, dict):
-                        kwargs[field_name] = field_type(**value)
+            for field_name, descriptor in nested_types.items():
+                if field_name not in kwargs:
+                    continue
+                value = kwargs[field_name]
+                if not isinstance(value, dict):
+                    continue
+                if isinstance(descriptor, _DiscriminatedUnion):
+                    target_cls = None
+                    disc_property = descriptor.discriminator_property
+                    if disc_property is not None:
+                        disc_value = value.get(disc_property)
+                        if disc_value is not None:
+                            target_cls = descriptor.mapping.get(disc_value)
+                    if target_cls is None:
+                        # Best effort: try each variant constructor until one succeeds. This is the
+                        # fallback path when no discriminator is specified or it does not match.
+                        for variant_cls in descriptor.variants:
+                            try:
+                                kwargs[field_name] = variant_cls(**value)
+                                break
+                            except TypeError:
+                                continue
+                    else:
+                        kwargs[field_name] = target_cls(**value)
+                else:
+                    kwargs[field_name] = descriptor(**value)
             original_init(self, *args, **kwargs)
 
         cls.__init__ = __init__  # type: ignore[method-assign, misc]
@@ -2419,6 +2573,18 @@ def _get_element_type(
             inner_type = _get_element_type(non_null[0], schema)
             return typing.Optional[inner_type] if has_null else inner_type  # type: ignore
         # return None if all types are None
+        return type(None)
+
+    # Handle oneOf (Pydantic v2 emits this for discriminated unions,
+    # e.g. Annotated[Union[A, B], Field(discriminator=...)])
+    if element_property.get("oneOf"):
+        variants = element_property["oneOf"]
+        non_null = [v for v in variants if v.get("type") != "null"]
+        has_null = len(non_null) < len(variants)
+        if non_null:
+            variant_types = tuple(_get_element_type(v, schema) for v in non_null)
+            inner_type = variant_types[0] if len(variant_types) == 1 else typing.Union[variant_types]  # type: ignore
+            return typing.Optional[inner_type] if has_null else inner_type  # type: ignore
         return type(None)
 
     element_type = element_property.get("type", "string")

--- a/tests/flyte/type_engine/pydantic/test_discriminated_union_in_pydantic.py
+++ b/tests/flyte/type_engine/pydantic/test_discriminated_union_in_pydantic.py
@@ -10,6 +10,7 @@ discriminated unions and made tasks with such inputs uninvocable.
 from __future__ import annotations
 
 import typing
+from enum import Enum
 from typing import Annotated, List, Literal, Optional, Union
 
 import pytest
@@ -21,6 +22,8 @@ from flyte.types._type_engine import (
     _DiscriminatedUnion,
     _get_element_type,
     _get_pydantic_element_type,
+    _normalize_discriminator_value,
+    _select_unambiguous_variant,
     convert_mashumaro_json_schema_to_python_class,
     generate_attribute_list_from_dataclass_json_mixin,
 )
@@ -173,3 +176,199 @@ async def test_list_of_discriminated_union_roundtrip():
     lv = await TypeEngine.to_literal(input_val, python_type=ListOfShapes, expected=lit)
     pv = await TypeEngine.to_python_value(lv, ListOfShapes)
     assert pv == input_val
+
+
+# ---------------------------------------------------------------------------
+# Regression tests
+# - Don't silently pick the wrong variant when discriminator dispatch fails.
+# - Enum-typed discriminator fields should still dispatch correctly.
+# ---------------------------------------------------------------------------
+
+
+class _OverlapA(BaseModel):
+    kind: Literal["a"] = "a"
+    shared: int = 0
+
+
+class _OverlapB(BaseModel):
+    kind: Literal["b"] = "b"
+    shared: int = 0
+
+
+_OverlapShape = Annotated[Union[_OverlapA, _OverlapB], Field(discriminator="kind")]
+
+
+class OverlapProperties(BaseModel):
+    shape: _OverlapShape
+
+
+def test_unknown_discriminator_value_raises_clear_error():
+    """An unknown discriminator value must raise ValueError instead of silently dispatching.
+
+    Two variants with overlapping fields previously caused the first-matching variant to
+    silently win when the discriminator lookup missed; we now fail loudly.
+    """
+    schema = OverlapProperties.model_json_schema()
+    cls = convert_mashumaro_json_schema_to_python_class(schema, "OverlapProperties")
+
+    with pytest.raises(ValueError, match="does not match any known variant"):
+        cls(shape={"kind": "c", "shared": 1})
+
+
+def test_missing_discriminator_field_raises_clear_error():
+    """When the discriminator property is missing from the input we surface a clear error."""
+    schema = OverlapProperties.model_json_schema()
+    cls = convert_mashumaro_json_schema_to_python_class(schema, "OverlapProperties")
+
+    with pytest.raises(ValueError, match="missing the discriminator property"):
+        cls(shape={"shared": 1})
+
+
+def test_overlapping_variants_dispatch_correctly_by_discriminator():
+    """Sanity check that overlapping-field variants dispatch via discriminator alone."""
+    schema = OverlapProperties.model_json_schema()
+    cls = convert_mashumaro_json_schema_to_python_class(schema, "OverlapProperties")
+
+    a_inst = cls(shape={"kind": "a", "shared": 1})
+    assert type(a_inst.shape).__name__ == "_OverlapA"
+
+    b_inst = cls(shape={"kind": "b", "shared": 2})
+    assert type(b_inst.shape).__name__ == "_OverlapB"
+
+
+# ---- Enum discriminator field --------------------------------------------------
+
+
+class _ShapeKind(str, Enum):
+    CIRCLE = "circle"
+    RECTANGLE = "rectangle"
+
+
+class _EnumCircle(BaseModel):
+    kind: Literal[_ShapeKind.CIRCLE] = _ShapeKind.CIRCLE
+    radius: float = 0.0
+
+
+class _EnumRectangle(BaseModel):
+    kind: Literal[_ShapeKind.RECTANGLE] = _ShapeKind.RECTANGLE
+    width: float = 0.0
+    height: float = 0.0
+
+
+_EnumShape = Annotated[Union[_EnumCircle, _EnumRectangle], Field(discriminator="kind")]
+
+
+class EnumDiscriminatorProperties(BaseModel):
+    shape: _EnumShape
+
+
+def test_enum_str_discriminator_dispatches_with_string_value():
+    """A ``str, Enum``-typed discriminator dispatches when the dict carries the string."""
+    schema = EnumDiscriminatorProperties.model_json_schema()
+    cls = convert_mashumaro_json_schema_to_python_class(schema, "EnumDiscriminatorProperties")
+
+    inst = cls(shape={"kind": "circle", "radius": 1.5})
+    assert type(inst.shape).__name__ == "_EnumCircle"
+    assert inst.shape.radius == 1.5
+
+
+def test_enum_discriminator_dispatches_with_enum_member_value():
+    """An ``Enum`` member used as the discriminator value should still resolve.
+
+    ``pydantic.BaseModel.model_dump()`` on a model with a non-``str`` enum returns the
+    enum member rather than its underlying value, so dict-to-object construction must
+    unwrap it before performing the mapping lookup.
+    """
+
+    class NonStrShapeKind(Enum):
+        CIRCLE = "circle"
+        RECTANGLE = "rectangle"
+
+    class NonStrCircle(BaseModel):
+        kind: Literal[NonStrShapeKind.CIRCLE] = NonStrShapeKind.CIRCLE
+        radius: float = 0.0
+
+    class NonStrRectangle(BaseModel):
+        kind: Literal[NonStrShapeKind.RECTANGLE] = NonStrShapeKind.RECTANGLE
+        width: float = 0.0
+        height: float = 0.0
+
+    NonStrShape = Annotated[Union[NonStrCircle, NonStrRectangle], Field(discriminator="kind")]
+
+    class NonStrProperties(BaseModel):
+        shape: NonStrShape
+
+    schema = NonStrProperties.model_json_schema()
+    cls = convert_mashumaro_json_schema_to_python_class(schema, "NonStrProperties")
+
+    inst = cls(shape={"kind": NonStrShapeKind.RECTANGLE, "width": 1.0, "height": 2.0})
+    assert type(inst.shape).__name__ == "NonStrRectangle"
+    assert inst.shape.width == 1.0
+
+
+# ---- Mapping backfill when schema omits discriminator.mapping ----------------
+
+
+def test_mapping_is_backfilled_when_schema_omits_explicit_mapping():
+    """If ``discriminator.mapping`` is absent the variants' ``const`` values are used."""
+    schema = Properties.model_json_schema()
+    # Drop the explicit mapping to simulate a JSON Schema generator that only supplies
+    # ``propertyName`` (which is what the OpenAPI/JSON Schema specs technically require).
+    del schema["properties"]["shape"]["discriminator"]["mapping"]
+
+    cls = convert_mashumaro_json_schema_to_python_class(schema, "Properties")
+    _, nested_types = generate_attribute_list_from_dataclass_json_mixin(schema, "Properties")
+    descriptor = nested_types["shape"]
+
+    assert isinstance(descriptor, _DiscriminatedUnion)
+    assert set(descriptor.mapping.keys()) == {"circle", "rectangle"}
+
+    circle_inst = cls(shape={"kind": "circle", "color": "red", "radius": 1.5})
+    assert type(circle_inst.shape).__name__ == "Circle"
+
+
+# ---- Helper unit tests --------------------------------------------------------
+
+
+def test_normalize_discriminator_value_unwraps_enums():
+    class _K(str, Enum):
+        A = "a"
+
+    class _K2(Enum):
+        B = 1
+
+    assert _normalize_discriminator_value(_K.A) == "a"
+    assert _normalize_discriminator_value(_K2.B) == 1
+    assert _normalize_discriminator_value("plain") == "plain"
+    assert _normalize_discriminator_value(7) == 7
+
+
+def test_select_unambiguous_variant_returns_none_on_ambiguity():
+    import dataclasses as _dc
+
+    @_dc.dataclass
+    class _A:
+        x: int = 0
+        y: int = 0
+
+    @_dc.dataclass
+    class _B:
+        x: int = 0
+        y: int = 0
+
+    assert _select_unambiguous_variant([_A, _B], {"x": 1, "y": 2}) is None
+
+
+def test_select_unambiguous_variant_returns_single_match():
+    import dataclasses as _dc
+
+    @_dc.dataclass
+    class _A:
+        x: int = 0
+
+    @_dc.dataclass
+    class _B:
+        y: int = 0
+
+    matched = _select_unambiguous_variant([_A, _B], {"x": 1})
+    assert matched is _A

--- a/tests/flyte/type_engine/pydantic/test_discriminated_union_in_pydantic.py
+++ b/tests/flyte/type_engine/pydantic/test_discriminated_union_in_pydantic.py
@@ -1,0 +1,175 @@
+"""Regression tests for Pydantic v2 tagged (discriminated) unions.
+
+Pydantic v2 emits JSON schemas for ``Annotated[Union[A, B], Field(discriminator=...)]``
+using ``oneOf`` and a top-level ``discriminator`` object instead of ``anyOf``. The
+type engine previously assumed any non-``$ref`` / non-``anyOf`` / non-``enum``
+property had a top-level ``type`` key, which crashed with ``KeyError: 'type'`` on
+discriminated unions and made tasks with such inputs uninvocable.
+"""
+
+from __future__ import annotations
+
+import typing
+from typing import Annotated, List, Literal, Optional, Union
+
+import pytest
+from pydantic import BaseModel, Field
+
+from flyte.types import TypeEngine
+from flyte.types._type_engine import (
+    _create_pydantic_model_from_schema,
+    _DiscriminatedUnion,
+    _get_element_type,
+    _get_pydantic_element_type,
+    convert_mashumaro_json_schema_to_python_class,
+    generate_attribute_list_from_dataclass_json_mixin,
+)
+
+
+class Circle(BaseModel):
+    kind: Literal["circle"] = "circle"
+    color: str = ""
+    radius: float = 0.0
+
+
+class Rectangle(BaseModel):
+    kind: Literal["rectangle"] = "rectangle"
+    color: str = ""
+    width: float = 0.0
+    height: float = 0.0
+
+
+Shape = Annotated[Union[Circle, Rectangle], Field(discriminator="kind")]
+
+
+class Properties(BaseModel):
+    shape: Shape
+
+
+class OptionalShapeProperties(BaseModel):
+    shape: Optional[Shape] = None
+
+
+class ListOfShapes(BaseModel):
+    shapes: List[Shape] = Field(default_factory=list)
+
+
+def test_oneof_schema_does_not_raise_key_error():
+    """Reproducer for the KeyError reported by customers using discriminated unions."""
+    schema = Properties.model_json_schema()
+    attribute_list, _ = generate_attribute_list_from_dataclass_json_mixin(schema, "Properties")
+    assert any(entry[0] == "shape" for entry in attribute_list)
+
+
+def test_oneof_resolves_to_union_type():
+    """The shape field should resolve to a Python Union of the variant classes."""
+    schema = Properties.model_json_schema()
+    cls = convert_mashumaro_json_schema_to_python_class(schema, "Properties")
+
+    import dataclasses
+
+    shape_field = next(f for f in dataclasses.fields(cls) if f.name == "shape")
+    origin = typing.get_origin(shape_field.type)
+    assert origin is Union
+    variants = typing.get_args(shape_field.type)
+    assert len(variants) == 2
+    variant_names = {v.__name__ for v in variants}
+    assert variant_names == {"Circle", "Rectangle"}
+
+
+def test_oneof_dispatches_on_discriminator():
+    """Constructing the generated dataclass from a dict should pick the right variant."""
+    schema = Properties.model_json_schema()
+    cls = convert_mashumaro_json_schema_to_python_class(schema, "Properties")
+
+    circle_instance = cls(shape={"kind": "circle", "color": "red", "radius": 1.5})
+    assert type(circle_instance.shape).__name__ == "Circle"
+    assert circle_instance.shape.radius == 1.5
+
+    rect_instance = cls(shape={"kind": "rectangle", "color": "blue", "width": 4.0, "height": 2.0})
+    assert type(rect_instance.shape).__name__ == "Rectangle"
+    assert rect_instance.shape.width == 4.0
+    assert rect_instance.shape.height == 2.0
+
+
+def test_discriminator_metadata_captured():
+    """The internal nested-type descriptor should carry the discriminator property name and mapping."""
+    schema = Properties.model_json_schema()
+    _, nested_types = generate_attribute_list_from_dataclass_json_mixin(schema, "Properties")
+    descriptor = nested_types["shape"]
+    assert isinstance(descriptor, _DiscriminatedUnion)
+    assert descriptor.discriminator_property == "kind"
+    assert set(descriptor.mapping.keys()) == {"circle", "rectangle"}
+    assert {cls.__name__ for cls in descriptor.variants} == {"Circle", "Rectangle"}
+
+
+def test_get_element_type_handles_oneof():
+    """_get_element_type should resolve oneOf to a Union[...] type."""
+    schema = Properties.model_json_schema()
+    prop = schema["properties"]["shape"]
+    result = _get_element_type(prop, schema)
+    assert typing.get_origin(result) is Union
+    assert len(typing.get_args(result)) == 2
+
+
+def test_get_pydantic_element_type_handles_oneof():
+    """_get_pydantic_element_type should also resolve oneOf to a Union[...] type."""
+    schema = Properties.model_json_schema()
+    prop = schema["properties"]["shape"]
+    result = _get_pydantic_element_type(prop, schema)
+    assert typing.get_origin(result) is Union
+
+
+def test_dynamic_pydantic_model_validates_discriminated_union():
+    """The dynamic Pydantic model created from a schema should validate discriminated input."""
+    schema = Properties.model_json_schema()
+    dynamic_model = _create_pydantic_model_from_schema(schema)
+
+    inst = dynamic_model.model_validate({"shape": {"kind": "circle", "color": "red", "radius": 1.5}})
+    assert type(inst.shape).__name__ == "Circle"
+
+    inst = dynamic_model.model_validate({"shape": {"kind": "rectangle", "width": 2.0, "height": 1.0}})
+    assert type(inst.shape).__name__ == "Rectangle"
+
+
+@pytest.mark.asyncio
+async def test_discriminated_union_roundtrip_via_type_engine():
+    """A model with a discriminated union should roundtrip through to_literal / to_python_value."""
+    input_val = Properties(shape=Circle(color="red", radius=1.5))
+    lit = TypeEngine.to_literal_type(Properties)
+    lv = await TypeEngine.to_literal(input_val, python_type=Properties, expected=lit)
+    assert lv
+
+    guessed = TypeEngine.guess_python_type(lit)
+    assert issubclass(guessed, BaseModel)
+
+    pv = await TypeEngine.to_python_value(lv, Properties)
+    assert pv == input_val
+
+
+@pytest.mark.asyncio
+async def test_optional_discriminated_union_roundtrip():
+    """Optional[Annotated[Union[..., ...], Field(discriminator=...)]] should roundtrip cleanly."""
+    lit = TypeEngine.to_literal_type(OptionalShapeProperties)
+    guessed = TypeEngine.guess_python_type(lit)
+    assert issubclass(guessed, BaseModel)
+
+    input_val = OptionalShapeProperties(shape=Rectangle(width=3.0, height=4.0))
+    lv = await TypeEngine.to_literal(input_val, python_type=OptionalShapeProperties, expected=lit)
+    pv = await TypeEngine.to_python_value(lv, OptionalShapeProperties)
+    assert pv == input_val
+
+    input_none = OptionalShapeProperties(shape=None)
+    lv_none = await TypeEngine.to_literal(input_none, python_type=OptionalShapeProperties, expected=lit)
+    pv_none = await TypeEngine.to_python_value(lv_none, OptionalShapeProperties)
+    assert pv_none == input_none
+
+
+@pytest.mark.asyncio
+async def test_list_of_discriminated_union_roundtrip():
+    """List[Annotated[Union[...], discriminator]] should roundtrip cleanly."""
+    input_val = ListOfShapes(shapes=[Circle(radius=1.0), Rectangle(width=2.0, height=3.0)])
+    lit = TypeEngine.to_literal_type(ListOfShapes)
+    lv = await TypeEngine.to_literal(input_val, python_type=ListOfShapes, expected=lit)
+    pv = await TypeEngine.to_python_value(lv, ListOfShapes)
+    assert pv == input_val


### PR DESCRIPTION
This pull request adds robust support for Pydantic v2 discriminated (tagged) unions—schemas using `oneOf` and a top-level `discriminator`—to Flyte's type engine. It fixes previous issues where such schemas would cause errors, and ensures that union types are correctly roundtripped, validated, and reconstructed. The changes include enhancements to schema parsing, dynamic class generation, and comprehensive regression tests.

**Support for Pydantic v2 discriminated unions:**

* Updated the type engine to recognize and properly handle JSON schemas with `oneOf` and a top-level `discriminator` (as emitted by Pydantic v2 for `Annotated[Union[...], Field(discriminator=...)]`), ensuring correct type inference and runtime dispatch.
* Added the `_DiscriminatedUnion` descriptor to capture discriminator metadata and variant mappings, enabling correct dict-to-object conversion during dataclass instantiation.
* Improved handling of optional and list fields containing discriminated unions, so that `Optional[...]` and `List[...]` of such types are supported seamlessly.

**Testing and documentation:**

* Added a comprehensive regression test suite covering schema generation, type inference, correct dispatch on discriminator values, roundtripping through the type engine, and validation using dynamically generated Pydantic models.
* Introduced a new example (`examples/basics/types/pydantic_union_types.py`) demonstrating end-to-end usage of Pydantic v2 discriminated unions as Flyte task inputs.

These changes ensure that Flyte tasks can now reliably accept and process Pydantic v2 discriminated unions, addressing previous limitations and improving compatibility with modern Pydantic codebases.