### PR TITLE
fix: include exception type in upload retry error when str(e) is empty

### DIFF
--- a/src/flyte/remote/_data.py
+++ b/src/flyte/remote/_data.py
@@ -119,11 +119,13 @@ async def _upload_with_retry(
         except RuntimeSystemError:
             raise
         except (httpx.TimeoutException, httpx.NetworkError, OSError) as e:
-            last_error = e
+            # Some httpx/httpcore errors (e.g. ReadError) carry an empty str(e),
+            # so include the exception type to keep the message actionable.
+            last_error = f"{type(e).__name__}: {e}" if str(e) else type(e).__name__
             if retry_attempt >= max_retries:
                 raise RuntimeSystemError(
                     "UploadFailed",
-                    f"Failed to upload {fp} after {max_retries} retries: {e}",
+                    f"Failed to upload {fp} after {max_retries} retries: {last_error}",
                 ) from e
 
         # Backoff and retry

--- a/tests/flyte/remote/test_upload_retry.py
+++ b/tests/flyte/remote/test_upload_retry.py
@@ -131,6 +131,28 @@ async def test_upload_retries_on_server_error_then_succeeds(upload_file):
 
 
 @pytest.mark.asyncio
+async def test_upload_error_message_includes_type_when_empty(upload_file):
+    # httpx.ReadError() with no message used to surface as
+    # "Failed to upload ... after N retries: " (trailing colon, no cause).
+    # The error message must include the exception type so the failure stays actionable.
+    with patch("flyte.remote._data.httpx.AsyncClient") as mock_cls:
+        client = AsyncMock()
+        client.put.side_effect = httpx.ReadError("")
+        ctx = AsyncMock()
+        ctx.__aenter__.return_value = client
+        ctx.__aexit__.return_value = False
+        mock_cls.return_value = ctx
+
+        with pytest.raises(RuntimeSystemError, match="ReadError") as exc_info:
+            await _upload_with_retry(
+                upload_file, "https://signed.url/upload", {}, verify=True, max_retries=1, min_backoff_sec=0.01
+            )
+
+        # Must not end with a bare ": " (the empty-cause regression).
+        assert not str(exc_info.value).rstrip().endswith("retries:")
+
+
+@pytest.mark.asyncio
 async def test_upload_no_retry_on_client_error(upload_file):
     with patch("flyte.remote._data.httpx.AsyncClient") as mock_cls:
         client = AsyncMock()


### PR DESCRIPTION
## Summary

`httpx.ReadError()` (and a few other httpx/httpcore exceptions) carry an empty `str(e)`. The retry exhaustion message in `flyte/remote/_data.py::_upload_with_retry` interpolates the exception directly, so the error reaching Sentry looks like:

```
RuntimeSystemError: Failed to upload /tmp/.../fast....tar.gz after 3 retries:
```

…a bare trailing colon with no cause. That's not actionable from a Sentry report.

## Fix

Capture `last_error` as `f"{type(e).__name__}: {e}"` (or just the type name when `str(e)` is empty), so the exhaustion message always carries an identifiable cause.

## Closes

- [FLYTE-SDK-36](https://unionai.sentry.io/issues/FLYTE-SDK-36/) — `Failed to upload ... after 3 retries:` (empty cause).

`fixes FLYTE-SDK-36`

## Test plan

- [x] Added `test_upload_error_message_includes_type_when_empty` — passing `httpx.ReadError("")` causes the wrapped `RuntimeSystemError` to include "ReadError" and to NOT end with a bare "retries:".
- [x] Existing tests in `tests/flyte/remote/test_upload_retry.py` still pass.
- [x] `make fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)