### PR TITLE
fix: wrap any user-module import exception as ModuleLoadError

### DIFF
--- a/src/flyte/_utils/module_loader.py
+++ b/src/flyte/_utils/module_loader.py
@@ -58,16 +58,13 @@ def load_python_modules(
             loaded_modules.append(imported_module)
         except flyte.errors.ModuleLoadError as e:
             failed_paths.append((path, str(e)))
-        except (
-            ImportError,
-            SyntaxError,
-            NameError,
-            AttributeError,
-            TypeError,
-            ValueError,
-            KeyError,
-            RuntimeError,
-        ) as e:
+        except Exception as e:
+            # Anything raised inside ``importlib.import_module(<user-module>)`` is by definition an
+            # error in the user's code or one of its third-party imports (e.g.
+            # ``google.api_core.exceptions.RetryError`` from expired gcloud creds at module top-level
+            # — FLYTE-SDK-39). Wrap as ``ModuleLoadError`` (a ``RuntimeUserError`` that
+            # ``flyte/_sentry.py:_is_user_error`` filters out) so deploy surfaces a clean message
+            # via ``--ignore-load-errors`` instead of crash-reporting to Sentry.
             raise flyte.errors.ModuleLoadError(f"Failed to load {path}: {type(e).__name__}: {e}") from e
 
     elif path.is_dir():
@@ -118,19 +115,13 @@ def load_python_modules(
                         loaded_modules.append(imported_module)
                     except flyte.errors.ModuleLoadError as e:
                         failed_paths.append((file_path, str(e)))
-                    except (
-                        ImportError,
-                        SyntaxError,
-                        NameError,
-                        AttributeError,
-                        TypeError,
-                        ValueError,
-                        KeyError,
-                        RuntimeError,
-                    ) as e:
-                        # User code failed at import time. Record as a load failure
-                        # (consistent with ModuleLoadError above) so deploy can either
-                        # warn or abort via --ignore-load-errors instead of crashing.
+                    except Exception as e:
+                        # Anything raised inside ``importlib.import_module(<user-module>)`` is by
+                        # definition an error in the user's code or one of its third-party imports
+                        # (e.g. ``google.api_core.exceptions.RetryError`` from expired gcloud creds
+                        # at module top-level — FLYTE-SDK-39). Record as a load failure (consistent
+                        # with ``ModuleLoadError`` above) so deploy can either warn or abort via
+                        # ``--ignore-load-errors`` instead of crash-reporting to Sentry.
                         failed_paths.append((file_path, f"{type(e).__name__}: {e}"))
 
                 progress.update(task, current_file="[green]Done[/green]")

--- a/tests/flyte/utils/test_module_loader.py
+++ b/tests/flyte/utils/test_module_loader.py
@@ -269,6 +269,75 @@ def test_load_python_modules_single_file_wraps_missing_env_var_keyerror(tmp_path
     assert "NEVER_SET_GCP_ADR_XYZ" in msg
 
 
+def test_load_python_modules_single_file_wraps_arbitrary_exception(tmp_path):
+    """A user module that raises an arbitrary third-party ``Exception`` subclass at import time
+    (e.g. ``google.api_core.exceptions.RetryError`` when gcloud creds are expired and the user's
+    module top-level calls Google Secret Manager) is a user environment problem, not an SDK crash.
+    It must surface as ``ModuleLoadError`` so the Sentry filter skips it.
+
+    Reproduces FLYTE-SDK-39. ``RetryError`` inherits directly from ``Exception`` (not
+    ``RuntimeError``/``ImportError``/etc.), so the previous narrow ``except`` tuple let it escape.
+    """
+
+    class FakeRetryError(Exception):
+        """Stand-in for ``google.api_core.exceptions.RetryError`` — inherits from ``Exception``."""
+
+    root = tmp_path / "project"
+    root.mkdir()
+    f = root / "workflow.py"
+    f.write_text("x = 1\n")
+
+    def boom(_mod):
+        raise FakeRetryError("Timeout of 60.0s exceeded")
+
+    with patch("importlib.import_module", side_effect=boom):
+        with pytest.raises(flyte.errors.ModuleLoadError) as excinfo:
+            load_python_modules(f, root_dir=root, recursive=False)
+
+    msg = str(excinfo.value)
+    assert "workflow.py" in msg
+    assert "FakeRetryError" in msg
+    assert "Timeout of 60.0s exceeded" in msg
+
+
+def test_load_python_modules_dir_collects_arbitrary_exception_in_failed_paths(tmp_path):
+    """Directory branch counterpart of the test above: an arbitrary ``Exception`` subclass raised
+    from one file's top-level should land in ``failed_paths`` (so the deploy command can warn or
+    abort via ``--ignore-load-errors``), not crash the whole loop and reach Sentry.
+
+    Reproduces FLYTE-SDK-39 for the recursive directory load path used by ``flyte deploy <dir>``.
+    """
+
+    class FakeRetryError(Exception):
+        pass
+
+    root = tmp_path / "project"
+    root.mkdir()
+    ok = root / "ok.py"
+    ok.write_text("x = 1\n")
+    bad = root / "bad.py"
+    bad.write_text("x = 1\n")
+
+    def fake_import(mod_name):
+        if mod_name == "bad":
+            raise FakeRetryError("Timeout of 60.0s exceeded")
+
+        class FakeMod:
+            __name__ = mod_name
+
+        return FakeMod()
+
+    with patch("importlib.import_module", side_effect=fake_import):
+        modules, failed = load_python_modules(root, root_dir=root, recursive=False)
+
+    assert len(modules) == 1
+    assert len(failed) == 1
+    failed_path, failed_msg = failed[0]
+    assert failed_path == bad
+    assert "FakeRetryError" in failed_msg
+    assert "Timeout of 60.0s exceeded" in failed_msg
+
+
 def test_load_python_modules_single_file_wraps_runtime_error(tmp_path):
     """A user/plugin module that raises ``RuntimeError`` at import time (e.g.
     ``union.sandbox`` raising "default environments are unavailable — install


### PR DESCRIPTION
## Problem

User modules can raise arbitrary third-party exceptions at **import time** that don't inherit from `RuntimeError` / `ImportError` / etc. The clearest example: `google.api_core.exceptions.RetryError` (parent: `Exception`) is raised when a user's module-top-level code calls Google Secret Manager and gcloud credentials have expired. The SDK's import loop only catches a narrow tuple — `(ImportError, SyntaxError, NameError, AttributeError, TypeError, ValueError, KeyError, RuntimeError)` — so anything else escapes and lands in Sentry as if it were an SDK bug.

PRs #1094 / #1134 / #1146 widened that tuple incrementally. Time to finish the job: anything raised inside `importlib.import_module(<user-module>)` is, by definition, an error in the user's code or its third-party imports.

## Fix

Widen both `except` clauses in `src/flyte/_utils/module_loader.py` (file-path branch and directory branch) from the explicit tuple to plain `except Exception`. Wrap as `flyte.errors.ModuleLoadError` (a `RuntimeUserError` already filtered by `flyte/_sentry.py:_is_user_error`) so deploy surfaces an actionable error and Sentry stops receiving user import-time crashes.

## Closes

- [FLYTE-SDK-39](https://unionai.sentry.io/issues/FLYTE-SDK-39/) — `google.api_core.exceptions.RetryError: Timeout of 60.0s exceeded` raised from the user's `gsm_secrets.set_secrets_as_dict_gcp_flyte` during user-module import (expired gcloud creds — `gcloud auth application-default login`).

`fixes FLYTE-SDK-39`

## Tests

- Added a test that a user module raising a non-RuntimeError `Exception` subclass at import time is captured as a load failure (or re-raised as `ModuleLoadError` for the file-path branch).