### PR TITLE
Scope local cache by init config and add _cache_scope tests

### DIFF
--- a/src/flyte/_persistence/_db.py
+++ b/src/flyte/_persistence/_db.py
@@ -2,6 +2,8 @@ import sqlite3
 import threading
 from pathlib import Path
 
+from flyte._initialize import get_init_config
+
 try:
     import aiosqlite
 
@@ -22,10 +24,10 @@ def _cache_scope() -> str:
     Used to scope image/bundle cache entries so that different environments
     don't collide.
     """
-    config = auto()
-    endpoint = config.platform.endpoint or ""
-    project = config.task.project or ""
-    domain = config.task.domain or ""
+    cfg = get_init_config()
+    endpoint = cfg.client.endpoint if cfg.client else ""
+    project = cfg.project or ""
+    domain = cfg.domain or ""
     return f"{endpoint}:{project}:{domain}"
 
 

--- a/tests/persistence/test_cache_scope.py
+++ b/tests/persistence/test_cache_scope.py
@@ -1,0 +1,65 @@
+import types
+from pathlib import Path
+
+import pytest
+
+import flyte._initialize as _init
+from flyte._initialize import _InitConfig
+from flyte._persistence._db import _cache_scope
+from flyte.errors import InitializationError
+
+
+@pytest.fixture(autouse=True)
+def _reset_init_config():
+    """Save, clear, and restore the global init config around each test."""
+    saved = _init._init_config
+    _init._init_config = None
+    yield
+    _init._init_config = saved
+
+
+def _set_init(*, project=None, domain=None, endpoint=None):
+    """Install an init config singleton, with an optional client carrying an endpoint."""
+    client = types.SimpleNamespace(endpoint=endpoint) if endpoint is not None else None
+    _init._init_config = _InitConfig(
+        root_dir=Path.cwd(),
+        project=project,
+        domain=domain,
+        client=client,
+    )
+
+
+def test_cache_scope_uses_endpoint_project_domain_from_init_config():
+    _set_init(project="proj", domain="dev", endpoint="dns:///example.union.ai")
+    assert _cache_scope() == "dns:///example.union.ai:proj:dev"
+
+
+def test_cache_scope_endpoint_empty_when_no_client():
+    _set_init(project="proj", domain="dev", endpoint=None)
+    assert _cache_scope() == ":proj:dev"
+
+
+def test_cache_scope_empty_when_project_and_domain_unset():
+    _set_init(project=None, domain=None, endpoint=None)
+    assert _cache_scope() == "::"
+
+
+def test_cache_scope_reflects_init_overrides_not_defaults():
+    """The scope must track the project/domain the run was initialized with."""
+    _set_init(project="flytesnacks", domain="development", endpoint="dns:///dogfood.union.ai")
+    first = _cache_scope()
+
+    # A different init (e.g. another domain) must yield a different scope so the
+    # two environments never share cache entries.
+    _set_init(project="flytesnacks", domain="staging", endpoint="dns:///dogfood.union.ai")
+    second = _cache_scope()
+
+    assert first != second
+    assert first.endswith(":flytesnacks:development")
+    assert second.endswith(":flytesnacks:staging")
+
+
+def test_cache_scope_raises_when_not_initialized():
+    # _init_config is None via the autouse fixture.
+    with pytest.raises(InitializationError):
+        _cache_scope()


### PR DESCRIPTION
## Summary
- `_cache_scope()` now sources `endpoint`/`project`/`domain` from `get_init_config()` instead of `config.auto()`, so the local image/bundle cache is scoped to the project/domain the run was **actually initialized with** (including programmatic overrides like `flyte.init(project=..., domain=...)`), not just whatever the on-disk config file contains.
- This closes a cache-collision hole: with `auto()`, two runs that share a config file but override the domain at init time produced the **same** scope string and shared cache entries.
- Adds a new test module `tests/persistence/test_cache_scope.py`.

## Behavior notes
- `endpoint` is read from `cfg.client.endpoint` (empty string when no client is set, e.g. local-only persistence).
- `get_init_config()` raises `InitializationError` when `flyte.init()` has not run; `_cache_scope()` propagates that. Today the callers (`image_builder`, `code_bundle`) run inside the post-init build/run path, so this is fine — but if a pre-init caller is ever added, it should fall back to `auto()`.

## Test plan
- `uv run pytest tests/persistence/ -q` → **56 passed** (5 new + 51 existing).
- New tests cover:
  - endpoint/project/domain composed from the init config (`endpoint:proj:dev`)
  - empty endpoint when `cfg.client is None`
  - empty project/domain
  - init-time overrides are reflected (different domain → different scope) — the case `auto()` missed
  - raises `InitializationError` when not initialized
- Verified RED first: all 5 tests fail against the previous `auto()` implementation (the override test shows it read the real config file and ignored overrides), then pass on this change.