### PR TITLE
feat(agents): decouple MemoryStore from Agent

### DIFF
--- a/examples/agents/codemode_durable_agent_ui.py
+++ b/examples/agents/codemode_durable_agent_ui.py
@@ -237,9 +237,9 @@ agent = CodeModeAgent(
 
 
 @task_env.task(report=True)
-async def codemode_agent_task_entrypoint(message: str, history: list[dict[str, str]]) -> dict[str, object]:
+async def codemode_agent_task_entrypoint(message: str, memory: list[dict[str, str]]) -> dict[str, object]:
     """Entrypoint for the durable CodeModeAgent analysis inside a Flyte task."""
-    result = await agent.run.aio(message, history=history)
+    result = await agent.run.aio(message, memory=memory)
     return {
         "code": result.code,
         "charts": result.charts,

--- a/examples/agents/codemode_durable_task_agent.py
+++ b/examples/agents/codemode_durable_task_agent.py
@@ -123,7 +123,7 @@ agent = CodeModeAgent(
 @task_env.task(report=True)
 async def analyze(request: str) -> str:
     """Run a durable CodeModeAgent analysis inside a Flyte task."""
-    result = await agent.run.aio(request, history=[])
+    result = await agent.run.aio(request, memory=[])
     return result.summary or result.error or ""
 
 

--- a/examples/agents/flyte_agent/README.md
+++ b/examples/agents/flyte_agent/README.md
@@ -55,8 +55,8 @@ the chat UI, webhook handlers, and structured loggers subscribe to.
 
 | Context | Call |
 |---------|------|
-| Scripts, notebooks, sync code | `result = agent.run(message, history=[])` |
-| `async def` tasks / handlers | `result = await agent.run.aio(message, history=[])` |
+| Scripts, notebooks, sync code | `result = agent.run(message, memory=[])` |
+| `async def` tasks / handlers | `result = await agent.run.aio(message, memory=[])` |
 
 `AgentChatAppEnvironment` calls `agent.run.aio` automatically when chat
 requests are routed to the agent directly (without a parent task entrypoint).
@@ -67,7 +67,7 @@ requests are routed to the agent directly (without a parent task entrypoint).
 |------|---------------|
 | `basic_agent.py` | Minimal agent — plain async tools, sync `agent.run()` from the CLI. |
 | `scheduled_triage_agent.py` | Agent that wakes daily via `flyte.Cron`, uses durable Flyte tasks. |
-| `agent_with_memory.py` | Persist `MemoryStore` (transcript + artifacts) to `flyte.io.Dir` between task invocations. |
+| `agent_with_memory.py` | Pass a keyed `MemoryStore` into `agent.run(message, memory=...)`; the transcript is auto-saved and persists across runs. |
 | `hitl_approval_agent.py` | Gate sensitive tools behind human approval (`flyteplugins-hitl`). |
 | `agent_chat_ui.py` | Wrap an `Agent` in the built-in `AgentChatAppEnvironment` UI. |
 | `mcp_powered_agent.py` | Mix local Flyte task tools with remote MCP servers. |

--- a/examples/agents/flyte_agent/agent_chat_ui.py
+++ b/examples/agents/flyte_agent/agent_chat_ui.py
@@ -129,9 +129,9 @@ agent = Agent(
 
 
 @task_env.task(report=True)
-async def chat_entrypoint(message: str, history: list[dict[str, Any]]) -> dict[str, Any]:
+async def chat_entrypoint(message: str, memory: list[dict[str, Any]]) -> dict[str, Any]:
     """Parent task that owns the agent loop and the nested tool tasks."""
-    result = await agent.run.aio(message, history=history)
+    result = await agent.run.aio(message, memory=memory)
     return {
         "summary": result.summary,
         "error": result.error,

--- a/examples/agents/flyte_agent/agent_with_memory.py
+++ b/examples/agents/flyte_agent/agent_with_memory.py
@@ -1,26 +1,39 @@
 """Long-lived agent that persists memory to a keyed blob-store namespace.
 
 This example shows how to give a :class:`flyte.ai.agents.Agent` continuity
-across runs by loading a deterministic :class:`~flyte.ai.agents.MemoryStore`
-with ``MemoryStore.get_or_create(key=...)``.
+across runs *functionally*: memory is not attached to the agent, it is passed
+into :meth:`Agent.run` per call and returned on the result.
 
 Use case: a recurring assistant that remembers context across wakeups (e.g. an
 "inbox triage" agent that recalls which threads it has already responded to,
 or a research agent that builds up its scratchpad over many days).
 
-The store lives under the stable raw-data root in the Flyte-managed
-``agents/memory-store/v0`` namespace. It holds ``messages.json`` (the live
-transcript), an opt-in ``audit/log.jsonl`` audit trail, and any path-addressed
-artifacts the agent / its tools have written.
+How memory flows
+----------------
+
+1. The caller loads (or creates) a deterministic, keyed store with
+   ``MemoryStore.get_or_create(key=...)``. It lives under the stable raw-data
+   root in the Flyte-managed ``agents/memory-store/v0`` namespace.
+2. The store is handed to ``agent.run(message, memory=store)``. The agent
+   prepends the prior transcript, runs the tool-use loop, and appends the new
+   transcript back to the store. No ``agent.memory = ...`` assignment.
+3. The caller saves the updated store with ``memory.save()`` (saving is
+   explicit, not magic). The same (updated) store is also returned on
+   ``result.memory``.
+
+Note that tools never touch the ``MemoryStore``: they are plain functions and
+their effects are captured in the conversation transcript, which is what gives
+the agent continuity. The store's path-addressed artifacts / audit / version
+features remain available to the *caller* (not tools) via
+``memory.read_json`` / ``memory.write_json`` when richer state is needed.
 """
 
 from __future__ import annotations
 
 import flyte
-from flyte.ai.agents import Agent, ConcurrencyError, MemoryStore
+from flyte.ai.agents import Agent, MemoryStore
 
 MEMORY_KEY = "my-assistant"
-NOTES_PATH = "notes/notes.json"
 
 env = flyte.TaskEnvironment(
     name="persistent-agent",
@@ -31,59 +44,26 @@ env = flyte.TaskEnvironment(
 
 
 @env.task
-async def add_note(note: str) -> str:
-    """Save a free-form note to the agent's scratchpad.
+async def current_time() -> str:
+    """Return the current UTC time as an ISO-8601 string.
 
-    Returns a short acknowledgement string.
+    A plain, stateless tool: it knows nothing about the agent's memory. Whatever
+    it returns is recorded in the transcript, so the agent can recall it later.
     """
-    memory = await MemoryStore.get_or_create.aio(key=MEMORY_KEY)
-    notes = await memory.read_json.aio(NOTES_PATH, default=[])
-    sha = await memory.current_sha.aio(NOTES_PATH)
-    notes.append(note)
-    try:
-        await memory.write_json.aio(NOTES_PATH, notes, expected_sha=sha, reason="agent note")
-    except ConcurrencyError:
-        # Another tool/task updated the notes between our read and write.
-        # Surface a retryable result to the agent rather than silently dropping
-        # memory.
-        return "Memory changed while saving the note; please retry add_note."
-    await memory.save.aio()
-    return f"Noted: {note}"
+    from datetime import datetime, timezone
 
-
-@env.task
-async def list_history(count: int = 5) -> str:
-    """Return recent persisted notes and conversation messages."""
-    memory = await MemoryStore.get_or_create.aio(key=MEMORY_KEY)
-    notes = await memory.read_json.aio(NOTES_PATH, default=[])
-    recent_notes = notes[-count:]
-    recent_messages = memory.messages[-count:]
-
-    parts: list[str] = []
-    if recent_notes:
-        parts.append("Persisted notes:\n" + "\n".join(f"- {note}" for note in recent_notes))
-    if recent_messages:
-        msg_lines = []
-        for msg in recent_messages:
-            role = msg.get("role", "unknown")
-            content = str(msg.get("content", ""))
-            if content:
-                msg_lines.append(f"- {role}: {content}")
-        if msg_lines:
-            parts.append("Recent transcript:\n" + "\n".join(msg_lines))
-    return "\n\n".join(parts) if parts else "No persisted memory found yet."
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
 
 agent = Agent(
     name="memory-assistant",
     instructions=(
-        "You are a continuity-aware assistant. You can record notes and look "
-        "up recent history. When the user asks you to remember something, call "
-        "add_note. When the user asks you to recall something, call list_history "
-        "and answer from the returned persisted notes."
+        "You are a continuity-aware assistant. You remember facts the user "
+        "shares with you across conversations because your prior transcript is "
+        "always available. When the user asks what time it is, call current_time."
     ),
     model="claude-haiku-4-5",
-    tools=[add_note, list_history],
+    tools=[current_time],
     max_turns=12,
 )
 
@@ -98,17 +78,16 @@ async def chat(message: str, memory_key: str = MEMORY_KEY) -> str:
             continuity across runs.
 
     Returns:
-        The agent's reply. Memory is saved back to the keyed store before the
-        task returns.
+        The agent's reply. The updated memory is saved explicitly via
+        ``memory.save`` before this task returns.
     """
     memory = await MemoryStore.get_or_create.aio(key=memory_key)
     flyte.logger.info("Restored %d prior messages from memory.", len(memory.messages))
 
-    agent.memory = memory
-    result = await agent.run.aio(message)
-
-    # Persist the updated transcript (and any tool-written artifacts) back to the
-    # deterministic key path so the next run picks up where this one left off.
+    # The agent prepends the prior transcript and appends this turn back onto the
+    # store, returning it on ``result.memory``. Saving is explicit: persist the
+    # updated transcript to the deterministic key path before returning.
+    result = await agent.run.aio(message, memory=memory)
     await memory.save.aio()
     return result.summary or result.error
 

--- a/examples/agents/sales_agent.py
+++ b/examples/agents/sales_agent.py
@@ -15,7 +15,7 @@ Architecture::
 
     Browser (FastAPI Chat UI)
       └── AgentChatAppEnvironment
-            └── CodeModeAgent.run.aio(message, history)  # async HTTP handler
+            └── CodeModeAgent.run.aio(message, memory)  # async HTTP handler
                   ├── LLM call (generate code using tool functions)
                   ├── Monty sandbox execution
                   └── retry on failure

--- a/src/flyte/ai/agents/agent.py
+++ b/src/flyte/ai/agents/agent.py
@@ -217,12 +217,6 @@ class Agent:
     call_llm:
         Optional async callback ``(model, system, messages, tools) -> LLMMessage``.
         Defaults to :func:`_default_call_llm` (uses litellm).
-    memory:
-        Optional :class:`MemoryStore` initialized from a previous session.
-        When provided, the existing transcript is prepended to every
-        conversation and the in-flight transcript is appended to it on each
-        call. Tools may also use the same instance for path-addressed
-        artifact reads / writes (with audit + optional concurrency).
     approval_callback:
         Optional async callback ``(tool, args) -> bool`` invoked when a tool
         with ``requires_approval=True`` is about to run. Defaults to a HITL
@@ -241,7 +235,6 @@ class Agent:
     skills: Sequence[str | pathlib.Path] = field(default_factory=tuple)
     max_turns: int = 25
     call_llm: LLMCallable = field(default=_default_call_llm)
-    memory: MemoryStore | None = None
     approval_callback: ApprovalCallback = field(default=_hitl_approval)
     parallel_tool_calls: bool = True
 
@@ -364,7 +357,7 @@ class Agent:
     async def run(
         self,
         message: str,
-        history: list[dict[str, Any]] | None = None,
+        memory: list[dict[str, Any]] | MemoryStore | None = None,
     ) -> AgentResult:
         """Drive the LLM ↔ tool loop until the assistant returns a final reply.
 
@@ -372,23 +365,47 @@ class Agent:
         instances can be plugged directly into
         :class:`~flyte.ai.chat.AgentChatAppEnvironment`.
 
+        The agent is decoupled from any persistent state: memory is passed in
+        per call rather than attached to the agent. ``memory`` may be:
+
+        - ``None``: a stateless, single-shot conversation.
+        - a ``list[dict]``: prior messages to prepend (e.g. a chat ``history``).
+          The returned :class:`AgentResult` carries no memory in this case.
+        - a :class:`MemoryStore`: its transcript is prepended, the in-flight
+          transcript is appended back to it, and it is returned on
+          :attr:`AgentResult.memory`. Persistence is the caller's
+          responsibility: call ``memory.save()`` (or ``.save.aio()``) after
+          ``run`` to write the updated transcript back to its keyed remote path.
+
         Call synchronously via ``run(...)``; in async contexts use ``run.aio(...)``.
         """
         await self._ensure_mcp_loaded()
         await _emit(AgentEvent("agent_start", {"name": self.name, "model": self.model}))
         t0 = time.monotonic()
 
+        store: MemoryStore | None = memory if isinstance(memory, MemoryStore) else None
         prior: list[dict[str, Any]] = []
-        if self.memory is not None:
-            prior.extend(self.memory.messages)
-        if history:
-            prior.extend(history)
+        if store is not None:
+            prior.extend(store.messages)
+        elif isinstance(memory, list):
+            prior.extend(memory)
         messages: list[dict[str, Any]] = [*prior, {"role": "user", "content": message}]
 
         tools_schema = self._llm_tools()
         attempts = 0
         last_text = ""
         error_msg = ""
+
+        def _finalize_memory() -> MemoryStore | None:
+            """Append the in-flight transcript back to the store and return it.
+
+            Persistence is left to the caller: ``run`` mutates the passed
+            :class:`MemoryStore` in place and returns it, but does not save it.
+            """
+            if store is None:
+                return None
+            store.extend(messages[len(prior) :])
+            return store
 
         for turn in range(self.max_turns):
             attempts = turn + 1
@@ -404,9 +421,8 @@ class Agent:
             except Exception as exc:
                 error_msg = f"LLM call failed on turn {attempts}: {exc}"
                 await _emit(AgentEvent("agent_end", {"error": error_msg, "turns": attempts}))
-                if self.memory is not None:
-                    self.memory.extend(messages[len(prior) :])
-                return AgentResult(error=error_msg, attempts=attempts, summary=last_text)
+                result_memory = _finalize_memory()
+                return AgentResult(error=error_msg, attempts=attempts, summary=last_text, memory=result_memory)
 
             assistant_msg: dict[str, Any] = {"role": "assistant", "content": llm_msg.content or ""}
             if llm_msg.tool_calls:
@@ -458,8 +474,7 @@ class Agent:
         else:
             error_msg = f"Reached max_turns={self.max_turns} without producing a final answer."
 
-        if self.memory is not None:
-            self.memory.extend(messages[len(prior) :])
+        result_memory = _finalize_memory()
 
         elapsed = int((time.monotonic() - t0) * 1000)
         await _emit(
@@ -468,7 +483,7 @@ class Agent:
                 {"turns": attempts, "elapsed_ms": elapsed, "error": error_msg, "summary_len": len(last_text)},
             )
         )
-        return AgentResult(summary=last_text, error=error_msg, attempts=attempts)
+        return AgentResult(summary=last_text, error=error_msg, attempts=attempts, memory=result_memory)
 
     async def _execute_calls(
         self,

--- a/src/flyte/ai/agents/codemode.py
+++ b/src/flyte/ai/agents/codemode.py
@@ -21,6 +21,7 @@ import flyte
 import flyte.sandbox
 from flyte.syncify import syncify
 
+from .memory import MemoryStore
 from .protocol import AgentResult
 
 # Per-request progress hook for UIs (e.g. Agent Chat NDJSON stream). Set by the
@@ -321,12 +322,21 @@ class CodeModeAgent:
     # ------------------------------------------------------------------
 
     @syncify
-    async def run(self, message: str, history: list[dict[str, str]]) -> AgentResult:
+    async def run(
+        self,
+        message: str,
+        memory: list[dict[str, Any]] | MemoryStore | None = None,
+    ) -> AgentResult:
         """Generate code, execute in sandbox, retry on failure.
+
+        ``memory`` may be a ``list[dict]`` of prior messages (e.g. a chat
+        ``history``) or a :class:`MemoryStore` whose transcript is used as prior
+        context. Only the prior messages are read here.
 
         Call synchronously via ``run(...)``; in async contexts use ``run.aio(...)``.
         """
-        messages: list[dict[str, str]] = [*history, {"role": "user", "content": message}]
+        prior: list[dict[str, Any]] = list(memory.messages) if isinstance(memory, MemoryStore) else (memory or [])
+        messages: list[dict[str, Any]] = [*prior, {"role": "user", "content": message}]
         max_attempts = 1 + self._max_retries
 
         try:

--- a/src/flyte/ai/agents/memory.py
+++ b/src/flyte/ai/agents/memory.py
@@ -35,6 +35,8 @@ from datetime import datetime, timezone
 from typing import Any, Sequence, cast
 from urllib.parse import quote, urlparse
 
+from mashumaro.types import SerializableType
+
 import flyte.storage as storage
 from flyte._context import internal_ctx
 from flyte.io import Dir
@@ -305,7 +307,7 @@ class _MemoryStoreExists:
 
 
 @dataclass
-class MemoryStore:
+class MemoryStore(SerializableType):
     """Conversation transcript + path-addressed artifact memory backed by :class:`flyte.io.Dir`.
 
     The construct combines two complementary stores:
@@ -318,13 +320,14 @@ class MemoryStore:
       :meth:`read_json` / :meth:`list_paths` for arbitrary named blobs that
       should round-trip through Flyte object storage.
 
-    Persistence is :class:`flyte.io.Dir`-backed. For durable agent memories,
-    prefer :meth:`create` or :meth:`get_or_create`; keyed stores save to a
-    deterministic blob-store namespace under the active Flyte raw-data bucket.
-    Lower-level callers can still call :meth:`save` directly to persist the
-    working root. :meth:`create`, :meth:`get_or_create`, and :meth:`save` are
-    sync-by-default (``MemoryStore.create(...)``) with an ``.aio(...)`` companion
-    for async call sites, mirroring the rest of the Flyte SDK.
+    Persistence is :class:`flyte.io.Dir`-backed. Obtain a store via
+    :meth:`create` or :meth:`get_or_create`; it saves to a deterministic
+    blob-store namespace under the active Flyte raw-data bucket, derived from
+    its ``key``. :meth:`save` always targets that deterministic
+    :attr:`remote_path`. :meth:`create`, :meth:`get_or_create`, and
+    :meth:`save` are sync-by-default (``MemoryStore.create(...)``) with an
+    ``.aio(...)`` companion for async call sites, mirroring the rest of the
+    Flyte SDK.
 
     The on-disk layout under ``root`` looks like::
 
@@ -355,8 +358,17 @@ class MemoryStore:
     version simply dispatches the sync version to a background thread via
     :func:`asyncio.to_thread`.
 
+    Every :class:`MemoryStore` is **keyed**: it is bound to a deterministic
+    blob-store namespace derived from its ``key``. Obtain one via
+    :meth:`create` or :meth:`get_or_create` (the recommended entry points);
+    direct construction is supported for serialization / advanced use but still
+    requires a ``key``. There is no such thing as an unkeyed / ephemeral store.
+
     Parameters
     ----------
+    key:
+        Deterministic memory key (a single path segment). Determines the
+        durable :attr:`remote_path` under the active raw-data root.
     messages:
         Pre-existing conversation transcript. Defaults to empty.
     root:
@@ -364,11 +376,12 @@ class MemoryStore:
         temporary directory is created (and automatically cleaned up when
         the :class:`MemoryStore` is garbage-collected). When pointing at an
         existing directory that contains ``messages.json``, the transcript
-        is auto-loaded.
-    key:
-        Optional deterministic memory key. Usually set by :meth:`create` or
-        :meth:`get_or_create`; keyed stores save back to their computed
-        ``remote_path`` unless explicitly reloaded without a key.
+        is auto-loaded. This is an internal staging directory; callers
+        normally never set it.
+    remote_path:
+        Durable destination for :meth:`save`. Usually resolved from ``key``
+        (and the Flyte context) by :meth:`create` / :meth:`get_or_create`;
+        when omitted it is resolved lazily on first :meth:`save` / hydration.
     read_only_prefixes:
         Prefixes that direct writes are not permitted to target.
     audit:
@@ -377,9 +390,9 @@ class MemoryStore:
         Snapshot every successful write under ``versions/``.
     """
 
+    key: str
     messages: list[dict[str, Any]] = field(default_factory=list)
     root: pathlib.Path | str | None = None
-    key: str | None = None
     remote_path: str | None = None
     read_only_prefixes: tuple[str, ...] = ()
     audit: bool = True
@@ -390,8 +403,8 @@ class MemoryStore:
     _root_real: pathlib.Path = field(init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
-        if self.key is not None:
-            self.key = _ensure_namespace_segment(self.key, name="key")
+        # Every store is keyed; an empty/invalid key is rejected up front.
+        self.key = _ensure_namespace_segment(self.key, name="key")
 
         explicit_root = self.root is not None
         if explicit_root:
@@ -403,6 +416,12 @@ class MemoryStore:
         resolved.mkdir(parents=True, exist_ok=True)
         self.root = resolved
         self._root_real = resolved.resolve()
+
+        # Whether the local working root still needs to be populated from the
+        # keyed ``remote_path``. Stores produced locally (fresh or via an
+        # explicit root) are already authoritative; only stores rebuilt from a
+        # serialized payload (see :meth:`_deserialize`) defer the download.
+        self._needs_remote_hydration = False
 
         # Auto-load messages.json when pointing at an existing directory and
         # the user did not pre-seed messages explicitly.
@@ -418,6 +437,73 @@ class MemoryStore:
     def _root(self) -> pathlib.Path:
         """Return :attr:`root` narrowed to :class:`pathlib.Path` (always set after ``__post_init__``)."""
         return cast(pathlib.Path, self.root)
+
+    def _require_remote_path(self) -> str:
+        """Return :attr:`remote_path`, resolving it from :attr:`key` on first use.
+
+        Resolution needs the active Flyte context (org / project / domain); it is
+        deferred until a durable operation (:meth:`save` / hydration) actually
+        needs it so a store can be constructed outside a task context.
+        """
+        if self.remote_path is None:
+            self.remote_path = self.remote_path_for_key(key=self.key)
+        return self.remote_path
+
+    # ------------------------------------------------------------------
+    # Flyte I/O serialization (mashumaro SerializableType)
+    # ------------------------------------------------------------------
+
+    def _serialize(self) -> dict[str, Any]:
+        """Serialize to a Flyte-portable payload (msgpack-native types only).
+
+        The local working directory is intentionally omitted: keyed stores are
+        re-hydrated from :attr:`remote_path` on first local access (see
+        :meth:`_ensure_hydrated`), and the transcript travels inline so common
+        message-only consumers need no download.
+        """
+        return {
+            "messages": self.messages,
+            "key": self.key,
+            "remote_path": self.remote_path,
+            "read_only_prefixes": list(self.read_only_prefixes),
+            "audit": self.audit,
+            "keep_versions": self.keep_versions,
+        }
+
+    @classmethod
+    def _deserialize(cls, value: dict[str, Any]) -> "MemoryStore":
+        """Rebuild a store from a :meth:`_serialize` payload.
+
+        The store is created against a fresh local working directory; when it is
+        keyed, the working directory is downloaded from :attr:`remote_path` lazily
+        on first artifact access / save.
+        """
+        store = cls(
+            messages=list(value.get("messages") or []),
+            key=value["key"],
+            remote_path=value.get("remote_path"),
+            read_only_prefixes=tuple(value.get("read_only_prefixes") or ()),
+            audit=value.get("audit", True),
+            keep_versions=value.get("keep_versions", False),
+        )
+        # Defer pulling artifacts/audit/versions from the remote until they are
+        # actually needed; ``messages`` already round-tripped inline.
+        store._needs_remote_hydration = store.remote_path is not None
+        return store
+
+    async def _ensure_hydrated(self) -> None:
+        """Populate the local working root from ``remote_path`` if still pending.
+
+        No-op for stores produced locally and for keyed stores that have already
+        been hydrated. The inline transcript is authoritative and never clobbered
+        by the downloaded ``messages.json``.
+        """
+        if not getattr(self, "_needs_remote_hydration", False):
+            return
+        remote_path = self._require_remote_path()
+        if await self._remote_store_exists(remote_path):
+            await Dir.from_existing_remote(remote_path).download(local_path=str(self._root))
+        self._needs_remote_hydration = False
 
     # ------------------------------------------------------------------
     # Keyed remote stores
@@ -617,6 +703,7 @@ class MemoryStore:
 
         Sync-by-default (``memory.read_text(...)``) with an ``.aio(...)`` companion.
         """
+        await self._ensure_hydrated()
         try:
             return self._abs(rel_path).read_text(encoding="utf-8")
         except FileNotFoundError:
@@ -675,6 +762,7 @@ class MemoryStore:
 
         Sync-by-default (``memory.get_meta(...)``) with an ``.aio(...)`` companion.
         """
+        await self._ensure_hydrated()
         mp = self._meta_path(rel_path)
         if not mp.exists():
             return None
@@ -732,6 +820,7 @@ class MemoryStore:
         Returns:
             The :class:`MemoryMeta` describing the new content.
         """
+        await self._ensure_hydrated()
         rel = _ensure_relative_posix(rel_path)
         self._assert_can_write(rel)
 
@@ -852,26 +941,23 @@ class MemoryStore:
         await asyncio.to_thread(self.flush_messages_sync)
 
     @syncify
-    async def save(self, remote_destination: str | None = None) -> Dir:
-        """Serialize this memory to a remote directory.
+    async def save(self) -> Dir:
+        """Serialize this memory to its deterministic keyed remote path.
 
         Call synchronously via ``memory.save(...)``; in async contexts use
         ``memory.save.aio(...)``.
 
         Flushes the conversation transcript to ``messages.json`` under the working
         root, then uploads the whole root (live files plus audit log, metadata
-        sidecars, and any version snapshots) to ``remote_destination``.
+        sidecars, and any version snapshots) to :attr:`remote_path` (resolved
+        from :attr:`key` if not already set).
         """
-        if self.remote_path is not None:
-            if remote_destination is not None and remote_destination != self.remote_path:
-                raise MemoryStoreError(
-                    "Keyed MemoryStores are saved to their deterministic key path; "
-                    f"got remote_destination={remote_destination!r}, expected {self.remote_path!r}"
-                )
-            remote_destination = self.remote_path
+        remote_destination = self._require_remote_path()
+        # Pull any remote artifacts/audit/versions into the local root before we
+        # re-upload, so a store received as a task input does not overwrite the
+        # keyed remote with an empty working directory.
+        await self._ensure_hydrated()
         await self.flush_messages()
-        if remote_destination is None:
-            return await Dir.from_local(str(self._root), remote_destination=None)
 
         # fsspec nests ``put(local_dir, dest)`` under ``dest/<basename>/`` whenever ``dest``
         # already exists (local and remote alike). Trailing slashes on both sides copy the
@@ -887,7 +973,7 @@ class MemoryStore:
         cls,
         dir: Dir,
         *,
-        key: str | None = None,
+        key: str,
         remote_path: str | None = None,
         read_only_prefixes: tuple[str, ...] = (),
         audit: bool = True,

--- a/src/flyte/ai/agents/protocol.py
+++ b/src/flyte/ai/agents/protocol.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from .memory import MemoryStore
 
 
 @dataclass
@@ -15,6 +18,7 @@ class AgentResult:
     summary: str = ""
     error: str = ""
     attempts: int = 1
+    memory: "MemoryStore | None" = None
 
 
 @runtime_checkable
@@ -23,8 +27,11 @@ class AgentProtocol(Protocol):
     :class:`AgentChatAppEnvironment`.
     """
 
-    def run(self, message: str, history: list[dict[str, str]]) -> AgentResult:
-        """Process *message* (with prior *history*) and return an :class:`AgentResult`.
+    def run(self, message: str, memory: list[dict[str, Any]] | "MemoryStore" | None = None) -> AgentResult:
+        """Process *message* (with prior *memory*) and return an :class:`AgentResult`.
+
+        ``memory`` may be a ``list[dict]`` of prior messages (e.g. a chat
+        ``history``) or a :class:`MemoryStore` for durable, cross-run state.
 
         Synchronous entry point. In async contexts, use ``run.aio(...)``.
         """

--- a/src/flyte/ai/chat/app.py
+++ b/src/flyte/ai/chat/app.py
@@ -381,6 +381,8 @@ class AgentChatAppEnvironment(flyte.app.AppEnvironment):
             progress_queue: asyncio.Queue[str | None] | None = None,
         ) -> AgentResult:
             if task_entrypoint is None:
+                # ``history`` is a ``list[dict]`` of prior messages; ``Agent.run`` accepts
+                # that directly as its ``memory`` argument (alongside a ``MemoryStore``).
                 result_obj: Any = await agent.run.aio(chat_req.message, chat_req.history)
             else:
                 import flyte

--- a/tests/flyte/ai/agents/test_agent.py
+++ b/tests/flyte/ai/agents/test_agent.py
@@ -572,45 +572,51 @@ class TestApproval:
 @pytest.mark.asyncio
 class TestMemoryStore:
     async def test_default_root_is_temp_dir(self):
-        memory = MemoryStore()
+        memory = MemoryStore(key="test")
         assert memory.root is not None and memory.root.exists()
         assert memory.messages == []
 
+    async def test_key_is_required(self):
+        with pytest.raises(TypeError):
+            MemoryStore()  # type: ignore[call-arg]
+
     async def test_explicit_root_auto_loads_messages(self, tmp_path: pathlib.Path):
-        seed = MemoryStore(root=tmp_path)
+        seed = MemoryStore(key="test", root=tmp_path)
         seed.append({"role": "user", "content": "hello"})
         seed.append({"role": "assistant", "content": "hi"})
         seed.flush_messages_sync()
 
-        restored = MemoryStore(root=tmp_path)
+        restored = MemoryStore(key="test", root=tmp_path)
         assert [m["content"] for m in restored.messages] == ["hello", "hi"]
 
     async def test_flush_messages_async_persists_transcript(self, tmp_path: pathlib.Path):
-        seed = MemoryStore(root=tmp_path)
+        seed = MemoryStore(key="test", root=tmp_path)
         seed.append({"role": "user", "content": "hello-async"})
         await seed.flush_messages()
 
-        restored = MemoryStore(root=tmp_path)
+        restored = MemoryStore(key="test", root=tmp_path)
         assert [m["content"] for m in restored.messages] == ["hello-async"]
 
     async def test_corrupt_messages_json_logs_and_resets(self, tmp_path: pathlib.Path):
         (tmp_path / "messages.json").write_text("not json", encoding="utf-8")
-        memory = MemoryStore(root=tmp_path)
+        memory = MemoryStore(key="test", root=tmp_path)
         assert memory.messages == []
 
     async def test_explicit_messages_take_precedence_over_disk(self, tmp_path: pathlib.Path):
-        seed = MemoryStore(root=tmp_path)
+        seed = MemoryStore(key="test", root=tmp_path)
         seed.append({"role": "user", "content": "old"})
         seed.flush_messages_sync()
 
-        restored = MemoryStore(root=tmp_path, messages=[{"role": "user", "content": "fresh"}])
+        restored = MemoryStore(key="test", root=tmp_path, messages=[{"role": "user", "content": "fresh"}])
         assert [m["content"] for m in restored.messages] == ["fresh"]
 
     async def test_memory_persists_conversation(self):
-        memory = MemoryStore()
+        memory = MemoryStore(key="test")
         llm = _make_llm([LLMMessage(content="ack", tool_calls=[])])
-        agent = Agent(name="t", instructions="I", call_llm=llm, memory=memory)
-        await agent.run.aio("hi", [])
+        agent = Agent(name="t", instructions="I", call_llm=llm)
+        result = await agent.run.aio("hi", memory=memory)
+        # The store is mutated in place and returned on the result.
+        assert result.memory is memory
         roles = [m["role"] for m in memory.messages]
         assert roles == ["user", "assistant"]
         assert memory.messages[0]["content"] == "hi"
@@ -618,15 +624,60 @@ class TestMemoryStore:
 
     async def test_memory_prepended_to_next_run(self):
         memory = MemoryStore(
-            messages=[{"role": "user", "content": "remember this"}, {"role": "assistant", "content": "noted"}]
+            key="test",
+            messages=[{"role": "user", "content": "remember this"}, {"role": "assistant", "content": "noted"}],
         )
         llm = _make_llm([LLMMessage(content="ok", tool_calls=[])])
-        agent = Agent(name="t", instructions="I", call_llm=llm, memory=memory)
-        await agent.run.aio("hi", [])
+        agent = Agent(name="t", instructions="I", call_llm=llm)
+        await agent.run.aio("hi", memory=memory)
         _, _, messages, _ = llm.await_args_list[0].args
         contents = [m["content"] for m in messages]
         assert "remember this" in contents
         assert "noted" in contents
+
+    async def test_result_memory_none_for_list_history(self):
+        llm = _make_llm([LLMMessage(content="ack", tool_calls=[])])
+        agent = Agent(name="t", instructions="I", call_llm=llm)
+        result = await agent.run.aio("hi", [{"role": "user", "content": "prior"}])
+        # A plain list history is not wrapped into a MemoryStore.
+        assert result.memory is None
+
+    async def test_run_does_not_save_memory(self):
+        """Saving is explicit: ``run`` mutates and returns the store but never saves it."""
+        memory = MemoryStore(key="k", remote_path="s3://bucket/agents/memory-store/v0/o/p/d/k")
+        llm = _make_llm([LLMMessage(content="ack", tool_calls=[])])
+        agent = Agent(name="t", instructions="I", call_llm=llm)
+        with patch.object(type(memory), "save") as mock_save:
+            mock_save.aio = AsyncMock(return_value=None)
+            result = await agent.run.aio("hi", memory=memory)
+            mock_save.aio.assert_not_awaited()
+        # The transcript is still updated in place for the caller to persist.
+        assert result.memory is memory
+        assert [m["content"] for m in memory.messages] == ["hi", "ack"]
+
+    async def test_memory_store_roundtrips_through_type_engine(self):
+        """MemoryStore can be passed as a Flyte task input/output (serializable dataclass)."""
+        from flyte.types import TypeEngine
+
+        memory = MemoryStore(
+            messages=[{"role": "user", "content": "hi"}, {"role": "assistant", "content": "ack"}],
+            key="k",
+            remote_path="s3://bucket/agents/memory-store/v0/o/p/d/k",
+            read_only_prefixes=("memory/",),
+            keep_versions=True,
+        )
+        lit_type = TypeEngine.to_literal_type(MemoryStore)
+        lv = await TypeEngine.to_literal(memory, MemoryStore, lit_type)
+        back = await TypeEngine.to_python_value(lv, MemoryStore)
+
+        assert isinstance(back, MemoryStore)
+        assert back.messages == memory.messages
+        assert back.key == "k"
+        assert back.remote_path == memory.remote_path
+        assert back.read_only_prefixes == ("memory/",)
+        assert back.keep_versions is True
+        # A rebuilt keyed store defers downloading its artifacts until first use.
+        assert back._needs_remote_hydration is True
 
 
 class TestRemotePathHelpers:
@@ -878,13 +929,6 @@ class TestMemoryStoreKeyedRemote:
             await MemoryStore.create.aio(key="my_memory", org="org", project="proj", domain="dev")
             assert await MemoryStore.exists(key="my_memory", org="org", project="proj", domain="dev")
 
-    async def test_keyed_save_rejects_non_deterministic_override(self, tmp_path: pathlib.Path):
-        ctx = internal_ctx().new_raw_data_path(RawDataPath(path=str(tmp_path / "raw")))
-        with ctx:
-            memory = await MemoryStore.create.aio(key="my_memory", org="org", project="proj", domain="dev")
-            with pytest.raises(MemoryStoreError, match="deterministic key path"):
-                await memory.save.aio(remote_destination=str(tmp_path / "elsewhere"))
-
     async def test_key_must_be_single_segment(self, tmp_path: pathlib.Path):
         ctx = internal_ctx().new_raw_data_path(RawDataPath(path=str(tmp_path / "raw")))
         with ctx:
@@ -913,7 +957,7 @@ class TestMemoryStoreSyncApi:
         assert [m["content"] for m in loaded.messages] == ["hi"]
 
     def test_path_addressed_io_sync(self, tmp_path: pathlib.Path):
-        memory = MemoryStore(root=tmp_path)
+        memory = MemoryStore(key="test", root=tmp_path)
         memory.write_text("notes/plan.md", "sync-step")
         assert memory.read_text("notes/plan.md") == "sync-step"
         memory.write_json("data/x.json", {"k": 1})
@@ -923,24 +967,24 @@ class TestMemoryStoreSyncApi:
 @pytest.mark.asyncio
 class TestMemoryStorePathAddressedIO:
     async def test_write_and_read_text_roundtrip(self, tmp_path: pathlib.Path):
-        memory = MemoryStore(root=tmp_path)
+        memory = MemoryStore(key="test", root=tmp_path)
         meta = await memory.write_text.aio("notes/plan.md", "step 1", actor="tester", reason="unit")
         assert meta.path == "notes/plan.md"
         assert meta.bytes == len(b"step 1")
         assert await memory.read_text.aio("notes/plan.md") == "step 1"
 
     async def test_write_and_read_json_roundtrip(self, tmp_path: pathlib.Path):
-        memory = MemoryStore(root=tmp_path)
+        memory = MemoryStore(key="test", root=tmp_path)
         await memory.write_json.aio("data/plan.json", {"a": 1, "b": [1, 2]})
         assert await memory.read_json.aio("data/plan.json") == {"a": 1, "b": [1, 2]}
 
     async def test_read_text_default_when_missing(self, tmp_path: pathlib.Path):
-        memory = MemoryStore(root=tmp_path)
+        memory = MemoryStore(key="test", root=tmp_path)
         assert await memory.read_text.aio("missing.txt", default="fallback") == "fallback"
         assert await memory.read_json.aio("missing.json", default={"x": 0}) == {"x": 0}
 
     async def test_list_paths_excludes_internals_and_messages(self, tmp_path: pathlib.Path):
-        memory = MemoryStore(root=tmp_path)
+        memory = MemoryStore(key="test", root=tmp_path)
         await memory.write_text.aio("user/a.txt", "a")
         await memory.write_text.aio("user/b.txt", "b")
         memory.append({"role": "user", "content": "hi"})
@@ -961,7 +1005,7 @@ class TestMemoryStorePathAddressedIO:
 
         root = tmp_path / "root"
         root.mkdir()
-        memory = MemoryStore(root=root)
+        memory = MemoryStore(key="test", root=root)
         await memory.write_text.aio("user/a.txt", "a")
 
         # Plant a symlink that ``list_paths`` must skip rather than expose.
@@ -972,11 +1016,11 @@ class TestMemoryStorePathAddressedIO:
         assert "user/leak.txt" not in paths
 
     async def test_list_paths_returns_empty_for_missing_prefix(self, tmp_path: pathlib.Path):
-        memory = MemoryStore(root=tmp_path)
+        memory = MemoryStore(key="test", root=tmp_path)
         assert memory.list_paths("does/not/exist") == []
 
     async def test_path_traversal_rejected(self, tmp_path: pathlib.Path):
-        memory = MemoryStore(root=tmp_path)
+        memory = MemoryStore(key="test", root=tmp_path)
         with pytest.raises(MemoryStoreError, match="traversal"):
             await memory.write_text.aio("../escape.txt", "no")
         with pytest.raises(MemoryStoreError, match="must be relative"):
@@ -996,7 +1040,7 @@ class TestMemoryStorePathAddressedIO:
         # malicious sidechannel.
         (root / "escape.txt").symlink_to(outside / "secret.txt")
 
-        memory = MemoryStore(root=root)
+        memory = MemoryStore(key="test", root=root)
         with pytest.raises(MemoryStoreError, match="outside the memory root"):
             await memory.read_text.aio("escape.txt")
         with pytest.raises(MemoryStoreError, match="outside the memory root"):
@@ -1005,12 +1049,12 @@ class TestMemoryStorePathAddressedIO:
         assert (outside / "secret.txt").read_text(encoding="utf-8") == "classified"
 
     async def test_messages_json_write_blocked(self, tmp_path: pathlib.Path):
-        memory = MemoryStore(root=tmp_path)
+        memory = MemoryStore(key="test", root=tmp_path)
         with pytest.raises(AccessDenied, match=r"messages\.json"):
             await memory.write_text.aio("messages.json", "{}")
 
     async def test_internal_prefixes_blocked(self, tmp_path: pathlib.Path):
-        memory = MemoryStore(root=tmp_path)
+        memory = MemoryStore(key="test", root=tmp_path)
         for path in ("audit/log.jsonl", "meta/x.json", "versions/x/y.txt"):
             with pytest.raises(AccessDenied, match="reserved"):
                 await memory.write_text.aio(path, "no")
@@ -1019,12 +1063,12 @@ class TestMemoryStorePathAddressedIO:
 @pytest.mark.asyncio
 class TestMemoryStoreReadOnlyPrefixes:
     async def test_writes_to_read_only_prefix_rejected(self, tmp_path: pathlib.Path):
-        memory = MemoryStore(root=tmp_path, read_only_prefixes=("memory/",))
+        memory = MemoryStore(key="test", root=tmp_path, read_only_prefixes=("memory/",))
         with pytest.raises(AccessDenied, match="read-only"):
             await memory.write_text.aio("memory/docs.txt", "no")
 
     async def test_writes_outside_read_only_prefix_allowed(self, tmp_path: pathlib.Path):
-        memory = MemoryStore(root=tmp_path, read_only_prefixes=("memory/",))
+        memory = MemoryStore(key="test", root=tmp_path, read_only_prefixes=("memory/",))
         await memory.write_text.aio("user/notes.txt", "ok")
         assert await memory.read_text.aio("user/notes.txt") == "ok"
 
@@ -1032,14 +1076,14 @@ class TestMemoryStoreReadOnlyPrefixes:
 @pytest.mark.asyncio
 class TestMemoryStoreConcurrency:
     async def test_expected_sha_match_succeeds(self, tmp_path: pathlib.Path):
-        memory = MemoryStore(root=tmp_path)
+        memory = MemoryStore(key="test", root=tmp_path)
         await memory.write_text.aio("a.txt", "v1")
         sha = await memory.current_sha.aio("a.txt")
         await memory.write_text.aio("a.txt", "v2", expected_sha=sha)
         assert await memory.read_text.aio("a.txt") == "v2"
 
     async def test_expected_sha_mismatch_raises(self, tmp_path: pathlib.Path):
-        memory = MemoryStore(root=tmp_path)
+        memory = MemoryStore(key="test", root=tmp_path)
         await memory.write_text.aio("a.txt", "v1")
         with pytest.raises(ConcurrencyError) as exc:
             await memory.write_text.aio("a.txt", "v2", expected_sha="deadbeef")
@@ -1047,12 +1091,12 @@ class TestMemoryStoreConcurrency:
         assert exc.value.expected_sha == "deadbeef"
 
     async def test_expected_sha_empty_for_create(self, tmp_path: pathlib.Path):
-        memory = MemoryStore(root=tmp_path)
+        memory = MemoryStore(key="test", root=tmp_path)
         await memory.write_text.aio("new.txt", "hello", expected_sha="")
         assert await memory.read_text.aio("new.txt") == "hello"
 
     async def test_current_sha_empty_when_missing(self, tmp_path: pathlib.Path):
-        memory = MemoryStore(root=tmp_path)
+        memory = MemoryStore(key="test", root=tmp_path)
         assert await memory.current_sha.aio("nope.txt") == ""
 
     async def test_current_sha_streams_files_without_sidecar(self, tmp_path: pathlib.Path):
@@ -1061,7 +1105,7 @@ class TestMemoryStoreConcurrency:
         root = tmp_path
         (root / "user").mkdir()
         (root / "user" / "raw.txt").write_text("raw-content", encoding="utf-8")
-        memory = MemoryStore(root=root)
+        memory = MemoryStore(key="test", root=root)
         expected = hashlib.sha256(b"raw-content").hexdigest()
         assert await memory.current_sha.aio("user/raw.txt") == expected
 
@@ -1069,7 +1113,7 @@ class TestMemoryStoreConcurrency:
 @pytest.mark.asyncio
 class TestMemoryStoreAudit:
     async def test_audit_records_create_then_update(self, tmp_path: pathlib.Path):
-        memory = MemoryStore(root=tmp_path)
+        memory = MemoryStore(key="test", root=tmp_path)
         await memory.write_text.aio("a.txt", "v1", actor="alice", reason="seed")
         await memory.write_text.aio("a.txt", "v2", actor="bob", reason="update")
         events = await memory.audit_tail()
@@ -1080,7 +1124,7 @@ class TestMemoryStoreAudit:
         assert events[1]["old_sha"] == events[0]["new_sha"]
 
     async def test_audit_disabled_writes_no_log(self, tmp_path: pathlib.Path):
-        memory = MemoryStore(root=tmp_path, audit=False)
+        memory = MemoryStore(key="test", root=tmp_path, audit=False)
         await memory.write_text.aio("a.txt", "v1")
         assert await memory.audit_tail() == []
         assert not (tmp_path / "audit" / "log.jsonl").exists()
@@ -1089,7 +1133,7 @@ class TestMemoryStoreAudit:
 @pytest.mark.asyncio
 class TestMemoryStoreVersions:
     async def test_keep_versions_snapshots_each_write(self, tmp_path: pathlib.Path):
-        memory = MemoryStore(root=tmp_path, keep_versions=True)
+        memory = MemoryStore(key="test", root=tmp_path, keep_versions=True)
         await memory.write_text.aio("a.txt", "v1")
         await memory.write_text.aio("a.txt", "v2")
         await memory.write_text.aio("a.txt", "v3")
@@ -1099,7 +1143,7 @@ class TestMemoryStoreVersions:
         assert contents == ["v1", "v2", "v3"]
 
     async def test_no_versions_by_default(self, tmp_path: pathlib.Path):
-        memory = MemoryStore(root=tmp_path)
+        memory = MemoryStore(key="test", root=tmp_path)
         await memory.write_text.aio("a.txt", "v1")
         assert not (tmp_path / "versions").exists()
 
@@ -1107,7 +1151,7 @@ class TestMemoryStoreVersions:
 @pytest.mark.asyncio
 class TestMemoryStoreMeta:
     async def test_meta_sidecar_records_actor_and_sha(self, tmp_path: pathlib.Path):
-        memory = MemoryStore(root=tmp_path)
+        memory = MemoryStore(key="test", root=tmp_path)
         meta = await memory.write_text.aio("a.txt", "hello", actor="tool-x", reason="seed")
         loaded = await memory.get_meta.aio("a.txt")
         assert loaded is not None
@@ -1117,14 +1161,14 @@ class TestMemoryStoreMeta:
         assert loaded.sha256 == meta.sha256
 
     async def test_get_meta_none_when_missing(self, tmp_path: pathlib.Path):
-        memory = MemoryStore(root=tmp_path)
+        memory = MemoryStore(key="test", root=tmp_path)
         assert await memory.get_meta.aio("nope.txt") is None
 
     async def test_meta_paths_distinct_for_collision_pair(self, tmp_path: pathlib.Path):
         # ``"a/b"`` and ``"a__b"`` would have collided on the old
         # ``replace("/", "__")`` encoding; the URL-quoted encoding keeps
         # their metadata sidecars and version histories distinct.
-        memory = MemoryStore(root=tmp_path, keep_versions=True)
+        memory = MemoryStore(key="test", root=tmp_path, keep_versions=True)
         await memory.write_text.aio("a/b", "first")
         await memory.write_text.aio("a__b", "second")
 
@@ -1376,24 +1420,25 @@ class TestDispatchEdgeCases:
 @pytest.mark.asyncio
 class TestMemoryPersistenceOnFailure:
     async def test_memory_retains_user_message_when_llm_errors(self):
-        memory = MemoryStore()
+        memory = MemoryStore(key="test")
         llm = AsyncMock(side_effect=RuntimeError("provider down"))
-        agent = Agent(name="t", instructions="I", call_llm=llm, memory=memory)
-        result = await agent.run.aio("remember me", [])
+        agent = Agent(name="t", instructions="I", call_llm=llm)
+        result = await agent.run.aio("remember me", memory=memory)
         assert "LLM call failed" in result.error
         # Even though the turn failed, the user message is committed to memory
         # so a later resume sees the in-flight prompt.
         assert [m["content"] for m in memory.messages] == ["remember me"]
+        assert result.memory is memory
 
     async def test_memory_retains_messages_when_max_turns_reached(self):
         looping = LLMMessage(
             content=None,
             tool_calls=[{"id": "loop", "name": "_add", "arguments": {"x": 0, "y": 0}}],
         )
-        memory = MemoryStore()
+        memory = MemoryStore(key="test")
         llm = AsyncMock(return_value=looping)
-        agent = Agent(name="t", instructions="I", tools=[_add], call_llm=llm, memory=memory, max_turns=2)
-        await agent.run.aio("loop forever", [])
+        agent = Agent(name="t", instructions="I", tools=[_add], call_llm=llm, max_turns=2)
+        await agent.run.aio("loop forever", memory=memory)
         roles = [m["role"] for m in memory.messages]
         assert roles[0] == "user"
         # Assistant + tool messages from the capped turns are persisted too.

--- a/tests/flyte/ai/agents/test_protocol.py
+++ b/tests/flyte/ai/agents/test_protocol.py
@@ -38,7 +38,10 @@ class TestAgentResult:
 
     def test_dataclass_fields(self):
         names = {f.name for f in fields(AgentResult)}
-        assert names == {"code", "charts", "summary", "error", "attempts"}
+        assert names == {"code", "charts", "summary", "error", "attempts", "memory"}
+
+    def test_memory_defaults_to_none(self):
+        assert AgentResult().memory is None
 
 
 class _MinimalAgent:


### PR DESCRIPTION
## Summary

Redesigns agent memory (`flyte.ai.agents`) to be more functional, decoupled, and easier to reason about.

- **MemoryStore is a serializable Flyte I/O type.** It implements mashumaro's `SerializableType`, so it can be passed as a task input/output. The transcript (`messages`) travels inline; the local working dir is transient and keyed stores hydrate their artifacts lazily from the remote path.
- **MemoryStore is keyed-only.** `key` is now required — there is no unkeyed/ephemeral store. `save()` always targets the deterministic keyed remote path (removed the `remote_destination` override and the `Dir.from_local` branch).
- **Agent is decoupled from memory.** Removed the `Agent.memory` field and the `agent.memory = ...` assignment. `Agent.run(message, memory=...)` accepts a `list[dict]` (chat history) **or** a `MemoryStore`, prepends the prior transcript, appends the new turn back onto the store, and returns it on `AgentResult.memory`.
- **Saving is explicit.** `run` never persists; the caller invokes `memory.save()` (e.g. right after `agent.run`). This removes hidden I/O from the loop.
- **Tools never touch MemoryStore.** Continuity comes from the auto-threaded transcript; the artifact/audit/version features remain available to the caller (not tools).

Also updates `AgentProtocol` / `CodeModeAgent.run` signatures (`history` -> `memory`), the chat app call site, and the agent examples (the `history` arg/usage is renamed to `memory`).

## Changes

- `src/flyte/ai/agents/memory.py`: `SerializableType` (`_serialize`/`_deserialize`), lazy `_ensure_hydrated`, required `key`, keyed-only `save()`, lazy `remote_path` resolution.
- `src/flyte/ai/agents/agent.py`: drop `memory` field; `run(message, memory=...)`; in-place transcript write-back; return `AgentResult.memory`.
- `src/flyte/ai/agents/protocol.py`: `AgentResult.memory` field; protocol `run` signature.
- `src/flyte/ai/agents/codemode.py`, `src/flyte/ai/chat/app.py`: signature/call-site updates.
- `examples/agents/**`: explicit `memory.save()` in the memory example; `history` -> `memory` renames.

## Test plan

- [x] `pytest tests/flyte/ai/agents tests/flyte/ai/chat` (230 passed)
- [x] `mypy` clean on changed sources (pre-commit hook)
- [x] Added a TypeEngine round-trip test proving `MemoryStore` survives a task I/O boundary
- [x] Added `test_run_does_not_save_memory` (explicit-save contract) and `test_key_is_required`
- [ ] Follow-ups (from review, not in this PR): trigger lazy-hydration coverage, end-to-end save+reload through `Agent.run`, transcript last-writer-wins docs

Made with [Cursor](https://cursor.com)