### PR TITLE
fix: raise InvalidImageNameError for unknown image ref in deploy

### DIFF
--- a/src/flyte/_deploy.py
+++ b/src/flyte/_deploy.py
@@ -380,6 +380,7 @@ async def _build_images(
     connectors, run) don't each need to duplicate that step.
     """
     from flyte._image import _DEFAULT_IMAGE_REF_NAME, resolve_code_bundle_layer
+    from flyte.errors import InvalidImageNameError
 
     from ._internal.imagebuild.image_builder import ImageCache
 
@@ -402,8 +403,13 @@ async def _build_images(
                     image_uri = image_refs[env.image._ref_name]
                     env.image = env.image.clone(base_image=image_uri)
                 else:
-                    raise ValueError(
-                        f"Image name '{env.image._ref_name}' not found in config. Available: {list(image_refs.keys())}"
+                    # The user referenced an image name that isn't declared in their
+                    # config — a user-config mistake, not an SDK crash. Raise a typed
+                    # RuntimeUserError so the Sentry filter (flyte/_sentry.py) skips it
+                    # and the user gets a clear, actionable message (FLYTE-SDK-4C).
+                    raise InvalidImageNameError(
+                        "InvalidImageName",
+                        f"Image name '{env.image._ref_name}' not found in config. Available: {list(image_refs.keys())}",
                     )
                 if not env.image._layers:
                     # No additional layers, use the base_image directly without building

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -15,6 +15,7 @@ from flyte._deploy import DeploymentPlan, _build_images
 from flyte._initialize import _get_init_config
 from flyte._task_environment import TaskEnvironment
 from flyte.cli._run import run
+from flyte.errors import InvalidImageNameError
 
 TEST_CODE_PATH = pathlib.Path(__file__).parent
 RUN_TESTDATA = TEST_CODE_PATH / "run_testdata"
@@ -173,8 +174,9 @@ def test_build_images_image_name_not_found_error(runner):
     deployment_plan = DeploymentPlan(envs={env_name: task_env})
 
     cfg = _get_init_config()
-    # Check if _build_images raises ValueError for missing image name
-    with pytest.raises(ValueError) as exc_info:
+    # A reference to an undeclared image name is a user-config mistake, surfaced as
+    # InvalidImageNameError (a RuntimeUserError) so it's filtered from Sentry.
+    with pytest.raises(InvalidImageNameError) as exc_info:
         asyncio.run(_build_images(deployment_plan, cfg.images))
 
     error_msg = str(exc_info.value)


### PR DESCRIPTION
## Summary

When a user references an image name in a `TaskEnvironment` that isn't declared in their config, `_build_images` raised a bare `ValueError`. During `flyte deploy` / `flyte run` this is captured and leaks into Sentry as if it were an SDK crash ([FLYTE-SDK-4C](https://unionai.sentry.io/issues/FLYTE-SDK-4C/)), even though it's a **user-config mistake**.

This swaps the bare `ValueError` for the purpose-built `InvalidImageNameError` (a `RuntimeUserError` subclass that already exists in `flyte/errors.py`). It is already filtered by `flyte/_sentry.py:_is_user_error`, so it stops polluting Sentry, and it gives the user a clearly-typed, actionable error.

```
ValueError: Image name 'usda-firecon' not found in config. Available: ['solution_image']
```

The message is preserved verbatim; only the exception type changes.

## Closes

- [FLYTE-SDK-4C](https://unionai.sentry.io/issues/FLYTE-SDK-4C/) — `ValueError: Image name '...' not found in config` from `flyte._deploy in _build_images`.

`fixes FLYTE-SDK-4C`

## Test plan

- [x] `tests/cli/test_run.py::test_build_images_image_name_not_found_error` updated to assert `InvalidImageNameError` (message assertions unchanged) — passes.
- [x] `make fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)