### PR TITLE
fix: handle None record name in flyte log record factory

### DIFF
--- a/src/flyte/_logging.py
+++ b/src/flyte/_logging.py
@@ -33,9 +33,7 @@ def _flyte_record_factory(*args: Any, **kwargs: Any) -> logging.LogRecord:
         record.action_name = None
 
     name = record.name or ""
-    record.is_flyte_internal = name == "flyte" or (
-        name.startswith("flyte.") and not name.startswith("flyte.user")
-    )
+    record.is_flyte_internal = name == "flyte" or (name.startswith("flyte.") and not name.startswith("flyte.user"))
     return record
 
 

--- a/src/flyte/_logging.py
+++ b/src/flyte/_logging.py
@@ -32,8 +32,9 @@ def _flyte_record_factory(*args: Any, **kwargs: Any) -> logging.LogRecord:
         record.run_name = None
         record.action_name = None
 
-    record.is_flyte_internal = record.name == "flyte" or (
-        record.name.startswith("flyte.") and not record.name.startswith("flyte.user")
+    name = record.name or ""
+    record.is_flyte_internal = name == "flyte" or (
+        name.startswith("flyte.") and not name.startswith("flyte.user")
     )
     return record
 

--- a/tests/flyte/test_logging.py
+++ b/tests/flyte/test_logging.py
@@ -1,7 +1,18 @@
+import logging
+
 import mock
 import pytest
 
 from flyte._logging import log
+
+
+def test_record_factory_with_none_name():
+    # Reproduces the structlog stdlib bridge bug: logging.makeLogRecord calls the
+    # global factory with name=None, which caused AttributeError on record.name.startswith(...)
+    factory = logging.getLogRecordFactory()
+    record = factory(None, None, "", 0, "", (), None, None)
+    # Should not raise; is_flyte_internal must be False for a None-named record
+    assert record.is_flyte_internal is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
  ## Motivation
  
  _flyte_record_factory crashed with AttributeError when record.name was None, which happens when logging.makeLogRecord (used by structlog's stdlib bridge) invokes the global record factory without a name.
  
 ## Summary

  - Coalesce record.name to an empty string before computing is_flyte_internal, preventing the NoneType.startswith crash.
  - A None-named record now safely resolves to is_flyte_internal = False.
  - Added test_record_factory_with_none_name to reproduce the original crash and guard against
  regressions.

  ## Test Plan
  
  - Run the logging tests: uv run pytest tests/flyte/test_logging.py -v
  - Verify both test_record_factory_with_none_name and test_logging pass (2 passed).
  - The new test directly invokes the factory with name=None and asserts it does not raise and returns is_flyte_internal is False.