### PR TITLE
fix: raise ImageBuildError for missing image source folder

### DIFF
--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -369,12 +369,18 @@ class CopyConfig(Layer):
             object.__setattr__(self, "src", Path(self.src))
 
     def validate(self):
+        # A missing / wrong-typed source path is a user mistake in the image spec
+        # (e.g. a stale `add_source(...)` path), not an SDK bug. Surface it as an
+        # ImageBuildError (a RuntimeUserError) so it is reported with a clear
+        # message and filtered out of Sentry. Reproduces FLYTE-SDK-4D.
+        from flyte.errors import ImageBuildError
+
         if not self.src.exists():
-            raise ValueError(f"Source folder {self.src.absolute()} does not exist")
+            raise ImageBuildError(f"Source folder {self.src.absolute()} does not exist")
         if not self.src.is_dir() and self.path_type == 1:
-            raise ValueError(f"Source folder {self.src.absolute()} is not a directory")
+            raise ImageBuildError(f"Source folder {self.src.absolute()} is not a directory")
         if not self.src.is_file() and self.path_type == 0:
-            raise ValueError(f"Source file {self.src.absolute()} is not a file")
+            raise ImageBuildError(f"Source file {self.src.absolute()} is not a file")
 
     def update_hash(self, hasher: hashlib._Hash, ignore: Optional[Any] = None):
         from ._code_bundle._ignore import DockerfileIgnore

--- a/tests/flyte/test_image.py
+++ b/tests/flyte/test_image.py
@@ -399,6 +399,32 @@ def test_uv_project_optional_uvlock():
         assert hash1 != hash2
 
 
+def test_copy_config_validate_missing_src_raises_image_build_error(tmp_path):
+    """A CopyConfig pointing at a non-existent source is a user mistake in the
+    image spec, not an SDK bug. validate() must raise ImageBuildError (a
+    RuntimeUserError filtered out of Sentry) rather than a bare ValueError.
+
+    Reproduces FLYTE-SDK-4D.
+    """
+    from flyte.errors import ImageBuildError
+
+    missing = tmp_path / "does-not-exist"
+    cc = CopyConfig(path_type=1, src=missing, dst="/app")
+    with pytest.raises(ImageBuildError, match=r"Source folder .* does not exist"):
+        cc.validate()
+
+
+def test_copy_config_validate_wrong_type_raises_image_build_error(tmp_path):
+    """A file passed where a directory (path_type=1) is expected is a user error."""
+    from flyte.errors import ImageBuildError
+
+    f = tmp_path / "a.txt"
+    f.write_text("hello")
+    cc = CopyConfig(path_type=1, src=f, dst="/app")
+    with pytest.raises(ImageBuildError, match=r"Source folder .* is not a directory"):
+        cc.validate()
+
+
 def test_copy_config_coerces_string_src_to_path(tmp_path):
     """CopyConfig accepts a str src and coerces it to Path so update_hash/validate work."""
     import hashlib

--- a/tests/flyte/test_image.py
+++ b/tests/flyte/test_image.py
@@ -113,12 +113,14 @@ def test_with_pip_packages():
 
 
 def test_with_source(tmp_path):
+    from flyte.errors import ImageBuildError
+
     file = tmp_path / "my_code.py"
     img = Image.from_debian_base(registry="localhost", name="test-image", flyte_version="0.2.0b14").with_source_file(
         file
     )
     assert img._layers[-1].src == file
-    with pytest.raises(ValueError):
+    with pytest.raises(ImageBuildError):
         img.validate()
     file.touch()
     img.validate()


### PR DESCRIPTION
## Problem

`CopyConfig.validate()` raised a bare `ValueError` when an image's source path is missing or the wrong type (e.g. a stale `add_source(...)` path pointing at a build dir that no longer exists). That escaped into the SDK's Sentry project as an SDK crash, even though a bad source path is a user mistake in the image spec.

## Fix

In `src/flyte/_image.py:CopyConfig.validate`, raise `flyte.errors.ImageBuildError` (a `RuntimeUserError` already filtered by `flyte/_sentry.py:_is_user_error`) for the three validation failures (missing path, not-a-directory, not-a-file). Messages are unchanged. No caller catches `ValueError` around this path (verified), and `ImageBuildError` is still a `RuntimeError` subclass.

## Closes
- [FLYTE-SDK-4D](https://unionai.sentry.io/issues/FLYTE-SDK-4D/) — `ValueError: Source folder /.../deploy/build/release/sandbox-server does not exist`.

`fixes FLYTE-SDK-4D`

## Tests
- Added `test_copy_config_validate_missing_src_raises_image_build_error` and `test_copy_config_validate_wrong_type_raises_image_build_error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)