### PR TITLE
PodTemplate capability helpers (allow_fuse / allow_nested_sandboxing, from_spec) + fix GPU accelerator in override()

### DIFF
--- a/examples/advanced/pod_capabilities.py
+++ b/examples/advanced/pod_capabilities.py
@@ -1,0 +1,160 @@
+# /// script
+# requires-python = "==3.12"
+# dependencies = [
+#    "kubernetes",
+#    "flyte",
+# ]
+#
+# [tool.uv.sources]
+# flyte = { path = "../..", editable = true }
+# ///
+"""
+Pod capability helpers — ``allow_fuse`` / ``allow_nested_sandboxing`` / ``from_spec``.
+
+Demonstrates requesting pod privileges through ``PodTemplate`` capability
+helpers instead of hand-writing Kubernetes security contexts, then verifying
+*inside the running pods* that the grants actually landed:
+
+1. ``verify_sandboxing`` runs with ``allow_nested_sandboxing()`` — the bwrap
+   prerequisite bundle (CAP_SYS_ADMIN + AppArmor unconfined +
+   allowPrivilegeEscalation=false). It checks the capability bitmask,
+   no_new_privs, the AppArmor profile, and actually exercises the syscalls the
+   grant exists for: ``unshare(CLONE_NEWNS)`` (needs CAP_SYS_ADMIN past
+   seccomp) and ``unshare(CLONE_NEWUSER)``.
+2. ``verify_fuse`` runs with ``from_spec(...).allow_fuse()`` and proves the
+   device-cgroup gate is open by ``open("/dev/fuse")`` — the one check that
+   fails without ``privileged`` on a stock cluster.
+
+Usage:
+    uv run examples/advanced/pod_capabilities.py
+"""
+
+import os
+import subprocess
+
+from kubernetes.client import V1Container, V1PodSpec
+
+import flyte
+
+# The helpers are new in this SDK version, so bake the local checkout into the
+# image (a plain PyPI `flyte` would lack them at runtime too). `kubernetes` is
+# not a flyte runtime dependency — this module imports it (for V1PodSpec), and
+# the task module is imported in-container, so the image needs it explicitly.
+# Pip layer goes BEFORE with_local_v2 so the local SDK wheel wins.
+image = (
+    flyte.Image.from_debian_base(install_flyte=False, name="pod-capabilities")
+    .with_pip_packages("kubernetes")
+    .with_local_v2()
+)
+
+# --------------------------------------------------------------------------- #
+# Environments
+# --------------------------------------------------------------------------- #
+
+# Nested-sandboxing grant: exactly what the bwrap sandbox backend needs.
+sandbox_env = flyte.TaskEnvironment(
+    name="cap-sandboxing",
+    image=image,
+    resources=flyte.Resources(cpu="500m", memory="512Mi"),
+    pod_template=flyte.PodTemplate().allow_nested_sandboxing(),
+)
+
+# FUSE grant, composed onto a user-supplied pod spec via from_spec().
+fuse_env = flyte.TaskEnvironment(
+    name="cap-fuse",
+    image=image,
+    resources=flyte.Resources(cpu="500m", memory="512Mi"),
+    pod_template=flyte.PodTemplate.from_spec(V1PodSpec(containers=[V1Container(name="primary")])).allow_fuse(),
+)
+
+sandbox_env.add_dependency(fuse_env)
+
+# --------------------------------------------------------------------------- #
+# In-pod verification helpers
+# --------------------------------------------------------------------------- #
+
+_CAP_SYS_ADMIN_BIT = 21
+_CLONE_NEWNS = 0x00020000
+_CLONE_NEWUSER = 0x10000000
+
+
+def _proc_status(field: str) -> str:
+    with open("/proc/self/status") as f:
+        for line in f:
+            if line.startswith(field + ":"):
+                return line.split(":", 1)[1].strip()
+    return ""
+
+
+def _has_cap_sys_admin(mask_field: str) -> bool:
+    mask = int(_proc_status(mask_field) or "0", 16)
+    return bool(mask & (1 << _CAP_SYS_ADMIN_BIT))
+
+
+def _apparmor_profile() -> str:
+    try:
+        with open("/proc/self/attr/current") as f:
+            return f.read().strip().rstrip("\x00") or "unconfined"
+    except OSError:
+        return "n/a (AppArmor not enabled on this node)"
+
+
+def _unshare_works(flag: int) -> bool:
+    # unshare() alters the calling process, so probe in a throwaway child.
+    code = f"import ctypes, sys; sys.exit(0 if ctypes.CDLL(None, use_errno=True).unshare({flag}) == 0 else 1)"
+    return subprocess.run(["python", "-c", code], check=False).returncode == 0
+
+
+@sandbox_env.task
+async def verify_sandboxing() -> dict[str, str]:
+    """Verify the allow_nested_sandboxing() grants from inside the pod."""
+    results = {
+        "cap_sys_admin_effective": str(_has_cap_sys_admin("CapEff")),
+        "no_new_privs": _proc_status("NoNewPrivs"),  # "1" == allowPrivilegeEscalation: false
+        "apparmor_profile": _apparmor_profile(),
+        # The syscalls bwrap needs: blocked by the default seccomp profile
+        # unless CAP_SYS_ADMIN is present, and by the default AppArmor profile
+        # unless unconfined.
+        "unshare_mountns": str(_unshare_works(_CLONE_NEWNS)),
+        "unshare_userns": str(_unshare_works(_CLONE_NEWUSER)),
+    }
+    print(f"sandboxing grants: {results}")
+    assert results["cap_sys_admin_effective"] == "True", "CAP_SYS_ADMIN missing from effective set"
+    assert results["no_new_privs"] == "1", "allowPrivilegeEscalation=false did not land (NoNewPrivs != 1)"
+    assert results["unshare_mountns"] == "True", "unshare(CLONE_NEWNS) blocked — seccomp/AppArmor still in the way"
+    return results
+
+
+@fuse_env.task
+async def verify_fuse() -> dict[str, str]:
+    """Verify the allow_fuse() grants from inside the pod."""
+    results = {"dev_fuse_exists": str(os.path.exists("/dev/fuse"))}
+    try:
+        # The real test: open() on the char device is gated by the device
+        # cgroup allowlist, which only `privileged` bypasses on stock clusters.
+        fd = os.open("/dev/fuse", os.O_RDWR)
+        os.close(fd)
+        results["dev_fuse_openable"] = "True"
+    except OSError as e:
+        results["dev_fuse_openable"] = f"False ({e})"
+    results["cap_sys_admin_effective"] = str(_has_cap_sys_admin("CapEff"))
+    print(f"fuse grants: {results}")
+    assert results["dev_fuse_exists"] == "True", "/dev/fuse hostPath volume did not land"
+    assert results["dev_fuse_openable"] == "True", "open(/dev/fuse) failed — device cgroup still blocks it"
+    return results
+
+
+@sandbox_env.task
+async def main() -> dict[str, dict[str, str]]:
+    return {
+        "sandboxing": await verify_sandboxing(),
+        "fuse": await verify_fuse(),
+    }
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(main)
+    print(run.name)
+    print(run.url)
+    run.wait()

