### PR TITLE
fix: filter ConnectError(INTERNAL) upstream 5xx / connection-refused from Sentry

### DIFF
--- a/src/flyte/_sentry.py
+++ b/src/flyte/_sentry.py
@@ -124,6 +124,51 @@ def _is_user_actionable_connect_error(exc: BaseException) -> bool:
     return getattr(code, "name", None) in _USER_ACTIONABLE_CONNECT_CODES
 
 
+# ConnectError(INTERNAL) is intentionally NOT in _USER_ACTIONABLE_CONNECT_CODES — that
+# code can indicate a real backend or SDK bug worth reporting. But INTERNAL is also the
+# bucket connectrpc uses for upstream HTTP 5xx (nginx 502/503/504, 500 from the rust
+# backend) and for ConnectionRefused inside the upstream service's outbound calls. Those
+# upstream failures aren't SDK bugs — they're transient infra problems that show up as
+# `desc = ...` strings in the ConnectError message. We catch them by message rather than
+# code so the INTERNAL-means-real-bug guarantee still holds for the bare INTERNAL case.
+_INTERNAL_UPSTREAM_INFRA_PHRASES: tuple[str, ...] = (
+    "502 Bad Gateway",
+    "503 Service Unavailable",
+    "504 Gateway Timeout",
+    "Internal Server Error",  # nginx upstream 500 surfaced as INTERNAL
+    "connection refused",  # upstream service couldn't reach its dependency
+)
+
+
+def _is_upstream_infra_internal_error(exc: BaseException) -> bool:
+    """ConnectError(INTERNAL) wrapping an upstream HTTP 5xx or connection failure.
+
+    When the rust backend's nginx returns 502/503/504, or the backend's outbound
+    call to its object store fails with "connection refused", the connectrpc
+    transport surfaces it as `ConnectError(INTERNAL, desc=<raw upstream body>)`.
+    From the SDK's perspective this is transient infra against a system we don't
+    own — not an SDK bug — so it shouldn't be crash-reported.
+
+    Narrow by design: only INTERNAL whose message body matches a known
+    upstream-infra signature is filtered. Bare INTERNAL ("backend panicked",
+    serialization mismatches, anything without a 5xx HTML body) still reaches
+    Sentry, preserving the guarantee that INTERNAL surfaces real backend bugs.
+
+    Closes FLYTE-SDK-4H, FLYTE-SDK-4J, FLYTE-SDK-4K, FLYTE-SDK-43.
+    """
+    try:
+        from connectrpc.errors import ConnectError
+    except ImportError:
+        return False
+    if not isinstance(exc, ConnectError):
+        return False
+    code = getattr(exc, "code", None)
+    if getattr(code, "name", None) != "INTERNAL":
+        return False
+    msg = getattr(exc, "message", None) or str(exc) or ""
+    return any(phrase in msg for phrase in _INTERNAL_UPSTREAM_INFRA_PHRASES)
+
+
 _USER_ENVIRONMENT_OSERROR_ERRNOS: frozenset[int] = frozenset({errno.ENOSPC})
 
 
@@ -177,6 +222,8 @@ def _is_user_error(exc: BaseException) -> bool:
         if user_excs and isinstance(cause, user_excs):
             return True
         if _is_user_actionable_connect_error(cause):
+            return True
+        if _is_upstream_infra_internal_error(cause):
             return True
         if _is_user_environment_oserror(cause):
             return True

--- a/tests/flyte/test_sentry.py
+++ b/tests/flyte/test_sentry.py
@@ -367,3 +367,82 @@ def test_capture_exception_skips_connect_error_deadline_exceeded_wrapped_as_syst
     with mock.patch.object(_sentry, "init") as init_mock:
         _sentry.capture_exception(err)
     init_mock.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "upstream_body",
