### PR TITLE
feat: coerce plain dicts into BaseModel/dataclass inputs for flyte.run

### DIFF
--- a/examples/basics/types/dict_to_model_inputs.py
+++ b/examples/basics/types/dict_to_model_inputs.py
@@ -1,0 +1,110 @@
+"""
+Passing plain dicts (and partial dicts) to BaseModel / dataclass task inputs.
+
+A client wants to launch a task whose input is a Pydantic ``BaseModel`` (or dataclass) *without*
+constructing the model object — and ideally without even importing the model class, because the
+task definition and the calling code live in different repos.
+
+``flyte.run`` coerces a dict into the target BaseModel/dataclass at the type-engine layer:
+
+* full dict     -> the model is built from the dict
+* partial dict  -> omitted fields are filled from the model's field defaults
+* it also works for remote tasks fetched via ``Task.get()``, where the client does not have the
+  class at all (the input type is reconstructed from the task's schema, defaults included)
+
+Note the ``tags: dict[str, str] | None`` field below — that exact shape used to crash with
+``KeyError: 'title'`` when the type was reconstructed on the client side.
+
+Run locally to see it work:
+
+    python examples/basics/types/dict_to_model_inputs.py
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel
+
+import flyte
+
+env = flyte.TaskEnvironment(name="dict_to_model_inputs")
+
+
+class ParametersOption(str, Enum):
+    DAL_OMS = "dal_oms"
+    DAL_ONLY = "dal_only"
+
+
+class QueryInfo(BaseModel):
+    """A Pydantic input model."""
+
+    query: str  # required, no default
+    name: str = "default"  # defaulted field -- can be omitted from the dict
+    tags: dict[str, str] | None = None  # the field shape from the original bug report
+
+
+@env.task
+async def regen_in_batch(
+    query_info: QueryInfo,
+    parameters_option: ParametersOption = ParametersOption.DAL_OMS,
+    min_success_ratio: float = 0.9,
+    concurrency: int = 4,
+) -> str:
+    return (
+        f"query={query_info.query!r} name={query_info.name!r} tags={query_info.tags} "
+        f"option={parameters_option.value} ratio={min_success_ratio} concurrency={concurrency}"
+    )
+
+
+# A dataclass input works exactly the same way.
+@dataclass
+class QueryInfoDC:
+    query: str
+    name: str = "default"
+    tags: Optional[dict[str, str]] = None
+
+
+@env.task
+async def regen_in_batch_dc(query_info: QueryInfoDC) -> str:
+    return f"query={query_info.query!r} name={query_info.name!r} tags={query_info.tags}"
+
+
+if __name__ == "__main__":
+    # Local execution, so you can run this file directly and verify the coercion.
+    flyte.init()
+
+    # 1) Full dict -- no need to construct QueryInfo(...).
+    r1 = flyte.run(regen_in_batch, query_info={"query": "select 1", "name": "full", "tags": {"team": "ml"}})
+    print("full dict   :", r1.outputs())
+
+    # 2) Minimal dict -- name/tags omitted, filled from QueryInfo's field defaults.
+    r2 = flyte.run(regen_in_batch, query_info={"query": "select 2"})
+    print("partial dict:", r2.outputs())
+
+    # 3) Partial dict + override a task-level defaulted argument.
+    r3 = flyte.run(
+        regen_in_batch,
+        query_info={"query": "select 3", "tags": {"k": "v"}},
+        parameters_option=ParametersOption.DAL_ONLY,
+    )
+    print("override arg:", r3.outputs())
+
+    # 4) Same behavior for a dataclass input.
+    r4 = flyte.run(regen_in_batch_dc, query_info={"query": "select 4"})
+    print("dataclass   :", r4.outputs())
+
+    # ---- Decoupled / remote usage (no QueryInfo import needed) ----------------------------------
+    # In a separate repo, a client can fetch the deployed task and launch it with a plain dict --
+    # it does NOT need to import QueryInfo. The input type is reconstructed from the task's schema
+    # (with defaults), so a minimal dict still works:
+    #
+    #     import flyte
+    #     from flyte.remote import Task
+    #
+    #     flyte.init_from_config()
+    #     task = Task.get("regen_in_batch", project="...", domain="...", auto_version="latest")
+    #     run = flyte.with_runcontext(mode="remote").run(task, query_info={"query": "select 1"})
+    #     run.wait()

--- a/src/flyte/types/_type_engine.py
+++ b/src/flyte/types/_type_engine.py
@@ -584,6 +584,17 @@ class PydanticTransformer(TypeTransformer[BaseModel]):
         python_type: Type[BaseModel],
         expected: LiteralType,
     ) -> Literal:
+        # Auto-coerce a plain dict into the target BaseModel so callers (e.g. flyte.run as an
+        # API-service entrypoint) can pass JSON-like inputs without constructing the model. Missing
+        # fields are filled from the model's defaults; only missing required fields error. This
+        # mirrors the CLI param-parsing path (cli/_params.py) and keeps the Union/Optional path
+        # working since UnionTransformer delegates here and catches TypeTransformerFailedError.
+        if isinstance(python_val, dict):
+            try:
+                python_val = python_type.model_validate(python_val, strict=False, context={"deserialize": True})
+            except Exception as e:
+                raise TypeTransformerFailedError(f"Failed to coerce dict into {python_type}: {e}") from e
+
         # Pre-process the model to invoke any lazy uploaders on nested Flyte IO types.
         # This ensures uploads happen in the syncify context where gRPC clients work correctly,
         # and prevents deadlocks when @model_serializer tries to run async code via loop_manager.
@@ -711,7 +722,16 @@ def _create_pydantic_model_from_schema(schema: dict) -> Type:
 
     title = schema.get(TITLE, "DynamicModel")
     properties = schema.get("properties", {})
-    property_order = schema.get("required", list(properties.keys()))
+    # Reconstruct every field, not just the required ones. ``required`` is an ordered list that
+    # preserves field-definition order (the ``properties`` map can lose ordering after the schema
+    # round-trips through a protobuf Struct), so we keep it first for byte/cache-key consistency,
+    # then append the remaining fields. Those remaining fields are exactly the ones with defaults;
+    # previously they were dropped entirely, which broke the decoupled flyte.run case (client
+    # without the original class) — defaulted fields would vanish and couldn't be filled from
+    # their defaults.
+    required_order = [name for name in (schema.get("required") or ()) if name in properties]
+    remaining = [name for name in properties if name not in set(required_order)]
+    property_order = required_order + remaining
 
     fields: dict[str, typing.Any] = {}
     required_set = set(schema.get("required") or ())
@@ -814,12 +834,20 @@ class DataclassTransformer(TypeTransformer[object]):
             # Find the Optional keys in expected_fields_dict
             optional_keys = {k for k, t in expected_fields_dict.items() if UnionTransformer.is_optional_type(t)}
 
+            # Fields with a default (or default_factory) may also be omitted from the dict and filled
+            # in during decoding, so they should not count as "missing".
+            defaulted_keys = {
+                f.name
+                for f in dataclasses.fields(expected_type)
+                if f.default is not dataclasses.MISSING or f.default_factory is not dataclasses.MISSING
+            }
+
             # Remove the Optional keys from the keys of original_dict
             original_key = set(original_dict.keys()) - optional_keys
             expected_key = set(expected_fields_dict.keys()) - optional_keys
 
-            # Check if original_key is missing any keys from expected_key
-            missing_keys = expected_key - original_key
+            # Check if original_key is missing any keys from expected_key (defaulted fields excepted)
+            missing_keys = (expected_key - original_key) - defaulted_keys
             if missing_keys:
                 raise TypeTransformerFailedError(
                     f"The original fields are missing the following keys from the dataclass fields: "
@@ -836,14 +864,23 @@ class DataclassTransformer(TypeTransformer[object]):
 
             for k, v in original_dict.items():
                 if k in expected_fields_dict:
+                    expected_type = expected_fields_dict[k]
+                    if UnionTransformer.is_optional_type(expected_type):
+                        expected_type = UnionTransformer.get_sub_type_in_optional(expected_type)
                     if isinstance(v, dict):
-                        self.assert_type(expected_fields_dict[k], v)
+                        # Only recurse for nested dataclasses. A plain dict-typed field
+                        # (e.g. Dict[str, str]) is a subscripted generic that can't be passed to
+                        # issubclass()/dataclasses.fields(); its contents are validated at decode time.
+                        if dataclasses.is_dataclass(expected_type):
+                            self.assert_type(expected_type, v)
                     else:
-                        expected_type = expected_fields_dict[k]
                         original_type = type(v)
-                        if UnionTransformer.is_optional_type(expected_type):
-                            expected_type = UnionTransformer.get_sub_type_in_optional(expected_type)
-                        if original_type != expected_type:
+                        # Only enforce when the field annotation resolved to a concrete type.
+                        # With `from __future__ import annotations`, dataclasses.fields(...).type
+                        # is the *string* annotation (e.g. "str"); likewise subscripted generics
+                        # (List[int]) are not plain types. In those cases skip the early check and
+                        # let the decode step in to_literal do the real validation.
+                        if isinstance(expected_type, type) and original_type is not expected_type:
                             raise TypeTransformerFailedError(
                                 f"Type of Val '{original_type}' is not an instance of {expected_type}"
                             )
@@ -914,8 +951,20 @@ class DataclassTransformer(TypeTransformer[object]):
 
     async def to_literal(self, python_val: T, python_type: Type[T], expected: LiteralType) -> Literal:
         if isinstance(python_val, dict):
-            msgpack_bytes = msgpack.dumps(python_val)
-            return Literal(scalar=Scalar(binary=Binary(value=msgpack_bytes, tag=MESSAGEPACK)))
+            # Auto-coerce a plain dict into the target dataclass so callers (e.g. flyte.run) can pass
+            # JSON-like inputs without constructing the dataclass. Decoding (rather than a raw
+            # msgpack dump of the dict) applies field validation and fills omitted fields from their
+            # defaults; only missing required fields error. This mirrors the CLI param-parsing path.
+            decode_type = get_underlying_type(python_type)
+            try:
+                decoder = self._json_decoder[decode_type]
+            except KeyError:
+                decoder = JSONDecoder(decode_type)
+                self._json_decoder[decode_type] = decoder
+            try:
+                python_val = decoder.decode(json.dumps(python_val))
+            except Exception as e:
+                raise TypeTransformerFailedError(f"Failed to coerce dict into {python_type}: {e}") from e
 
         if not dataclasses.is_dataclass(python_val):
             raise TypeTransformerFailedError(
@@ -1327,9 +1376,14 @@ def generate_attribute_list_from_dataclass_json_mixin(schema: dict, schema_name:
     # (for $ref / anyOf single-variant fields) or a _DiscriminatedUnion (for oneOf fields).
     nested_types: typing.Dict[str, typing.Any] = {}
 
-    # Use 'required' field to preserve property order, as protobuf Struct doesn't preserve dict order
+    # Use 'required' field to preserve property order, as protobuf Struct doesn't preserve dict order.
+    # ``required`` lists only the no-default fields though, so we keep it first (for ordering) and
+    # then append the remaining (defaulted) fields, which were previously dropped entirely. Dropping
+    # them broke the decoupled flyte.run case (client without the original class): defaulted fields
+    # would vanish and couldn't be filled in from their defaults.
     properties = schema["properties"]
-    property_order = schema.get("required", list(properties.keys()))
+    required_order = [name for name in (schema.get("required") or ()) if name in properties]
+    property_order = required_order + [name for name in properties if name not in set(required_order)]
 
     for property_key in property_order:
         property_val = properties[property_key]
@@ -1466,9 +1520,26 @@ def generate_attribute_list_from_dataclass_json_mixin(schema: dict, schema_name:
         # Handle dataclass and dict
         elif property_type == "object":
             if property_val.get("anyOf"):
-                # For optional with dataclass
-                sub_schemea = property_val["anyOf"][0]
-                sub_schemea_name = sub_schemea["title"]
+                # For optional with dataclass / dict. Use the non-null variant (e.g. X | None -> X).
+                non_null_variants = [
+                    v
+                    for v in property_val["anyOf"]
+                    if not (isinstance(v, dict) and v.get("type") == "null")
+                ]
+                sub_schemea = non_null_variants[0] if non_null_variants else property_val["anyOf"][0]
+                # A dict-shaped variant (e.g. dict[str, str] | None) has additionalProperties and no
+                # "title"; handle it as a typing.Dict, not a nested dataclass. Reading ["title"]
+                # blindly here is what caused the original KeyError on dict[str, str] | None.
+                if isinstance(sub_schemea, dict) and sub_schemea.get("additionalProperties"):
+                    elem_type = _get_element_type(sub_schemea["additionalProperties"], schema)
+                    _append_schema_field(
+                        attribute_list,
+                        property_key,
+                        typing.Dict[str, elem_type],  # type: ignore
+                        property_val,
+                        schema,
+                    )
+                    continue
                 matched_type = _match_registered_type_from_schema(property_val) or _match_registered_type_from_schema(
                     sub_schemea
                 )
@@ -1477,6 +1548,7 @@ def generate_attribute_list_from_dataclass_json_mixin(schema: dict, schema_name:
                         attribute_list, property_key, typing.cast(GenericAlias, matched_type), property_val, schema
                     )
                     continue
+                sub_schemea_name = sub_schemea.get("title", property_key)
                 nested_class = convert_mashumaro_json_schema_to_python_class(sub_schemea, sub_schemea_name)
                 _append_schema_field(
                     attribute_list, property_key, typing.cast(GenericAlias, nested_class), property_val, schema

--- a/src/flyte/types/_type_engine.py
+++ b/src/flyte/types/_type_engine.py
@@ -1522,9 +1522,7 @@ def generate_attribute_list_from_dataclass_json_mixin(schema: dict, schema_name:
             if property_val.get("anyOf"):
                 # For optional with dataclass / dict. Use the non-null variant (e.g. X | None -> X).
                 non_null_variants = [
-                    v
-                    for v in property_val["anyOf"]
-                    if not (isinstance(v, dict) and v.get("type") == "null")
+                    v for v in property_val["anyOf"] if not (isinstance(v, dict) and v.get("type") == "null")
                 ]
                 sub_schemea = non_null_variants[0] if non_null_variants else property_val["anyOf"][0]
                 # A dict-shaped variant (e.g. dict[str, str] | None) has additionalProperties and no

--- a/tests/flyte/type_engine/test_dict_coercion.py
+++ b/tests/flyte/type_engine/test_dict_coercion.py
@@ -1,0 +1,195 @@
+"""Tests for auto-coercing a plain dict into a BaseModel/dataclass at the type-engine layer.
+
+This lets callers (e.g. ``flyte.run`` used as an API-service entrypoint) pass JSON-like dicts for
+BaseModel/dataclass parameters instead of constructing the model. Missing fields are filled from the
+model's defaults; only missing *required* fields error. See PydanticTransformer.to_literal /
+DataclassTransformer.to_literal in flyte/types/_type_engine.py.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import pytest
+from pydantic import BaseModel
+
+from flyte.types import TypeEngine
+from flyte.types._type_engine import DataclassTransformer, PydanticTransformer, TypeTransformerFailedError
+
+
+# ---------------------------------------------------------------------------
+# Pydantic BaseModel
+# ---------------------------------------------------------------------------
+class MyModel(BaseModel):
+    x: int
+    y: float = 4.1
+    z: str = "foo"
+
+
+class Nested(BaseModel):
+    inner: MyModel
+    name: str
+
+
+@pytest.mark.asyncio
+async def test_dict_to_basemodel_full():
+    lit = TypeEngine.to_literal_type(MyModel)
+    from_dict = await TypeEngine.to_literal({"x": 5, "y": 1.5, "z": "bar"}, MyModel, lit)
+    from_model = await TypeEngine.to_literal(MyModel(x=5, y=1.5, z="bar"), MyModel, lit)
+    assert from_dict == from_model
+
+    # round-trips back to the model
+    back = await TypeEngine.to_python_value(from_dict, MyModel)
+    assert back == MyModel(x=5, y=1.5, z="bar")
+
+
+@pytest.mark.asyncio
+async def test_dict_to_basemodel_partial_uses_defaults():
+    lit = TypeEngine.to_literal_type(MyModel)
+    lv = await TypeEngine.to_literal({"x": 5}, MyModel, lit)
+    back = await TypeEngine.to_python_value(lv, MyModel)
+    assert back == MyModel(x=5, y=4.1, z="foo")
+
+
+@pytest.mark.asyncio
+async def test_dict_to_optional_basemodel():
+    lit = TypeEngine.to_literal_type(Optional[MyModel])
+    lv = await TypeEngine.to_literal({"x": 7}, Optional[MyModel], lit)
+    back = await TypeEngine.to_python_value(lv, Optional[MyModel])
+    assert back == MyModel(x=7, y=4.1, z="foo")
+
+    none_lv = await TypeEngine.to_literal(None, Optional[MyModel], lit)
+    assert await TypeEngine.to_python_value(none_lv, Optional[MyModel]) is None
+
+
+@pytest.mark.asyncio
+async def test_nested_dict_to_basemodel():
+    lit = TypeEngine.to_literal_type(Nested)
+    lv = await TypeEngine.to_literal({"inner": {"x": 1}, "name": "n"}, Nested, lit)
+    back = await TypeEngine.to_python_value(lv, Nested)
+    assert back == Nested(inner=MyModel(x=1), name="n")
+
+
+@pytest.mark.asyncio
+async def test_dict_to_basemodel_missing_required_raises():
+    lit = TypeEngine.to_literal_type(MyModel)
+    with pytest.raises(TypeTransformerFailedError):
+        await TypeEngine.to_literal({"y": 1.0}, MyModel, lit)
+
+
+# ---------------------------------------------------------------------------
+# Decoupled remote case: the client does NOT have the original model class, so
+# the type is reconstructed from the JSON schema via guess_python_type. The
+# reconstructed model must still carry every field (including defaulted ones)
+# so a minimal dict can be filled in from defaults.
+# ---------------------------------------------------------------------------
+class QueryInfo(BaseModel):
+    query: str  # required, no default
+    name: str = "default"
+    tags: Optional[dict] = None
+
+
+@pytest.mark.asyncio
+async def test_reconstructed_model_keeps_defaulted_fields():
+    lit = TypeEngine.to_literal_type(QueryInfo)
+    reconstructed = PydanticTransformer().guess_python_type(lit)
+    # All fields present, required field first (definition order preserved for cache consistency).
+    assert set(reconstructed.model_fields.keys()) == {"query", "name", "tags"}
+
+
+@pytest.mark.asyncio
+async def test_decoupled_dict_minimal_fills_defaults():
+    lit = TypeEngine.to_literal_type(QueryInfo)
+    reconstructed = PydanticTransformer().guess_python_type(lit)
+
+    lv = await TypeEngine.to_literal({"query": "select 1"}, reconstructed, lit)
+    back = await TypeEngine.to_python_value(lv, reconstructed)
+    assert back.query == "select 1"
+    assert back.name == "default"
+    assert back.tags is None
+
+
+@pytest.mark.asyncio
+async def test_decoupled_dict_overrides_defaults():
+    lit = TypeEngine.to_literal_type(QueryInfo)
+    reconstructed = PydanticTransformer().guess_python_type(lit)
+
+    lv = await TypeEngine.to_literal({"query": "q", "name": "n", "tags": {"a": "b"}}, reconstructed, lit)
+    back = await TypeEngine.to_python_value(lv, reconstructed)
+    assert (back.query, back.name, back.tags) == ("q", "n", {"a": "b"})
+
+
+# ---------------------------------------------------------------------------
+# Dataclass
+# ---------------------------------------------------------------------------
+@dataclass
+class MyDC:
+    x: int
+    y: float = 4.1
+    z: str = "foo"
+
+
+@pytest.mark.asyncio
+async def test_dict_to_dataclass_full():
+    lit = TypeEngine.to_literal_type(MyDC)
+    from_dict = await TypeEngine.to_literal({"x": 5, "y": 1.5, "z": "bar"}, MyDC, lit)
+    back = await TypeEngine.to_python_value(from_dict, MyDC)
+    assert back == MyDC(x=5, y=1.5, z="bar")
+
+
+@pytest.mark.asyncio
+async def test_dict_to_dataclass_partial_uses_defaults():
+    lit = TypeEngine.to_literal_type(MyDC)
+    lv = await TypeEngine.to_literal({"x": 5}, MyDC, lit)
+    back = await TypeEngine.to_python_value(lv, MyDC)
+    assert back == MyDC(x=5, y=4.1, z="foo")
+
+
+@pytest.mark.asyncio
+async def test_dict_to_dataclass_missing_required_raises():
+    lit = TypeEngine.to_literal_type(MyDC)
+    with pytest.raises(TypeTransformerFailedError):
+        await TypeEngine.to_literal({"y": 1.0}, MyDC, lit)
+
+
+# ---------------------------------------------------------------------------
+# Dataclass with `dict[str, str] | None` — the exact type that triggered the
+# customer's original KeyError on the decoupled (reconstructed) path. Covers
+# both the direct (class available) and decoupled (reconstructed) cases.
+# ---------------------------------------------------------------------------
+@dataclass
+class TaskInput:
+    query: str  # required, no default
+    name: str = "default"
+    tags: Optional[Dict[str, str]] = None
+
+
+@pytest.mark.asyncio
+async def test_dataclass_dict_optional_direct():
+    lit = TypeEngine.to_literal_type(TaskInput)
+    lv = await TypeEngine.to_literal({"query": "q", "tags": {"a": "b"}}, TaskInput, lit)
+    back = await TypeEngine.to_python_value(lv, TaskInput)
+    assert back == TaskInput(query="q", name="default", tags={"a": "b"})
+
+
+@pytest.mark.asyncio
+async def test_dataclass_dict_optional_decoupled_reconstruction():
+    lit = TypeEngine.to_literal_type(TaskInput)
+    # Reconstruct from schema only (client without the original class). This used to raise
+    # KeyError: 'title' on the dict[str, str] | None field.
+    reconstructed = DataclassTransformer().guess_python_type(lit)
+
+    import dataclasses as _dc
+
+    assert {f.name for f in _dc.fields(reconstructed)} == {"query", "name", "tags"}
+
+    # minimal input -> defaults filled
+    lv = await TypeEngine.to_literal({"query": "q"}, reconstructed, lit)
+    back = await TypeEngine.to_python_value(lv, reconstructed)
+    assert back.query == "q"
+    assert back.name == "default"
+    assert back.tags is None
+
+    # dict value provided
+    lv2 = await TypeEngine.to_literal({"query": "q", "tags": {"a": "b"}}, reconstructed, lit)
+    back2 = await TypeEngine.to_python_value(lv2, reconstructed)
+    assert back2.tags == {"a": "b"}