--- a/src/flyte/_pod.py
+++ b/src/flyte/_pod.py
@@ -1,13 +1,30 @@
+from __future__ import annotations
+
+import copy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, Optional
 
 if TYPE_CHECKING:
     from flyteidl2.core.tasks_pb2 import K8sPod
-    from kubernetes.client import V1PodSpec
+    from kubernetes.client import V1Container, V1PodSpec
 
 
 _PRIMARY_CONTAINER_NAME_FIELD = "primary_container_name"
 _PRIMARY_CONTAINER_DEFAULT_NAME = "primary"
+
+# Name used for the hostPath volume and its volumeMount added by
+# ``PodTemplate.allow_fuse()``.
+_FUSE_DEVICE_VOLUME_NAME = "fuse-device"
+_FUSE_DEVICE_PATH = "/dev/fuse"
+
+# Every capability helper stamps ``flyte.org/capability-<name>: "true"`` on the
+# resulting template so the requested grant is auditable on the pod itself
+# (admission controllers and humans can match on the annotation) regardless of
+# how the template was built.
+_CAPABILITY_ANNOTATION_PREFIX = "flyte.org/capability-"
+
+_APPARMOR_ANNOTATION_PREFIX = "container.apparmor.security.beta.kubernetes.io/"
+_APPARMOR_UNCONFINED = "unconfined"
 
 
 @dataclass(init=True, repr=True, eq=True, frozen=False)
@@ -18,6 +35,143 @@ class PodTemplate(object):
     primary_container_name: str = _PRIMARY_CONTAINER_DEFAULT_NAME
     labels: Optional[Dict[str, str]] = None
     annotations: Optional[Dict[str, str]] = None
