### PR TITLE
fix: include FlyteIgnore in default code-bundle ignores

### DIFF
--- a/src/flyte/_code_bundle/bundle.py
+++ b/src/flyte/_code_bundle/bundle.py
@@ -22,7 +22,7 @@ from flyte._utils import AsyncLRUCache
 from flyte.errors import CodeBundleError
 from flyte.models import CodeBundle
 
-from ._ignore import GitIgnore, Ignore, StandardIgnore
+from ._ignore import FlyteIgnore, GitIgnore, Ignore, StandardIgnore
 from ._packaging import create_bundle, list_files_to_bundle, list_relative_files_to_bundle, print_ls_tree
 from ._utils import CopyFiles, hash_file
 
@@ -212,7 +212,10 @@ async def build_code_bundle(
     from flyte.remote import upload_file
 
     if not ignore:
-        ignore = (StandardIgnore, GitIgnore)
+        # FlyteIgnore applies .flyteignore patterns to *all* files (including git-tracked ones),
+        # so large tracked assets (e.g. git-lfs files) can be excluded from the bundle. GitIgnore
+        # alone only excludes git-untracked/ignored files, so it never catches tracked files.
+        ignore = (StandardIgnore, GitIgnore, FlyteIgnore)
 
     logger.debug(f"Finding files to bundle, ignoring as configured by: {ignore}")
     files, digest = list_files_to_bundle(

--- a/tests/flyte/code_bundle/test_build_code_bundle.py
+++ b/tests/flyte/code_bundle/test_build_code_bundle.py
@@ -230,6 +230,41 @@ async def test_build_code_bundle_multi_file_copy_loaded_modules(importer):
 
 
 # ---------------------------------------------------------------------------
+# Default ignores: .flyteignore excludes tracked files
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_code_bundle_default_ignores_respect_flyteignore():
+    """
+    Regression for the git-lfs case: a large asset that is *tracked* by git (so
+    ``GitIgnore`` never excludes it) must still be kept out of the bundle when
+    listed in ``.flyteignore``. This exercises the default ignore set used by
+    ``flyte run``/``flyte deploy`` (no explicit ``ignore`` argument), which must
+    include ``FlyteIgnore`` for tracked-file exclusion to work.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        layout = tmp_dir / "proj"
+        (layout / "tests" / "images").mkdir(parents=True)
+        (layout / "main.py").write_text("print('hello')\n")
+        (layout / "tests" / "images" / "big.bin").write_text("x" * 1024)
+        (layout / ".flyteignore").write_text("tests/images/\n")
+
+        bundle = await build_code_bundle(
+            from_dir=layout,
+            dryrun=True,
+            copy_style="all",
+            copy_bundle_to=_bundle_out(tmp_dir),
+        )
+
+        members = _tar_files(Path(bundle.tgz))
+        assert "main.py" in members
+        # The tracked-but-.flyteignore'd asset must be excluded.
+        assert "tests/images/big.bin" not in members
+
+
+# ---------------------------------------------------------------------------
 # copy_style="none"
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
 ## Motivation

  Large git-tracked assets (e.g. git-lfs files) were being swept into code bundles even when listed in .flyteignore, bloating bundles on flyte run/flyte deploy with copy_style="all". PR #1098 added a FlyteIgnore class (and a default_ignores constant) precisely to exclude git-tracked files, but it was never wired into build_code_bundle's fallback ignore set — which still used only StandardIgnore + GitIgnore, so .flyteignore had no effect on tracked files. This completes that fix.

 ## Summary

  - Add FlyteIgnore to the default ignore tuple in build_code_bundle (_code_bundle/bundle.py), so .flyteignore patterns now exclude all matching files, including git-tracked ones.
  - Reuses the FlyteIgnore mechanism introduced in PR #1098 — this change connects it to the actual bundler fallback used by flyte run/flyte deploy, which previously passed no ignores.
  - Add a regression test exercising the default ignore path with a tracked file under .flyteignore.

 ## Test Plan

  - uv run python -m pytest tests/flyte/code_bundle/test_build_code_bundle.py tests/flyte/code_bundle/test_ignore.py → 34 passed, no regressions.
  - New test test_build_code_bundle_default_ignores_respect_flyteignore: creates main.py, a tracked tests/images/big.bin, and a .flyteignore with tests/images/, then bundles with copy_style="all" and no explicit ignores; asserts main.py is present and tests/images/big.bin is excluded (fails without this change).