### PR TITLE
(bugfix) Overrides not applied to pods

### DIFF
--- a/src/flyte/remote/_task.py
+++ b/src/flyte/remote/_task.py
@@ -19,6 +19,7 @@ from flyte._context import internal_ctx
 from flyte._initialize import ensure_client, get_client, get_init_config
 from flyte._internal.runtime.resources_serde import get_proto_extended_resources, get_proto_resources
 from flyte._internal.runtime.task_serde import (
+    _sanitize_resource_name,
     get_proto_max_runtime,
     get_proto_retry_strategy,
     get_proto_timeout_strategy,
@@ -29,6 +30,61 @@ from flyte.models import NativeInterface
 from flyte.syncify import syncify
 
 from ._common import ToJSONMixin
+
+
+def _apply_overrides_to_primary_container(
+    template: Any,
+    resources: Optional[flyte.Resources] = None,
+    env_vars: Optional[Dict[str, str]] = None,
+) -> None:
+    """Apply container-level overrides to the primary container of a ``k8s_pod`` task.
+
+    Pod-template tasks store the primary container's resources and env inside
+    the ``k8s_pod.pod_spec`` Struct rather than in ``template.container``.
+    Mirror the build path (``task_serde._get_k8s_pod``): convert the resource
+    override to k8s resource maps (``cpu`` / ``memory`` / ``gpu`` /
+    ``ephemeral-storage``) and replace the primary container's ``resources``;
+    replace its ``env`` with the override entries. Both are full replacements,
+    matching the ``template.container`` override semantics.
+    """
+    from google.protobuf import json_format
+
+    # Lazy import: flyte._pod pulls in kubernetes, which we keep off the
+    # module-load path for `flyte.remote`.
+    from flyte._pod import _PRIMARY_CONTAINER_NAME_FIELD
+
+    primary_name = template.config.get(_PRIMARY_CONTAINER_NAME_FIELD)
+    spec = json_format.MessageToDict(template.k8s_pod.pod_spec)
+    containers = spec.get("containers", [])
+    # Fall back to a single-container pod's only container if the primary name
+    # isn't recorded in config for some reason.
+    target = None
+    for c in containers:
+        if c.get("name") == primary_name:
+            target = c
+            break
+    if target is None and len(containers) == 1:
+        target = containers[0]
+    if target is None:
+        return
+
+    if resources:
+        proto_res = get_proto_resources(resources)
+        if proto_res is not None:
+            requests = {_sanitize_resource_name(e): e.value for e in proto_res.requests}
+            limits = {_sanitize_resource_name(e): e.value for e in proto_res.limits}
+            rr: Dict[str, Any] = {}
+            if requests:
+                rr["requests"] = requests
+            if limits:
+                rr["limits"] = limits
+            target["resources"] = rr
+
+    if env_vars:
+        target["env"] = [{"name": k, "value": v} for k, v in env_vars.items()]
+
+    new_spec = json_format.ParseDict(spec, type(template.k8s_pod.pod_spec)())
+    template.k8s_pod.pod_spec.CopyFrom(new_spec)
 
 
 def _repr_task_metadata(metadata: task_definition_pb2.TaskMetadata) -> rich.repr.Result:
@@ -371,6 +427,15 @@ class TaskDetails(ToJSONMixin):
                 template.container.env.extend([literals_pb2.KeyValuePair(key=k, value=v) for k, v in env_vars.items()])
             if resources:
                 template.container.resources.CopyFrom(get_proto_resources(resources))
+        elif template.HasField("k8s_pod") and (resources or env_vars):
+            # Pod-template tasks (e.g. multi-container / sandbox envs) carry the
+            # primary container's resources and env inside the k8s_pod pod_spec
+            # Struct, not in template.container. Apply the override there too —
+            # otherwise the container resource requests (including the GPU
+            # *count*, nvidia.com/gpu) and env vars are dropped, and the pod
+            # schedules without a GPU even though the accelerator type is set
+            # below.
+            _apply_overrides_to_primary_container(template, resources=resources, env_vars=env_vars)
 
         if resources:
             # Resource overrides must also carry the extended resources — the

--- a/tests/flyte/remote/test_task.py
+++ b/tests/flyte/remote/test_task.py
@@ -229,3 +229,86 @@ class TestTaskDetailsOverrideResources:
         # Re-overriding with no GPU must drop the accelerator (full replacement).
         cpu_only = gpu.override(resources=flyte.Resources(cpu="2", memory="2Gi"))
         assert not cpu_only.pb2.spec.task_template.HasField("extended_resources")
+
+    def _k8s_pod_task_details(self) -> TaskDetails:
+        """A pod-template task: primary container resources live in the k8s_pod
+        pod_spec Struct, not template.container (e.g. multi-container / sandbox)."""
+        from flyteidl2.task import task_definition_pb2
+        from google.protobuf import json_format
+
+        from flyte._pod import _PRIMARY_CONTAINER_NAME_FIELD
+
+        pb2 = task_definition_pb2.TaskDetails()
+        tmpl = pb2.spec.task_template
+        tmpl.config[_PRIMARY_CONTAINER_NAME_FIELD] = "primary"
+        spec = {
+            "containers": [
+                {
+                    "name": "primary",
+                    "image": "example:latest",
+                    "resources": {"requests": {"cpu": "1", "memory": "1Gi"}},
+                    "env": [{"name": "BASE", "value": "from-pod-template"}],
+                },
+                {"name": "sidecar", "image": "side:latest"},
+            ]
+        }
+        json_format.ParseDict(spec, tmpl.k8s_pod.pod_spec)
+        return TaskDetails(pb2)
+
+    def test_gpu_override_on_pod_template_sets_container_request(self):
+        # Regression: a GPU override on a pod-template task must populate the
+        # primary container's resource *requests* (incl. the GPU count) inside
+        # the pod_spec — not just the accelerator type. Without the count the
+        # pod schedules without a GPU.
+        from google.protobuf import json_format
+
+        td = self._k8s_pod_task_details()
+        out = td.override(resources=flyte.Resources(cpu="4", memory="16Gi", gpu="L4:1"))
+        tmpl = out.pb2.spec.task_template
+
+        # Accelerator type (nodeSelector/toleration).
+        assert tmpl.HasField("extended_resources")
+        assert tmpl.extended_resources.gpu_accelerator.device == "nvidia-l4"
+
+        spec = json_format.MessageToDict(tmpl.k8s_pod.pod_spec)
+        primary = next(c for c in spec["containers"] if c["name"] == "primary")
+        reqs = primary["resources"]["requests"]
+        assert reqs.get("gpu") == "1", f"GPU request missing: {reqs}"
+        assert reqs.get("cpu") == "4"
+        assert reqs.get("memory") == "16Gi"
+
+        # The non-primary container must be left untouched.
+        side = next(c for c in spec["containers"] if c["name"] == "sidecar")
+        assert not side.get("resources")
+
+    def test_env_override_on_pod_template_sets_container_env(self):
+        # Regression: env_vars overrides on a pod-template task were silently
+        # dropped — they were only applied to template.container, which a
+        # k8s_pod task does not have. They must land on the primary container
+        # inside the pod_spec (full replacement, matching the container path).
+        from google.protobuf import json_format
+
+        td = self._k8s_pod_task_details()
+        out = td.override(env_vars={"FOO": "bar"})
+        tmpl = out.pb2.spec.task_template
+
+        spec = json_format.MessageToDict(tmpl.k8s_pod.pod_spec)
+        primary = next(c for c in spec["containers"] if c["name"] == "primary")
+        env = {e["name"]: e.get("value") for e in primary.get("env", [])}
+        assert env == {"FOO": "bar"}, f"env override missing: {env}"
+
+        # The non-primary container must be left untouched.
+        side = next(c for c in spec["containers"] if c["name"] == "sidecar")
+        assert not side.get("env")
+
+    def test_override_does_not_mutate_original_pod_template(self):
+        # override() must return a new TaskDetails without touching the source.
+        from google.protobuf import json_format
+
+        td = self._k8s_pod_task_details()
+        td.override(resources=flyte.Resources(cpu="4", memory="16Gi", gpu="L4:1"), env_vars={"FOO": "bar"})
+        spec = json_format.MessageToDict(td.pb2.spec.task_template.k8s_pod.pod_spec)
+        primary = next(c for c in spec["containers"] if c["name"] == "primary")
+        assert "gpu" not in primary["resources"]["requests"]
+        env = {e["name"]: e.get("value") for e in primary.get("env", [])}
+        assert env == {"BASE": "from-pod-template"}


### PR DESCRIPTION
## Problem

`TaskDetails.override(resources=...)` applied the container resource override **only when the task template had a `container` field**. Pod-template tasks (multi-container environments — e.g. the code-execution sandbox) carry the primary container's resources inside the `k8s_pod.pod_spec` Struct and have **no** `template.container`, so the override was silently skipped. Only `extended_resources` (the GPU accelerator *type* → nodeSelector/toleration) was set.

Result: a per-run `override(resources=Resources(gpu="L4:1"))` produced a pod with the accelerator nodeSelector but **no `nvidia.com/gpu` request**, so it scheduled without a GPU. cpu/memory overrides were dropped the same way.

This was found via the unionai-sandbox GPU notebook override path (follow-up to #1170, which fixed the accelerator-type half of the same `override`).

## Fix

When the template uses `k8s_pod`, apply the resource override to the **primary container inside the pod_spec Struct**, mirroring the build path (`task_serde._get_k8s_pod`): convert the override to k8s resource maps via `_sanitize_resource_name` and replace the primary container's `resources` (full replacement, matching `template.container.resources.CopyFrom`). The primary container is located by `_PRIMARY_CONTAINER_NAME_FIELD` (with a single-container fallback); other containers are left untouched.

## Tests

- `test_gpu_override_on_pod_template_sets_container_request` — GPU override populates the primary container's `requests` (cpu/memory/gpu) and the accelerator type; sidecar untouched.
- `test_override_does_not_mutate_original_pod_template` — override returns a new `TaskDetails` without mutating the source.
- Existing container-path override tests still pass (67 passed in `test_task.py` + `test_pod_template.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)