### PR TITLE
feat(cli): add `flyte build --all` and a global `--no-progress` flag

### DIFF
--- a/src/flyte/_deploy.py
+++ b/src/flyte/_deploy.py
@@ -648,16 +648,29 @@ async def deploy(
 
 
 @syncify
-async def build_images(envs: Environment, copy_style: "CopyFiles" = "loaded_modules") -> ImageCache:
+async def build_images(*envs: Environment, copy_style: "CopyFiles" = "loaded_modules") -> ImageCache:
     """
-    Build the images for the given environment.
-    :param envs: Environment to build images for.
+    Build the images for the given environment(s).
+    :param envs: One or more environments to build images for. When multiple environments are
+        passed they are planned together in a single pass (mirroring ``deploy``), and the
+        resulting image caches are merged into one.
     :param copy_style: Copy style that the eventual deploy will use. Must match the deploy's
         ``--copy-style`` so the image content hashes — and therefore the registry tags — line
         up, letting deploy reuse the pre-built image.
     :return: ImageCache containing the built images.
     """
+    from ._internal.imagebuild.image_builder import ImageCache
+
     cfg = get_init_config()
     images = cfg.images if cfg else {}
-    deployment = plan_deploy(envs)
-    return await _build_images(deployment[0], images, copy_style)
+    deployment_plans = plan_deploy(*envs)
+    caches = [await _build_images(plan, images, copy_style) for plan in deployment_plans]
+    if len(caches) == 1:
+        return caches[0]
+
+    merged_lookup: Dict[str, str] = {}
+    merged_build_run_ids: Dict[str, Any] = {}
+    for cache in caches:
+        merged_lookup.update(cache.image_lookup)
+        merged_build_run_ids.update(cache.build_run_ids)
+    return ImageCache(image_lookup=merged_lookup, build_run_ids=merged_build_run_ids)

--- a/src/flyte/cli/_build.py
+++ b/src/flyte/cli/_build.py
@@ -1,3 +1,4 @@
+import pathlib
 from dataclasses import dataclass, field, fields
 from pathlib import Path
 from types import ModuleType
@@ -36,6 +37,36 @@ class BuildArguments:
             )
         },
     )
+    recursive: bool = field(
+        default=False,
+        metadata={
+            "click.option": click.Option(
+                ["--recursive", "-r"],
+                is_flag=True,
+                help="Recursively build all environments in the current directory and its subdirectories.",
+            )
+        },
+    )
+    all: bool = field(
+        default=False,
+        metadata={
+            "click.option": click.Option(
+                ["--all"],
+                is_flag=True,
+                help="Build the images for all environments in the file or directory, ignoring the file name.",
+            )
+        },
+    )
+    ignore_load_errors: bool = field(
+        default=False,
+        metadata={
+            "click.option": click.Option(
+                ["--ignore-load-errors", "-i"],
+                is_flag=True,
+                help="Ignore errors when loading environments, especially when using --recursive or --all.",
+            )
+        },
+    )
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> "BuildArguments":
@@ -62,10 +93,69 @@ class BuildEnvCommand(click.Command):
         obj: CLIConfig = ctx.obj
         status.step(f"Building environment: {self.obj_name}")
         obj.init(root_dir=self.build_args.root_dir)
-        with common.cli_status(obj.output_format, "Building...", spinner="dots"):
+        with common.cli_status(obj.output_format, "Building...", spinner="dots", no_progress=obj.no_progress):
             image_cache = flyte.build_images(self.obj, copy_style=self.build_args.copy_style)
 
         status.success(f"Environment {self.obj_name} built")
