### PR TITLE
fix: honor Retry-After on upload 429/503 + raise default max backoff

### DIFF
--- a/src/flyte/remote/_data.py
+++ b/src/flyte/remote/_data.py
@@ -57,6 +57,25 @@ def hash_file(file_path: typing.Union[os.PathLike, str]) -> Tuple[bytes, str, in
     return h.digest(), h.hexdigest(), size
 
 
+def _parse_retry_after(value: typing.Optional[str], cap_sec: float) -> typing.Optional[float]:
+    """
+    Parse a Retry-After header value in integer-seconds form.
+
+    Returns the parsed (and capped) sleep duration in seconds, or None if the
+    value is missing or in HTTP-date form (which we don't honor — callers
+    should fall back to exponential backoff).
+    """
+    if value is None:
+        return None
+    try:
+        seconds = float(int(value.strip()))
+    except (ValueError, AttributeError):
+        return None
+    if seconds < 0:
+        return None
+    return min(seconds, cap_sec)
+
+
 async def _upload_with_retry(
     fp: Path,
     signed_url: str,
@@ -64,13 +83,19 @@ async def _upload_with_retry(
     verify: bool,
     max_retries: int = 3,
     min_backoff_sec: float = 0.5,
-    max_backoff_sec: float = 10.0,
+    max_backoff_sec: float = 30.0,
+    retry_after_cap_sec: float = 60.0,
 ):
     """
     Upload file to signed URL with exponential backoff retry.
 
     Retries on transient network errors and 5xx/429/408 HTTP errors.
     Does not retry on 4xx client errors (except 408/429).
+
+    When the response is 429 or 503 and carries a ``Retry-After`` header in
+    integer-seconds form, the next backoff honors that value (clamped to
+    ``retry_after_cap_sec``). HTTP-date form is not parsed; in that case we
+    fall back to exponential backoff.
 
     Args:
         fp: Path to file to upload
@@ -79,7 +104,9 @@ async def _upload_with_retry(
         verify: Whether to verify SSL certificates
         max_retries: Maximum retry attempts (default: 3)
         min_backoff_sec: Initial backoff delay (default: 0.5)
-        max_backoff_sec: Maximum backoff delay (default: 10.0)
+        max_backoff_sec: Maximum exponential backoff delay (default: 30.0)
+        retry_after_cap_sec: Upper bound for any honored Retry-After value
+            (default: 60.0)
 
     Raises:
         RuntimeSystemError: If upload fails after all retries
@@ -88,8 +115,10 @@ async def _upload_with_retry(
 
     retry_attempt = 0
     last_error: str | Exception | None = None
+    next_backoff_override: typing.Optional[float] = None
 
     while retry_attempt <= max_retries:
+        next_backoff_override = None
         try:
             async with aiofiles.open(str(fp), "rb") as file:
                 async with httpx.AsyncClient(verify=verify, timeout=_UPLOAD_TIMEOUT) as aclient:
@@ -110,6 +139,11 @@ async def _upload_with_retry(
                                 "UploadFailed",
                                 f"Failed to upload {fp} after {max_retries} retries: {last_error}",
                             )
+                        # Honor Retry-After for rate-limit / overload signals.
+                        if put_resp.status_code in (429, 503):
+                            next_backoff_override = _parse_retry_after(
+                                put_resp.headers.get("Retry-After"), retry_after_cap_sec
+                            )
                     else:
                         # Non-retryable HTTP error
                         raise RuntimeSystemError(
@@ -129,7 +163,10 @@ async def _upload_with_retry(
         # Backoff and retry
         retry_attempt += 1
         if retry_attempt <= max_retries:
-            backoff_delay = min(min_backoff_sec * (2 ** (retry_attempt - 1)), max_backoff_sec)
+            if next_backoff_override is not None:
+                backoff_delay = next_backoff_override
+            else:
+                backoff_delay = min(min_backoff_sec * (2 ** (retry_attempt - 1)), max_backoff_sec)
             logger.warning(
                 f"Upload failed for {fp.name}, backing off for {backoff_delay:.2f}s "
                 f"[retry {retry_attempt}/{max_retries}]: {last_error}"

--- a/tests/flyte/remote/test_upload_retry.py
+++ b/tests/flyte/remote/test_upload_retry.py
@@ -146,3 +146,87 @@ async def test_upload_no_retry_on_client_error(upload_file):
             )
 
         assert client.put.call_count == 1  # no retries for 4xx
+
+
+@pytest.mark.asyncio
+async def test_upload_honors_retry_after_seconds(upload_file):
+    """When the server returns 429 with Retry-After: <int>, we sleep that long."""
+    with patch("flyte.remote._data.httpx.AsyncClient") as mock_cls:
+        client = AsyncMock()
+        client.put.side_effect = [
+            httpx.Response(429, headers={"Retry-After": "2"}, text="slow down"),
+            httpx.Response(200),
+        ]
+        ctx = AsyncMock()
+        ctx.__aenter__.return_value = client
+        ctx.__aexit__.return_value = False
+        mock_cls.return_value = ctx
+
+        with patch("flyte.remote._data.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            result = await _upload_with_retry(
+                upload_file, "https://signed.url/upload", {}, verify=True, max_retries=3, min_backoff_sec=0.01
+            )
+
+        assert result.status_code == 200
+        assert client.put.call_count == 2
+        # Honored the Retry-After value (2s) rather than the exponential value (~0.01s).
+        mock_sleep.assert_awaited_once_with(2.0)
+
+
+@pytest.mark.asyncio
+async def test_upload_caps_absurd_retry_after(upload_file):
+    """A misbehaving server returning Retry-After: 99999 should be clamped."""
+    with patch("flyte.remote._data.httpx.AsyncClient") as mock_cls:
+        client = AsyncMock()
+        client.put.side_effect = [
+            httpx.Response(429, headers={"Retry-After": "99999"}, text="slow down"),
+            httpx.Response(200),
+        ]
+        ctx = AsyncMock()
+        ctx.__aenter__.return_value = client
+        ctx.__aexit__.return_value = False
+        mock_cls.return_value = ctx
+
+        with patch("flyte.remote._data.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            result = await _upload_with_retry(
+                upload_file,
+                "https://signed.url/upload",
+                {},
+                verify=True,
+                max_retries=3,
+                min_backoff_sec=0.01,
+                retry_after_cap_sec=5.0,
+            )
+
+        assert result.status_code == 200
+        mock_sleep.assert_awaited_once_with(5.0)
+
+
+@pytest.mark.asyncio
+async def test_upload_429_without_retry_after_uses_exponential(upload_file):
+    """If no Retry-After header is sent, normal exponential backoff applies."""
+    with patch("flyte.remote._data.httpx.AsyncClient") as mock_cls:
+        client = AsyncMock()
+        client.put.side_effect = [
+            httpx.Response(429, text="slow down"),
+            httpx.Response(200),
+        ]
+        ctx = AsyncMock()
+        ctx.__aenter__.return_value = client
+        ctx.__aexit__.return_value = False
+        mock_cls.return_value = ctx
+
+        with patch("flyte.remote._data.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            result = await _upload_with_retry(
+                upload_file,
+                "https://signed.url/upload",
+                {},
+                verify=True,
+                max_retries=3,
+                min_backoff_sec=0.01,
+                max_backoff_sec=10.0,
+            )
+
+        assert result.status_code == 200
+        # Exponential value for the first retry: min_backoff_sec * 2**0 = 0.01
+        mock_sleep.assert_awaited_once_with(0.01)


### PR DESCRIPTION
## Summary

S3 returns `status 429 SlowDown` when an object is mutated too fast. The SDK's `_upload_with_retry` (in `src/flyte/remote/_data.py`) gives up after 3 attempts with exponential backoff capped at **10s** — not long enough to clear a SlowDown rate-limit window. Users see:

```
RuntimeSystemError: Failed to upload ... after 3 retries: status 429: <Error><Code>SlowDown</Code>...
```

## Changes

1. **Honor `Retry-After` on 429/503 responses.** When the upstream sends `Retry-After: <seconds>`, the next retry sleeps for that many seconds (clamped to `retry_after_cap_sec`, default 60s). HTTP-date form falls back to exponential backoff. New `retry_after_cap_sec` parameter (default 60).
2. **Default `max_backoff_sec` raised from 10s → 30s.** Gives the exponential path room to grow long enough to ride out a typical SlowDown window when no header is present. Still parameterized.

Both knobs remain function parameters; existing callers are unchanged.

## Closes

- [FLYTE-SDK-4A](https://unionai.sentry.io/issues/FLYTE-SDK-4A/) — `Failed to upload ... after 3 retries: status 429 SlowDown` from `_upload_with_retry`.

`fixes FLYTE-SDK-4A`

## Test plan

- [x] New: honors `Retry-After` integer-seconds.
- [x] New: clamps absurd `Retry-After` values to `retry_after_cap_sec`.
- [x] New: 429 without `Retry-After` still uses exponential backoff.
- [x] All 11 tests in `tests/flyte/remote/test_upload_retry.py` pass.
- [x] `make fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)