### PR TITLE
Fallback to constant start time and add lock around submit_sync

### DIFF
--- a/src/flyte/_bin/runtime.py
+++ b/src/flyte/_bin/runtime.py
@@ -117,7 +117,14 @@ def main(
 
     from datetime import datetime, timezone
 
-    parsed_run_start_time: datetime | None = None
+    # If {{.runStartTime}} template is unsubstituted (or sends an
+    # unparseable value), fall back to a CONSTANT epoch time rather than datetime.now().
+    # run_start_time is baked into each sub-action's container args (see
+    # TaskTemplate.container_args), which are hashed into the deterministic sub-action ID.
+    # A wall-clock fallback would differ on every retry attempt of the parent and thus mint
+    # a new child action names each attempt instead of reusing the deterministically-hashed one.
+    epoch_run_start_time = datetime(1970, 1, 1, tzinfo=timezone.utc)
+    parsed_run_start_time: datetime = epoch_run_start_time
     if run_start_time and not run_start_time.startswith("{{"):
         raw = run_start_time.rstrip()
         # tolerate trailing "Z" — datetime.fromisoformat only handles it on 3.11+
@@ -130,8 +137,8 @@ def main(
             else:
                 parsed_run_start_time = parsed_run_start_time.astimezone(timezone.utc)
         except ValueError:
-            logger.warning(f"Could not parse --run-start-time {run_start_time!r}; falling back to current UTC time.")
-            parsed_run_start_time = None
+            logger.warning(f"Could not parse --run-start-time {run_start_time!r}; falling back to epoch.")
+            parsed_run_start_time = epoch_run_start_time
 
     logger.warning(f"Flyte runtime started for action {name} with run name {run_name}")
 

--- a/src/flyte/_bin/runtime.py
+++ b/src/flyte/_bin/runtime.py
@@ -118,7 +118,7 @@ def main(
     from datetime import datetime, timezone
 
     # If {{.runStartTime}} template is unsubstituted (or sends an
-    # unparseable value), fall back to a CONSTANT epoch time rather than datetime.now().
+    # unparsable value), fall back to a CONSTANT epoch time rather than datetime.now().
     # run_start_time is baked into each sub-action's container args (see
     # TaskTemplate.container_args), which are hashed into the deterministic sub-action ID.
     # A wall-clock fallback would differ on every retry attempt of the parent and thus mint

--- a/src/flyte/_internal/controllers/remote/_controller.py
+++ b/src/flyte/_internal/controllers/remote/_controller.py
@@ -136,6 +136,7 @@ class RemoteController(Controller):
         self._sequencer = TaskCallSequencer()
         self._submit_loop: asyncio.AbstractEventLoop | None = None
         self._submit_thread: threading.Thread | None = None
+        self._submit_init_lock = threading.Lock()
 
     def generate_task_call_sequence(self, task_obj: object, action_id: ActionID) -> int:
         """
@@ -190,6 +191,11 @@ class RemoteController(Controller):
             tctx, task_spec, inputs_hash, _task_call_seq
         )
         logger.info(f"Sub action {sub_action_id} output path {sub_action_output_path}")
+        logger.warning(
+            f"[hashdebug] _submit task={_task.name} parent={current_action_id.name} "
+            f"input_hash={inputs_hash} task_hash={convert.hash_data(task_spec.SerializeToString(deterministic=True))} "
+            f"seq={_task_call_seq} -> {sub_action_id.name}"
+        )
 
         serialized_inputs = inputs.proto_inputs.SerializeToString(deterministic=True)
         inputs_uri = io.inputs_path(sub_action_output_path)
@@ -309,9 +315,9 @@ class RemoteController(Controller):
     def submit_sync(self, _task: TaskTemplate, *args, **kwargs) -> concurrent.futures.Future:
         """
         This function creates a cached thread and loop for the purpose of calling the submit method synchronously,
-        returning a concurrent Future that can be awaited. There's no need for a lock because this function itself is
-        single threaded and non-async. This pattern here is basically the trivial/degenerate case of the thread pool
-        in the LocalController.
+        returning a concurrent Future that can be awaited. There's no need for a lock butbecause this function should be
+        single threaded and is non-async, but we have one anyway just in case. This pattern here is basically
+        the trivial/degenerate case of the thread pool in the LocalController.
         Please see additional comments in protocol.
 
         :param _task:
@@ -320,20 +326,22 @@ class RemoteController(Controller):
         :return:
         """
         if self._submit_thread is None:
-            # Please see LocalController for the general implementation of this pattern.
-            def exc_handler(loop, context):
-                logger.error(f"Remote controller submit sync loop caught exception in {loop}: {context}")
+            with self._submit_init_lock:
+                if self._submit_thread is None:
+                    # Please see LocalController for the general implementation of this pattern.
+                    def exc_handler(loop, context):
+                        logger.error(f"Remote controller submit sync loop caught exception in {loop}: {context}")
 
-            with _selector_policy():
-                self._submit_loop = asyncio.new_event_loop()
-                self._submit_loop.set_exception_handler(exc_handler)
+                    with _selector_policy():
+                        self._submit_loop = asyncio.new_event_loop()
+                        self._submit_loop.set_exception_handler(exc_handler)
 
-            self._submit_thread = threading.Thread(
-                name=f"remote-controller-{os.getpid()}-submitter",
-                daemon=True,
-                target=self._sync_thread_loop_runner,
-            )
-            self._submit_thread.start()
+                    self._submit_thread = threading.Thread(
+                        name=f"remote-controller-{os.getpid()}-submitter",
+                        daemon=True,
+                        target=self._sync_thread_loop_runner,
+                    )
+                    self._submit_thread.start()
 
         coro = self.submit(_task, *args, **kwargs)
         assert self._submit_loop is not None, "Submit loop should always have been initialized by now"
@@ -386,6 +394,10 @@ class RemoteController(Controller):
 
         sub_action_id, sub_action_output_path = convert.generate_sub_action_id_and_output_path(
             tctx, func_name, inputs_hash, invoke_seq_num
+        )
+        logger.warning(
+            f"[hashdebug] get_action_outputs func={func_name} parent={current_action_id.name} "
+            f"input_hash={inputs_hash} task_hash={func_name} seq={invoke_seq_num} -> {sub_action_id.name}"
         )
 
         inputs_uri = io.inputs_path(sub_action_output_path)
@@ -512,6 +524,10 @@ class RemoteController(Controller):
         inputs_hash = convert.generate_inputs_hash_from_proto(inputs.proto_inputs)
         sub_action_id, sub_action_output_path = convert.generate_sub_action_id_and_output_path(
             tctx, task_name, inputs_hash, invoke_seq_num
+        )
+        logger.warning(
+            f"[hashdebug] _submit_task_ref task={task_name} parent={current_action_id.name} "
+            f"input_hash={inputs_hash} task_hash={task_name} seq={invoke_seq_num} -> {sub_action_id.name}"
         )
 
         serialized_inputs = inputs.proto_inputs.SerializeToString(deterministic=True)

--- a/src/flyte/_internal/controllers/remote/_controller.py
+++ b/src/flyte/_internal/controllers/remote/_controller.py
@@ -191,11 +191,6 @@ class RemoteController(Controller):
             tctx, task_spec, inputs_hash, _task_call_seq
         )
         logger.info(f"Sub action {sub_action_id} output path {sub_action_output_path}")
-        logger.warning(
-            f"[hashdebug] _submit task={_task.name} parent={current_action_id.name} "
-            f"input_hash={inputs_hash} task_hash={convert.hash_data(task_spec.SerializeToString(deterministic=True))} "
-            f"seq={_task_call_seq} -> {sub_action_id.name}"
-        )
 
         serialized_inputs = inputs.proto_inputs.SerializeToString(deterministic=True)
         inputs_uri = io.inputs_path(sub_action_output_path)
@@ -395,10 +390,6 @@ class RemoteController(Controller):
         sub_action_id, sub_action_output_path = convert.generate_sub_action_id_and_output_path(
             tctx, func_name, inputs_hash, invoke_seq_num
         )
-        logger.warning(
-            f"[hashdebug] get_action_outputs func={func_name} parent={current_action_id.name} "
-            f"input_hash={inputs_hash} task_hash={func_name} seq={invoke_seq_num} -> {sub_action_id.name}"
-        )
 
         inputs_uri = io.inputs_path(sub_action_output_path)
         await upload_inputs_with_retry(serialized_inputs, inputs_uri, max_bytes=MAX_TRACE_BYTES)
@@ -524,10 +515,6 @@ class RemoteController(Controller):
         inputs_hash = convert.generate_inputs_hash_from_proto(inputs.proto_inputs)
         sub_action_id, sub_action_output_path = convert.generate_sub_action_id_and_output_path(
             tctx, task_name, inputs_hash, invoke_seq_num
-        )
-        logger.warning(
-            f"[hashdebug] _submit_task_ref task={task_name} parent={current_action_id.name} "
-            f"input_hash={inputs_hash} task_hash={task_name} seq={invoke_seq_num} -> {sub_action_id.name}"
         )
 
         serialized_inputs = inputs.proto_inputs.SerializeToString(deterministic=True)

--- a/src/flyte/_task.py
+++ b/src/flyte/_task.py
@@ -536,6 +536,13 @@ class AsyncFunctionTaskTemplate(TaskTemplate[P, R, F]):
         else:
             run_start_time_arg = "{{.runStartTime}}"
 
+        from flyte._logging import logger as _hashdebug_logger
+
+        _hashdebug_logger.warning(
+            f"[hashdebug] container_args task={self.name} run_start_time_arg={run_start_time_arg!r} "
+            f"parent_run_start_time={parent_tctx.run_start_time if parent_tctx else None}"
+        )
+
         args = [
             "a0",
             "--inputs",

--- a/src/flyte/_task.py
+++ b/src/flyte/_task.py
@@ -536,13 +536,6 @@ class AsyncFunctionTaskTemplate(TaskTemplate[P, R, F]):
         else:
             run_start_time_arg = "{{.runStartTime}}"
 
-        from flyte._logging import logger as _hashdebug_logger
-
-        _hashdebug_logger.warning(
-            f"[hashdebug] container_args task={self.name} run_start_time_arg={run_start_time_arg!r} "
-            f"parent_run_start_time={parent_tctx.run_start_time if parent_tctx else None}"
-        )
-
         args = [
             "a0",
             "--inputs",


### PR DESCRIPTION
Child actions weren't deduping across parent retries — a `retries=2` parent with 3 children spawned 9 child actions instead of 3.

Cause: the sub-action ID hash includes the task spec, which bakes in `run_start_time`. When the backend doesn't substitute `{{.runStartTime}}`, we fell back to `datetime.now()`, so each retry attempt of the parent hashed to a different child name.

Fix: fall back to a constant epoch (1970) instead of `now()`, so the hash is stable across attempts.

Also adds a lock around `submit_sync`.