+        common.print_output(common.format("Images", image_cache.repr(), obj.output_format), obj.output_format)
+
+
+class BuildEnvRecursiveCommand(click.Command):
+    """
+    Command to build the images for all loaded environments in a file or directory, optionally recursively.
+
+    This mirrors ``flyte deploy --all`` (see ``DeployEnvRecursiveCommand``): it loads all python modules
+    found at the path, collects every ``flyte.Environment`` instantiated at import time, and builds the
+    images for all of them in a single planning pass.
+    """
+
+    def __init__(self, path: pathlib.Path, build_args: BuildArguments, *args, **kwargs):
+        self.path = path
+        self.build_args = build_args
+        super().__init__(*args, **kwargs)
+
+    def invoke(self, ctx: click.Context):
+        from flyte._environment import list_loaded_environments
+        from flyte._status import status
+        from flyte._utils import load_python_modules
+
+        obj: CLIConfig = ctx.obj
+        obj.init(root_dir=self.build_args.root_dir)
+
+        root_dir = Path.cwd()
+        if self.build_args.root_dir:
+            root_dir = pathlib.Path(self.build_args.root_dir).resolve()
+
+        # Load all python modules so their Environments register themselves.
+        loaded_modules, failed_paths = load_python_modules(self.path, root_dir, self.build_args.recursive)
+        if failed_paths:
+            status.warn(f"Loaded {len(loaded_modules)} modules, but failed to load {len(failed_paths)} paths")
+            common.print_output(
+                common.format("Modules", [[("Path", p), ("Err", e)] for p, e in failed_paths], obj.output_format),
+                obj.output_format,
+            )
+        else:
+            status.info(f"Loaded {len(loaded_modules)} modules")
+
+        all_envs = list_loaded_environments()
+        if not all_envs:
+            status.info("No environments found to build")
+            return
+
+        common.print_output(
+            common.format("Loaded Environments", [[("name", e.name)] for e in all_envs], obj.output_format),
+            obj.output_format,
+        )
+
+        if not self.build_args.ignore_load_errors and len(failed_paths) > 0:
+            raise click.ClickException(
+                f"Failed to load {len(failed_paths)} files. Use --ignore-load-errors to ignore these errors."
+            )
+
+        with common.cli_status(obj.output_format, "Building...", spinner="dots", no_progress=obj.no_progress):
+            image_cache = flyte.build_images(*all_envs, copy_style=self.build_args.copy_style)
+
+        status.success(f"Built images for {len(all_envs)} environments")
         common.print_output(common.format("Images", image_cache.repr(), obj.output_format), obj.output_format)
 
 
@@ -103,17 +193,33 @@ class EnvFiles(common.FileGroup):
     def __init__(
         self,
         *args,
+        directory: Path | None = None,
         **kwargs,
     ):
         if "params" not in kwargs:
             kwargs["params"] = []
         kwargs["params"].extend(BuildArguments.options())
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, directory=directory, **kwargs)
 
     def get_command(self, ctx, filename):
         build_args = BuildArguments.from_dict(ctx.params)
