### PR TITLE
fix: filter ConnectError(UNAVAILABLE/DEADLINE_EXCEEDED) from Sentry

### DIFF
--- a/src/flyte/_sentry.py
+++ b/src/flyte/_sentry.py
@@ -80,24 +80,39 @@ def _iter_cause_chain(exc: BaseException):
 
 _USER_ACTIONABLE_CONNECT_CODES: frozenset[str] = frozenset(
     {
+        # User/config problems — backend rejects the request as invalid.
         "UNAUTHENTICATED",
         "PERMISSION_DENIED",
         "FAILED_PRECONDITION",
         "INVALID_ARGUMENT",
         "NOT_FOUND",
         "ALREADY_EXISTS",
+        # Transient infra / availability problems — DNS lookup failed, TCP
+        # connect refused, connection reset, request timed out. The SDK
+        # cannot recover from these, so they shouldn't be crash-reported.
+        "UNAVAILABLE",
+        "DEADLINE_EXCEEDED",
     }
 )
 
 
 def _is_user_actionable_connect_error(exc: BaseException) -> bool:
-    """ConnectError responses the backend uses to tell the user their request was wrong.
+    """ConnectError responses the SDK cannot recover from.
 
-    The CLI's InvokeBaseMixin (flyte/cli/_common.py) already maps these same codes
-    to ClickException — they are user/config problems, not SDK crashes. But code
-    paths outside the CLI (capture_exception in _run.py, capture_errors on deploy)
-    surface RuntimeSystemError wrappers whose cause chain still terminates in a
-    ConnectError, and those leak into Sentry as if they were SDK bugs.
+    Two flavors live in the same filter set:
+
+    * User/config problems (UNAUTHENTICATED, PERMISSION_DENIED, INVALID_ARGUMENT, …)
+      — the backend rejects the request as invalid; the CLI's InvokeBaseMixin
+      (flyte/cli/_common.py) already maps these to ClickException.
+    * Transient infrastructure problems (UNAVAILABLE, DEADLINE_EXCEEDED) — DNS
+      lookup failures, TCP connect refused, connection reset, request timed out
+      against the cluster service. These are not SDK bugs; INTERNAL is
+      intentionally NOT filtered because it can indicate a real bug.
+
+    Code paths outside the CLI (capture_exception in _run.py, capture_errors on
+    deploy) surface RuntimeSystemError wrappers whose cause chain still
+    terminates in a ConnectError, and those leak into Sentry as if they were
+    SDK bugs. The cause-chain walk in _is_user_error catches them here.
     """
     try:
         from connectrpc.errors import ConnectError

--- a/tests/flyte/test_sentry.py
+++ b/tests/flyte/test_sentry.py
@@ -271,8 +271,9 @@ def test_capture_exception_skips_connect_error_failed_precondition_wrapped_as_sy
 
 
 def test_capture_exception_still_reports_connect_error_internal():
-    """ConnectError with Internal/Unavailable/Unknown is NOT user-actionable — those
-    indicate backend bugs or outages and should still be reported to Sentry."""
+    """ConnectError(INTERNAL/UNKNOWN) can indicate a real backend or SDK bug
+    and should still be reported. UNAVAILABLE / DEADLINE_EXCEEDED are filtered
+    separately (transient infra)."""
     from connectrpc.code import Code
     from connectrpc.errors import ConnectError
 
@@ -309,3 +310,60 @@ def test_capture_exception_still_reports_other_oserror():
     ):
         _sentry.capture_exception(err)
     capture_mock.assert_called_once_with(err)
+
+
+def test_capture_exception_skips_connect_error_unavailable_wrapped_as_system_error():
+    """FLYTE-SDK-47/48/3W: SelectCluster transient network failures (Connection
+    refused / reset / DNS lookup failed) surface as ConnectError(UNAVAILABLE)
+    wrapped through RuntimeError -> RuntimeSystemError. These are infra
+    problems, not SDK bugs."""
+    from connectrpc.code import Code
+    from connectrpc.errors import ConnectError
+
+    from flyte.errors import RuntimeSystemError
+
+    try:
+        try:
+            try:
+                raise ConnectError(
+                    Code.UNAVAILABLE,
+                    "Request failed: error sending request for url (...): client error (Connect): "
+                    "tcp connect error: Connection refused",
+                )
+            except ConnectError as ce:
+                raise RuntimeError(f"SelectCluster failed for operation=1: {ce}") from ce
+        except RuntimeError:
+            raise RuntimeSystemError(
+                "RuntimeError", "Failed to get signed url for /tmp/x.tar.gz: SelectCluster failed..."
+            )
+    except RuntimeSystemError as e:
+        err = e
+
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()
+
+
+def test_capture_exception_skips_connect_error_deadline_exceeded_wrapped_as_system_error():
+    """FLYTE-SDK-29: SelectCluster Request timed out surfaces as
+    ConnectError(DEADLINE_EXCEEDED) wrapped through RuntimeError ->
+    RuntimeSystemError. Transient infra, not an SDK bug."""
+    from connectrpc.code import Code
+    from connectrpc.errors import ConnectError
+
+    from flyte.errors import RuntimeSystemError
+
+    try:
+        try:
+            try:
+                raise ConnectError(Code.DEADLINE_EXCEEDED, "Request timed out")
+            except ConnectError as ce:
+                raise RuntimeError(f"SelectCluster failed for operation=1: {ce}") from ce
+        except RuntimeError:
+            raise RuntimeSystemError("RuntimeError", "Failed to get signed url for /tmp/x.pb: SelectCluster failed...")
+    except RuntimeSystemError as e:
+        err = e
+
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()


### PR DESCRIPTION
## Summary

SelectCluster failures land in Sentry as SDK crashes even though they are transient infra problems — DNS lookup failed, TCP connect refused, connection reset, deadline exceeded. The chain is:

```
ConnectError(UNAVAILABLE | DEADLINE_EXCEEDED)
  -> RuntimeError("SelectCluster failed for operation=...")        # _select_and_build
  -> RuntimeSystemError("Failed to get signed url for /tmp/...")   # _upload_single_file
```

The SDK cannot recover from these; they belong in the same user-error bucket the CLI's `InvokeBaseMixin` (in `src/flyte/cli/_common.py`) already routes to `ClickException`.

## Change

Extends `_USER_ACTIONABLE_CONNECT_CODES` in `src/flyte/_sentry.py` to include:
- `UNAVAILABLE` — connection refused/reset, DNS lookup failure, backend down.
- `DEADLINE_EXCEEDED` — request timed out.

`INTERNAL` is intentionally **not** added — that code can indicate a real backend/SDK bug worth a crash report. Docstring on `_is_user_actionable_connect_error` is updated to spell out the two-flavor (user-config + transient-infra) scope.

## Closes

- [FLYTE-SDK-29](https://unionai.sentry.io/issues/FLYTE-SDK-29/) — SelectCluster `Request timed out` (DEADLINE_EXCEEDED)
- [FLYTE-SDK-47](https://unionai.sentry.io/issues/FLYTE-SDK-47/) — SelectCluster `Connection refused` (UNAVAILABLE)
- [FLYTE-SDK-48](https://unionai.sentry.io/issues/FLYTE-SDK-48/) — SelectCluster transient failure (UNAVAILABLE)
- [FLYTE-SDK-3W](https://unionai.sentry.io/issues/FLYTE-SDK-3W/) — SelectCluster `Connection reset` (UNAVAILABLE)

\`fixes FLYTE-SDK-29\`
\`fixes FLYTE-SDK-47\`
\`fixes FLYTE-SDK-48\`
\`fixes FLYTE-SDK-3W\`

## Test plan

- [x] New: `ConnectError(UNAVAILABLE)` wrapped through RuntimeError + RuntimeSystemError — filtered.
- [x] New: `ConnectError(DEADLINE_EXCEEDED)` wrapped variant — filtered.
- [x] Existing `test_capture_exception_still_reports_connect_error_internal` — `INTERNAL` still reported (regression guard).
- [x] All 22 tests in \`tests/flyte/test_sentry.py\` pass.
- [x] \`make fmt\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)