### PR TITLE
fix: wrap KeyError at user-module import as ModuleLoadError

### DIFF
--- a/src/flyte/_utils/module_loader.py
+++ b/src/flyte/_utils/module_loader.py
@@ -58,7 +58,7 @@ def load_python_modules(
             loaded_modules.append(imported_module)
         except flyte.errors.ModuleLoadError as e:
             failed_paths.append((path, str(e)))
-        except (ImportError, SyntaxError, NameError, AttributeError, TypeError, ValueError) as e:
+        except (ImportError, SyntaxError, NameError, AttributeError, TypeError, ValueError, KeyError) as e:
             raise flyte.errors.ModuleLoadError(f"Failed to load {path}: {type(e).__name__}: {e}") from e
 
     elif path.is_dir():
@@ -109,7 +109,7 @@ def load_python_modules(
                         loaded_modules.append(imported_module)
                     except flyte.errors.ModuleLoadError as e:
                         failed_paths.append((file_path, str(e)))
-                    except (ImportError, SyntaxError, NameError, AttributeError, TypeError, ValueError) as e:
+                    except (ImportError, SyntaxError, NameError, AttributeError, TypeError, ValueError, KeyError) as e:
                         # User code failed at import time. Record as a load failure
                         # (consistent with ModuleLoadError above) so deploy can either
                         # warn or abort via --ignore-load-errors instead of crashing.

--- a/tests/flyte/utils/test_module_loader.py
+++ b/tests/flyte/utils/test_module_loader.py
@@ -213,6 +213,7 @@ def test_load_python_modules_dir_collects_import_errors_in_failed_paths(tmp_path
         (AttributeError, {}),
         (TypeError, {}),
         (ValueError, {}),
+        (KeyError, {}),
     ],
 )
 def test_load_python_modules_single_file_wraps_user_code_errors(tmp_path, exc_type, exc_kwargs):
@@ -235,3 +236,33 @@ def test_load_python_modules_single_file_wraps_user_code_errors(tmp_path, exc_ty
             load_python_modules(f, root_dir=root, recursive=False)
 
     assert exc_type.__name__ in str(excinfo.value)
+
+
+def test_load_python_modules_single_file_wraps_missing_env_var_keyerror(tmp_path):
+    """When a user module does ``os.environ["GCP_ADR"]`` at top level and the env
+    var is missing, the resulting ``KeyError`` is a user config issue, not an
+    SDK crash. It must surface as ``ModuleLoadError`` so the Sentry filter
+    skips it (consistent with NameError/TypeError already wrapped).
+
+    Reproduces FLYTE-SDK-3D.
+    """
+    root = tmp_path / "project"
+    root.mkdir()
+    f = root / "workflow.py"
+    f.write_text('import os\nGCP_ADR = os.environ["NEVER_SET_GCP_ADR_XYZ"]\n')
+
+    # Make sure the env var truly is missing.
+    os.environ.pop("NEVER_SET_GCP_ADR_XYZ", None)
+
+    sys.path.insert(0, str(root))
+    try:
+        with pytest.raises(flyte.errors.ModuleLoadError) as excinfo:
+            load_python_modules(f, root_dir=root, recursive=False)
+    finally:
+        sys.path.remove(str(root))
+        sys.modules.pop("workflow", None)
+
+    msg = str(excinfo.value)
+    assert "workflow.py" in msg
+    assert "KeyError" in msg
+    assert "NEVER_SET_GCP_ADR_XYZ" in msg


### PR DESCRIPTION
## Summary

When a user module does \`os.environ[\"GCP_ADR\"]\` at top level and the env var is missing, the resulting \`KeyError\` escapes the module loader and bubbles into Sentry as if it were an SDK crash (FLYTE-SDK-3D — same user produces sibling \`TypeError\` (FLYTE-SDK-3B) and \`NameError\` (FLYTE-SDK-3C) which are already wrapped).

The module loader's two \`except\` clauses already catch \`(ImportError, SyntaxError, NameError, AttributeError, TypeError, ValueError)\` at user-code import time and wrap them as \`ModuleLoadError\`. This change adds \`KeyError\` to both clauses so env-var-missing failures at the top of user modules surface as \`ModuleLoadError\` — a \`RuntimeUserError\` subclass already filtered by \`flyte/_sentry.py:_is_user_error\`.

The list is intentionally not broadened further. \`KeyError\` is consistent with \`NameError\` (also a common top-level user-config failure) and tight enough to not mask runtime SDK bugs.

## Closes

- [FLYTE-SDK-3D](https://unionai.sentry.io/issues/FLYTE-SDK-3D/) — \`KeyError: 'GCP_ADR'\` from \`os in __getitem__\` at the top of a user task module.

\`fixes FLYTE-SDK-3D\`

## Test plan

- [x] Parametrized \`test_load_python_modules_single_file_wraps_user_code_errors\` now includes \`KeyError\` and asserts \`ModuleLoadError\` is raised.
- [x] New \`test_load_python_modules_single_file_wraps_missing_env_var_keyerror\` reproduces the FLYTE-SDK-3D shape (\`os.environ[\"NEVER_SET_GCP_ADR_XYZ\"]\` at module top level) and asserts \`ModuleLoadError\` wraps it with the file path and the missing key in the message.
- [x] All 12 tests in \`tests/flyte/utils/test_module_loader.py\` pass.
- [x] \`make fmt\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)