+        fp = Path(filename)
+        if not fp.exists():
+            raise click.BadParameter(f"File {filename} does not exist")
+        if build_args.recursive or build_args.all:
+            # If recursive or all, build the images for every environment in the file/directory,
+            # without naming one (mirrors `flyte deploy --all`).
+            return BuildEnvRecursiveCommand(
+                path=fp,
+                build_args=build_args,
+                name=filename,
+                help="Build images for all loaded environments from the file, or directory (optional recursively)",
+            )
+        if fp.is_dir():
+            # If the path is a directory, expose the files within it as subcommands.
+            return EnvFiles(directory=fp)
         return EnvPerFileGroup(
-            filename=Path(filename),
+            filename=fp,
             build_args=build_args,
             name=filename,
             help=f"Run, functions decorated `env.task` or instances of Tasks in {filename}",
@@ -125,5 +231,23 @@ build = EnvFiles(
     help="""
     Build the environments defined in a python file or directory. This will build the images associated with the
     environments.
+
+    To build the image for a single named environment:
+
+    ```bash
+    flyte build hello.py my_env
+    ```
+
+    To build the images for all environments in a file (without naming one), use the `--all` flag:
+
+    ```bash
+    flyte build --all hello.py
+    ```
+
+    To recursively build all environments in a directory and its subdirectories, use the `--recursive` flag:
+
+    ```bash
+    flyte build --all --recursive ./src
+    ```
     """,
 )

--- a/src/flyte/cli/_common.py
+++ b/src/flyte/cli/_common.py
@@ -114,6 +114,7 @@ class CLIConfig:
     org: str | None = None
     auth_type: str | None = None
     output_format: OutputFormat = "table"
+    no_progress: bool = False
     run_args: RunArguments | None = (
         None  # run_args is set when running tasks via CLI to provide context to parameter converters
     )
@@ -494,15 +495,51 @@ def safe_spinner(spinner: str = "dots") -> str:
     return spinner
 
 
-def cli_status(output_format: OutputFormat, message: str, spinner: str = "dots"):
+class _StaticStatus:
+    """
+    A no-op replacement for Rich's animated ``Status`` context manager.
+
+    Prints the (initial) message once instead of rendering an animated spinner,
+    so CI / non-interactive logs aren't polluted with hundreds of spinner frames.
+    Implements the small subset of the ``Status`` API that callers use (``update``).
+    """
+
+    def __init__(self, message: str):
+        self._message = message
+
+    def __enter__(self) -> "_StaticStatus":
+        if self._message:
+            get_console().print(self._message)
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        return None
+
+    def update(self, message: str | None = None, **_kwargs) -> None:
+        if message:
+            self._message = message
+            get_console().print(message)
+
+
+def cli_status(
+    output_format: OutputFormat,
+    message: str,
+    spinner: str = "dots",
+    no_progress: bool = False,
+):
     """
     Return a context manager for status display.
+
     Returns nullcontext for json/table-simple formats, otherwise a console status spinner.
+    When ``no_progress`` is set, or stdout is not attached to a TTY (the common CI case),
+    the animated spinner is disabled and a static message is printed instead.
     """
     from contextlib import nullcontext
 
     if output_format in ("json", "table-simple", "json-raw"):
         return nullcontext()
+    if no_progress or not sys.stdout.isatty():
+        return _StaticStatus(message)
     return get_console().status(message, spinner=safe_spinner(spinner))
 
 

--- a/src/flyte/cli/_deploy.py
+++ b/src/flyte/cli/_deploy.py
@@ -141,7 +141,7 @@ class DeployEnvCommand(click.RichCommand):
             sync_local_sys_paths=not self.deploy_args.no_sync_local_sys_paths,
             images=tuple(self.deploy_args.image) or None,
         )
-        with common.cli_status(obj.output_format, "Deploying..."):
+        with common.cli_status(obj.output_format, "Deploying...", no_progress=obj.no_progress):
             deployment = flyte.deploy(
                 self.env,
                 dryrun=self.deploy_args.dry_run,
@@ -213,7 +213,7 @@ class DeployEnvRecursiveCommand(click.Command):
                 f"Failed to load {len(failed_paths)} files. Use --ignore-load-errors to ignore these errors."
             )
 
-        with common.cli_status(obj.output_format, "Deploying..."):
+        with common.cli_status(obj.output_format, "Deploying...", no_progress=obj.no_progress):
             deployments = flyte.deploy(
                 *all_envs,
                 dryrun=self.deploy_args.dry_run,

--- a/src/flyte/cli/main.py
+++ b/src/flyte/cli/main.py
@@ -184,6 +184,15 @@ def _verbosity_to_loglevel(verbosity: int) -> int | None:
     default=False,
     show_default=True,
 )
