### PR TITLE
fix: filter ConnectError(UNIMPLEMENTED) from Sentry

### DIFF
--- a/src/flyte/_sentry.py
+++ b/src/flyte/_sentry.py
@@ -87,6 +87,11 @@ _USER_ACTIONABLE_CONNECT_CODES: frozenset[str] = frozenset(
         "INVALID_ARGUMENT",
         "NOT_FOUND",
         "ALREADY_EXISTS",
+        # Endpoint/version skew — the control-plane route the SDK called isn't
+        # served (HTTP 404 → connect maps to UNIMPLEMENTED, not NOT_FOUND). This
+        # is a wrong endpoint / incompatible backend version / misrouted ingress,
+        # never a Python-SDK logic bug, so the SDK can't recover from it.
+        "UNIMPLEMENTED",
         # Transient infra / availability problems — DNS lookup failed, TCP
         # connect refused, connection reset, request timed out. The SDK
         # cannot recover from these, so they shouldn't be crash-reported.
@@ -108,6 +113,10 @@ def _is_user_actionable_connect_error(exc: BaseException) -> bool:
       lookup failures, TCP connect refused, connection reset, request timed out
       against the cluster service. These are not SDK bugs; INTERNAL is
       intentionally NOT filtered because it can indicate a real bug.
+    * Endpoint/version skew (UNIMPLEMENTED) — a raw HTTP 404 from the ingress or
+      a missing control-plane route (connect maps 404 → UNIMPLEMENTED). The
+      endpoint config is wrong or the backend doesn't serve that RPC; the SDK
+      can't recover (FLYTE-SDK-4F: SelectCluster "Not Found" → RuntimeSystemError).
 
     Code paths outside the CLI (capture_exception in _run.py, capture_errors on
     deploy) surface RuntimeSystemError wrappers whose cause chain still

--- a/tests/flyte/test_sentry.py
+++ b/tests/flyte/test_sentry.py
@@ -369,6 +369,33 @@ def test_capture_exception_skips_connect_error_deadline_exceeded_wrapped_as_syst
     init_mock.assert_not_called()
 
 
+def test_capture_exception_skips_connect_error_unimplemented_wrapped_as_system_error():
+    """FLYTE-SDK-4F: a raw HTTP 404 from the control-plane ingress surfaces as
+    ConnectError(UNIMPLEMENTED, "Not Found") (connect maps 404 → UNIMPLEMENTED,
+    not NOT_FOUND) wrapped through RuntimeError("SelectCluster failed...") ->
+    RuntimeSystemError("Upload failed..."). The endpoint is wrong or the backend
+    doesn't serve that RPC — not an SDK bug, so it shouldn't be crash-reported."""
+    from connectrpc.code import Code
+    from connectrpc.errors import ConnectError
+
+    from flyte.errors import RuntimeSystemError
+
+    try:
+        try:
+            try:
+                raise ConnectError(Code.UNIMPLEMENTED, "Not Found")
+            except ConnectError as ce:
+                raise RuntimeError(f"SelectCluster failed for operation=1: {ce}") from ce
+        except RuntimeError:
+            raise RuntimeSystemError("RuntimeError", "Upload failed for /tmp/x/spec.pb (org='apple', ...): Not Found")
+    except RuntimeSystemError as e:
+        err = e
+
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()
+
+
 def _wrap_as_upload_system_error(inner: BaseException):
     """Reproduce the flyte.remote._data shape: the real network failure is wrapped
     in RuntimeError('SelectCluster failed...') -> RuntimeSystemError('Failed to


### PR DESCRIPTION
## Summary

Filters `ConnectError(UNIMPLEMENTED)` out of Sentry crash reporting.

A raw HTTP **404** from the control-plane ingress — wrong endpoint config, a missing/unrouted RPC, or backend/SDK version skew — is mapped by the connect protocol to `Code.UNIMPLEMENTED` (404 → `unimplemented`), **not** `NOT_FOUND`. During the `flyte run`/`flyte deploy` upload path it surfaces as:

```
ConnectError(UNIMPLEMENTED, "Not Found")            # connectrpc validate_response, raw 404
  -> RuntimeError("SelectCluster failed for operation=1: Not Found")
    -> RuntimeSystemError("Upload failed for .../spec.pb (org=...): Not Found")
```

and leaked into Sentry as if it were an SDK crash (**FLYTE-SDK-4F**, recurring on the latest 2.4.x SDK). The Python SDK cannot recover from a 404 on the RPC route, so `UNIMPLEMENTED` joins the other client/infra codes in `_USER_ACTIONABLE_CONNECT_CODES`. `INTERNAL`/`UNKNOWN` remain reported — they can still indicate a real backend or SDK bug.

## Test

Adds `test_capture_exception_skips_connect_error_unimplemented_wrapped_as_system_error`, reproducing the exact `ConnectError(UNIMPLEMENTED) -> RuntimeError -> RuntimeSystemError` chain from the Sentry event. Full `tests/flyte/test_sentry.py` suite passes (33 tests).

fixes FLYTE-SDK-4F

🤖 Generated with [Claude Code](https://claude.com/claude-code)