### PR TITLE
set ImageIdentifier.repository for custom registries

### DIFF
--- a/src/flyte/_internal/imagebuild/remote_builder.py
+++ b/src/flyte/_internal/imagebuild/remote_builder.py
@@ -57,6 +57,15 @@ IMAGE_TASK_PROJECT = "system"
 IMAGE_TASK_DOMAIN = os.environ.get("FLYTE_IMAGEBUILDER_TASK_DOMAIN", "production")
 
 
+def _custom_repository(repository: str) -> str:
+    # SE-775: for a custom registry override (clone(registry=...)) the image is pushed to a custom
+    # repo; tell GetImage to look there instead of the cluster's default repo. Empty for the default.
+    first_segment = repository.split("/", maxsplit=1)[0]
+    if "." in first_segment and not repository.startswith(f"{_BASE_REGISTRY}/"):
+        return repository
+    return ""
+
+
 class RemoteImageChecker(ImageChecker):
     _images_client = None
 
@@ -90,7 +99,9 @@ class RemoteImageChecker(ImageChecker):
             cfg = _get_init_config()
             if cfg is None:
                 raise ValueError("Init config should not be None")
-            image_id = image_definition__pb2.ImageIdentifier(name=image_name)
+            image_id = image_definition__pb2.ImageIdentifier(
+                name=image_name, repository=_custom_repository(repository)
+            )
             req = image_payload__pb2.GetImageRequest(
                 id=image_id,
                 organization=cfg.org,

--- a/tests/flyte/imagebuild/test_remote_builder.py
+++ b/tests/flyte/imagebuild/test_remote_builder.py
@@ -1,0 +1,29 @@
+import pytest
+
+from flyte._image import _BASE_REGISTRY
+from flyte._internal.imagebuild.remote_builder import _custom_repository
+
+
+@pytest.mark.parametrize(
+    "repository, expected",
+    [
+        # Bare name (no registry) -> default repo, no override.
+        ("ai", ""),
+        # Multi-segment name without a registry host -> default repo, no override.
+        ("union/demo", ""),
+        # _BASE_REGISTRY (default imagebuilder repo) -> default repo, no override.
+        (f"{_BASE_REGISTRY}/ai", ""),
+        # Custom ECR registry (clone(registry=...)) -> passed through so GetImage looks there (SE-775).
+        (
+            "869913524964.dkr.ecr.us-west-2.amazonaws.com/ai",
+            "869913524964.dkr.ecr.us-west-2.amazonaws.com/ai",
+        ),
+        # Custom registry with a nested repo path -> preserved.
+        (
+            "869913524964.dkr.ecr.us-west-2.amazonaws.com/custom/repo",
+            "869913524964.dkr.ecr.us-west-2.amazonaws.com/custom/repo",
+        ),
+    ],
+)
+def test_custom_repository(repository, expected):
+    assert _custom_repository(repository) == expected


### PR DESCRIPTION
## Set `ImageIdentifier.repository` for custom registries

When checking whether an image already exists, tell the backend which repo to look in.

**Why:** for images built with `clone(registry=...)`, the existence check (`GetImage`) was
implicitly looking in the cluster's default repo, never finding the image, so it rebuilt every
run. Now we pass the custom registry/repo explicitly via the new `ImageIdentifier.repository`
field so the lookup hits. (SE-775)

Default-repo images send an empty `repository`, so nothing changes for them. Pulled the
detection into a small `_custom_repository()` helper with a unit test.

**Depends on** the `flyteidl2` release that includes `ImageIdentifier.repository` — needs a
`flyteidl2` version bump here once it's out.