### PR TITLE
fix intermittent 404 (NoSuchKey) in `Dir.download_sync` for remote directories

### DIFF
--- a/src/flyte/io/_dir.py
+++ b/src/flyte/io/_dir.py
@@ -597,7 +597,30 @@ class Dir(BaseModel, Generic[T], SerializableType):
                 return local_dest
 
         fs = storage.get_underlying_filesystem(path=self.path)
-        fs.get(self.path, local_dest, recursive=True)
+
+        # Enumerate the concrete object keys under the prefix and download each
+        # individually, rather than relying on fsspec's recursive get(). A
+        # recursive get() must first decide the remote prefix is a directory:
+        # it HEADs the bare prefix key (a 404, since only the child objects
+        # exist) and falls back to a listing. When that listing momentarily
+        # misfires, fsspec treats the prefix as a *file* and issues a GET on the
+        # directory key itself and errors out with 404 NoSuchKey, even though
+        # the data is present. find()/get_file() only ever touch real object keys,
+        # avoiding that.
+        files = fs.find(self.path)
+        if not files:
+            # Nothing under the prefix; fall back to a recursive get so behavior
+            # (and any error) matches the prior implementation.
+            fs.get(self.path, local_dest, recursive=True)
+            return local_dest
+
+        src_prefix = fs._strip_protocol(self.path).rstrip("/")
+        for remote_file in files:
+            rel = fs._strip_protocol(remote_file)[len(src_prefix) :].lstrip("/")
+            dest = os.path.join(local_dest, rel) if rel else local_dest
+            os.makedirs(os.path.dirname(dest) or local_dest, exist_ok=True)
+            fs.get_file(remote_file, dest)
+
         return local_dest
 
     @classmethod

--- a/tests/flyte/io_types/test_dirs.py
+++ b/tests/flyte/io_types/test_dirs.py
@@ -553,3 +553,47 @@ async def test_list_dir_local_fs(tmp_path, tmp_dir_structure, ctx_with_test_raw_
     replica_dir = Dir(path=uploaded_dir.path + "/")
     files = await replica_dir.list_files()
     assert len(files) == 3
+
+
+def test_download_sync_remote_multifile(tmp_path):
+    """Regression: download_sync must fetch every object under a remote prefix.
+
+    download_sync() previously delegated to fsspec's recursive get(), whose
+    directory detection could intermittently classify the prefix as a *file*
+    and issue a GET on the directory key (-> 404 NoSuchKey) even though the
+    child objects exist. It now enumerates concrete keys via find() and
+    downloads each, so every file lands and nested structure is preserved.
+
+    Uses an in-memory fsspec filesystem (a non-"file" protocol, so it takes the
+    remote code path) to keep the test deterministic and infra-free.
+    """
+    import fsspec
+
+    fs = fsspec.filesystem("memory")
+    base = "memory://regression-download-sync"
+    # The memory filesystem is a process-wide singleton; clear any leftover state.
+    try:
+        fs.rm(base, recursive=True)
+    except FileNotFoundError:
+        pass
+
+    contents = {
+        f"{base}/root.txt": b"root",
+        f"{base}/nested1/file1.txt": b"f1",
+        f"{base}/nested1/nested2/file2.txt": b"f2",
+        f"{base}/sibling/sibling_file.txt": b"sib",
+    }
+    for path, data in contents.items():
+        with fs.open(path, "wb") as fh:
+            fh.write(data)
+
+    assert storage.is_remote(base), "test must exercise the remote download path"
+
+    dest = tmp_path / "downloaded"
+    returned = Dir(path=base).download_sync(str(dest))
+
+    assert pathlib.Path(returned) == dest
+    assert (dest / "root.txt").read_bytes() == b"root"
+    assert (dest / "nested1" / "file1.txt").read_bytes() == b"f1"
+    assert (dest / "nested1" / "nested2" / "file2.txt").read_bytes() == b"f2"
+    assert (dest / "sibling" / "sibling_file.txt").read_bytes() == b"sib"


### PR DESCRIPTION
### Problem
`Dir.download_sync()` intermittently fails with a 404 when downloading a remote directory, even though the directory's objects exist:

```
    FileNotFoundError: Object at location .../fineweb-edu-seq2048 not found
    ... GET https://s3.../fineweb-edu-seq2048 -> 404 NoSuchKey
```

It "works on retry" though. Observed in sync (`def`) tasks that download a directory produced upstream.

### Root cause
`download_sync` delegated to fsspec's recursive `fs.get(self.path, dest, recursive=True)`. Before copying, fsspec must decide whether the remote *prefix* is a directory:

1. check the dircache,
2. else `HEAD` the bare prefix key - a 404, since only the child objects are real keys, not the prefix itself,
3. fall back to a listing to infer "directory"

This HEAD-then-list-then-cache detection is timing/state dependent. When it resolves to "directory", the children are listed and downloaded. When the listing/cache evidence isn't present at the moment `_isdir` is consulted, fsspec
treats the prefix as a *file* and issues a `GET` on the directory key resulting in `404 NoSuchKey`. The outcome is nondeterministic across invocations, hence it fails first and succeeds on retry. The data is always present; only the
classification flakes.

Note the async `Dir.download()` is unaffected: it routes through `storage.get()` → `ObstoreParallelReader`, which lists the prefix and downloads each concrete object. The sync path was the only one relying on fsspec's recursive-get directory detection.

### Fix
`download_sync` now mirrors what the async reader does, using sync fsspec: enumerate concrete object keys with `fs.find(self.path)` and download each with`fs.get_file()`. Only real keys are ever fetched, so there is no file-vs-directory
inference to flake. Falls back to the previous recursive `get` when `find` returns nothing, preserving prior behavior/errors for empty/edge cases.