+
+    @classmethod
+    def from_spec(
+        cls,
+        pod_spec: "V1PodSpec",
+        *,
+        primary_container_name: Optional[str] = None,
+        labels: Optional[Dict[str, str]] = None,
+        annotations: Optional[Dict[str, str]] = None,
+    ) -> PodTemplate:
+        """
+        Create a :class:`PodTemplate` from an existing ``V1PodSpec``.
+
+        The spec is deep-copied, so later mutations of the input (or of the
+        returned template) don't leak into each other.
+
+        The primary container — the one Flyte injects the task image/command
+        into — is resolved as follows:
+
+        1. If ``primary_container_name`` is given, a container with that name
+           must exist in the spec.
+        2. Otherwise, a container named ``primary`` is used if present.
+        3. Otherwise, if the spec has exactly one container, that container is
+           adopted as the primary.
+        4. Otherwise (multiple containers, none named ``primary``), a
+           ``ValueError`` is raised — pass ``primary_container_name`` to pick
+           one explicitly.
+
+        :param pod_spec: The ``kubernetes.client.V1PodSpec`` to wrap.
+        :param primary_container_name: Optional explicit name of the primary
+            container within ``pod_spec``.
+        :param labels: Optional pod labels.
+        :param annotations: Optional pod annotations.
+        """
+        container_names = [getattr(c, "name", None) for c in (pod_spec.containers or [])]
+
+        if primary_container_name is not None:
+            if primary_container_name not in container_names:
+                raise ValueError(
+                    f"primary_container_name {primary_container_name!r} not found in pod spec; "
+                    f"available containers: {container_names}"
+                )
+            resolved = primary_container_name
+        elif _PRIMARY_CONTAINER_DEFAULT_NAME in container_names:
+            resolved = _PRIMARY_CONTAINER_DEFAULT_NAME
+        elif len(container_names) == 1 and container_names[0]:
+            resolved = container_names[0]
+        else:
+            raise ValueError(
+                f"Cannot determine the primary container: the pod spec has containers {container_names} and none "
+                f"is named {_PRIMARY_CONTAINER_DEFAULT_NAME!r}. Pass primary_container_name= to pick one."
+            )
+
+        return cls(
+            pod_spec=copy.deepcopy(pod_spec),
+            primary_container_name=resolved,
+            labels=dict(labels) if labels else None,
+            annotations=dict(annotations) if annotations else None,
+        )
+
+    def allow_fuse(self, privileged: bool = True) -> PodTemplate:
+        """
+        Return a copy of this template granted everything a container needs to
+        perform an in-process FUSE mount (e.g. for ``Volume`` support).
+
+        Specifically, the copy:
+
+        * adds a ``hostPath`` volume named ``fuse-device`` pointing at
+          ``/dev/fuse`` on the node, mounted into the primary container;
+        * adds ``CAP_SYS_ADMIN`` to the primary container so the ``mount``
+          syscall is permitted;
+        * with ``privileged=True`` (the default), sets ``privileged: true`` on
+          the primary container; with ``privileged=False``, instead sets the
+          ``container.apparmor.security.beta.kubernetes.io/<primary>:
+          unconfined`` pod annotation (the default AppArmor profile would
+          otherwise block ``mount``);
+        * stamps the ``flyte.org/capability-fuse`` annotation for auditability.
+
+        Why privileged is the default: opening ``/dev/fuse`` is gated by the
+        container runtime's device-cgroup allowlist, which only ``privileged``
+        bypasses — there is no pod-spec field to whitelist a device for a
+        non-privileged container. Pass ``privileged=False`` **only** on
+        clusters that permit ``/dev/fuse`` for non-privileged containers (e.g.
+        via a FUSE device plugin or runtime device-allowlist configuration);
+        otherwise the pod deploys fine but ``open("/dev/fuse")`` fails with
+        ``EPERM`` at runtime. ``privileged=False`` composes with
+        ``allow_nested_sandboxing()``; ``privileged=True`` does not (Kubernetes
+        rejects privileged containers that set
+        ``allowPrivilegeEscalation: false``).
+
+        The original template is never mutated; existing volumes, mounts,
+        sidecars, labels, annotations, and unrelated security-context fields
+        are preserved. Re-applying with the same arguments is idempotent.
+
+        Raises ``ValueError`` if the template already pins a conflicting
+        security posture (with ``privileged=True``: ``privileged: false`` or
+        ``allowPrivilegeEscalation: false`` pre-set; with ``privileged=False``:
+        a different AppArmor profile for the primary container).
+        """
+        return _apply_fuse(self, privileged=privileged)
+
+    def allow_nested_sandboxing(self) -> PodTemplate:
+        """
+        Return a copy of this template granted the prerequisites for creating
+        nested sandboxes (e.g. the bubblewrap/``bwrap`` backend of
+        ``SandboxEnvironment``) — and nothing more.
+
+        bwrap runs as a non-root user via unprivileged user namespaces, but the
+        containerd default seccomp profile only permits the ``mount`` /
+        ``pivot_root`` / ``setns`` / ``unshare`` syscalls it needs when the
+        container's capability set includes ``CAP_SYS_ADMIN``, and the default
+        AppArmor profile must be unconfined so those calls aren't blocked.
+        The copy carries exactly that:
+
+        * ``CAP_SYS_ADMIN`` added to the primary container's capabilities;
+        * ``allowPrivilegeEscalation: false`` (no other caps, not privileged);
+        * the ``container.apparmor.security.beta.kubernetes.io/<primary>:
+          unconfined`` pod annotation (on K8s >= 1.30 the
+          ``securityContext.appArmorProfile: {type: Unconfined}`` field is the
+          equivalent; the annotation is used here for version compatibility);
+        * the ``flyte.org/capability-nested-sandboxing`` annotation for
+          auditability.
+
+        A cluster that already permits unprivileged user namespaces needs none
+        of this for the ``userns`` sandbox backend — only use this when the
+        seccomp/AppArmor defaults block the sandboxing syscalls.
+
+        Composes with ``allow_fuse(privileged=False)``; not with the default
+        ``allow_fuse()``, which makes the container privileged.
+
+        The original template is never mutated; existing fields are preserved
+        and re-applying is idempotent. Raises ``ValueError`` if the template
+        already pins a conflicting security posture (``privileged: true``,
+        ``allowPrivilegeEscalation: true``, or a different AppArmor profile
+        for the primary container).
+        """
+        return _apply_sandboxing(self)
 
     def to_k8s_pod(self) -> "K8sPod":
         from flyteidl2.core.tasks_pb2 import K8sObjectMetadata, K8sPod
