### PR TITLE
fix(storage): auto-size multipart parts so large uploads don't exceed the 10k-part limit

### DIFF
--- a/src/flyte/storage/_storage.py
+++ b/src/flyte/storage/_storage.py
@@ -32,6 +32,10 @@ BATCH_SIZE = int(os.getenv("FLYTE_IO_BATCH_SIZE", str(32)))
 # part size imposes a hard file-size ceiling (obstore's 5 MiB default => ~48.8 GiB). We instead
 # auto-scale the part size with the file size so uploads never run out of part numbers, while small
 # files keep small parts. Nothing here is user-tunable -- it just works.
+#
+# The floor and concurrency mirror obstore's own put/put_async defaults (chunk_size=5242880,
+# max_concurrency=12), defined here:
+# https://github.com/developmentseed/obstore/blob/c6279ce19f73eef89321179d55930d0dd7ba6a62/obstore/python/obstore/store.py#L500-L501
 _UPLOAD_CHUNK_FLOOR = 5 * 2**20  # 5 MiB -- obstore's own default; floor for small/multipart files
 _UPLOAD_MAX_CONCURRENCY = 12  # obstore's own default
 _MAX_SAFE_PARTS = 9000  # margin below the cloud 10,000-part hard limit

--- a/src/flyte/storage/_storage.py
+++ b/src/flyte/storage/_storage.py
@@ -28,6 +28,27 @@ if typing.TYPE_CHECKING:
 _OBSTORE_SUPPORTED_PROTOCOLS = ["s3", "gs", "abfs", "abfss"]
 BATCH_SIZE = int(os.getenv("FLYTE_IO_BATCH_SIZE", str(32)))
 
