### PR TITLE
fix: filter transient network/timeout errors from Sentry

### DIFF
--- a/src/flyte/_sentry.py
+++ b/src/flyte/_sentry.py
@@ -140,6 +140,52 @@ def _is_user_environment_oserror(exc: BaseException) -> bool:
     return exc.errno in _USER_ENVIRONMENT_OSERROR_ERRNOS
 
 
+def _is_transient_network_error(exc: BaseException) -> bool:
+    """Transient network / connectivity failures, not SDK bugs.
+
+    The `flyte deploy`/`flyte run` upload path (flyte.remote._data) reaches the
+    cluster service (SelectCluster) and then PUTs the bundle to a signed object
+    store URL. Both legs ride the user's network, so flaky links, VPN drops,
+    refused/reset connections and request timeouts surface here as
+    RuntimeSystemError wrappers whose cause chain terminates in a timeout or a
+    transport-level connection error. None of those are something the SDK can
+    fix, so they shouldn't be reported as crashes. Covers, among others:
+
+    - FLYTE-SDK-29: SelectCluster ``TimeoutError`` ("Request timed out")
+    - FLYTE-SDK-47: builtin ``ConnectionError`` ("Connection refused")
+    - FLYTE-SDK-3W: ``httpx.WriteError`` ("Connection reset by peer")
+    - FLYTE-SDK-36: ``httpx.ReadError`` during the signed-URL upload
+    - FLYTE-SDK-4M: ``httpx.RemoteProtocolError`` ("Server disconnected without
+      sending a response") — the object store dropped the PUT mid-flight
+
+    Transient ConnectError status codes (DEADLINE_EXCEEDED / UNAVAILABLE) are
+    handled by ``_is_user_actionable_connect_error`` and intentionally not
+    duplicated here. INTERNAL / UNKNOWN stay reported — they can signal a real
+    backend bug worth tracking.
+    """
+    # Builtin timeouts (asyncio.TimeoutError and socket.timeout are both aliases
+    # of TimeoutError on 3.11+) and connection errors (ConnectionRefused/Reset/
+    # Aborted/BrokenPipe) are all OSError subclasses raised by the network stack,
+    # never by SDK logic.
+    if isinstance(exc, (TimeoutError, ConnectionError)):
+        return True
+
+    # httpx transport failures from the signed-URL PUT. TimeoutException and
+    # NetworkError are the two transport-error families (ConnectTimeout,
+    # ReadTimeout, ReadError, WriteError, ConnectError, PoolTimeout, ...).
+    # RemoteProtocolError (a ProtocolError, not a NetworkError) is the server
+    # hanging up mid-response. None are OSError subclasses, so check explicitly.
+    try:
+        import httpx
+
+        if isinstance(exc, (httpx.TimeoutException, httpx.NetworkError, httpx.RemoteProtocolError)):
+            return True
+    except ImportError:
+        pass
+
+    return False
+
+
 def _is_user_error(exc: BaseException) -> bool:
     """Errors raised intentionally as user-facing messages — not crash reports."""
     try:
@@ -179,6 +225,8 @@ def _is_user_error(exc: BaseException) -> bool:
         if _is_user_actionable_connect_error(cause):
             return True
         if _is_user_environment_oserror(cause):
+            return True
+        if _is_transient_network_error(cause):
             return True
     return False
 

--- a/tests/flyte/test_sentry.py
+++ b/tests/flyte/test_sentry.py
@@ -367,3 +367,71 @@ def test_capture_exception_skips_connect_error_deadline_exceeded_wrapped_as_syst
     with mock.patch.object(_sentry, "init") as init_mock:
         _sentry.capture_exception(err)
     init_mock.assert_not_called()
