### PR TITLE
fix: wrap RuntimeError at user-module import as ModuleLoadError

### DIFF
--- a/src/flyte/_utils/module_loader.py
+++ b/src/flyte/_utils/module_loader.py
@@ -58,7 +58,16 @@ def load_python_modules(
             loaded_modules.append(imported_module)
         except flyte.errors.ModuleLoadError as e:
             failed_paths.append((path, str(e)))
-        except (ImportError, SyntaxError, NameError, AttributeError, TypeError, ValueError, KeyError) as e:
+        except (
+            ImportError,
+            SyntaxError,
+            NameError,
+            AttributeError,
+            TypeError,
+            ValueError,
+            KeyError,
+            RuntimeError,
+        ) as e:
             raise flyte.errors.ModuleLoadError(f"Failed to load {path}: {type(e).__name__}: {e}") from e
 
     elif path.is_dir():
@@ -109,7 +118,16 @@ def load_python_modules(
                         loaded_modules.append(imported_module)
                     except flyte.errors.ModuleLoadError as e:
                         failed_paths.append((file_path, str(e)))
-                    except (ImportError, SyntaxError, NameError, AttributeError, TypeError, ValueError, KeyError) as e:
+                    except (
+                        ImportError,
+                        SyntaxError,
+                        NameError,
+                        AttributeError,
+                        TypeError,
+                        ValueError,
+                        KeyError,
+                        RuntimeError,
+                    ) as e:
                         # User code failed at import time. Record as a load failure
                         # (consistent with ModuleLoadError above) so deploy can either
                         # warn or abort via --ignore-load-errors instead of crashing.

--- a/tests/flyte/utils/test_module_loader.py
+++ b/tests/flyte/utils/test_module_loader.py
@@ -214,6 +214,7 @@ def test_load_python_modules_dir_collects_import_errors_in_failed_paths(tmp_path
         (TypeError, {}),
         (ValueError, {}),
         (KeyError, {}),
+        (RuntimeError, {}),
     ],
 )
 def test_load_python_modules_single_file_wraps_user_code_errors(tmp_path, exc_type, exc_kwargs):
@@ -266,3 +267,33 @@ def test_load_python_modules_single_file_wraps_missing_env_var_keyerror(tmp_path
     assert "workflow.py" in msg
     assert "KeyError" in msg
     assert "NEVER_SET_GCP_ADR_XYZ" in msg
+
+
+def test_load_python_modules_single_file_wraps_runtime_error(tmp_path):
+    """A user/plugin module that raises ``RuntimeError`` at import time (e.g.
+    ``union.sandbox`` raising "default environments are unavailable — install
+    union-sandbox[deploy]" when an optional dependency is missing) is a user
+    environment problem, not an SDK crash. It must surface as ``ModuleLoadError``
+    so the Sentry filter skips it.
+
+    Reproduces FLYTE-SDK-46.
+    """
+    root = tmp_path / "project"
+    root.mkdir()
+    f = root / "workflow.py"
+    f.write_text(
+        "raise RuntimeError('union.sandbox default environments are unavailable — install `union-sandbox[deploy]`')\n"
+    )
+
+    sys.path.insert(0, str(root))
+    try:
+        with pytest.raises(flyte.errors.ModuleLoadError) as excinfo:
+            load_python_modules(f, root_dir=root, recursive=False)
+    finally:
+        sys.path.remove(str(root))
+        sys.modules.pop("workflow", None)
+
+    msg = str(excinfo.value)
+    assert "workflow.py" in msg
+    assert "RuntimeError" in msg
+    assert "union.sandbox" in msg


### PR DESCRIPTION
## Problem

A user or plugin module that raises a plain `RuntimeError` at **import time** leaks into the SDK's Sentry project as if it were an SDK crash.

The module loader's two `except` clauses already wrap `(ImportError, SyntaxError, NameError, AttributeError, TypeError, ValueError, KeyError)` raised during user-code import as `ModuleLoadError` — a `RuntimeUserError` subclass already filtered by `flyte/_sentry.py:_is_user_error`. But `RuntimeError` was not in the tuple, so it bubbled straight through.

## Fix

Add `RuntimeError` to both `except` clauses in `src/flyte/_utils/module_loader.py` (single-file path and directory path). `flyte.errors.ModuleLoadError` is still caught first, so SDK-wrapped load errors keep their existing behavior.

## Closes
- [FLYTE-SDK-46](https://unionai.sentry.io/issues/FLYTE-SDK-46/) — `RuntimeError: union.sandbox default environments are unavailable — install union-sandbox[deploy]` raised at import of `union/sandbox/task/_server.py`.

`fixes FLYTE-SDK-46`

## Tests
- Extended the `test_load_python_modules_single_file_wraps_user_code_errors` parametrization with `RuntimeError`.
- Added `test_load_python_modules_single_file_wraps_runtime_error` reproducing the FLYTE-SDK-46 shape (a module that raises the union.sandbox message at top level), asserting `ModuleLoadError` wraps it with the file path and original type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)