### PR TITLE
[Devbox] Skip k8s context switch and kubeconfig update when kubectl not installed

### DIFF
--- a/src/flyte/cli/_devbox.py
+++ b/src/flyte/cli/_devbox.py
@@ -36,12 +36,9 @@ def _ensure_docker_available() -> None:
         )
 
 
-def _ensure_kubectl_available() -> None:
-    if shutil.which("kubectl") is None:
-        raise click.ClickException(
-            "kubectl is not installed or not on PATH. Install kubectl "
-            "(https://kubernetes.io/docs/tasks/tools/) and try again."
-        )
+def _ensure_kubectl_available() -> bool:
+    """Return True if kubectl is installed and on PATH, False otherwise."""
+    return shutil.which("kubectl") is not None
 
 
 def _run_docker(cmd: list[str], failure_message: str) -> subprocess.CompletedProcess:
@@ -170,6 +167,12 @@ def _wait_for_kubeconfig(kubeconfig_path: Path, timeout: int = 60) -> None:
 
 
 def _switch_k8s_context(context: str = "flyte-devbox", namespace: str = "flyte") -> None:
+    if not _ensure_kubectl_available():
+        click.echo(
+            f"Warning: kubectl is not installed or not on PATH. Skipping switch to k8s context '{context}'.",
+            err=True,
+        )
+        return
     try:
         subprocess.run(["kubectl", "config", "use-context", context], check=True, capture_output=True, text=True)
         subprocess.run(
@@ -201,7 +204,13 @@ def _flatten_kubeconfig(default_kubeconfig: Path, kubeconfig_path: Path) -> subp
 def _merge_kubeconfig(kubeconfig_path: Path, container_name: str) -> None:
     import tempfile
 
-    _ensure_kubectl_available()
+    if not _ensure_kubectl_available():
+        click.echo(
+            "Warning: kubectl is not installed or not on PATH. Skipping kubeconfig merge. "
+            "Install kubectl (https://kubernetes.io/docs/tasks/tools/) to interact with the devbox cluster.",
+            err=True,
+        )
+        return
 
     default_kubeconfig = Path.home() / ".kube" / "config"
     default_kubeconfig.parent.mkdir(parents=True, exist_ok=True)

--- a/src/flyte/cli/_devbox.py
+++ b/src/flyte/cli/_devbox.py
@@ -36,7 +36,7 @@ def _ensure_docker_available() -> None:
         )
 
 
-def _ensure_kubectl_available() -> bool:
+def _is_kubectl_installed() -> bool:
     """Return True if kubectl is installed and on PATH, False otherwise."""
     return shutil.which("kubectl") is not None
 
@@ -167,10 +167,9 @@ def _wait_for_kubeconfig(kubeconfig_path: Path, timeout: int = 60) -> None:
 
 
 def _switch_k8s_context(context: str = "flyte-devbox", namespace: str = "flyte") -> None:
-    if not _ensure_kubectl_available():
-        click.echo(
-            f"Warning: kubectl is not installed or not on PATH. Skipping switch to k8s context '{context}'.",
-            err=True,
+    if not _is_kubectl_installed():
+        console.print(
+            f"[red]Warning: kubectl is not installed or not on PATH. Skipping switch to k8s context '{context}'.[/red]"
         )
         return
     try:
@@ -204,11 +203,10 @@ def _flatten_kubeconfig(default_kubeconfig: Path, kubeconfig_path: Path) -> subp
 def _merge_kubeconfig(kubeconfig_path: Path, container_name: str) -> None:
     import tempfile
 
-    if not _ensure_kubectl_available():
-        click.echo(
-            "Warning: kubectl is not installed or not on PATH. Skipping kubeconfig merge. "
-            "Install kubectl (https://kubernetes.io/docs/tasks/tools/) to interact with the devbox cluster.",
-            err=True,
+    if not _is_kubectl_installed():
+        console.print(
+            "[red]Warning: kubectl is not installed or not on PATH. Skipping kubeconfig merge. "
+            "Install kubectl (https://kubernetes.io/docs/tasks/tools/) to interact with the devbox cluster.[/red]"
         )
         return
 

--- a/tests/cli/test_devbox.py
+++ b/tests/cli/test_devbox.py
@@ -239,8 +239,6 @@ class TestDockerSubprocessFailures:
     """Docker CLI failures should surface as click.ClickException, not raw CalledProcessError."""
 
     def test_ensure_volume_failure_raises_click_exception(self):
-        import click
-
         from flyte.cli._devbox import _ensure_volume
 
         with patch("flyte.cli._devbox.subprocess.run") as mock_run:
@@ -251,8 +249,6 @@ class TestDockerSubprocessFailures:
             assert "docker daemon not reachable" in str(excinfo.value.message)
 
     def test_container_is_running_failure_raises_click_exception(self):
-        import click
-
         from flyte.cli._devbox import _container_is_running
 
         with patch("flyte.cli._devbox.subprocess.run") as mock_run:
@@ -261,8 +257,6 @@ class TestDockerSubprocessFailures:
                 _container_is_running("flyte-devbox")
 
     def test_container_is_paused_failure_raises_click_exception(self):
-        import click
-
         from flyte.cli._devbox import _container_is_paused
 
         with patch("flyte.cli._devbox.subprocess.run") as mock_run:

--- a/tests/cli/test_devbox.py
+++ b/tests/cli/test_devbox.py
@@ -10,7 +10,6 @@ import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import click
 import pytest
 from click.testing import CliRunner
 
@@ -239,6 +238,8 @@ class TestDockerSubprocessFailures:
     """Docker CLI failures should surface as click.ClickException, not raw CalledProcessError."""
 
     def test_ensure_volume_failure_raises_click_exception(self):
+        import click
+
         from flyte.cli._devbox import _ensure_volume
 
         with patch("flyte.cli._devbox.subprocess.run") as mock_run:
@@ -249,6 +250,8 @@ class TestDockerSubprocessFailures:
             assert "docker daemon not reachable" in str(excinfo.value.message)
 
     def test_container_is_running_failure_raises_click_exception(self):
+        import click
+
         from flyte.cli._devbox import _container_is_running
 
         with patch("flyte.cli._devbox.subprocess.run") as mock_run:
@@ -257,6 +260,8 @@ class TestDockerSubprocessFailures:
                 _container_is_running("flyte-devbox")
 
     def test_container_is_paused_failure_raises_click_exception(self):
+        import click
+
         from flyte.cli._devbox import _container_is_paused
 
         with patch("flyte.cli._devbox.subprocess.run") as mock_run:

--- a/tests/cli/test_devbox.py
+++ b/tests/cli/test_devbox.py
@@ -14,7 +14,7 @@ import pytest
 from click.testing import CliRunner
 
 from flyte.cli._devbox import (
-    _ensure_kubectl_available,
+    _is_kubectl_installed,
     _merge_kubeconfig,
     _run_container,
     _switch_k8s_context,
@@ -139,50 +139,50 @@ class TestMergeKubeconfigRetry:
                 _merge_kubeconfig(kubeconfig, "flyte-devbox")
 
 
-class TestEnsureKubectlAvailable:
-    """`_ensure_kubectl_available` reports kubectl presence as a bool instead of raising,
+class TestIsKubectlInstalled:
+    """`_is_kubectl_installed` reports kubectl presence as a bool instead of raising,
     and callers skip kubectl-dependent steps (with a warning) when it is missing."""
 
     def test_missing_kubectl_returns_false(self):
         with patch("flyte.cli._devbox.shutil.which", return_value=None):
-            assert _ensure_kubectl_available() is False
+            assert _is_kubectl_installed() is False
 
     def test_present_kubectl_returns_true(self):
         with patch("flyte.cli._devbox.shutil.which", return_value="/usr/local/bin/kubectl"):
-            assert _ensure_kubectl_available() is True
+            assert _is_kubectl_installed() is True
 
     def test_merge_kubeconfig_skips_and_warns_when_kubectl_missing(self, tmp_path):
         kubeconfig = tmp_path / "kubeconfig"
         kubeconfig.write_text("")
         with (
-            patch("flyte.cli._devbox._ensure_kubectl_available", return_value=False),
+            patch("flyte.cli._devbox._is_kubectl_installed", return_value=False),
             patch("flyte.cli._devbox._flatten_kubeconfig") as mock_flatten,
-            patch("flyte.cli._devbox.click.echo") as mock_echo,
+            patch("flyte.cli._devbox.console.print") as mock_print,
             patch("flyte.cli._devbox.Path.home", return_value=tmp_path),
         ):
             # Should not raise, and should not attempt to flatten/merge.
             _merge_kubeconfig(kubeconfig, "flyte-devbox")
 
             mock_flatten.assert_not_called()
-            mock_echo.assert_called_once()
-            message = mock_echo.call_args.args[0]
+            mock_print.assert_called_once()
+            message = mock_print.call_args.args[0]
             assert "kubectl" in message
-            assert mock_echo.call_args.kwargs.get("err") is True
+            assert "[red]" in message
 
     def test_switch_k8s_context_skips_and_warns_when_kubectl_missing(self):
         with (
-            patch("flyte.cli._devbox._ensure_kubectl_available", return_value=False),
+            patch("flyte.cli._devbox._is_kubectl_installed", return_value=False),
             patch("flyte.cli._devbox.subprocess.run") as mock_run,
-            patch("flyte.cli._devbox.click.echo") as mock_echo,
+            patch("flyte.cli._devbox.console.print") as mock_print,
         ):
             # Should not raise, and should never shell out to kubectl.
             _switch_k8s_context()
 
             mock_run.assert_not_called()
-            mock_echo.assert_called_once()
-            message = mock_echo.call_args.args[0]
+            mock_print.assert_called_once()
+            message = mock_print.call_args.args[0]
             assert "kubectl" in message
-            assert mock_echo.call_args.kwargs.get("err") is True
+            assert "[red]" in message
 
 
 class TestDevboxCliGpuFlag:

--- a/tests/cli/test_devbox.py
+++ b/tests/cli/test_devbox.py
@@ -14,7 +14,12 @@ import click
 import pytest
 from click.testing import CliRunner
 
-from flyte.cli._devbox import _ensure_kubectl_available, _merge_kubeconfig, _run_container
+from flyte.cli._devbox import (
+    _ensure_kubectl_available,
+    _merge_kubeconfig,
+    _run_container,
+    _switch_k8s_context,
+)
 from flyte.cli._start import devbox
 
 
@@ -136,28 +141,49 @@ class TestMergeKubeconfigRetry:
 
 
 class TestEnsureKubectlAvailable:
-    """`_merge_kubeconfig` must surface a friendly ClickException when kubectl is missing,
-    instead of leaking a raw FileNotFoundError from `subprocess.run`."""
+    """`_ensure_kubectl_available` reports kubectl presence as a bool instead of raising,
+    and callers skip kubectl-dependent steps (with a warning) when it is missing."""
 
-    def test_missing_kubectl_raises_click_exception(self):
+    def test_missing_kubectl_returns_false(self):
         with patch("flyte.cli._devbox.shutil.which", return_value=None):
-            with pytest.raises(click.ClickException) as excinfo:
-                _ensure_kubectl_available()
-            assert "kubectl" in str(excinfo.value.message)
+            assert _ensure_kubectl_available() is False
 
-    def test_present_kubectl_does_not_raise(self):
+    def test_present_kubectl_returns_true(self):
         with patch("flyte.cli._devbox.shutil.which", return_value="/usr/local/bin/kubectl"):
-            _ensure_kubectl_available()
+            assert _ensure_kubectl_available() is True
 
-    def test_merge_kubeconfig_raises_click_exception_when_kubectl_missing(self, tmp_path):
+    def test_merge_kubeconfig_skips_and_warns_when_kubectl_missing(self, tmp_path):
         kubeconfig = tmp_path / "kubeconfig"
         kubeconfig.write_text("")
         with (
-            patch("flyte.cli._devbox.shutil.which", return_value=None),
+            patch("flyte.cli._devbox._ensure_kubectl_available", return_value=False),
+            patch("flyte.cli._devbox._flatten_kubeconfig") as mock_flatten,
+            patch("flyte.cli._devbox.click.echo") as mock_echo,
             patch("flyte.cli._devbox.Path.home", return_value=tmp_path),
         ):
-            with pytest.raises(click.ClickException):
-                _merge_kubeconfig(kubeconfig, "flyte-devbox")
+            # Should not raise, and should not attempt to flatten/merge.
+            _merge_kubeconfig(kubeconfig, "flyte-devbox")
+
+            mock_flatten.assert_not_called()
+            mock_echo.assert_called_once()
+            message = mock_echo.call_args.args[0]
+            assert "kubectl" in message
+            assert mock_echo.call_args.kwargs.get("err") is True
+
+    def test_switch_k8s_context_skips_and_warns_when_kubectl_missing(self):
+        with (
+            patch("flyte.cli._devbox._ensure_kubectl_available", return_value=False),
+            patch("flyte.cli._devbox.subprocess.run") as mock_run,
+            patch("flyte.cli._devbox.click.echo") as mock_echo,
+        ):
+            # Should not raise, and should never shell out to kubectl.
+            _switch_k8s_context()
+
+            mock_run.assert_not_called()
+            mock_echo.assert_called_once()
+            message = mock_echo.call_args.args[0]
+            assert "kubectl" in message
+            assert mock_echo.call_args.kwargs.get("err") is True
 
 
 class TestDevboxCliGpuFlag:


### PR DESCRIPTION
## Goal
Skip k8s context switch and kubeconfig update when kubectl not installed instead of blocking the devbox start up process

## tests
Unit tests