@@ -31,3 +185,157 @@ class PodTemplate(object):
             pod_spec=ApiClient().sanitize_for_serialization(self.pod_spec),
             primary_container_name=self.primary_container_name,
         )
+
+
+def _clone_with_primary(pt: PodTemplate) -> PodTemplate:
+    """Deep-copy ``pt``, ensuring it has a pod spec containing the primary container."""
+    from kubernetes.client import V1Container, V1PodSpec
+
+    pt = copy.deepcopy(pt)
+    if pt.pod_spec is None:
+        pt.pod_spec = V1PodSpec(containers=[V1Container(name=pt.primary_container_name)])
+
+    containers = list(pt.pod_spec.containers or [])
+    if not any(getattr(c, "name", None) == pt.primary_container_name for c in containers):
+        containers.append(V1Container(name=pt.primary_container_name))
+        pt.pod_spec.containers = containers
+    return pt
+
+
+def _get_primary_container(pt: PodTemplate) -> "V1Container":
+    """Return the primary container of a template prepared by ``_clone_with_primary``."""
+    assert pt.pod_spec is not None  # _clone_with_primary guarantees it
+    primary = next((c for c in pt.pod_spec.containers if c.name == pt.primary_container_name), None)
+    assert primary is not None  # _clone_with_primary guarantees it
+    return primary
+
+
+def _stamp_capability(pt: PodTemplate, name: str) -> None:
+    """Record the granted capability as a pod annotation for auditability."""
+    annotations = dict(pt.annotations or {})
+    annotations[f"{_CAPABILITY_ANNOTATION_PREFIX}{name}"] = "true"
+    pt.annotations = annotations
+
+
+def _add_sys_admin(primary: "V1Container") -> None:
+    """Set-merge ``CAP_SYS_ADMIN`` into the primary container's capability set."""
+    from kubernetes.client import V1Capabilities, V1SecurityContext
+
+    sc = primary.security_context or V1SecurityContext()
+    caps = sc.capabilities or V1Capabilities()
+    existing_add = list(caps.add or [])
+    if "SYS_ADMIN" not in existing_add:
+        existing_add.append("SYS_ADMIN")
+    caps.add = existing_add
+    sc.capabilities = caps
+    primary.security_context = sc
+
+
+def _set_apparmor_unconfined(pt: PodTemplate, caller: str) -> None:
+    """Set the AppArmor-unconfined annotation for the primary container.
+
+    Raises ``ValueError`` if a different AppArmor profile is already pinned.
+    """
+    apparmor_key = f"{_APPARMOR_ANNOTATION_PREFIX}{pt.primary_container_name}"
+    existing_apparmor = (pt.annotations or {}).get(apparmor_key)
+    if existing_apparmor is not None and existing_apparmor != _APPARMOR_UNCONFINED:
+        raise ValueError(
+            f"{caller} requires the AppArmor profile of the primary container to be "
+            f"{_APPARMOR_UNCONFINED!r}, but the pod template sets {apparmor_key}={existing_apparmor!r}."
+        )
+    annotations = dict(pt.annotations or {})
+    annotations[apparmor_key] = _APPARMOR_UNCONFINED
+    pt.annotations = annotations
+
+
+def _apply_fuse(pod_template: PodTemplate, *, privileged: bool = True) -> PodTemplate:
+    """Augmentor behind :meth:`PodTemplate.allow_fuse`."""
+    from kubernetes.client import V1HostPathVolumeSource, V1Volume, V1VolumeMount
+
+    pt = _clone_with_primary(pod_template)
+    primary = _get_primary_container(pt)
+
+    if privileged:
+        # Conflict checks: a privileged container cannot deny privilege
+        # escalation (Kubernetes rejects the combination), and an explicit
+        # privileged=False contradicts what this grant needs.
+        sc = primary.security_context
+        if sc is not None:
+            if sc.privileged is False:
+                raise ValueError(
+                    f"allow_fuse() requires privileged=true on the primary container "
+                    f"({pt.primary_container_name!r}), but the pod template explicitly sets privileged=false. "
+                    "On clusters that permit /dev/fuse for non-privileged containers, use "
+                    "allow_fuse(privileged=False)."
+                )
+            if sc.allow_privilege_escalation is False:
+                raise ValueError(
+                    "allow_fuse() makes the primary container privileged, which Kubernetes rejects when "
+                    "allowPrivilegeEscalation=false is set (e.g. after allow_nested_sandboxing()). On clusters "
+                    "that permit /dev/fuse for non-privileged containers, use allow_fuse(privileged=False), "
+                    "which composes with allow_nested_sandboxing()."
+                )
+    else:
+        # Non-privileged FUSE: mount needs CAP_SYS_ADMIN (added below) and an
+        # unconfined AppArmor profile; the cluster must separately permit
+        # /dev/fuse for non-privileged containers (device plugin or runtime
+        # device-allowlist config). Leaves privileged/allowPrivilegeEscalation
+        # untouched, so it composes with allow_nested_sandboxing().
+        _set_apparmor_unconfined(pt, "allow_fuse(privileged=False)")
+
+    # Volume + volumeMount for /dev/fuse — idempotent: skip if already present.
+    assert pt.pod_spec is not None  # _clone_with_primary guarantees it
+    volumes = list(pt.pod_spec.volumes or [])
+    if not any(getattr(v, "name", None) == _FUSE_DEVICE_VOLUME_NAME for v in volumes):
+        volumes.append(
+            V1Volume(
+                name=_FUSE_DEVICE_VOLUME_NAME,
+                host_path=V1HostPathVolumeSource(path=_FUSE_DEVICE_PATH, type="CharDevice"),
+            )
+        )
+        pt.pod_spec.volumes = volumes
+
+    mounts = list(primary.volume_mounts or [])
+    if not any(getattr(m, "name", None) == _FUSE_DEVICE_VOLUME_NAME for m in mounts):
+        mounts.append(V1VolumeMount(name=_FUSE_DEVICE_VOLUME_NAME, mount_path=_FUSE_DEVICE_PATH))
+        primary.volume_mounts = mounts
+
+    # SecurityContext: CAP_SYS_ADMIN (+ privileged unless opted out). Preserve
+    # any other security-context fields the caller set.
+    _add_sys_admin(primary)
+    if privileged:
+        primary.security_context.privileged = True
+
+    _stamp_capability(pt, "fuse")
+    return pt
+
+
+def _apply_sandboxing(pod_template: PodTemplate) -> PodTemplate:
+    """Augmentor behind :meth:`PodTemplate.allow_nested_sandboxing`."""
+    pt = _clone_with_primary(pod_template)
+    primary = _get_primary_container(pt)
+
+    # Conflict checks — refuse to silently widen or narrow a security posture
+    # the user pinned explicitly.
+    sc = primary.security_context
+    if sc is not None:
+        if sc.privileged is True:
+            raise ValueError(
+                "allow_nested_sandboxing() grants only CAP_SYS_ADMIN with allowPrivilegeEscalation=false, but the "
+                "pod template sets privileged=true on the primary container, which Kubernetes rejects in "
+                "combination with allowPrivilegeEscalation=false (note: this also means allow_nested_sandboxing() "
+                "cannot be combined with allow_fuse() unless the latter uses allow_fuse(privileged=False))."
+            )
+        if sc.allow_privilege_escalation is True:
+            raise ValueError(
+                "allow_nested_sandboxing() sets allowPrivilegeEscalation=false on the primary container, but the pod "
+                "template explicitly sets allowPrivilegeEscalation=true."
+            )
+
+    _set_apparmor_unconfined(pt, "allow_nested_sandboxing()")
+
+    _add_sys_admin(primary)
+    primary.security_context.allow_privilege_escalation = False
+
+    _stamp_capability(pt, "nested-sandboxing")
+    return pt

