### PR TITLE
init_in_cluster: fall back to init_from_config when config file is present

### DIFF
--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -17,6 +17,7 @@ from ._logging import LogFormat, initialize_logger, logger
 if TYPE_CHECKING:
     from flyte._internal.imagebuild import ImageBuildEngine
     from flyte.config import Config
+    from flyte.config._config import PlatformConfig
     from flyte.remote._client.auth import AuthType, ClientConfig
     from flyte.remote._client.controlplane import ClientSet
     from flyte.storage import Storage
@@ -54,6 +55,54 @@ class _InitConfig(CommonInit):
 # Global singleton to store initialization configuration
 _init_config: _InitConfig | None = None
 _init_lock = threading.RLock()  # Reentrant lock for thread safety
+
+
+def _platform_to_client_kwargs(pc: "PlatformConfig") -> dict[str, typing.Any]:
+    """Translate PlatformConfig fields into kwargs accepted by both
+    _initialize_client (via init) and create_remote_controller. Single
+    source of truth — extending the HTTP/auth stack with a new
+    PlatformConfig field means editing this one function.
+
+    Callers may need to layer on caller-specific kwargs that are NOT
+    derived from PlatformConfig (api_key, headless, in-cluster env-var
+    overrides); those stay at the call site.
+
+    ca_cert_file_path takes precedence over insecure_skip_verify when
+    both are present. _resolve_tls_ca_cert otherwise prefers the
+    bootstrap path, which fetches only what the server's leaf presents
+    and trips "UnknownIssuer" on chains nginx serves without
+    intermediates.
+    """
+    kw: dict[str, typing.Any] = {}
+    if pc.endpoint:
+        kw["endpoint"] = pc.endpoint
+    if pc.insecure:
+        kw["insecure"] = True
+    if pc.ca_cert_file_path:
+        kw["ca_cert_file_path"] = pc.ca_cert_file_path
+    elif pc.insecure_skip_verify:
+        kw["insecure_skip_verify"] = True
+    if pc.client_id:
+        kw["client_id"] = pc.client_id
+    if pc.client_credentials_secret:
+        kw["client_credentials_secret"] = pc.client_credentials_secret
+    if pc.auth_mode:
+        kw["auth_type"] = pc.auth_mode
+    if pc.command:
+        kw["command"] = pc.command
+    if pc.proxy_command:
+        kw["proxy_command"] = pc.proxy_command
+    if pc.http_proxy_url:
+        kw["http_proxy_url"] = pc.http_proxy_url
+    if pc.rpc_retries:
+        kw["rpc_retries"] = pc.rpc_retries
+    # NOTE: disable_keyring is intentionally NOT emitted here. The helper
+    # output flows both into _initialize_client (via init) AND into
+    # create_remote_controller (via init_in_cluster). The controller's
+    # constructor doesn't accept disable_keyring, so emitting it would
+    # raise TypeError on the in-cluster path. init_from_config threads
+    # disable_keyring through to init separately, alongside this helper.
+    return kw
 
 
 async def _initialize_client(
@@ -283,6 +332,7 @@ async def init_from_config(
     log_level: int | None = None,
     log_format: LogFormat = "console",
     user_log_level: int | None = None,
+    org: str | None = None,
     project: str | None = None,
     domain: str | None = None,
     storage: Storage | None = None,
@@ -296,6 +346,7 @@ async def init_from_config(
     other Flyte remote API methods are called. Thread-safe implementation.
 
     :param path_or_config: Path to the configuration file or Config object
+    :param org: Org name, this will override the org in the configuration file when non-empty
     :param project: Project name, this will override any project names in the configuration file
     :param domain: Domain name, this will override any domain names in the configuration file
     :param root_dir: Optional root directory from which to determine how to load files, and find paths to
@@ -345,19 +396,9 @@ async def init_from_config(
     parse_images(cfg, images)
 
     await init.aio(
-        org=cfg.task.org,
+        org=org or cfg.task.org,
         project=project or cfg.task.project,
         domain=domain or cfg.task.domain,
-        endpoint=cfg.platform.endpoint,
-        insecure=cfg.platform.insecure,
-        insecure_skip_verify=cfg.platform.insecure_skip_verify,
-        ca_cert_file_path=cfg.platform.ca_cert_file_path,
-        auth_type=cfg.platform.auth_mode,
-        command=cfg.platform.command,
-        proxy_command=cfg.platform.proxy_command,
-        client_id=cfg.platform.client_id,
-        client_credentials_secret=cfg.platform.client_credentials_secret,
-        disable_keyring=cfg.platform.disable_keyring,
         root_dir=root_dir,
         log_level=log_level,
         log_format=log_format,
@@ -369,6 +410,12 @@ async def init_from_config(
         source_config_path=cfg_path,
         sync_local_sys_paths=sync_local_sys_paths,
         local_persistence=cfg.local.persistence,
+        # disable_keyring is threaded outside _platform_to_client_kwargs
+        # because the helper output is also spread into
+        # create_remote_controller from init_in_cluster, and the
+        # controller's constructor doesn't accept this kwarg.
+        disable_keyring=cfg.platform.disable_keyring,
+        **_platform_to_client_kwargs(cfg.platform),
     )
 
 
@@ -471,6 +518,45 @@ async def init_in_cluster(
     INSECURE_OVERRIDE = "_U_INSECURE"
     _UNION_EAGER_API_KEY_ENV_VAR = "_UNION_EAGER_API_KEY"
     EAGER_API_KEY = "EAGER_API_KEY"
+
+    # When the cluster mounts a credentials config file (typical for the
+    # file-mounted client-secret deploy path), prefer it over the legacy
+    # env-var-injected api key. The chart sets FLYTECTL_CONFIG on the
+    # task pod pointing at the mount, so a direct env-var probe is all
+    # we need — no point walking resolve_config_path's full precedence
+    # chain (which includes a `git rev-parse` subprocess that is wasted
+    # work in a task pod and shows up in subprocess-mock tests).
+    # If api_key is supplied by the caller explicitly, that wins.
+    if api_key is None:
+        from flyte.config._reader import FLYTECTL_CONFIG_ENV_VAR, UCTL_CONFIG_ENV_VAR
+
+        cfg_path_str = os.getenv(UCTL_CONFIG_ENV_VAR) or os.getenv(FLYTECTL_CONFIG_ENV_VAR)
+        if cfg_path_str:
+            # Existence is intentionally NOT pre-checked: a typo in the
+            # env var should surface as the FileNotFoundError that
+            # init_from_config raises when it tries to open the path,
+            # not silently fall back to the legacy api-key branch.
+            logger.info(f"init_in_cluster: delegating to init_from_config({cfg_path_str})")
+            # init_from_config is @syncify-decorated; call its async form so we don't
+            # block the syncify thread.
+            await init_from_config.aio(
+                path_or_config=cfg_path_str,
+                org=org or os.getenv(ORG_NAME),
+                project=project or os.getenv(PROJECT_NAME),
+                domain=domain or os.getenv(DOMAIN_NAME),
+            )
+            # runtime._run_action spreads our return as **kwargs into
+            # create_remote_controller. Build that dict from the same
+            # PlatformConfig mapping init_from_config used above so the
+            # two clients can't drift apart on a future field addition.
+            from flyte.config import Config
+
+            cfg = Config.auto(cfg_path_str)
+            kwargs = _platform_to_client_kwargs(cfg.platform)
+            kwargs["headless"] = True  # task pod never has a browser available
+            if ep := os.getenv(ENDPOINT_OVERRIDE):
+                kwargs["endpoint"] = ep
+            return kwargs
 
     org = org or os.getenv(ORG_NAME)
     project = project or os.getenv(PROJECT_NAME)

--- a/tests/user_api/test_init_in_cluster_fallback.py
+++ b/tests/user_api/test_init_in_cluster_fallback.py
@@ -1,0 +1,205 @@
+"""Tests for init_in_cluster's file-mounted config fallback.
+
+When the chart-managed file-mount deploy sets FLYTECTL_CONFIG (or
+UCTL_CONFIG) on the task pod, init_in_cluster picks the path up
+directly and delegates to init_from_config instead of reading the
+legacy _UNION_EAGER_API_KEY env var. resolve_config_path's full
+precedence chain is deliberately NOT walked here — it does a
+`git rev-parse` subprocess that is wasted work in a task pod.
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from flyte._initialize import _platform_to_client_kwargs, init_in_cluster
+from flyte.config import Config
+from flyte.config._config import PlatformConfig
+from flyte.errors import InitializationError
+
+
+@pytest.fixture
+def yaml_config(tmp_path: Path) -> Path:
+    """Write a minimal valid SDK config (and the secret it references) to tmp."""
+    secret = tmp_path / "client_secret"
+    secret.write_text("test-secret-value")
+    p = tmp_path / "config.yaml"
+    p.write_text(
+        f"""admin:
+  endpoint: dns:///example.com:443
+  clientId: test-client
+  clientSecretLocation: {secret}
+  authType: ClientSecret
+"""
+    )
+    return p
+
+
+# init_from_config is @syncify-decorated; init_in_cluster calls its
+# ``.aio`` form to stay inside the async context, so the tests patch
+# the ``.aio`` attribute as an AsyncMock.
+INIT_FROM_CONFIG_AIO = "flyte._initialize.init_from_config.aio"
+
+
+class TestInitInClusterFallback:
+    @pytest.mark.asyncio
+    async def test_flytectl_config_env_var_is_picked_up(self, yaml_config, monkeypatch):
+        """FLYTECTL_CONFIG pointing at a real file -> init_in_cluster
+        delegates to init_from_config and returns controller kwargs
+        derived from the same PlatformConfig.
+        """
+        monkeypatch.delenv("_UNION_EAGER_API_KEY", raising=False)
+        monkeypatch.delenv("EAGER_API_KEY", raising=False)
+        monkeypatch.delenv("UCTL_CONFIG", raising=False)
+        monkeypatch.setenv("FLYTECTL_CONFIG", str(yaml_config))
+
+        with patch(INIT_FROM_CONFIG_AIO, new_callable=AsyncMock) as mock_init_from_config:
+            result = await init_in_cluster.aio()
+
+        mock_init_from_config.assert_awaited_once()
+        assert mock_init_from_config.call_args.kwargs["path_or_config"] == str(yaml_config)
+        # Returned kwargs match create_remote_controller's signature so the
+        # runtime caller can spread them directly.
+        assert result["endpoint"] == "dns:///example.com:443"
+        assert result["client_id"] == "test-client"
+        assert result["client_credentials_secret"] == "test-secret-value"
+        assert result["auth_type"] == "ClientSecret"
+        assert result["headless"] is True
+
+    @pytest.mark.asyncio
+    async def test_org_propagates_from_env_to_init_from_config(self, yaml_config, monkeypatch):
+        """Runtime org (via _U_ORG_NAME) must reach init_from_config so the
+        config-file fallback doesn't silently lose it. The legacy api-key
+        branch threads org=os.getenv("_U_ORG_NAME") into init.aio(org=...);
+        the fallback path must preserve the same semantics.
+        """
+        monkeypatch.delenv("_UNION_EAGER_API_KEY", raising=False)
+        monkeypatch.delenv("EAGER_API_KEY", raising=False)
+        monkeypatch.delenv("UCTL_CONFIG", raising=False)
+        monkeypatch.setenv("FLYTECTL_CONFIG", str(yaml_config))
+        monkeypatch.setenv("_U_ORG_NAME", "apple")
+
+        with patch(INIT_FROM_CONFIG_AIO, new_callable=AsyncMock) as mock_init_from_config:
+            await init_in_cluster.aio()
+
+        mock_init_from_config.assert_awaited_once()
+        assert mock_init_from_config.call_args.kwargs.get("org") == "apple"
+
+    @pytest.mark.asyncio
+    async def test_explicit_org_kwarg_wins_over_env_in_fallback(self, yaml_config, monkeypatch):
+        """An org explicitly passed to init_in_cluster takes precedence over
+        the _U_ORG_NAME env var, same shape as the legacy branch."""
+        monkeypatch.delenv("_UNION_EAGER_API_KEY", raising=False)
+        monkeypatch.delenv("EAGER_API_KEY", raising=False)
+        monkeypatch.delenv("UCTL_CONFIG", raising=False)
+        monkeypatch.setenv("FLYTECTL_CONFIG", str(yaml_config))
+        monkeypatch.setenv("_U_ORG_NAME", "ignored")
+
+        with patch(INIT_FROM_CONFIG_AIO, new_callable=AsyncMock) as mock_init_from_config:
+            await init_in_cluster.aio(org="explicit")
+
+        mock_init_from_config.assert_awaited_once()
+        assert mock_init_from_config.call_args.kwargs.get("org") == "explicit"
+
+    @pytest.mark.asyncio
+    async def test_uctl_config_env_var_takes_precedence_over_flytectl(self, yaml_config, monkeypatch):
+        """UCTL_CONFIG matches uctl/flytectl convention: UCTL_CONFIG wins
+        when both are set, since the Union CLI is the newer surface.
+        """
+        monkeypatch.delenv("_UNION_EAGER_API_KEY", raising=False)
+        monkeypatch.delenv("EAGER_API_KEY", raising=False)
+        monkeypatch.setenv("UCTL_CONFIG", str(yaml_config))
+        monkeypatch.setenv("FLYTECTL_CONFIG", "/non/existent/path.yaml")
+
+        with patch(INIT_FROM_CONFIG_AIO, new_callable=AsyncMock) as mock_init_from_config:
+            await init_in_cluster.aio()
+
+        mock_init_from_config.assert_awaited_once()
+        assert mock_init_from_config.call_args.kwargs["path_or_config"] == str(yaml_config)
+
+    @pytest.mark.asyncio
+    async def test_no_fallback_when_env_var_unset(self, monkeypatch):
+        """Neither env var set -> legacy api-key/env-var branch runs."""
+        monkeypatch.delenv("UCTL_CONFIG", raising=False)
+        monkeypatch.delenv("FLYTECTL_CONFIG", raising=False)
+        monkeypatch.setenv("_UNION_EAGER_API_KEY", "legacy-composite-token")
+
+        with patch(INIT_FROM_CONFIG_AIO, new_callable=AsyncMock) as mock_init_from_config:
+            with patch("flyte._initialize.init", new_callable=AsyncMock):
+                await init_in_cluster.aio()
+
+        mock_init_from_config.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_path_surfaces_loud_error(self, monkeypatch, tmp_path):
+        """Env var set to a path that does not exist -> init_from_config
+        raises InitializationError("ConfigFileNotFoundError"). A typo in
+        FLYTECTL_CONFIG must NOT silently route to the legacy api-key
+        branch — that would mask the misconfiguration. The chart
+        contract is "env var points at a real mounted file"; anything
+        else is loud."""
+        monkeypatch.delenv("UCTL_CONFIG", raising=False)
+        missing = tmp_path / "missing.yaml"
+        monkeypatch.setenv("FLYTECTL_CONFIG", str(missing))
+        monkeypatch.setenv("_UNION_EAGER_API_KEY", "legacy-composite-token")
+
+        with pytest.raises(InitializationError, match="does not exist"):
+            await init_in_cluster.aio()
+
+    @pytest.mark.asyncio
+    async def test_no_fallback_when_explicit_api_key_passed(self, yaml_config, monkeypatch):
+        """Explicit api_key kwarg wins over file-mount fallback even
+        when FLYTECTL_CONFIG is set."""
+        monkeypatch.setenv("FLYTECTL_CONFIG", str(yaml_config))
+
+        with patch(INIT_FROM_CONFIG_AIO, new_callable=AsyncMock) as mock_init_from_config:
+            with patch("flyte._initialize.init", new_callable=AsyncMock):
+                await init_in_cluster.aio(api_key="explicit-key")
+
+        mock_init_from_config.assert_not_awaited()
+
+    def test_platform_kwargs_helper_covers_every_used_field(self, yaml_config):
+        """Drift catcher: the helper is the single source of truth shared
+        by init_from_config (laptop/SDK Client path) and init_in_cluster
+        (in-pod runtime-controller path). If a new PlatformConfig field
+        needs to reach the HTTP/auth stack, both paths must pick it up;
+        this test asserts that adding it to the helper is sufficient.
+        """
+        cfg = Config.auto(str(yaml_config))
+        kw = _platform_to_client_kwargs(cfg.platform)
+        # Fields the chart-mounted in-cluster config sets — these MUST
+        # round-trip through the helper or the controller misconfigures.
+        assert kw["endpoint"] == cfg.platform.endpoint
+        assert kw["client_id"] == cfg.platform.client_id
+        assert kw["client_credentials_secret"] == cfg.platform.client_credentials_secret
+        assert kw["auth_type"] == cfg.platform.auth_mode
+
+    def test_platform_kwargs_helper_omits_disable_keyring(self):
+        """disable_keyring is intentionally NOT in the helper output:
+        the dict is spread into create_remote_controller from
+        init_in_cluster, and the controller's constructor does not
+        accept disable_keyring. Threading it would raise TypeError on
+        every in-cluster task pod. init_from_config passes
+        disable_keyring to init separately, alongside the helper."""
+        pc = PlatformConfig(
+            endpoint="dns:///example.com:443",
+            disable_keyring=True,
+        )
+        kw = _platform_to_client_kwargs(pc)
+        assert "disable_keyring" not in kw
+
+    def test_platform_kwargs_helper_prefers_ca_file_over_skip_verify(self):
+        """When both ca_cert_file_path and insecure_skip_verify are set,
+        the helper picks ca_cert_file_path. _resolve_tls_ca_cert routes
+        on the first present flag and the bootstrap-from-server path
+        only fetches the leaf, which trips UnknownIssuer when nginx is
+        configured to serve the leaf alone (no intermediates)."""
+        pc = PlatformConfig(
+            endpoint="dns:///example.com:443",
+            ca_cert_file_path="/etc/flyte/credentials/ca.crt",
+            insecure_skip_verify=True,
+        )
+        kw = _platform_to_client_kwargs(pc)
+        assert kw["ca_cert_file_path"] == "/etc/flyte/credentials/ca.crt"
+        assert "insecure_skip_verify" not in kw

--- a/tests/user_api/test_initialize.py
+++ b/tests/user_api/test_initialize.py
@@ -644,6 +644,15 @@ class TestInitInCluster:
         yield
         init_module._init_config = None
 
+    @pytest.fixture(autouse=True)
+    def no_config_env_vars(self, monkeypatch):
+        """These tests cover the legacy api-key / endpoint-env-var branch.
+        init_in_cluster's new fallback fires when UCTL_CONFIG or
+        FLYTECTL_CONFIG point at an existing file; clear them so we
+        exercise the legacy branch we mean to test."""
+        monkeypatch.delenv("UCTL_CONFIG", raising=False)
+        monkeypatch.delenv("FLYTECTL_CONFIG", raising=False)
+
     @patch("flyte._initialize.init")
     @pytest.mark.asyncio
     async def test_init_in_cluster_default_insecure_with_docker_endpoint(self, mock_init, monkeypatch):


### PR DESCRIPTION
## Context

Running v2 actions today requires a two-phase deploy: install the dataplane chart, **then** run `flyte create secret EAGER_API_KEY ...` before any action can execute. That side-channel step breaks GitOps for selfhosted users.

`_UNION_EAGER_API_KEY` is also base64-encoded but **not encrypted** on the task pod manifest — readable via `pods/get`, in audit logs, and via `echo \$_UNION_EAGER_API_KEY` inside the user container.

## Change

When no `api_key=` is passed, `init_in_cluster()` checks `UCTL_CONFIG` and `FLYTECTL_CONFIG` env vars in that order. If either is set, it delegates to `init_from_config.aio()` for the SDK side effects (logger, type transformers, sys.path, `_init_config` globals) and returns controller-shaped kwargs derived from the same `PlatformConfig` so `runtime._run_action` can spread them into `create_remote_controller(**kwargs)` — no env var on the pod manifest.

`_platform_to_client_kwargs(pc: PlatformConfig) -> dict` is the single source of truth for translating PlatformConfig fields into the kwargs accepted by `_initialize_client` and `create_remote_controller`. `init_from_config` spreads its output into `init.aio(...)` instead of threading each field by hand. A new PlatformConfig field that needs to reach the HTTP/auth stack is added in one place.

`ca_cert_file_path` takes precedence over `insecure_skip_verify` in the helper. `_resolve_tls_ca_cert` otherwise prefers the bootstrap-from-server path, which fetches only what the leaf presents — nginx typically serves the leaf alone, so the bootstrapped chain has no path back to the trust anchor and pyqwest reports `UnknownIssuer`. The chart-managed CA bundle, when mounted, is unambiguously the correct trust anchor.

### What this PR deliberately does NOT do

- Does **not** walk `resolve_config_path()`'s full precedence chain in `init_in_cluster`. That walk includes a `git rev-parse` subprocess, which is wasted work in a task pod and shows up in `Popen`-mocking tests as an extra call. The chart contract is "the pod's env var points at the mounted file"; honoring just that env var is enough.
- Does **not** add a hardcoded `/etc/flyte/config.yaml` fallback to `resolve_config_path()`. The chart sets `FLYTECTL_CONFIG` explicitly; no fallback default is needed.
- Does **not** introduce a new SDK-level config-loading entry point. `init_from_config()` is the existing public surface; this PR adds one new call site (inside `init_in_cluster`) and refactors `init_from_config`'s internal field threading to use the helper.

A typo in `FLYTECTL_CONFIG` raises `InitializationError("ConfigFileNotFoundError")` rather than silently routing to the legacy api-key branch — keeps misconfiguration loud.

Explicit `api_key=` and the legacy env-var path are unchanged when no env var is set.

## Caveats

Solves the two-phase deploy. **Reduces — does not eliminate — API-key leakage**: the mounted `client_secret` file is still readable from inside the user container. _Tentative:_ a follow-up `union-auth-proxy` sidecar (Phase 2, not implemented, subject to review) is one candidate for closing that remaining gap. Alternatives (capability-only narrowing, short-lived token exchange) are still open.

## Test plan

- [x] `FLYTECTL_CONFIG` set → delegates and returns controller-shaped kwargs
- [x] `UCTL_CONFIG` takes precedence over `FLYTECTL_CONFIG`
- [x] Neither env var set → legacy api-key/env-var branch runs
- [x] Env var points at missing path → loud `InitializationError`, no silent fallback
- [x] Explicit `api_key=` → no fallback even when env var is set
- [x] Helper round-trips every chart-set `PlatformConfig` field
- [x] Helper picks `ca_cert_file_path` over `insecure_skip_verify` when both set
- [x] End-to-end: v2 eager run on Union selfmanaged dataplane (mike-apple-aws), file-mounted creds, internal-CA TLS, no env var, first-attempt success — run [`ucbzldwjldgtq9fwxchs`](https://mike-andromeda-aws.sh-us-west-2.union.ai/v2/domain/development/project/union-health-monitoring/runs/ucbzldwjldgtq9fwxchs), 4/4 actions Success.