+@click.option(
+    "--no-progress",
+    is_flag=True,
+    required=False,
+    help="Disable the animated progress spinner — useful in CI / non-interactive logs.",
+    type=bool,
+    default=False,
+    show_default=True,
+)
 @click.rich_config(help_config=help_config)
 @click.pass_context
 def main(
@@ -199,6 +208,7 @@ def main(
     auth_type: str | None = None,
     output_format: common.OutputFormat = "table",
     user_log_level: str = "info",
+    no_progress: bool = False,
 ):
     """
     The Flyte CLI is the command line interface for working with the Flyte SDK and backend.
@@ -264,6 +274,7 @@ def main(
         ctx=ctx,
         auth_type=auth_type,
         output_format=output_format,
+        no_progress=no_progress,
     )
 
     from flyte._status import set_output_mode

--- a/tests/cli/test_build.py
+++ b/tests/cli/test_build.py
@@ -1,9 +1,12 @@
 import pathlib
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
 
-from flyte.cli._build import build
+from flyte._internal.imagebuild.image_builder import ImageCache
+from flyte.cli._build import BuildEnvRecursiveCommand, build
+from flyte.cli.main import main
 
 TEST_CODE_PATH = pathlib.Path(__file__).parent
 HELLO_WORLD_PY = TEST_CODE_PATH / "run_testdata" / "hello_world.py"
@@ -32,3 +35,86 @@ def test_build_rejects_invalid_copy_style(runner):
     )
     assert result.exit_code != 0
     assert "bogus" in result.output.lower() or "invalid" in result.output.lower()
+
+
+def test_build_exposes_all_flag(runner):
+    """`flyte build --all` mirrors `flyte deploy --all` so CI can build every
+    environment in a module without naming one."""
+    result = runner.invoke(build, ["--help"])
+    assert result.exit_code == 0, result.output
+    assert "--all" in result.output
+    assert "--recursive" in result.output
+
+
+def test_build_all_resolves_to_recursive_command():
+    """With --all set, EnvFiles.get_command must return the recursive command
+    instead of listing the module's environments as sub-commands."""
+    import click
+
+    ctx = click.Context(build)
+    ctx.params = {
+        "all": True,
+        "recursive": False,
+        "copy_style": "loaded_modules",
+        "root_dir": None,
+        "ignore_load_errors": False,
+    }
+    resolved = build.get_command(ctx, str(HELLO_WORLD_PY))
+    assert isinstance(resolved, BuildEnvRecursiveCommand)
+
+
+def test_build_all_builds_every_environment(runner):
+    """`flyte build --all <file>` builds images for ALL environments in the
+    module in a single pass and prints the resulting image(s)."""
+    fake_cache = ImageCache(image_lookup={"hello_world": "ghcr.io/org/img:abc123"})
+
+    with (
+        patch("flyte.build_images", return_value=fake_cache) as mock_build,
+        patch("flyte.cli._common.CLIConfig.init"),
+    ):
+        result = main.main(
+            args=["build", "--all", str(HELLO_WORLD_PY)],
+            standalone_mode=False,
+        )
+    # main.main returns the command's return value (None) and raises on error;
+    # assert the build path actually invoked build_images with all envs.
+    assert result is None
+    assert mock_build.called
+    # The env from hello_world.py must have been passed positionally.
+    called_env_names = [getattr(e, "name", None) for e in mock_build.call_args.args]
+    assert "hello_world" in called_env_names
+
+
+def test_no_progress_uses_static_status(runner):
+    """The global --no-progress flag must disable the animated spinner and use
+    a static, CI-friendly status instead."""
+    from flyte.cli import _common
+
+    fake_cache = ImageCache(image_lookup={"hello_world": "ghcr.io/org/img:abc123"})
+
+    seen = {}
+    real_cli_status = _common.cli_status
+
+    def spy_cli_status(output_format, message, spinner="dots", no_progress=False):
+        seen["no_progress"] = no_progress
+        return real_cli_status(output_format, message, spinner=spinner, no_progress=no_progress)
+
+    with (
+        patch("flyte.build_images", return_value=fake_cache),
+        patch("flyte.cli._common.CLIConfig.init"),
+        patch("flyte.cli._build.common.cli_status", side_effect=spy_cli_status),
+    ):
+        main.main(
+            args=["--no-progress", "build", "--all", str(HELLO_WORLD_PY)],
+            standalone_mode=False,
+        )
+
+    assert seen.get("no_progress") is True
+
+
+def test_cli_status_static_when_no_progress():
+    """cli_status returns a non-animated context manager when no_progress=True."""
+    from flyte.cli._common import _StaticStatus, cli_status
+
+    cm = cli_status("table", "Building...", no_progress=True)
+    assert isinstance(cm, _StaticStatus)


### PR DESCRIPTION
Feature 1 — `flyte build --all`:
Mirror `flyte deploy --all` so images for every environment in a module/dir can be built without naming one. Adds `--all`/`--recursive`/`--ignore-load-errors` to BuildArguments, a BuildEnvRecursiveCommand that loads modules, collects list_loaded_environments() and builds them in one planning pass, and branches EnvFiles.get_command() on --all/--recursive. `build_images` now accepts *envs and merges the per-plan ImageCaches.

Feature 2 — `--no-progress`:
Global root flag to disable the animated spinner so CI / non-TTY logs aren't flooded with spinner frames. Threaded onto CLIConfig and honored by cli_status (via a static _StaticStatus context manager); cli_status also auto-disables the spinner when stdout is not a TTY. Both build and deploy honor it.