### PR TITLE
fix: filter OSError(ENOSPC) from Sentry as user environment error

### DIFF
--- a/src/flyte/_sentry.py
+++ b/src/flyte/_sentry.py
@@ -5,6 +5,7 @@ Initializes Sentry with a hardcoded DSN to report errors from CLI commands
 (e.g., `flyte start demo`). Users can opt out by setting FLYTE_DISABLE_SENTRY=true.
 """
 
+import errno
 import logging
 import os
 
@@ -108,6 +109,22 @@ def _is_user_actionable_connect_error(exc: BaseException) -> bool:
     return getattr(code, "name", None) in _USER_ACTIONABLE_CONNECT_CODES
 
 
+_USER_ENVIRONMENT_OSERROR_ERRNOS: frozenset[int] = frozenset({errno.ENOSPC})
+
+
+def _is_user_environment_oserror(exc: BaseException) -> bool:
+    """OSError variants caused by the user's local environment, not SDK bugs.
+
+    ENOSPC ("No space left on device") surfaces from shutil._fastcopy_sendfile
+    during `flyte deploy` bundle uploads when the user's machine is out of disk
+    (FLYTE-SDK-32). Disk-full is a user environment problem, not something the
+    SDK can fix, so it shouldn't be reported as a crash.
+    """
+    if not isinstance(exc, OSError):
+        return False
+    return exc.errno in _USER_ENVIRONMENT_OSERROR_ERRNOS
+
+
 def _is_user_error(exc: BaseException) -> bool:
     """Errors raised intentionally as user-facing messages — not crash reports."""
     try:
@@ -145,6 +162,8 @@ def _is_user_error(exc: BaseException) -> bool:
         if user_excs and isinstance(cause, user_excs):
             return True
         if _is_user_actionable_connect_error(cause):
+            return True
+        if _is_user_environment_oserror(cause):
             return True
     return False
 

--- a/tests/flyte/test_sentry.py
+++ b/tests/flyte/test_sentry.py
@@ -1,3 +1,4 @@
+import errno
 from unittest import mock
 
 import click
@@ -276,6 +277,30 @@ def test_capture_exception_still_reports_connect_error_internal():
     from connectrpc.errors import ConnectError
 
     err = ConnectError(Code.INTERNAL, "backend panicked")
+    with (
+        mock.patch.object(_sentry, "init"),
+        mock.patch("sentry_sdk.is_initialized", return_value=True),
+        mock.patch("sentry_sdk.capture_exception") as capture_mock,
+        mock.patch("sentry_sdk.flush"),
+    ):
+        _sentry.capture_exception(err)
+    capture_mock.assert_called_once_with(err)
+
+
+def test_capture_exception_skips_oserror_no_space_left():
+    """FLYTE-SDK-32: OSError(ENOSPC) from shutil._fastcopy_sendfile during
+    `flyte deploy` bundle upload is a user environment problem (disk full),
+    not an SDK bug."""
+    err = OSError(errno.ENOSPC, "No space left on device", "/some/path")
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()
+
+
+def test_capture_exception_still_reports_other_oserror():
+    """OSError with errnos other than ENOSPC may legitimately indicate SDK bugs
+    and should still be reported to Sentry."""
+    err = PermissionError(errno.EACCES, "Permission denied", "/some/path")
     with (
         mock.patch.object(_sentry, "init"),
         mock.patch("sentry_sdk.is_initialized", return_value=True),


### PR DESCRIPTION
## Summary

`OSError` with `errno=ENOSPC` ("No space left on device") surfaces from `shutil._fastcopy_sendfile` during `flyte deploy` bundle uploads when the user's machine is out of disk. It is currently captured by the `@_sentry.capture_errors` decorator on the deploy CLI invoke path and reported to the SDK's Sentry project as if it were an SDK crash. Disk-full is a user environment problem the SDK cannot fix, so it shouldn't reach Sentry.

This change extends `flyte/_sentry.py:_is_user_error` to recognize `OSError(errno=ENOSPC)` anywhere in the `__cause__`/`__context__` chain via a new tightly scoped helper `_is_user_environment_oserror`.

The filter is intentionally narrow — only `ENOSPC` for now. Other `OSError` errnos (`EACCES`, `ENOENT`, etc.) may legitimately indicate SDK bugs and continue to be reported. A regression test pins this behavior.

## Closes

- [FLYTE-SDK-32](https://unionai.sentry.io/issues/FLYTE-SDK-32/) — `OSError: [Errno 28] No space left on device` from `shutil._fastcopy_sendfile` during deploy bundle copy.

\`fixes FLYTE-SDK-32\`

## Test plan

- [x] \`test_capture_exception_skips_oserror_no_space_left\` — bare \`OSError(ENOSPC)\` is filtered.
- [x] \`test_capture_exception_still_reports_other_oserror\` — \`PermissionError(EACCES)\` is NOT filtered (regression guard against over-broad suppression).
- [x] All 22 tests in \`tests/flyte/test_sentry.py\` pass.
- [x] \`make fmt\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)