--- a/tests/flyte/type_engine/test_dict_coercion_future_annotations.py
+++ b/tests/flyte/type_engine/test_dict_coercion_future_annotations.py
@@ -1,0 +1,45 @@
+"""dict -> dataclass coercion when the module uses ``from __future__ import annotations``.
+
+With PEP 563, ``dataclasses.fields(...).type`` is the *string* annotation (e.g. "str"), so the
+early type check in DataclassTransformer.assert_type must not compare a real type against that
+string. Regression coverage for that path (validation still happens at decode time).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from flyte.types import TypeEngine
+from flyte.types._type_engine import TypeTransformerFailedError
+
+
+@dataclass
+class QueryInfoDC:
+    query: str  # required, no default
+    name: str = "default"
+    tags: dict[str, str] | None = None
+
+
+@pytest.mark.asyncio
+async def test_dict_to_dataclass_with_stringized_annotations_full():
+    lit = TypeEngine.to_literal_type(QueryInfoDC)
+    lv = await TypeEngine.to_literal({"query": "q", "name": "n", "tags": {"a": "b"}}, QueryInfoDC, lit)
+    back = await TypeEngine.to_python_value(lv, QueryInfoDC)
+    assert back == QueryInfoDC(query="q", name="n", tags={"a": "b"})
+
+
+@pytest.mark.asyncio
+async def test_dict_to_dataclass_with_stringized_annotations_partial():
+    lit = TypeEngine.to_literal_type(QueryInfoDC)
+    lv = await TypeEngine.to_literal({"query": "q"}, QueryInfoDC, lit)
+    back = await TypeEngine.to_python_value(lv, QueryInfoDC)
+    assert back == QueryInfoDC(query="q", name="default", tags=None)
+
+
+@pytest.mark.asyncio
+async def test_dict_to_dataclass_with_stringized_annotations_missing_required_raises():
+    lit = TypeEngine.to_literal_type(QueryInfoDC)
+    with pytest.raises(TypeTransformerFailedError):
+        await TypeEngine.to_literal({"name": "n"}, QueryInfoDC, lit)


### PR DESCRIPTION
##  Motivation

  Callers want to launch a task whose input is a Pydantic BaseModel/dataclass by passing a plain dict — including a partial dict where omitted fields fall back to defaults — and without importing the input class (so the task definition and client can live in separate repos). The CLI already did this in its param layer, but the Python flyte.run path didn't: Pydantic inputs crashed (AttributeError: model_dump_json) and dataclass inputs were passed through unvalidated. The decoupled (reconstructed-type) path had additional latent bugs, including the original KeyError: 'title' on dict[str, str] | None.

##  Summary

  - Coercion at the type-engine layer (_type_engine.py): PydanticTransformer.to_literal now model_validates a dict; DataclassTransformer.to_literal decodes a dict (validated, defaults applied) instead of dumping it raw. Failures raise TypeTransformerFailedError so Union variants fall through.
  - Partial inputs: DataclassTransformer.assert_type allows fields with defaults to be omitted, only recurses into nested dataclass fields, and skips the early type check when the annotation isn't a concrete type (handles from __future__ import annotations).
  - Decoupled / reconstructed types: _create_pydantic_model_from_schema and generate_attribute_list_from_dataclass_json_mixin now reconstruct all fields (not just required), so defaulted fields survive; the dataclass anyOf branch handles dict-shaped variants and no longer KeyErrors on a missing title (fixes the original dict[str, str] | None crash).
  - Example + tests: added examples/basics/types/dict_to_model_inputs.py and 16 new unit tests covering full/partial/nested/optional dicts, decoupled reconstruction, and the dict[str,str] | None shape (Pydantic + dataclass, incl. stringized annotations).

##  Test Plan

  - pytest tests/flyte/type_engine → 414 passed (incl. 16 new coercion tests).
  - Full pytest tests/flyte → 2710 passed; the 18 failures are pre-existing infra tests (S3, remote roundtrip, obstore, serve) — identical count on a clean tree.
  - Run the example end-to-end: python examples/basics/types/dict_to_model_inputs.py — confirms full dict, minimal dict (defaults filled), arg override, and dataclass input all succeed.
  - Decoupled check: reconstruct the type from schema via guess_python_type (no original class) and convert a minimal dict — defaults fill for both Pydantic and dataclass, including dict[str, str] | None.