### PR TITLE
Update edit settings to remove unused string list setting 

### DIFF
--- a/src/flyte/cli/_edit.py
+++ b/src/flyte/cli/_edit.py
@@ -118,11 +118,7 @@ def settings(cfg: common.CLIConfig, project: str | None, domain: str | None, fro
 
     console = common.Console()
 
-    try:
-        settings = remote.Settings.get_settings_for_edit(project=project, domain=domain)
-    except Exception as e:
-        console.print(f"[red]Error fetching settings:[/red] {e}")
-        raise click.Abort
+    settings = remote.Settings.get_settings_for_edit(project=project, domain=domain)
 
     # -------------------- non-interactive path -----------------------------
     if from_file is not None:

--- a/src/flyte/remote/_settings.py
+++ b/src/flyte/remote/_settings.py
@@ -105,9 +105,6 @@ _YAML_UNSET_TOKEN = "~unset"
 _MAP_MERGE_COMMENT = (
     "## Map entries merge across scopes — parent entries are shown below and applied unless overridden here."
 )
-_LIST_ADDITIVE_COMMENT = (
-    "## List values add across scopes — parent items are shown below and included unless overridden here."
-)
 
 # Scope level mapping from proto enum to human-readable strings
 _SCOPE_NAMES = {
@@ -121,12 +118,11 @@ _SCOPE_NAMES = {
 # ``(dotkey, leaf_kind, field_descriptor)``.
 #
 # Leaf kinds map to the proto *Setting types:
-#     "string"     → StringSetting
-#     "int"        → Int64Setting
-#     "bool"       → BoolSetting
-#     "quantity"   → QuantitySetting (string-encoded k8s quantity)
-#     "stringlist" → StringListSetting
-#     "stringmap"  → StringMapSetting
+#     "string"   → StringSetting
+#     "int"      → Int64Setting
+#     "bool"     → BoolSetting
+#     "quantity" → QuantitySetting (string-encoded k8s quantity)
+#     "stringmap"→ StringMapSetting
 
 
 @dataclass(frozen=True)
@@ -140,12 +136,6 @@ class _LeafIO:
     proto_class: type
     extract: Callable[[Any], Any]
     build_kwargs: Callable[[Any], dict[str, Any]]
-
-
-def _build_list_kwargs(v: Any) -> dict[str, Any]:
-    if not isinstance(v, (list, tuple)):
-        raise TypeError(f"expected list for stringlist leaf, got {type(v).__name__}")
-    return {"list_value": settings_definition_pb2.StringValues(values=[str(x) for x in v])}
 
 
 def _build_map_kwargs(v: Any) -> dict[str, Any]:
@@ -175,11 +165,6 @@ _LEAF_IO: dict[str, _LeafIO] = {
         lambda leaf: leaf.quantity_value,
         lambda v: {"quantity_value": str(v)},
     ),
-    "stringlist": _LeafIO(
-        settings_definition_pb2.StringListSetting,
-        lambda leaf: list(leaf.list_value.values),
-        _build_list_kwargs,
-    ),
     "stringmap": _LeafIO(
         settings_definition_pb2.StringMapSetting,
         lambda leaf: dict(leaf.map_value.entries),
@@ -199,7 +184,6 @@ _PLACEHOLDER_BY_KIND: dict[str, str] = {
     "int": "0",
     "bool": "false",
     "quantity": "''",
-    "stringlist": "[]",
     "stringmap": "{}",
 }
 
@@ -368,7 +352,6 @@ class Settings(ToJSONMixin):
     _version: int = field(default=0, repr=False)
     _parent_effective: dict[str, EffectiveSetting] = field(default_factory=dict, repr=False)
     _map_entry_origins: dict[str, dict[str, EffectiveSetting]] = field(default_factory=dict, repr=False)
-    _list_item_origins: dict[str, list[EffectiveSetting]] = field(default_factory=dict, repr=False)
 
     @staticmethod
     def available_keys() -> list[str]:
@@ -415,44 +398,33 @@ class Settings(ToJSONMixin):
         return str(value)
 
     def _render_merge_collection(self, l_setting: LocalSetting) -> list[str]:
-        """Render a stringmap or stringlist local override as YAML lines, with
-        parent-scope items shown as ``#``-commented lines tagged with their
-        origin scope.
+        """Render a stringmap local override as YAML lines, with parent-scope
+        entries shown as ``#``-commented lines tagged with their origin scope.
 
-        When the local container has entries::
+        When the local map has entries::
 
-            ## merge/additive comment
+            ## merge comment
             {key}:
               {local entries...}
               # {parent entry}  ## defined at {origin}
 
-        When the local container is empty, the key line itself is commented so
+        When the local map is empty, the key line itself is commented so
         saving an unedited file does not replace inherited values with ``null``::
 
-            ## merge/additive comment
+            ## merge comment
             # {key}:
             #   {parent entry}  ## defined at {origin}
         """
         key = l_setting.key
-        if _LEAF_TYPES.get(key) == "stringmap":
-            merge_comment = _MAP_MERGE_COMMENT
-            local_dict = l_setting.value if isinstance(l_setting.value, dict) else {}
-            local_items = [(k, f"{k}: {self._format_value(v)}") for k, v in local_dict.items()]
-            parent_items = [
-                (k, f"{k}: {self._format_value(eff.value)}", eff.origin)
-                for k, eff in self._map_entry_origins.get(key, {}).items()
-            ]
-        else:  # stringlist
-            merge_comment = _LIST_ADDITIVE_COMMENT
-            local_list = l_setting.value if isinstance(l_setting.value, list) else []
-            local_items = [(v, f"- {self._format_value(v)}") for v in local_list]
-            parent_items = [
-                (eff.value, f"- {self._format_value(eff.value)}", eff.origin)
-                for eff in self._list_item_origins.get(key, [])
-            ]
+        local_dict = l_setting.value if isinstance(l_setting.value, dict) else {}
+        local_items = [(k, f"{k}: {self._format_value(v)}") for k, v in local_dict.items()]
+        parent_items = [
+            (k, f"{k}: {self._format_value(eff.value)}", eff.origin)
+            for k, eff in self._map_entry_origins.get(key, {}).items()
+        ]
 
         local_dedup_keys = {dk for dk, _ in local_items}
-        lines = [merge_comment]
+        lines = [_MAP_MERGE_COMMENT]
         if local_items:
             lines.append(f"{key}:")
             lines.extend(f"  {repr_str}" for _, repr_str in local_items)
@@ -477,15 +449,12 @@ class Settings(ToJSONMixin):
         local_keys = {s.key for s in self.local_settings}
         effective_keys = {s.key for s in self.effective_settings}
 
-        # A stringmap or stringlist local setting with no local entries has nothing to override
+        # A stringmap local setting with no local entries has nothing to override
         # — treat it as inherited for display so it appears in the Inherited section, not Local overrides.
         empty_local_map_keys = {
             s.key
             for s in self.local_settings
-            if (
-                (_LEAF_TYPES.get(s.key) == "stringmap" and not (isinstance(s.value, dict) and s.value))
-                or (_LEAF_TYPES.get(s.key) == "stringlist" and not (isinstance(s.value, list) and s.value))
-            )
+            if _LEAF_TYPES.get(s.key) == "stringmap" and not (isinstance(s.value, dict) and s.value)
         }
         display_local_settings = [s for s in self.local_settings if s.key not in empty_local_map_keys]
         display_local_keys = local_keys - empty_local_map_keys
@@ -502,7 +471,7 @@ class Settings(ToJSONMixin):
                 d = _describe(l_setting.key)
                 if d:
                     lines.append(d)
-                if _LEAF_TYPES.get(l_setting.key) in ("stringmap", "stringlist"):
+                if _LEAF_TYPES.get(l_setting.key) == "stringmap":
                     lines.extend(self._render_merge_collection(l_setting))
                 else:
                     lines.append(f"{l_setting.key}: {self._format_value(l_setting.value)}")
@@ -524,10 +493,6 @@ class Settings(ToJSONMixin):
                     lines.append(f"# {setting.key}:  ## inherited from {setting.origin}")
                     for entry_key, entry_val in setting.value.items():
                         lines.append(f"#   {entry_key}: {self._format_value(entry_val)}")
-                elif _LEAF_TYPES.get(setting.key) == "stringlist" and isinstance(setting.value, list):
-                    lines.append(f"# {setting.key}:  ## inherited from {setting.origin}")
-                    for item in setting.value:
-                        lines.append(f"#   - {self._format_value(item)}")
                 else:
                     lines.append(
                         f"# {setting.key}: {self._format_value(setting.value)}  ## inherited from {setting.origin}"
@@ -596,7 +561,7 @@ class Settings(ToJSONMixin):
 
         Uses ``yaml.safe_load``, so all YAML syntax is supported — including
         flow collections (``[a, b]``, ``{k: v}``) and block collections — for
-        the list and map leaves (``labels``, ``annotations``,
+        the map leaves (``labels``, ``annotations``,
         ``environment_variables``). Commented lines are ignored (template
         entries stay as comments until the user uncomments them).
         """
@@ -657,7 +622,6 @@ class Settings(ToJSONMixin):
         effective: dict[str, EffectiveSetting] = {}
         parent_effective: dict[str, EffectiveSetting] = {}
         map_entry_origins: dict[str, dict[str, EffectiveSetting]] = {}
-        list_item_origins: dict[str, list[EffectiveSetting]] = {}
         for record in resp.levels:
             is_local = (record.key.domain or "") == want_domain and (record.key.project or "") == want_project
             origin = _scope_origin_from_key(record.key)
@@ -671,14 +635,6 @@ class Settings(ToJSONMixin):
                             entry_map = map_entry_origins.setdefault(dotkey, {})
                             for entry_key, entry_val in val.items():
                                 entry_map[entry_key] = EffectiveSetting(key=dotkey, value=entry_val, origin=origin)
-                    elif _LEAF_TYPES.get(dotkey) == "stringlist":
-                        if val is UNSET:
-                            list_item_origins.pop(dotkey, None)
-                        elif isinstance(val, list):
-                            item_map = {es.value: es for es in list_item_origins.get(dotkey, [])}
-                            for item in val:
-                                item_map[item] = EffectiveSetting(key=dotkey, value=item, origin=origin)
-                            list_item_origins[dotkey] = list(item_map.values())
                 effective[dotkey] = EffectiveSetting(key=dotkey, value=val, origin=origin)
 
         # Local settings come from the level whose key equals the requested scope
@@ -703,7 +659,6 @@ class Settings(ToJSONMixin):
             _version=version,
             _parent_effective=parent_effective,
             _map_entry_origins=map_entry_origins,
-            _list_item_origins=list_item_origins,
         )
 
     @syncify

--- a/tests/flyte/cli/test_edit_settings.py
+++ b/tests/flyte/cli/test_edit_settings.py
@@ -138,8 +138,6 @@ def test_from_file_handles_commented_template(tmp_path: Path):
         "security.service_account: ml-sa\n"
         "\n"
         "### Available settings (uncomment and edit to set at this scope)\n"
-        "## Default queue for task runs\n"
-        "# run.default_queue: ''\n"
     )
     result, s, _ = _invoke_from_file(body, tmp_path=tmp_path)
     assert result.exit_code == 0, result.output

--- a/tests/flyte/remote/test_settings.py
+++ b/tests/flyte/remote/test_settings.py
@@ -63,13 +63,6 @@ class TestExtractLeafValue:
     def test_quantity(self):
         assert _extract_leaf_value(_sv_quantity("2"), "quantity") == "2"
 
-    def test_stringlist(self):
-        leaf = settings_definition_pb2.StringListSetting(
-            state=settings_definition_pb2.SETTING_STATE_VALUE,
-            list_value=settings_definition_pb2.StringValues(values=["a", "b"]),
-        )
-        assert _extract_leaf_value(leaf, "stringlist") == ["a", "b"]
-
     def test_stringmap(self):
         leaf = settings_definition_pb2.StringMapSetting(
             state=settings_definition_pb2.SETTING_STATE_VALUE,
@@ -93,7 +86,6 @@ class TestExtractLeafValue:
             (settings_definition_pb2.Int64Setting, "int"),
             (settings_definition_pb2.BoolSetting, "bool"),
             (settings_definition_pb2.QuantitySetting, "quantity"),
-            (settings_definition_pb2.StringListSetting, "stringlist"),
             (settings_definition_pb2.StringMapSetting, "stringmap"),
         ]:
             leaf = cls(state=settings_definition_pb2.SETTING_STATE_UNSET)
@@ -122,19 +114,10 @@ class TestBuildLeaf:
         assert isinstance(leaf, settings_definition_pb2.QuantitySetting)
         assert leaf.quantity_value == "2"
 
-    def test_stringlist(self):
-        leaf = _build_leaf("stringlist", ["a", "b"])
-        assert isinstance(leaf, settings_definition_pb2.StringListSetting)
-        assert list(leaf.list_value.values) == ["a", "b"]
-
     def test_stringmap(self):
         leaf = _build_leaf("stringmap", {"k": "v"})
         assert isinstance(leaf, settings_definition_pb2.StringMapSetting)
         assert dict(leaf.map_value.entries) == {"k": "v"}
-
-    def test_stringlist_requires_sequence(self):
-        with pytest.raises(TypeError):
-            _build_leaf("stringlist", "not-a-list")
 
     def test_stringmap_requires_dict(self):
         with pytest.raises(TypeError):
@@ -158,11 +141,6 @@ class TestBuildLeaf:
     def test_build_unset_quantity(self):
         leaf = _build_leaf("quantity", UNSET)
         assert isinstance(leaf, settings_definition_pb2.QuantitySetting)
-        assert leaf.state == settings_definition_pb2.SETTING_STATE_UNSET
-
-    def test_build_unset_stringlist(self):
-        leaf = _build_leaf("stringlist", UNSET)
-        assert isinstance(leaf, settings_definition_pb2.StringListSetting)
         assert leaf.state == settings_definition_pb2.SETTING_STATE_UNSET
 
     def test_build_unset_stringmap(self):
@@ -304,9 +282,7 @@ class TestToYaml:
         assert "### Inherited settings" in yaml
         assert "### Available settings" in yaml
         assert "run.default_queue: gpu" in yaml
-        assert '# storage.raw_data_path: "s3://bucket/data"' in yaml
         assert "# security.service_account: sa" in yaml
-        assert "## inherited from DOMAIN(prod)" in yaml
         assert "## inherited from ORG" in yaml
         for key in Settings.available_keys():
             if key in {"run.default_queue", "storage.raw_data_path", "security.service_account"}:
@@ -363,6 +339,98 @@ class TestToYaml:
                 assert lines[idx - 1] == f"## {description}", (
                     f"expected description above {dotkey!r}; got {lines[idx - 1]!r}"
                 )
+
+    def test_inherited_map_labels_renders_one_line_per_entry(self):
+        settings = Settings(
+            effective_settings=[
+                EffectiveSetting(
+                    key="labels",
+                    value={"env": "prod", "team": "ml"},
+                    origin=SettingOrigin("DOMAIN", "prod"),
+                ),
+            ],
+            local_settings=[],
+            domain="prod",
+            project="ml",
+        )
+        yaml = settings.to_yaml()
+        assert "#   env: prod" in yaml
+        assert "#   team: ml" in yaml
+        assert "## inherited from DOMAIN(prod)" in yaml
+        assert "{env:" not in yaml and "env: prod," not in yaml
+
+    def test_local_map_labels_renders_as_block_yaml(self):
+        settings = Settings(
+            effective_settings=[],
+            local_settings=[LocalSetting(key="labels", value={"team": "ml"})],
+            domain="prod",
+        )
+        yaml = settings.to_yaml()
+        assert "labels:" in yaml
+        assert "  team: ml" in yaml
+        assert "labels: {" not in yaml
+
+    def test_local_map_labels_parent_entries_commented_with_origin(self):
+        settings = Settings(
+            effective_settings=[],
+            local_settings=[LocalSetting(key="labels", value={"team": "ml"})],
+            domain="prod",
+            project="ml",
+            _map_entry_origins={
+                "labels": {
+                    "env": EffectiveSetting(key="labels", value="prod", origin=SettingOrigin("ORG")),
+                }
+            },
+        )
+        yaml = settings.to_yaml()
+        assert "  # env: prod  ## defined at ORG" in yaml
+
+    def test_local_map_labels_local_key_not_duplicated_as_comment(self):
+        settings = Settings(
+            effective_settings=[],
+            local_settings=[LocalSetting(key="labels", value={"env": "staging"})],
+            domain="prod",
+            project="ml",
+            _map_entry_origins={
+                "labels": {
+                    "env": EffectiveSetting(key="labels", value="prod", origin=SettingOrigin("ORG")),
+                }
+            },
+        )
+        yaml = settings.to_yaml()
+        assert "  env: staging" in yaml
+        assert "  # env:" not in yaml
+
+    def test_local_map_labels_how_maps_work_comment_present(self):
+        settings = Settings(
+            effective_settings=[],
+            local_settings=[LocalSetting(key="labels", value={"team": "ml"})],
+            domain="prod",
+        )
+        yaml = settings.to_yaml()
+        assert "Map entries merge across scopes" in yaml
+
+    def test_labels_with_only_inherited_entries_appears_in_inherited_section(self):
+        settings = Settings(
+            effective_settings=[
+                EffectiveSetting(key="labels", value={"env": "prod"}, origin=SettingOrigin("ORG")),
+            ],
+            local_settings=[LocalSetting(key="labels", value={})],
+            domain="prod",
+            project="ml",
+            _map_entry_origins={
+                "labels": {
+                    "env": EffectiveSetting(key="labels", value="prod", origin=SettingOrigin("ORG")),
+                }
+            },
+        )
+        yaml = settings.to_yaml()
+        lines = yaml.split("\n")
+        inherited_idx = next(i for i, line in enumerate(lines) if "### Inherited settings" in line)
+        available_idx = next(i for i, line in enumerate(lines) if "### Available settings" in line)
+        labels_idx = next(i for i, line in enumerate(lines) if "labels:" in line)
+        assert inherited_idx < labels_idx < available_idx
+        assert "### Local overrides" not in yaml
 
     def test_inherited_map_renders_one_line_per_entry(self):
         settings = Settings(
@@ -595,9 +663,9 @@ security.service_account: my-sa
         overrides = Settings.parse_yaml('run.default_queue: "123"\n')
         assert overrides["run.default_queue"] == "123"
 
-    def test_parse_flow_list(self):
-        overrides = Settings.parse_yaml("labels: ['env:prod', 'team:ml']\n")
-        assert overrides["labels"] == ["env:prod", "team:ml"]
+    def test_parse_flow_map_labels(self):
+        overrides = Settings.parse_yaml("labels: {env: prod, team: ml}\n")
+        assert overrides["labels"] == {"env": "prod", "team": "ml"}
 
     def test_parse_flow_map(self):
         overrides = Settings.parse_yaml("annotations: {oncall: ml-team}\n")
@@ -626,7 +694,7 @@ security.service_account: my-sa
         assert proto.security.service_account.string_value == "ml-sa"
 
     def test_parse_tilde_unset_only_in_values_not_keys(self):
-        overrides = Settings.parse_yaml("security.service_account: ml-sa\n")
+        overrides = Settings.parse_yaml("run.default_queue: gpu\n")
         assert "~unset" not in overrides
 
 
@@ -799,6 +867,66 @@ class TestSettingsGet:
         # Effective still surfaces the DOMAIN-level value.
         assert any(s.key == "run.default_queue" and s.value == "gpu" for s in settings.effective_settings)
 
+    def test_get_populates_map_entry_origins_from_parent_levels_labels(
+        self, mock_client, mock_settings_service, mock_init_config
+    ):
+        org_record = _make_record(org="myorg", version=1, labels={"env": "prod", "team": "ml"})
+        project_record = _make_record(org="myorg", domain="prod", project="ml", version=2, labels={"oncall": "ml-team"})
+        mock_settings_service.get_settings_for_edit.return_value = settings_service_pb2.GetSettingsForEditResponse(
+            requestedKey=settings_definition_pb2.SettingsKey(org="myorg", domain="prod", project="ml"),
+            levels=[org_record, project_record],
+        )
+        with (
+            patch(_PATCH_ENSURE, new_callable=AsyncMock),
+            patch(_PATCH_CLIENT, return_value=mock_client),
+            patch(_PATCH_CONFIG, return_value=mock_init_config),
+        ):
+            settings = Settings.get_settings_for_edit(domain="prod", project="ml")
+
+        origins = settings._map_entry_origins["labels"]
+        assert origins["env"].value == "prod"
+        assert origins["env"].origin.scope_type == "ORG"
+        assert origins["team"].value == "ml"
+        assert origins["team"].origin.scope_type == "ORG"
+        assert "oncall" not in origins
+
+    def test_get_map_entry_origins_excludes_local_scope_labels(
+        self, mock_client, mock_settings_service, mock_init_config
+    ):
+        project_record = _make_record(org="myorg", domain="prod", project="ml", version=1, labels={"env": "prod"})
+        mock_settings_service.get_settings_for_edit.return_value = settings_service_pb2.GetSettingsForEditResponse(
+            requestedKey=settings_definition_pb2.SettingsKey(org="myorg", domain="prod", project="ml"),
+            levels=[project_record],
+        )
+        with (
+            patch(_PATCH_ENSURE, new_callable=AsyncMock),
+            patch(_PATCH_CLIENT, return_value=mock_client),
+            patch(_PATCH_CONFIG, return_value=mock_init_config),
+        ):
+            settings = Settings.get_settings_for_edit(domain="prod", project="ml")
+
+        assert "labels" not in settings._map_entry_origins
+
+    def test_get_unset_at_parent_clears_ancestor_map_entries_labels(
+        self, mock_client, mock_settings_service, mock_init_config
+    ):
+        org_record = _make_record(org="myorg", version=1, labels={"env": "prod"})
+        domain_record = _make_record(org="myorg", domain="prod", version=2, labels=UNSET)
+        project_record = _make_record(org="myorg", domain="prod", project="ml", version=3, labels={"team": "ml"})
+        mock_settings_service.get_settings_for_edit.return_value = settings_service_pb2.GetSettingsForEditResponse(
+            requestedKey=settings_definition_pb2.SettingsKey(org="myorg", domain="prod", project="ml"),
+            levels=[org_record, domain_record, project_record],
+        )
+        with (
+            patch(_PATCH_ENSURE, new_callable=AsyncMock),
+            patch(_PATCH_CLIENT, return_value=mock_client),
+            patch(_PATCH_CONFIG, return_value=mock_init_config),
+        ):
+            settings = Settings.get_settings_for_edit(domain="prod", project="ml")
+
+        origins = settings._map_entry_origins.get("labels", {})
+        assert "env" not in origins, "ORG entry should be cleared by DOMAIN's UNSET"
+
     def test_get_populates_map_entry_origins_from_parent_levels(
         self, mock_client, mock_settings_service, mock_init_config
     ):
@@ -941,6 +1069,27 @@ class TestSettingsGet:
         origins = settings._map_entry_origins.get("annotations", {})
         assert "team" not in origins, "ORG entry 'team' should be blocked by DOMAIN's UNSET"
         assert "env" not in origins, "ORG entry 'env' should be blocked by DOMAIN's UNSET"
+
+    def test_unset_at_parent_scope_clears_ancestor_map_labels(
+        self, mock_client, mock_settings_service, mock_init_config
+    ):
+        """When a parent scope sets a map to UNSET, the effective value must be UNSET, not the ancestor map."""
+        org_record = _make_record(org="myorg", version=1, labels={"env": "prod", "team": "ml"})
+        domain_record = _make_record(org="myorg", domain="prod", version=2, labels=UNSET)
+        project_record = _make_record(org="myorg", domain="prod", project="ml", version=3)
+        mock_settings_service.get_settings_for_edit.return_value = settings_service_pb2.GetSettingsForEditResponse(
+            requestedKey=settings_definition_pb2.SettingsKey(org="myorg", domain="prod", project="ml"),
+            levels=[org_record, domain_record, project_record],
+        )
+        with (
+            patch(_PATCH_ENSURE, new_callable=AsyncMock),
+            patch(_PATCH_CLIENT, return_value=mock_client),
+            patch(_PATCH_CONFIG, return_value=mock_init_config),
+        ):
+            settings = Settings.get_settings_for_edit(domain="prod", project="ml")
+
+        effective = {s.key: s.value for s in settings.effective_settings}
+        assert effective.get("labels") is UNSET, "ORG map should be blocked by DOMAIN's UNSET"
 
     def test_get_surfaces_unset_from_local_scope(self, mock_client, mock_settings_service, mock_init_config):
         """A SETTING_STATE_UNSET leaf in the server response appears as UNSET in local_settings."""
@@ -1139,7 +1288,7 @@ class TestProgrammaticAccess:
         """The schema must come from walking Settings.DESCRIPTOR, not a hand-written list."""
         assert len(_LEAF_SCHEMA) > 0
         for dotkey, kind, field_descriptor in _LEAF_SCHEMA:
-            assert kind in {"string", "int", "bool", "quantity", "stringlist", "stringmap"}
+            assert kind in {"string", "int", "bool", "quantity", "stringmap"}
             # The field descriptor points at a *Setting message in the proto schema.
             assert field_descriptor.message_type is not None
             assert field_descriptor.message_type.name.endswith("Setting")


### PR DESCRIPTION
This change also improves string map handling.
The label setting changed types from string list to map, and was the only instance of a string list.  This change removes the unused type.  It also improves how maps display entries from different scopes.  Each entry is displayed on its own line with a comment as to its source scope.