### PR TITLE
fix: wrap _ensure_buildx_builder CalledProcessError as ImageBuildError

### DIFF
--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -686,9 +686,18 @@ class DockerImageBuilder(ImageBuilder):
             raise ImageBuildError("Docker buildx is not available. Make sure BuildKit is installed and enabled.")
 
         # List builders
-        result = await run_sync_with_loop(
-            subprocess.run, ["docker", "buildx", "ls"], capture_output=True, text=True, check=True
-        )
+        try:
+            result = await run_sync_with_loop(
+                subprocess.run, ["docker", "buildx", "ls"], capture_output=True, text=True, check=True
+            )
+        except subprocess.CalledProcessError as e:
+            stderr = (e.stderr or "").strip() if isinstance(e.stderr, str) else ""
+            detail = f": {stderr}" if stderr else ""
+            raise ImageBuildError(
+                f"Failed to list docker buildx builders (`docker buildx ls`){detail}. "
+                "Ensure the docker daemon is running, or use the remote image builder by "
+                "setting `image_builder='remote'` on your `flyte.Image`."
+            ) from e
         builders = result.stdout
 
         # Check if there's any usable builder with the correct driver options
@@ -714,21 +723,34 @@ class DockerImageBuilder(ImageBuilder):
         else:
             logger.info("No buildx builder found, creating one...")
 
