### PR TITLE
fix: raise DeploymentError for unknown image ref name

### DIFF
--- a/src/flyte/_deploy.py
+++ b/src/flyte/_deploy.py
@@ -379,6 +379,7 @@ async def _build_images(
     Resolves any ``CodeBundleLayer`` layers first so callers (apply, build_images, serve,
     connectors, run) don't each need to duplicate that step.
     """
+    import flyte.errors
     from flyte._image import _DEFAULT_IMAGE_REF_NAME, resolve_code_bundle_layer
 
     from ._internal.imagebuild.image_builder import ImageCache
@@ -402,7 +403,7 @@ async def _build_images(
                     image_uri = image_refs[env.image._ref_name]
                     env.image = env.image.clone(base_image=image_uri)
                 else:
-                    raise ValueError(
+                    raise flyte.errors.DeploymentError(
                         f"Image name '{env.image._ref_name}' not found in config. Available: {list(image_refs.keys())}"
                     )
                 if not env.image._layers:

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -173,8 +173,8 @@ def test_build_images_image_name_not_found_error(runner):
     deployment_plan = DeploymentPlan(envs={env_name: task_env})
 
     cfg = _get_init_config()
-    # Check if _build_images raises ValueError for missing image name
-    with pytest.raises(ValueError) as exc_info:
+    # Check if _build_images raises DeploymentError for missing image name
+    with pytest.raises(flyte.errors.DeploymentError) as exc_info:
         asyncio.run(_build_images(deployment_plan, cfg.images))
 
     error_msg = str(exc_info.value)

--- a/tests/flyte/test_deploy.py
+++ b/tests/flyte/test_deploy.py
@@ -405,6 +405,26 @@ async def test_build_images_no_build_run_urls_for_local_build():
     assert cache.build_run_ids == {}
 
 
+@pytest.mark.asyncio
+async def test_build_images_unknown_ref_name_raises_deployment_error():
+    """An image referenced by a name that is not present in the config is a user
+    configuration mistake, not an SDK bug. _build_images must raise
+    DeploymentError (a RuntimeUserError filtered out of Sentry) instead of a bare
+    ValueError.
+
+    Reproduces FLYTE-SDK-4C.
+    """
+    import flyte.errors
+
+    flyte.init()
+    image = flyte.Image.from_ref_name("usda-firecon")
+    env = flyte.TaskEnvironment(name="my-env", image=image)
+    plan = DeploymentPlan(envs={"my-env": env})
+
+    with pytest.raises(flyte.errors.DeploymentError, match=r"Image name 'usda-firecon' not found in config"):
+        await _build_images(plan, image_refs={"solution_image": "registry/solution:latest"})
+
+
 # ---------------------------------------------------------------------------
 # resolve_code_bundle_layer across depends_on environments
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When a `TaskEnvironment` references an image by a name that is not present in the deploy config, `_build_images` raised a bare `ValueError` that escaped into the SDK's Sentry project as if it were an SDK crash. This is a user configuration mistake (a typo'd or missing image ref), not an SDK bug.

## Fix

In `src/flyte/_deploy.py:_build_images`, raise `flyte.errors.DeploymentError` (a `RuntimeUserError` already filtered by `flyte/_sentry.py:_is_user_error`) instead of `ValueError`. The message is unchanged.

## Closes
- [FLYTE-SDK-4C](https://unionai.sentry.io/issues/FLYTE-SDK-4C/) — `ValueError: Image name 'usda-firecon' not found in config. Available: ['solution_image']`.

`fixes FLYTE-SDK-4C`

## Tests
- Added `test_build_images_unknown_ref_name_raises_deployment_error`, which builds an image via `Image.from_ref_name("usda-firecon")` and asserts `_build_images` raises `DeploymentError` when the ref is absent from `image_refs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)