### PR TITLE
Pin default-dev-image PyPI fallback to flyte<{base_version}

### DIFF
--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -658,8 +658,14 @@ class Image:
             }
         )
         image = image.with_apt_packages("build-essential", "ca-certificates")
-        if install_flyte and dev_mode and os.path.exists(DIST_FOLDER):
-            image = image.with_local_v2()
+        if install_flyte and dev_mode:
+            if os.path.exists(DIST_FOLDER):
+                image = image.with_local_v2()
+            else:
+                from packaging.version import Version
+
+                base = Version(__version__).base_version
+                image = image.with_pip_packages(f"flyte<{base}")
             # Bake the Rust controller when opted in via `_F_USE_RUST_CONTROLLER=1`. Use the locally-built wheel if
             # available; otherwise fall back to the released PyPI version
             use_rust = os.getenv("_F_USE_RUST_CONTROLLER", "").lower() in ("1", "true", "yes")

--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -673,7 +673,10 @@ class Image:
                 if os.path.exists(RS_CONTROLLER_DIST_FOLDER):
                     image = image.with_local_rs_controller()
                 else:
-                    image = image.with_pip_packages("flyte_controller_base")
+                    from packaging.version import Version
+
+                    base = Version(__version__).base_version
+                    image = image.with_pip_packages(f"flyte_controller_base<{base}")
         if not dev_mode:
             object.__setattr__(image, "_tag", preset_tag)
 

--- a/tests/flyte/test_image.py
+++ b/tests/flyte/test_image.py
@@ -895,3 +895,32 @@ def test_from_ref_name_is_not_cloned():
     """Image.from_ref_name is a pointer to an externally configured image and should not be rebuilt."""
     image = Image.from_ref_name("my-ref")
     assert image._is_cloned is False
+
+
+def test_default_image_dev_mode_pypi_fallback(monkeypatch):
+    """
+    In dev mode with no local dist folder, the default image should install
+    `flyte<{base_version}` from PyPI so it picks up the latest already-released
+    version below the current dev line.
+    """
+    import flyte._image as image_module
+    import flyte._version as version_module
+    from flyte._image import PipPackages
+
+    monkeypatch.setattr(version_module, "__version__", "2.3.7.dev6+gabc12345")
+
+    real_exists = image_module.os.path.exists
+
+    def fake_exists(path):
+        if str(path) == str(image_module.DIST_FOLDER):
+            return False
+        return real_exists(path)
+
+    monkeypatch.setattr(image_module.os.path, "exists", fake_exists)
+
+    image = Image._get_default_image_for(python_version=(3, 12))
+
+    pip_packages = tuple(
+        pkg for layer in image._layers if isinstance(layer, PipPackages) for pkg in (layer.packages or ())
+    )
+    assert "flyte<2.3.7" in pip_packages, f"expected 'flyte<2.3.7' in pip layers, got {pip_packages}"


### PR DESCRIPTION
## Summary

- In dev mode with no local `dist/` folder, the default image previously installed unpinned `flyte` from PyPI, which could resolve to a pre-release matching the in-progress dev line.
- Use `packaging.version.Version(__version__).base_version` to derive the upcoming release (e.g. `2.3.7` from `2.3.7.dev6+gabc...`) and constrain pip to `flyte<{base}`. That makes pip pick the latest already-released version *below* the current dev line, with no network call from our code.
- Adds a unit test covering the dev-mode/no-dist branch in `src/flyte/_image.py::Image._get_default_image_for`.

## Test plan

- [x] `pytest tests/flyte/test_image.py` — all 70 tests pass, including the new `test_default_image_dev_mode_pypi_fallback`.
- [ ] Sanity-check: build a default image on a dev tip and confirm the PyPI fallback resolves to the latest released version below the current dev base.