-        await run_sync_with_loop(
-            subprocess.run,
-            [
-                "docker",
-                "buildx",
-                "create",
-                "--name",
-                DockerImageBuilder._builder_name,
-                "--platform",
-                "linux/amd64,linux/arm64",
-                "--driver-opt",
-                "network=host",
-            ],
-            check=True,
-        )
+        try:
+            await run_sync_with_loop(
+                subprocess.run,
+                [
+                    "docker",
+                    "buildx",
+                    "create",
+                    "--name",
+                    DockerImageBuilder._builder_name,
+                    "--platform",
+                    "linux/amd64,linux/arm64",
+                    "--driver-opt",
+                    "network=host",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            stderr = (e.stderr or "").strip() if isinstance(e.stderr, str) else ""
+            detail = f": {stderr}" if stderr else ""
+            raise ImageBuildError(
+                f"Failed to create the '{DockerImageBuilder._builder_name}' docker buildx builder{detail}. "
+                f"Try `docker buildx rm {DockerImageBuilder._builder_name}` and retry, "
+                "or set FLYTE_DOCKER_BUILDKIT_BUILDER_NAME=<existing-builder> to reuse an existing buildx "
+                "builder, or use the remote image builder by setting `image_builder='remote'` on your "
+                "`flyte.Image`."
+            ) from e
 
     async def _build_image(self, image: Image, *, push: bool = True, dry_run: bool = False, wait: bool = True) -> str:
         """

--- a/tests/flyte/imagebuild/test_docker_builder.py
+++ b/tests/flyte/imagebuild/test_docker_builder.py
@@ -884,6 +884,58 @@ async def test_ensure_buildx_builder_recreates_when_network_host_missing():
 
 
 @pytest.mark.asyncio
+async def test_ensure_buildx_builder_wraps_ls_called_process_error():
+    """
+    Regression for FLYTE-SDK-4R: a CalledProcessError from `docker buildx ls`
+    must be wrapped as ImageBuildError (a RuntimeUserError filtered by
+    flyte/_sentry.py:_is_user_error) so that local docker hiccups stop leaking
+    into Sentry as if they were SDK bugs.
+    """
+    from flyte.errors import ImageBuildError
+
+    def mock_run(cmd, **kwargs):
+        if cmd == ["docker", "buildx", "version"]:
+            return subprocess.CompletedProcess(cmd, 0)
+        if cmd == ["docker", "buildx", "ls"]:
+            raise subprocess.CalledProcessError(returncode=1, cmd=cmd, stderr="error: cannot connect to daemon")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    with patch(
+        "flyte._internal.imagebuild.docker_builder.run_sync_with_loop", side_effect=lambda fn, *a, **kw: fn(*a, **kw)
+    ):
+        with patch("subprocess.run", side_effect=mock_run):
+            with pytest.raises(ImageBuildError, match="Failed to list docker buildx builders"):
+                await DockerImageBuilder._ensure_buildx_builder()
+
+
+@pytest.mark.asyncio
+async def test_ensure_buildx_builder_wraps_create_called_process_error():
+    """
+    Regression for FLYTE-SDK-4R: a CalledProcessError from `docker buildx
+    create --name flytex ...` (e.g. stale builder, daemon error) must be
+    wrapped as ImageBuildError so the user gets an actionable message and the
+    crash stops leaking into Sentry as an SDK bug.
+    """
+    from flyte.errors import ImageBuildError
+
+    def mock_run(cmd, **kwargs):
+        if cmd == ["docker", "buildx", "version"]:
+            return subprocess.CompletedProcess(cmd, 0)
+        if cmd == ["docker", "buildx", "ls"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="default", stderr="")
+        if len(cmd) >= 3 and cmd[:3] == ["docker", "buildx", "create"]:
+            raise subprocess.CalledProcessError(returncode=1, cmd=cmd, stderr='ERROR: existing instance for "flytex"')
+        return subprocess.CompletedProcess(cmd, 0)
+
+    with patch(
+        "flyte._internal.imagebuild.docker_builder.run_sync_with_loop", side_effect=lambda fn, *a, **kw: fn(*a, **kw)
+    ):
+        with patch("subprocess.run", side_effect=mock_run):
+            with pytest.raises(ImageBuildError, match="Failed to create the 'flytex' docker buildx builder"):
+                await DockerImageBuilder._ensure_buildx_builder()
+
+
+@pytest.mark.asyncio
 async def test_build_image_uses_custom_builder_from_env(monkeypatch):
     """When FLYTE_DOCKER_BUILDKIT_BUILDER_NAME is set, _build_image should use it and skip _ensure_buildx_builder."""
     from flyte._internal.imagebuild import docker_builder as db


### PR DESCRIPTION
## Problem

`DockerImageBuilder._ensure_buildx_builder()` runs `docker buildx ls` and `docker buildx create --name flytex ...` via `subprocess.run(..., check=True)`. When those commands fail (stale `flytex` builder, daemon hiccup, conflicting builder, ...), the raw `subprocess.CalledProcessError` bubbles up to Sentry as if it were an SDK bug — but it is the user's local docker environment misbehaving and they have no actionable error.

PR #1082 already wrapped `docker buildx build` failures as `ImageBuildError`. The same treatment now extends to the `_ensure_buildx_builder` subprocess calls.

## Fix

In `src/flyte/_internal/imagebuild/docker_builder.py`:

- Wrap `docker buildx ls` `subprocess.CalledProcessError` as `ImageBuildError` (with docker stderr captured for context).
- Wrap `docker buildx create --name flytex ...` `subprocess.CalledProcessError` as `ImageBuildError`, with a hint to run `docker buildx rm flytex` or override via `FLYTE_DOCKER_BUILDKIT_BUILDER_NAME`.

`ImageBuildError` is a `RuntimeUserError` already filtered by `flyte/_sentry.py:_is_user_error`, so these crashes stop polluting Sentry while the user gets an actionable message.

## Closes

- [FLYTE-SDK-4R](https://unionai.sentry.io/issues/FLYTE-SDK-4R/) — `CalledProcessError: Command '['docker', 'buildx', 'create', ...]' returned non-zero exit status 1.`

`fixes FLYTE-SDK-4R`

## Tests

- Added `test_ensure_buildx_builder_wraps_create_called_process_error` (create fails → `ImageBuildError`).
- Added `test_ensure_buildx_builder_wraps_ls_called_process_error` (ls fails → `ImageBuildError`).