--- a/src/flyte/remote/_task.py
+++ b/src/flyte/remote/_task.py
@@ -17,7 +17,7 @@ import flyte.errors
 from flyte._cache.cache import CacheBehavior
 from flyte._context import internal_ctx
 from flyte._initialize import ensure_client, get_client, get_init_config
-from flyte._internal.runtime.resources_serde import get_proto_resources
+from flyte._internal.runtime.resources_serde import get_proto_extended_resources, get_proto_resources
 from flyte._internal.runtime.task_serde import (
     get_proto_max_runtime,
     get_proto_retry_strategy,
@@ -371,6 +371,22 @@ class TaskDetails(ToJSONMixin):
                 template.container.env.extend([literals_pb2.KeyValuePair(key=k, value=v) for k, v in env_vars.items()])
             if resources:
                 template.container.resources.CopyFrom(get_proto_resources(resources))
+
+        if resources:
+            # Resource overrides must also carry the extended resources — the
+            # GPU/accelerator (device type -> nodeSelector/toleration) and
+            # shared memory — not just the container CPU/memory/GPU-count
+            # entries. Without this an override that requests a GPU (e.g.
+            # Resources(gpu="L40s:1")) drops the accelerator entirely, so the
+            # pod never schedules on a GPU node. Mirrors the build path
+            # (task_serde.get_proto_extended_resources). `resources` is a full
+            # replacement, so clear the field when the override has no extended
+            # resources rather than leaving a stale accelerator behind.
+            ext = get_proto_extended_resources(resources)
+            if ext is not None:
+                template.extended_resources.CopyFrom(ext)
+            else:
+                template.ClearField("extended_resources")
 
         md = template.metadata
         if retries:

--- a/tests/flyte/remote/test_task.py
+++ b/tests/flyte/remote/test_task.py
@@ -195,3 +195,37 @@ class TestLazyEntityIntegration:
         fetched_task = await integration_lazy_entity.fetch.aio()
         assert fetched_task is task_details
         assert fetched_task.name == "integration_task"
+
+
+class TestTaskDetailsOverrideResources:
+    """`TaskDetails.override(resources=...)` must carry both the container
+    resources AND the extended resources (GPU accelerator / shared memory)."""
+
+    def _container_task_details(self) -> TaskDetails:
+        from flyteidl2.task import task_definition_pb2
+
+        pb2 = task_definition_pb2.TaskDetails()
+        pb2.spec.task_template.container.image = "example:latest"
+        return TaskDetails(pb2)
+
+    def test_gpu_override_carries_accelerator(self):
+        td = self._container_task_details()
+        out = td.override(resources=flyte.Resources(cpu="4", memory="16Gi", gpu="L40s:1"))
+
+        tmpl = out.pb2.spec.task_template
+        # The accelerator (device -> nodeSelector/toleration) must be present,
+        # otherwise the pod never schedules on a GPU node.
+        assert tmpl.HasField("extended_resources")
+        assert tmpl.extended_resources.gpu_accelerator.device == "nvidia-l40s"
+        # The container still gets the cpu/memory/gpu-count entries.
+        from flyteidl2.core import tasks_pb2
+
+        names = {e.name for e in tmpl.container.resources.requests}
+        assert tasks_pb2.Resources.ResourceName.GPU in names
+
+    def test_cpu_only_override_clears_stale_accelerator(self):
+        td = self._container_task_details()
+        gpu = td.override(resources=flyte.Resources(cpu="4", memory="16Gi", gpu="L40s:1"))
+        # Re-overriding with no GPU must drop the accelerator (full replacement).
+        cpu_only = gpu.override(resources=flyte.Resources(cpu="2", memory="2Gi"))
+        assert not cpu_only.pb2.spec.task_template.HasField("extended_resources")

--- a/tests/user_api/test_pod_template.py
+++ b/tests/user_api/test_pod_template.py
@@ -1,3 +1,7 @@
+import copy
+
+import pytest
+
 import flyte
 from flyte._pod import PodTemplate
 
@@ -60,3 +64,244 @@ def test_pod_template_to_k8s_pod_with_empty_container():
 
 def test_pod_template_importable():
     assert flyte.PodTemplate is PodTemplate
+
+
+# --------------------------------------------------------------------------- #
+# PodTemplate.from_spec
+# --------------------------------------------------------------------------- #
+
+
+def _spec(*names: str):
+    from kubernetes.client import V1Container, V1PodSpec
+
+    return V1PodSpec(containers=[V1Container(name=n) for n in names])
+
+
+class TestFromSpec:
+    def test_explicit_primary(self):
+        pt = PodTemplate.from_spec(_spec("worker", "sidecar"), primary_container_name="worker")
+        assert pt.primary_container_name == "worker"
+
+    def test_explicit_primary_missing_raises(self):
+        with pytest.raises(ValueError, match="not found in pod spec"):
+            PodTemplate.from_spec(_spec("worker", "sidecar"), primary_container_name="nope")
+
+    def test_container_named_primary_wins(self):
+        pt = PodTemplate.from_spec(_spec("sidecar", "primary"))
+        assert pt.primary_container_name == "primary"
+
+    def test_single_container_adopted(self):
+        pt = PodTemplate.from_spec(_spec("worker"))
+        assert pt.primary_container_name == "worker"
+
+    def test_multiple_containers_ambiguous_raises(self):
+        with pytest.raises(ValueError, match="Cannot determine the primary container"):
+            PodTemplate.from_spec(_spec("a", "b"))
+
+    def test_labels_and_annotations_passthrough(self):
+        pt = PodTemplate.from_spec(_spec("primary"), labels={"team": "ml"}, annotations={"a": "b"})
+        assert pt.labels == {"team": "ml"}
+        assert pt.annotations == {"a": "b"}
+
+    def test_input_spec_not_mutated(self):
+        spec = _spec("primary")
+        snapshot = copy.deepcopy(spec)
+        pt = PodTemplate.from_spec(spec)
+        pt.pod_spec.containers[0].name = "changed"
+        assert spec == snapshot
+
+
+# --------------------------------------------------------------------------- #
+# Capability helpers: allow_fuse / allow_nested_sandboxing
+# --------------------------------------------------------------------------- #
+
+# (method name, kwargs) — every grant variant must satisfy the augmentor laws.
+CAPABILITY_CALLS = [
+    ("allow_fuse", {}),
+    ("allow_fuse", {"privileged": False}),
+    ("allow_nested_sandboxing", {}),
+]
+CAPABILITY_IDS = ["allow_fuse", "allow_fuse_unprivileged", "allow_nested_sandboxing"]
+
+
+def _rich_template() -> PodTemplate:
+    """A template with pre-existing sidecars, volumes, mounts, labels, and
+    annotations that augmentation must preserve."""
+    from kubernetes.client import (
+        V1Container,
+        V1EmptyDirVolumeSource,
+        V1PodSpec,
+        V1SecurityContext,
+        V1Volume,
+        V1VolumeMount,
+    )
+
+    return PodTemplate(
+        pod_spec=V1PodSpec(
+            containers=[
+                V1Container(
+                    name="primary",
+                    volume_mounts=[V1VolumeMount(name="scratch", mount_path="/scratch")],
+                    security_context=V1SecurityContext(run_as_user=1000),
+                ),
+                V1Container(name="sidecar"),
+            ],
+            volumes=[V1Volume(name="scratch", empty_dir=V1EmptyDirVolumeSource())],
+        ),
+        labels={"team": "ml"},
+        annotations={"note": "keep-me"},
+    )
+
+
+@pytest.mark.parametrize(("method", "kwargs"), CAPABILITY_CALLS, ids=CAPABILITY_IDS)
+class TestCapabilityLaws:
+    def test_pure_original_unchanged(self, method, kwargs):
+        original = _rich_template()
+        snapshot = copy.deepcopy(original)
+        getattr(original, method)(**kwargs)
+        assert original == snapshot
+
+    def test_idempotent(self, method, kwargs):
+        once = getattr(_rich_template(), method)(**kwargs)
+        twice = getattr(once, method)(**kwargs)
+        assert once == twice
+
+    def test_additive_preserves_existing_fields(self, method, kwargs):
+        pt = getattr(_rich_template(), method)(**kwargs)
+        container_names = [c.name for c in pt.pod_spec.containers]
+        assert "sidecar" in container_names
+        assert any(v.name == "scratch" for v in pt.pod_spec.volumes)
+        primary = next(c for c in pt.pod_spec.containers if c.name == "primary")
+        assert any(m.name == "scratch" for m in primary.volume_mounts)
+        assert primary.security_context.run_as_user == 1000
+        assert pt.labels == {"team": "ml"}
+        assert pt.annotations["note"] == "keep-me"
+
+    def test_standalone_creates_primary(self, method, kwargs):
+        pt = getattr(PodTemplate(), method)(**kwargs)
+        assert any(c.name == "primary" for c in pt.pod_spec.containers)
+
+    def test_stamps_capability_annotation(self, method, kwargs):
+        pt = getattr(PodTemplate(), method)(**kwargs)
+        name = method.removeprefix("allow_").replace("_", "-")
+        assert pt.annotations[f"flyte.org/capability-{name}"] == "true"
+
+    def test_adds_sys_admin(self, method, kwargs):
+        pt = getattr(_rich_template(), method)(**kwargs)
+        primary = next(c for c in pt.pod_spec.containers if c.name == "primary")
+        assert "SYS_ADMIN" in primary.security_context.capabilities.add
+
+    def test_sys_admin_not_duplicated(self, method, kwargs):
+        pt = getattr(getattr(_rich_template(), method)(**kwargs), method)(**kwargs)
+        primary = next(c for c in pt.pod_spec.containers if c.name == "primary")
+        assert primary.security_context.capabilities.add.count("SYS_ADMIN") == 1
+
+
+class TestAllowFuse:
+    def test_fuse_device_volume_and_mount(self):
+        pt = PodTemplate().allow_fuse()
+        vol = next(v for v in pt.pod_spec.volumes if v.name == "fuse-device")
+        assert vol.host_path.path == "/dev/fuse"
+        assert vol.host_path.type == "CharDevice"
+        primary = next(c for c in pt.pod_spec.containers if c.name == "primary")
+        mount = next(m for m in primary.volume_mounts if m.name == "fuse-device")
+        assert mount.mount_path == "/dev/fuse"
+
+    def test_privileged(self):
+        pt = PodTemplate().allow_fuse()
+        primary = next(c for c in pt.pod_spec.containers if c.name == "primary")
+        assert primary.security_context.privileged is True
+
+    def test_conflicts_with_explicit_unprivileged(self):
+        from kubernetes.client import V1Container, V1PodSpec, V1SecurityContext
+
+        pt = PodTemplate(
+            pod_spec=V1PodSpec(
+                containers=[V1Container(name="primary", security_context=V1SecurityContext(privileged=False))]
+            )
+        )
+        with pytest.raises(ValueError, match="privileged=false"):
+            pt.allow_fuse()
+
+    def test_conflicts_allow_nested_sandboxing(self):
+        with pytest.raises(ValueError, match="allowPrivilegeEscalation"):
+            PodTemplate().allow_nested_sandboxing().allow_fuse()
+
+
+class TestAllowFuseUnprivileged:
+    def test_not_privileged(self):
+        pt = PodTemplate().allow_fuse(privileged=False)
+        primary = next(c for c in pt.pod_spec.containers if c.name == "primary")
+        sc = primary.security_context
+        assert sc.privileged is not True
+        assert "SYS_ADMIN" in sc.capabilities.add
+        # composability: must not pin allowPrivilegeEscalation either way
+        assert sc.allow_privilege_escalation is None
+
+    def test_device_volume_still_mounted(self):
+        pt = PodTemplate().allow_fuse(privileged=False)
+        assert any(v.name == "fuse-device" for v in pt.pod_spec.volumes)
+
+    def test_sets_apparmor_unconfined(self):
+        pt = PodTemplate(primary_container_name="worker").allow_fuse(privileged=False)
+        assert pt.annotations["container.apparmor.security.beta.kubernetes.io/worker"] == "unconfined"
+
+    def test_conflicts_with_other_apparmor_profile(self):
+        pt = PodTemplate(annotations={"container.apparmor.security.beta.kubernetes.io/primary": "runtime/default"})
+        with pytest.raises(ValueError, match="AppArmor"):
+            pt.allow_fuse(privileged=False)
+
+    def test_composes_with_sandboxing_in_both_orders(self):
+        a = PodTemplate().allow_fuse(privileged=False).allow_nested_sandboxing()
+        b = PodTemplate().allow_nested_sandboxing().allow_fuse(privileged=False)
+        assert a == b  # order-free law holds for the composable pair
+        primary = next(c for c in a.pod_spec.containers if c.name == "primary")
+        sc = primary.security_context
+        assert sc.capabilities.add == ["SYS_ADMIN"]
+        assert sc.allow_privilege_escalation is False
+        assert sc.privileged is not True
+        assert any(v.name == "fuse-device" for v in a.pod_spec.volumes)
+        assert a.annotations["container.apparmor.security.beta.kubernetes.io/primary"] == "unconfined"
+        assert a.annotations["flyte.org/capability-fuse"] == "true"
+        assert a.annotations["flyte.org/capability-nested-sandboxing"] == "true"
+
+
+class TestAllowNestedSandboxing:
+    def test_security_posture(self):
+        pt = PodTemplate().allow_nested_sandboxing()
+        primary = next(c for c in pt.pod_spec.containers if c.name == "primary")
+        sc = primary.security_context
+        assert sc.capabilities.add == ["SYS_ADMIN"]
+        assert sc.allow_privilege_escalation is False
+        assert sc.privileged is not True
+
+    def test_apparmor_annotation_uses_primary_container_name(self):
+        pt = PodTemplate(primary_container_name="worker").allow_nested_sandboxing()
+        key = "container.apparmor.security.beta.kubernetes.io/worker"
+        assert pt.annotations[key] == "unconfined"
+
+    def test_conflicts_with_privileged(self):
+        from kubernetes.client import V1Container, V1PodSpec, V1SecurityContext
+
+        pt = PodTemplate(
+            pod_spec=V1PodSpec(
+                containers=[V1Container(name="primary", security_context=V1SecurityContext(privileged=True))]
+            )
+        )
+        with pytest.raises(ValueError, match="privileged=true"):
+            pt.allow_nested_sandboxing()
+
+    def test_conflicts_allow_fuse(self):
+        with pytest.raises(ValueError, match="privileged"):
+            PodTemplate().allow_fuse().allow_nested_sandboxing()
+
+    def test_conflicts_with_other_apparmor_profile(self):
+        pt = PodTemplate(annotations={"container.apparmor.security.beta.kubernetes.io/primary": "runtime/default"})
+        with pytest.raises(ValueError, match="AppArmor"):
+            pt.allow_nested_sandboxing()
+
+    def test_composes_with_user_spec_via_from_spec(self):
+        pt = PodTemplate.from_spec(_spec("worker", "primary")).allow_nested_sandboxing()
+        primary = next(c for c in pt.pod_spec.containers if c.name == "primary")
+        assert "SYS_ADMIN" in primary.security_context.capabilities.add
+        assert [c.name for c in pt.pod_spec.containers] == ["worker", "primary"]


### PR DESCRIPTION
Two changes:

## 1. PodTemplate capability helpers

Image-style chainable methods for requesting pod privileges without hand-writing Kubernetes security contexts:

```python
pt = flyte.PodTemplate.from_spec(my_v1_pod_spec)        # wrap an existing pod spec
pt = flyte.PodTemplate().allow_fuse()                   # /dev/fuse + SYS_ADMIN + privileged
pt = my_pt.allow_nested_sandboxing()                    # bwrap prerequisites: SYS_ADMIN + AppArmor unconfined + allowPrivilegeEscalation=false
pt = my_pt.allow_fuse(privileged=False).allow_nested_sandboxing()  # composable on clusters that permit /dev/fuse unprivileged
```

Helpers are pure augmentors with tested laws: never mutate the input, idempotent, additive over user-set fields (sidecars/volumes/securityContext preserved), order-free where composable, stamp `flyte.org/capability-<name>` annotations for auditability, and raise loudly on conflicting pre-set security posture (e.g. `allow_fuse()` after `allow_nested_sandboxing()`).

## 2. Fix: `task.override(resources=...)` dropped the GPU accelerator

`TaskDetails.override` only copied `container.resources` and never set `task_template.extended_resources`, so `task.override(resources=flyte.Resources(gpu="L40s:1"))` produced a pod with no accelerator nodeSelector/toleration and scheduled on a non-GPU node. Now mirrors the build path (`get_proto_extended_resources`), clearing the field when the replacement has no extended resources. Enables per-run GPU overrides.

## Test plan
- `tests/user_api/test_pod_template.py`: 51 tests — `from_spec` resolution rules, parametrized augmentor-law suite over all three grant variants, conflict and both-order composition tests
- `tests/flyte/remote/test_task.py`: GPU override sets `gpu_accelerator.device == "nvidia-l40s"`; cpu-only re-override clears `extended_resources`
- Full sweep: 662 passed (user_api + remote + task/app/resources serde)

🤖 Generated with [Claude Code](https://claude.com/claude-code)