+    [
+        "request failed with status code 502. Body: <html>\r\n<head><title>502 Bad Gateway</title></head>",
+        "request failed with status code 503. Body: <html>\r\n<head><title>503 Service Unavailable</title></head>",
+        "request failed with status code 504. Body: <html>\r\n<head><title>504 Gateway Timeout</title></head>",
+        "Internal Server Error",
+    ],
+)
+def test_capture_exception_skips_connect_error_internal_upstream_5xx(upstream_body):
+    """FLYTE-SDK-4H/4K/43: ConnectError(INTERNAL) carrying an upstream nginx
+    5xx body (502/503/504, or Internal Server Error) is an upstream-infra
+    failure against a system the SDK doesn't own, not an SDK bug."""
+    from connectrpc.code import Code
+    from connectrpc.errors import ConnectError
+
+    from flyte.errors import RuntimeSystemError
+
+    try:
+        try:
+            raise ConnectError(Code.INTERNAL, upstream_body)
+        except ConnectError as ce:
+            raise RuntimeSystemError("UploadFailed", f"Failed to create run: {ce}") from ce
+    except RuntimeSystemError as e:
+        err = e
+
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()
+
+
+def test_capture_exception_skips_connect_error_internal_connection_refused():
+    """FLYTE-SDK-4J: rust backend's outbound PutObject to its object store
+    surfaces ``connection refused`` wrapped as ConnectError(INTERNAL). The
+    backend's own dependency being down isn't an SDK bug."""
+    from connectrpc.code import Code
+    from connectrpc.errors import ConnectError
+
+    from flyte.errors import RuntimeSystemError
+
+    upstream = (
+        "failed to write inputs: Failed to write data [13b] to path "
+        "[uploads/.../inputs.pb].: PutObject, putting object: RequestError: "
+        'send request failed\ncaused by: Put "http://rustfs-svc.flyte:9000/...": '
+        "dial tcp 10.43.94.220:9000: connect: connection refused"
+    )
+    try:
+        try:
+            raise ConnectError(Code.INTERNAL, upstream)
+        except ConnectError as ce:
+            raise RuntimeSystemError("CreateRunFailed", f"Failed to create run: {ce}") from ce
+    except RuntimeSystemError as e:
+        err = e
+
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()
+
+
+def test_capture_exception_still_reports_connect_error_internal_without_upstream_signature():
+    """Bare ConnectError(INTERNAL) — backend panics, serialization mismatches,
+    anything without a recognized upstream-5xx / connection-refused body —
+    still reaches Sentry. Regression guard so the narrow message-based filter
+    doesn't swallow real INTERNAL bugs (paired with
+    test_capture_exception_still_reports_connect_error_internal)."""
+    from connectrpc.code import Code
+    from connectrpc.errors import ConnectError
+
+    err = ConnectError(Code.INTERNAL, "backend panicked: serialization mismatch")
+    with (
+        mock.patch.object(_sentry, "init"),
+        mock.patch("sentry_sdk.is_initialized", return_value=True),
+        mock.patch("sentry_sdk.capture_exception") as capture_mock,
+        mock.patch("sentry_sdk.flush"),
+    ):
+        _sentry.capture_exception(err)
+    capture_mock.assert_called_once_with(err)


### PR DESCRIPTION
## Summary

The rust backend's nginx returns **502/503/504/500** when overloaded or restarting, and the backend's own outbound calls to its object store occasionally fail with **connection refused**. Both surface to the SDK as:

```
ConnectError(INTERNAL, desc=<raw upstream body>)
  → RuntimeSystemError("Failed to ... : <body>")
```

and leak into Sentry as if they were SDK crashes. They aren't — the system is upstream of the SDK and the SDK can't recover.

`INTERNAL` is intentionally **not** in `_USER_ACTIONABLE_CONNECT_CODES` (#1137) because that code is also where real backend/SDK bugs land. So we can't filter on code alone — we need to distinguish the upstream-infra flavor by message body.

## Change

New `_is_upstream_infra_internal_error` in `src/flyte/_sentry.py`, walked over the existing cause chain alongside `_is_user_actionable_connect_error` and `_is_user_environment_oserror`. It matches `ConnectError(INTERNAL)` **only** when the message body contains one of:

- `502 Bad Gateway`
- `503 Service Unavailable`
- `504 Gateway Timeout`
- `Internal Server Error` (HTTP 500 from upstream nginx)
- `connection refused` (rust backend's outbound dependency)

Bare `INTERNAL` ("backend panicked", serialization mismatches, anything without a recognized upstream-infra signature) **still reaches Sentry** — a regression-guard test covers that, paired with the existing `test_capture_exception_still_reports_connect_error_internal`.

## Sentry issues closed

- [FLYTE-SDK-4H](https://unionai.sentry.io/issues/FLYTE-SDK-4H/) — `Failed to create run: failed to upload inputs: rpc error: code = Internal desc = ... 502 Bad Gateway` (12 events, escalating)
- [FLYTE-SDK-4K](https://unionai.sentry.io/issues/FLYTE-SDK-4K/) — `Upload failed for ... rpc error: code = Internal ... 502 Bad Gateway`
- [FLYTE-SDK-4J](https://unionai.sentry.io/issues/FLYTE-SDK-4J/) — `Failed to write data ... PutObject ... dial tcp 10.43.94.220:9000: connect: connection refused` (rust backend can't reach rustfs)
- [FLYTE-SDK-43](https://unionai.sentry.io/issues/FLYTE-SDK-43/) — `SelectCluster failed for operation=1: Internal Server Error` (HTTP 500 upstream)

`fixes FLYTE-SDK-4H`
`fixes FLYTE-SDK-4J`
`fixes FLYTE-SDK-4K`
`fixes FLYTE-SDK-43`

## Test plan

- [x] Parametrized `test_capture_exception_skips_connect_error_internal_upstream_5xx` — 502/503/504/500 bodies all filtered.
- [x] New `test_capture_exception_skips_connect_error_internal_connection_refused` — the rustfs PutObject connection-refused chain filtered.
- [x] New `test_capture_exception_still_reports_connect_error_internal_without_upstream_signature` — regression guard; `ConnectError(INTERNAL, "backend panicked: serialization mismatch")` still reaches Sentry.
- [x] All 30 tests in `tests/flyte/test_sentry.py` pass (was 25).
- [x] `make fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)