### PR TITLE
docs: snowflake connector runs in the data plane, not the control plane

### DIFF
--- a/plugins/snowflake/src/flyteplugins/snowflake/__init__.py
+++ b/plugins/snowflake/src/flyteplugins/snowflake/__init__.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     # Run locally (connector runs in-process, requires credentials and packages locally)
     run = flyte.with_runcontext(mode="local").run(count_users)
 
-    # Run remotely (connector runs on the control plane)
+    # Run remotely (connector runs as a service in your data plane)
     run = flyte.with_runcontext(mode="remote").run(count_users)
 
     print(run.url)


### PR DESCRIPTION
## Summary
The `flyteplugins.snowflake` module docstring example labels the remote-run line:

```python
# Run remotely (connector runs on the control plane)
run = flyte.with_runcontext(mode="remote").run(count_users)
```

That's inaccurate — connectors run as services in the **data plane**, not the control plane (the integrations overview states connectors "normally run inside the data plane" as their own Kubernetes deployments). This PR corrects the comment to:

```python
# Run remotely (connector runs as a service in your data plane)
```

## Why it matters
Beyond accuracy, it's a data-residency point: the Snowflake connector handles credentials and query results, which stay in the customer's data plane and never transit the control plane. The docstring generates the published API-reference page, so the wrong claim was surfacing in the docs.

## Scope
One-line comment fix in `plugins/snowflake/src/flyteplugins/snowflake/__init__.py`. Checked the other plugins (bigquery, etc.) — only snowflake had this wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)