+
+
+def _wrap_as_upload_system_error(inner: BaseException):
+    """Reproduce the flyte.remote._data shape: the real network failure is wrapped
+    in RuntimeError('SelectCluster failed...') -> RuntimeSystemError('Failed to
+    get signed url...'), so isinstance() on the outer exc misses the cause."""
+    from flyte.errors import RuntimeSystemError
+
+    try:
+        try:
+            try:
+                raise inner
+            except BaseException as net_err:
+                raise RuntimeError(f"SelectCluster failed for operation=1: {net_err}") from net_err
+        except RuntimeError:
+            raise RuntimeSystemError("RuntimeError", "Failed to get signed url for /tmp/x.tar.gz.")
+    except RuntimeSystemError as e:
+        return e
+
+
+def test_capture_exception_skips_timeout_error():
+    """FLYTE-SDK-29: SelectCluster request times out (``TimeoutError``) on the way
+    to the cluster service. A network/backend timeout is not an SDK crash."""
+    err = _wrap_as_upload_system_error(TimeoutError("Request timed out"))
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()
+
+
+def test_capture_exception_skips_connection_error():
+    """FLYTE-SDK-47: builtin ``ConnectionError`` (connection refused) reaching the
+    cluster service is a local network problem, not an SDK bug."""
+    err = _wrap_as_upload_system_error(ConnectionRefusedError(errno.ECONNREFUSED, "Connection refused"))
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "httpx_exc_name", ["WriteError", "ReadError", "ConnectError", "ConnectTimeout", "RemoteProtocolError"]
+)
+def test_capture_exception_skips_httpx_transport_errors(httpx_exc_name):
+    """FLYTE-SDK-3W / FLYTE-SDK-36 / FLYTE-SDK-4M: the signed-URL PUT fails at the
+    transport layer (connection reset, read/write error, connect timeout) or the
+    server hangs up mid-response (RemoteProtocolError). Transient network."""
+    import httpx
+
+    err = _wrap_as_upload_system_error(getattr(httpx, httpx_exc_name)("boom"))
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()
+
+
+def test_capture_exception_still_reports_connect_error_internal_in_upload_chain():
+    """ConnectError(INTERNAL) — a backend 500 (FLYTE-SDK-43) — is intentionally NOT
+    treated as transient: it can be a real backend bug, so it still reaches Sentry."""
+    from connectrpc.code import Code
+    from connectrpc.errors import ConnectError
+
+    err = _wrap_as_upload_system_error(ConnectError(Code.INTERNAL, "Internal Server Error"))
+    with (
+        mock.patch.object(_sentry, "init"),
+        mock.patch("sentry_sdk.is_initialized", return_value=True),
+        mock.patch("sentry_sdk.capture_exception") as capture_mock,
+        mock.patch("sentry_sdk.flush"),
+    ):
+        _sentry.capture_exception(err)
+    capture_mock.assert_called_once_with(err)


### PR DESCRIPTION
## Summary

The `flyte deploy` / `flyte run` upload path (`flyte.remote._data`) reaches the cluster service (`SelectCluster`) and then `PUT`s the bundle to a signed object-store URL. Both legs ride the **user's network**, so flaky links, VPN drops, refused/reset connections and request timeouts surface as `RuntimeSystemError` wrappers whose cause chain terminates in a timeout or transport-level connection error.

These are user-environment / transient-infra failures, **not SDK crashes**, but they currently leak into Sentry (the `flyte-sdk` crash-reporting project) as if they were SDK bugs — and they're some of the noisiest issues there.

This follows the established `flyte/_sentry.py` pattern (#1039, #1052, #1056, #1078, #1094, #1109, #1133, #1137) of classifying non-crash errors and skipping them via `_is_user_error`'s cause-chain walk.

## What it filters

New `_is_transient_network_error`, walked over the existing cause chain:

- builtin `TimeoutError` (asyncio/socket timeouts) and `ConnectionError` (refused / reset / aborted / broken-pipe)
- `httpx.TimeoutException` / `httpx.NetworkError` — the signed-URL PUT transport errors (`ConnectTimeout`, `ReadTimeout`, `ReadError`, `WriteError`, `ConnectError`, `PoolTimeout`, …)
- `httpx.RemoteProtocolError` — "Server disconnected without sending a response", the object store hanging up mid-PUT (**FLYTE-SDK-4M**)

Transient `ConnectError` status codes (`DEADLINE_EXCEEDED` / `UNAVAILABLE`) are already handled by `_is_user_actionable_connect_error` (merged in #1137), so they are **not duplicated** here. `INTERNAL` / `UNKNOWN` ConnectError codes are **deliberately left reported** — those can indicate real backend bugs worth tracking (a covering test asserts this).

## Sentry issues addressed

- `fixes FLYTE-SDK-29` — SelectCluster `TimeoutError` ("Request timed out")
- `fixes FLYTE-SDK-47` — builtin `ConnectionError` (connection refused)
- `fixes FLYTE-SDK-3W` — `httpx.WriteError` (connection reset by peer)
- `fixes FLYTE-SDK-36` — `httpx.ReadError` during the signed-URL upload
- `fixes FLYTE-SDK-4M` — `httpx.RemoteProtocolError` (server disconnected mid-PUT)
- `fixes FLYTE-SDK-4G` — SelectCluster `TimeoutError` ("operation timed out")

## Tests

`tests/flyte/test_sentry.py` — covers builtin timeout/connection errors, the httpx transport family (incl. `RemoteProtocolError`), and asserts `ConnectError(INTERNAL)` still reaches Sentry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
