### PR TITLE
fix(logging): include log level in console log lines

### DIFF
--- a/src/flyte/_internal/runtime/taskrunner.py
+++ b/src/flyte/_internal/runtime/taskrunner.py
@@ -240,6 +240,4 @@ async def extract_download_run_upload(
         logger.info(f"Task {task.name} completed successfully, no outputs")
         return
     await upload_outputs(outputs, output_path) if output_path else None
-    logger.info(
-        f"Task {task.name} completed successfully, uploaded outputs to {output_path} in {time.time() - t:.2f}s"
-    )
+    logger.info(f"Task {task.name} completed successfully, uploaded outputs to {output_path} in {time.time() - t:.2f}s")

--- a/src/flyte/_internal/runtime/taskrunner.py
+++ b/src/flyte/_internal/runtime/taskrunner.py
@@ -240,4 +240,6 @@ async def extract_download_run_upload(
         logger.info(f"Task {task.name} completed successfully, no outputs")
         return
     await upload_outputs(outputs, output_path) if output_path else None
-    logger.info(f"Task {task.name} completed successfully, uploaded outputs to {output_path} in {time.time() - t}s")
+    logger.info(
+        f"Task {task.name} completed successfully, uploaded outputs to {output_path} in {time.time() - t:.2f}s"
+    )

--- a/src/flyte/_logging.py
+++ b/src/flyte/_logging.py
@@ -51,6 +51,11 @@ _LOG_LEVEL_MAP = {
 DEFAULT_LOG_LEVEL = logging.WARNING
 DEFAULT_USER_LOG_LEVEL = logging.INFO
 
+# Base console layout. The [run][action] and [flyte] markers are prepended by
+# ContextFormatter; the level name is included here so console output carries the
+# severity (WARNING/DEBUG/...) just like the JSON handler and the rich handler do.
+DEFAULT_CONSOLE_FORMAT = "%(levelname)s %(message)s"
+
 
 def make_hyperlink(label: str, url: str):
     """
@@ -243,7 +248,7 @@ def initialize_logger(
     if flyte_handler is None:
         flyte_handler = logging.StreamHandler()
         flyte_handler.setLevel(log_level)
-        flyte_handler.setFormatter(ContextFormatter(fmt="%(message)s", internal_prefix=True))
+        flyte_handler.setFormatter(ContextFormatter(fmt=DEFAULT_CONSOLE_FORMAT, internal_prefix=True))
 
     flyte_logger.addHandler(flyte_handler)
     flyte_logger.setLevel(log_level)
@@ -267,11 +272,11 @@ def initialize_logger(
         user_handler = rich_handler if rich_handler is not None else logging.StreamHandler()
         user_handler.setLevel(user_log_level)
         if not rich_handler:
-            user_handler.setFormatter(ContextFormatter(fmt="%(message)s"))
+            user_handler.setFormatter(ContextFormatter(fmt=DEFAULT_CONSOLE_FORMAT))
     else:
         user_handler = logging.StreamHandler()
         user_handler.setLevel(user_log_level)
-        user_handler.setFormatter(ContextFormatter(fmt="%(message)s"))
+        user_handler.setFormatter(ContextFormatter(fmt=DEFAULT_CONSOLE_FORMAT))
 
     user_flyte_logger.addHandler(user_handler)
     user_flyte_logger.setLevel(user_log_level)
@@ -315,7 +320,7 @@ class ContextFormatter(logging.Formatter):
 
     def __init__(
         self,
-        fmt: str = "%(message)s",
+        fmt: str = DEFAULT_CONSOLE_FORMAT,
         *,
         internal_prefix: bool = False,
         inner: logging.Formatter | None = None,
@@ -357,7 +362,7 @@ def _setup_root_logger(use_json: bool, use_rich: bool, log_level: int):
     # get_rich_handler can return None in some environments
     if not root_handler:
         root_handler = logging.StreamHandler()
-        root_handler.setFormatter(ContextFormatter(fmt="%(message)s"))
+        root_handler.setFormatter(ContextFormatter(fmt=DEFAULT_CONSOLE_FORMAT))
 
     root_handler.setLevel(log_level)
     root.addHandler(root_handler)
@@ -375,7 +380,7 @@ def _create_user_logger() -> logging.Logger:
 
     handler = logging.StreamHandler()
     handler.setLevel(user_log_level)
-    handler.setFormatter(ContextFormatter(fmt="%(message)s"))
+    handler.setFormatter(ContextFormatter(fmt=DEFAULT_CONSOLE_FORMAT))
 
     user_flyte_logger.propagate = False
     user_flyte_logger.addHandler(handler)
@@ -392,7 +397,7 @@ def _create_flyte_logger() -> logging.Logger:
 
     handler = logging.StreamHandler()
     handler.setLevel(get_env_log_level())
-    handler.setFormatter(ContextFormatter(fmt="%(message)s", internal_prefix=True))
+    handler.setFormatter(ContextFormatter(fmt=DEFAULT_CONSOLE_FORMAT, internal_prefix=True))
 
     # Prevent propagation to root to avoid double logging
     flyte_logger.propagate = False

--- a/tests/user_api/test_logging.py
+++ b/tests/user_api/test_logging.py
@@ -193,6 +193,79 @@ def test_user_logger_no_flyte_prefix_after_rich_init():
         initialize_logger(enable_rich=False)
 
 
+def test_default_console_format_includes_level():
+    """The console base format must carry the log level so severity is visible."""
+    from flyte._logging import DEFAULT_CONSOLE_FORMAT
+
+    assert "%(levelname)s" in DEFAULT_CONSOLE_FORMAT
+
+
+def test_context_formatter_renders_level():
+    """A console-formatted record must include its level name."""
+    from flyte._logging import ContextFormatter
+
+    formatter = ContextFormatter()
+    record = logging.LogRecord(
+        name="myapp",
+        level=logging.WARNING,
+        pathname="test.py",
+        lineno=1,
+        msg="boom",
+        args=None,
+        exc_info=None,
+    )
+    output = formatter.format(record)
+    assert output == "WARNING boom"
+
+
+def test_context_formatter_level_after_context_and_internal_markers():
+    """Level renders after the [run][action] and [flyte] markers, before the message."""
+    from flyte._logging import ContextFormatter
+
+    formatter = ContextFormatter(internal_prefix=True)
+    record = logging.LogRecord(
+        name="flyte",
+        level=logging.DEBUG,
+        pathname="test.py",
+        lineno=1,
+        msg="hello",
+        args=None,
+        exc_info=None,
+    )
+    record.run_name = "r1"
+    record.action_name = "a0"
+    record.is_flyte_internal = True
+    output = formatter.format(record)
+    assert output == "[r1][a0] [flyte] DEBUG hello"
+
+
+def test_initialized_console_handlers_emit_level():
+    """After initialize_logger, both flyte and user console handlers carry the level."""
+    import io
+
+    from flyte._logging import initialize_logger
+
+    initialize_logger(log_level=logging.DEBUG, user_log_level=logging.DEBUG, enable_rich=False)
+    try:
+        from flyte._logging import logger as internal_logger
+
+        for lgr, msg, expected in (
+            (internal_logger, "internal-line", "WARNING internal-line"),
+            (flyte.logger, "user-line", "WARNING user-line"),
+        ):
+            buf = io.StringIO()
+            handler = logging.StreamHandler(buf)
+            handler.setFormatter(lgr.handlers[0].formatter)
+            lgr.addHandler(handler)
+            try:
+                lgr.warning(msg)
+            finally:
+                lgr.removeHandler(handler)
+            assert expected in buf.getvalue()
+    finally:
+        initialize_logger()
+
+
 def test_json_formatter_with_context():
     formatter = JSONFormatter()
     record = logging.LogRecord(


### PR DESCRIPTION
## Problem

Log lines emitted by reusable container tasks don't show the log level (`WARNING`, `DEBUG`, ...).

Console log records were set up with `fmt="%(message)s"`, so the severity was never rendered. This wasn't caught because the **rich** handler renders the level in its own column — but a reusable container task runs **in-cluster**, where `get_rich_handler()` returns `None` (`ctx.is_in_cluster()`). The plain `StreamHandler` path is used instead, and that path dropped the level entirely.

Before:
```
user warning line
[flyte] internal debug line
```

After:
```
WARNING user warning line
[flyte] DEBUG internal debug line
```

Regression introduced alongside #1038 (`ContextFilter`/`FlyteInternalFilter` → `ContextFormatter`).

## Fix

- Add a shared `DEFAULT_CONSOLE_FORMAT = "%(levelname)s %(message)s"` constant.
- Point every console `ContextFormatter` call site (flyte internal, user, root, and the import-time default loggers) plus the `ContextFormatter` default at it.
- Leave the **rich** handler and the **JSON** formatter untouched — both already emit the level, so this avoids double-printing it.

The level renders after the context markers, before the message:
```
[r1][a0] [flyte] WARNING hello     # internal, with run/action context
INFO user-line                     # user logger, no context
```

## Test plan

- [x] Added 4 unit tests in `tests/user_api/test_logging.py`: constant includes the level, formatter renders the level, marker ordering (`[run][action] [flyte] LEVEL message`), and initialized console handlers emit the level.
- [x] `pytest tests/user_api/test_logging.py tests/flyte/test_logging.py` → 29 passed.
- [x] `ruff check` → clean.