+# Multipart upload sizing. GCS and S3 both hard-cap a multipart upload at 10,000 parts, so a fixed
+# part size imposes a hard file-size ceiling (obstore's 5 MiB default => ~48.8 GiB). We instead
+# auto-scale the part size with the file size so uploads never run out of part numbers, while small
+# files keep small parts. Nothing here is user-tunable -- it just works.
+_UPLOAD_CHUNK_FLOOR = 5 * 2**20  # 5 MiB -- obstore's own default; floor for small/multipart files
+_UPLOAD_MAX_CONCURRENCY = 12  # obstore's own default
+_MAX_SAFE_PARTS = 9000  # margin below the cloud 10,000-part hard limit
+
+
+def _compute_upload_chunk_size(file_size: int | None) -> int:
+    """
+    Pick a multipart part size that keeps the part count under the cloud 10,000-part limit.
+
+    Returns the 5 MiB floor for small/unknown files, and scales up just enough (ceil division) for
+    large files so ``file_size / chunk_size <= _MAX_SAFE_PARTS``.
+    """
+    if not file_size:
+        return _UPLOAD_CHUNK_FLOOR
+    needed = -(-file_size // _MAX_SAFE_PARTS)  # integer ceil division
+    return max(_UPLOAD_CHUNK_FLOOR, needed)
+
 
 def _is_obstore_supported_protocol(protocol: str) -> bool:
     """
@@ -263,6 +284,56 @@ async def _get_from_filesystem(
     return str(to_path)
 
 
+async def _put_single_obstore(store: ObjectStore, local_path: str | pathlib.Path, remote_key: str) -> None:
+    """Upload a single local file to ``remote_key`` with an auto-sized multipart part size."""
+    chunk_size = _compute_upload_chunk_size(os.path.getsize(local_path))
+    # Passing a pathlib.Path streams the file from disk rather than reading it all into memory.
+    await store.put_async(
+        remote_key,
+        pathlib.Path(local_path),
+        chunk_size=chunk_size,
+        max_concurrency=_UPLOAD_MAX_CONCURRENCY,
+    )
+
+
+async def _put_obstore_bypass(from_path: str, to_path: str, recursive: bool = False) -> str:
+    """
+    Upload via the obstore native API so we can control multipart part sizing.
+
+    fsspec's obstore backend (``_put_file``) calls ``store.put_async`` without a ``chunk_size``,
+    leaving it pinned to obstore's 5 MiB default and thus a ~48.8 GiB hard ceiling (10,000 parts).
+    This bypass computes the part size from each file's size so uploads of any size succeed. Mirrors
+    the download-side ``_get_obstore_bypass`` / ``ObstoreParallelReader`` pattern.
+    """
+    import asyncio
+
+    fs = get_underlying_filesystem(path=to_path)
+    bucket, prefix = fs._split_path(to_path)  # pylint: disable=W0212
+    store: ObjectStore = fs._construct_store(bucket)
+
+    if not recursive:
+        logger.debug(f"Uploading single file {from_path} to {to_path}")
+        await _put_single_obstore(store, from_path, prefix)
+        return to_path
+
+    # Recursive: walk the local tree and upload each file, preserving its path relative to from_path.
+    source_root = pathlib.Path(from_path)
+    files = [p for p in source_root.rglob("*") if p.is_file()]
+    logger.debug(f"Uploading {len(files)} files recursively from {from_path} to {to_path}")
+
+    prefix_path = pathlib.PurePosixPath(prefix)
+    semaphore = asyncio.Semaphore(BATCH_SIZE)
+
+    async def _upload(local_file: pathlib.Path) -> None:
+        relative = local_file.relative_to(source_root).as_posix()
+        remote_key = str(prefix_path / relative)
+        async with semaphore:
+            await _put_single_obstore(store, local_file, remote_key)
+
+    await asyncio.gather(*(_upload(f) for f in files))
+    return to_path
+
+
 async def put(
     from_path: str,
     to_path: Optional[str] = None,
@@ -282,6 +353,16 @@ async def put(
 
     file_system = get_underlying_filesystem(path=to_path)
     from_path = strip_file_header(from_path)
+
+    # Check if we should use obstore bypass (to control multipart part sizing -- see
+    # _put_obstore_bypass). Guarded identically to the download bypass in get().
+    if (
+        _is_obstore_supported_protocol(file_system.protocol)
+        and hasattr(file_system, "_split_path")
+        and hasattr(file_system, "_construct_store")
+    ):
+        return await _put_obstore_bypass(from_path, to_path, recursive)
+
     if isinstance(file_system, AsyncFileSystem):
         dst = await file_system._put(from_path, to_path, recursive=recursive, batch_size=batch_size, **kwargs)  # pylint: disable=W0212
     else:

--- a/tests/internal/storage/test_storage.py
+++ b/tests/internal/storage/test_storage.py
@@ -1,3 +1,4 @@
+import math
 import os
 import tempfile
 import unittest
@@ -8,6 +9,10 @@ import pytest
 import flyte
 import flyte.storage as storage
 from flyte.storage._storage import (
+    _MAX_SAFE_PARTS,
+    _UPLOAD_CHUNK_FLOOR,
+    _UPLOAD_MAX_CONCURRENCY,
+    _compute_upload_chunk_size,
     _is_obstore_supported_protocol,
     _open_obstore_bypass,
 )
@@ -177,6 +182,94 @@ async def test_get_underlying_filesystem_upload_download(tmp_path, ctx_with_test
     downloaded_file_2 = tmp_path / "downloaded_2.txt"
     await storage.get(s3_path_2, str(downloaded_file_2))
     assert downloaded_file_2.exists()
+
+
+def test_compute_upload_chunk_size():
+    # Small / unknown files keep the 5 MiB floor.
+    assert _compute_upload_chunk_size(None) == _UPLOAD_CHUNK_FLOOR
+    assert _compute_upload_chunk_size(0) == _UPLOAD_CHUNK_FLOOR
+    assert _compute_upload_chunk_size(1024 * 1024) == _UPLOAD_CHUNK_FLOOR
+    # A file right at the 5 MiB * 9000 boundary still uses the floor.
+    assert _compute_upload_chunk_size(_UPLOAD_CHUNK_FLOOR * _MAX_SAFE_PARTS) == _UPLOAD_CHUNK_FLOOR
+
+    # Large files scale the part size up so the part count stays under the 10,000 hard limit.
+    big = 60 * 2**30  # 60 GiB -- well past the ~48.8 GiB ceiling of a fixed 5 MiB part size
+    cs = _compute_upload_chunk_size(big)
+    assert cs > _UPLOAD_CHUNK_FLOOR
+    assert math.ceil(big / cs) <= _MAX_SAFE_PARTS
+    assert math.ceil(big / cs) <= 10000
+
+
+class _FakeStore:
+    def __init__(self, captured):
+        self._captured = captured
+
+    async def put_async(self, remote_key, local, *, chunk_size, max_concurrency):
+        self._captured.append(
+            {
+                "remote_key": remote_key,
+                "local": str(local),
+                "chunk_size": chunk_size,
+                "max_concurrency": max_concurrency,
+            }
+        )
+
+
+class _FakeObstoreFS:
+    """Minimal stand-in for an obstore-backed AsyncFileSystem to exercise the put bypass."""
+
+    protocol = "gs"
+
+    def __init__(self, captured):
+        self._captured = captured
+
+    def _split_path(self, path):
+        p = path.replace("gs://", "")
+        bucket, _, key = p.partition("/")
+        return bucket, key
+
+    def _construct_store(self, bucket):
+        return _FakeStore(self._captured)
+
+
+@pytest.mark.asyncio
+async def test_put_routes_through_obstore_bypass(monkeypatch):
+    from flyte.storage import _storage
+
+    captured = []
+    monkeypatch.setattr(_storage, "get_underlying_filesystem", lambda path: _FakeObstoreFS(captured))
+
+    temp_file = tempfile.mktemp()
+    with open(temp_file, "wb") as f:  # noqa: ASYNC230
+        f.write(os.urandom(1024))
+
+    result = await storage.put(temp_file, "gs://bucket/path/to/obj")
+
+    assert result == "gs://bucket/path/to/obj"
+    assert len(captured) == 1
+    assert captured[0]["remote_key"] == "path/to/obj"
+    assert captured[0]["chunk_size"] == _UPLOAD_CHUNK_FLOOR
+    assert captured[0]["max_concurrency"] == _UPLOAD_MAX_CONCURRENCY
+
+
+@pytest.mark.asyncio
+async def test_put_obstore_bypass_recursive(monkeypatch):
+    from flyte.storage import _storage
+
+    captured = []
+    monkeypatch.setattr(_storage, "get_underlying_filesystem", lambda path: _FakeObstoreFS(captured))
+
+    src = tempfile.mkdtemp()
+    os.makedirs(os.path.join(src, "sub"))
+    for rel in ["a.txt", os.path.join("sub", "b.txt")]:
+        with open(os.path.join(src, rel), "wb") as f:  # noqa: ASYNC230
+            f.write(b"x")
+
+    await storage.put(src, "gs://bucket/prefix", recursive=True)
+
+    keys = sorted(c["remote_key"] for c in captured)
+    assert keys == ["prefix/a.txt", "prefix/sub/b.txt"]
+    assert all(c["max_concurrency"] == _UPLOAD_MAX_CONCURRENCY for c in captured)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

A user uploading a large `.fastq.gz` to GCS (Flyte v2) hit:

```
InvalidArgument: Part number, 10002, must be between 1 and 10000
```

**Root cause — not a GCS or obstore bug.** `flyte.storage.put()` delegated to fsspec → obstore-fsspec `_put_file`, which calls `store.put_async(...)` **without a `chunk_size`**, leaving it pinned to obstore's **5 MiB** default. GCS and S3 both **hard-cap multipart uploads at 10,000 parts**, so 5 MiB × 10,000 = a silent **~48.8 GiB (~52 GB) upload ceiling**. Any file above that fails at `partNumber=10001+`. (The reported "30 GB" file is larger than estimated — part 10002 ≈ a ~52 GB object at 5 MiB parts.)

The upload path exposed **no** way to raise the part size (downloads already have `FLYTE_IO_CHUNK_SIZE` / `MAX_CONCURRENCY` via `ObstoreParallelReader`; uploads had nothing).

## Fix

Auto-scale the multipart part size from the file size so the part count always stays under the limit — **fully automatic, no user-facing knob**:

- `_compute_upload_chunk_size(size)` → `max(5 MiB, ceil(size / 9000))`.
- `_put_obstore_bypass()` calls `obstore.put_async` directly with the computed `chunk_size` (streams from a `pathlib.Path`, no full read into memory); handles single files and recursive directory uploads.
- `put()` routes obstore-protocol uploads (`s3`/`gs`/`abfs`/`abfss`) through the bypass, guarded identically to the existing download bypass; everything else falls back to fsspec unchanged.

Mirrors the existing download-side `_get_obstore_bypass` / `ObstoreParallelReader` pattern.

## Behavior / perf

- Files ≤ ~45 GiB: identical 5 MiB parts → **no change**.
- Files > ~45 GiB: larger parts → **fewer** PUTs (these used to fail outright). A 1 TB file uses ~117 MiB parts and succeeds.
- Only added work per file is one `os.path.getsize` stat — negligible next to the upload.
- Recursive directory uploads keep the same concurrency (`BATCH_SIZE`) and per-file path as before.

## Verification

- Confirmed the recursive bypass produces an **identical destination key layout** to fsspec's `_put` (contents directly under the prefix, no basename nesting) for both the async obstore backend and `LocalFileSystem` — so `DataFrame`/`Dir` round-trips are unaffected.
- New unit tests: chunk-size math (small → 5 MiB floor; 60 GiB → parts < 10,000), put routing through the bypass with auto-sized `chunk_size`, and recursive multi-file layout.
- `tests/internal/storage/` — **58 passed** (1 deselected = the LocalStack `@pytest.mark.sandbox` test, needs a running cluster). Lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
