### PR TITLE
fix: clear error for missing .dockerignore in with_dockerignore

### DIFF
--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -1278,7 +1278,17 @@ class Image:
         return self.clone(addl_layer=CodeBundleLayer(copy_style=copy_style, dst=dst))
 
     def with_dockerignore(self, path: Path) -> Image:
-        new_image = self.clone(addl_layer=DockerIgnore(path=str(path)))
+        import flyte.errors
+
+        # Resolve to an absolute path so the file can still be located at build time, which may run
+        # from a different working directory than where the image was defined (e.g. the remote builder).
+        resolved = Path(path).expanduser()
+        if not resolved.is_file():
+            raise flyte.errors.ImageBuildError(
+                f"The .dockerignore file specified via with_dockerignore() was not found at '{path}'. "
+                f"Ensure the path points to an existing file."
+            )
+        new_image = self.clone(addl_layer=DockerIgnore(path=str(resolved.resolve())))
         return new_image
 
     def with_uv_project(

--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -1278,17 +1278,12 @@ class Image:
         return self.clone(addl_layer=CodeBundleLayer(copy_style=copy_style, dst=dst))
 
     def with_dockerignore(self, path: Path) -> Image:
-        import flyte.errors
-
-        # Resolve to an absolute path so the file can still be located at build time, which may run
-        # from a different working directory than where the image was defined (e.g. the remote builder).
-        resolved = Path(path).expanduser()
-        if not resolved.is_file():
-            raise flyte.errors.ImageBuildError(
-                f"The .dockerignore file specified via with_dockerignore() was not found at '{path}'. "
-                f"Ensure the path points to an existing file."
-            )
-        new_image = self.clone(addl_layer=DockerIgnore(path=str(resolved.resolve())))
+        # Deliberately no existence check here: image definitions are module-level code that also
+        # runs inside the container at task runtime, where the developer's .dockerignore is absent.
+        # Validating at definition time would raise spuriously there -- note DockerIgnore.update_hash
+        # already tolerates a missing file. The path is validated at build time instead, where the
+        # file genuinely has to exist (see remote_builder._get_layers_proto / DockerIgnoreHandler).
+        new_image = self.clone(addl_layer=DockerIgnore(path=str(path)))
         return new_image
 
     def with_uv_project(

--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -483,6 +483,13 @@ class PoetryProjectHandler:
 class DockerIgnoreHandler:
     @staticmethod
     async def handle(layer: DockerIgnore, context_path: Path, _: str):
+        if not Path(layer.path).is_file():
+            from flyte.errors import ImageBuildError
+
+            raise ImageBuildError(
+                f"The .dockerignore file specified via with_dockerignore() was not found at '{layer.path}'. "
+                f"Ensure the path points to an existing file."
+            )
         shutil.copy(layer.path, context_path)
 
 

--- a/src/flyte/_internal/imagebuild/remote_builder.py
+++ b/src/flyte/_internal/imagebuild/remote_builder.py
@@ -413,6 +413,11 @@ def _get_layers_proto(image: Image, context_path: Path) -> "image_definition_pb2
             )
             layers.append(commands_layer)
         elif isinstance(layer, DockerIgnore):
+            if not Path(layer.path).is_file():
+                raise flyte.errors.ImageBuildError(
+                    f"The .dockerignore file specified via with_dockerignore() was not found at '{layer.path}'. "
+                    f"Ensure the path points to an existing file."
+                )
             shutil.copy(layer.path, context_path)
         elif isinstance(layer, CodeBundleLayer):
             if layer.root_dir is None:

--- a/tests/flyte/imagebuild/test_docker_builder.py
+++ b/tests/flyte/imagebuild/test_docker_builder.py
@@ -1463,3 +1463,35 @@ async def test_code_bundle_handler_uses_chown_flyte():
 
             assert "COPY --chown=flyte:flyte" in result
             assert "/home/flyte/code" in result
+
+
+@pytest.mark.asyncio
+async def test_dockerignore_handler_missing_file_raises_image_build_error(tmp_path):
+    """FLYTE-SDK-4Z: a missing .dockerignore must surface as ImageBuildError at build time.
+
+    The raw `shutil.copy` used to raise `FileNotFoundError: '.dockerignore'`, which got
+    crash-reported to Sentry as an SDK bug instead of being shown to the user as the config
+    mistake it is (typically running `flyte deploy` from outside the project root).
+    """
+    from flyte._image import DockerIgnore
+    from flyte._internal.imagebuild.docker_builder import DockerIgnoreHandler
+    from flyte.errors import ImageBuildError
+
+    layer = DockerIgnore(path=str(tmp_path / "does-not-exist" / ".dockerignore"))
+    with pytest.raises(ImageBuildError, match="with_dockerignore"):
+        await DockerIgnoreHandler.handle(layer, tmp_path, "")
+
+
+@pytest.mark.asyncio
+async def test_dockerignore_handler_copies_existing_file(tmp_path):
+    """The happy path is unchanged: an existing .dockerignore is copied into the context."""
+    from flyte._image import DockerIgnore
+    from flyte._internal.imagebuild.docker_builder import DockerIgnoreHandler
+
+    src = tmp_path / ".dockerignore"
+    src.write_text("*.log\n")
+    context = tmp_path / "context"
+    context.mkdir()
+
+    await DockerIgnoreHandler.handle(DockerIgnore(path=str(src)), context, "")
+    assert (context / ".dockerignore").read_text() == "*.log\n"

--- a/tests/flyte/test_image.py
+++ b/tests/flyte/test_image.py
@@ -723,6 +723,31 @@ def test_image_uri_changes_when_dockerignore_content_changes(tmp_path):
     assert uri1 != img2.uri
 
 
+def test_with_dockerignore_missing_file_raises_image_build_error(tmp_path):
+    """A non-existent .dockerignore path must raise a clear ImageBuildError, not a raw FileNotFoundError."""
+    from flyte.errors import ImageBuildError
+
+    missing = tmp_path / ".dockerignore"  # never created
+    with pytest.raises(ImageBuildError, match="with_dockerignore"):
+        Image.from_debian_base(registry="localhost", name="test").with_dockerignore(missing)
+
+
+def test_with_dockerignore_resolves_to_absolute_path(tmp_path, monkeypatch):
+    """with_dockerignore must store an absolute path so the file is locatable from any cwd at build time."""
+    from flyte._image import DockerIgnore
+
+    di_file = tmp_path / ".dockerignore"
+    di_file.write_text("*.log\n")
+
+    # Reference the file via a relative path from tmp_path, then change cwd to simulate the builder.
+    monkeypatch.chdir(tmp_path)
+    img = Image.from_debian_base(registry="localhost", name="test").with_dockerignore(Path(".dockerignore"))
+
+    layer = next(layer for layer in img._layers if isinstance(layer, DockerIgnore))
+    assert Path(layer.path).is_absolute()
+    assert Path(layer.path).is_file()
+
+
 def test_ids_for_different_python_version():
     ex_11 = Image.from_debian_base(python_version=(3, 11), install_flyte=False).with_source_file(Path(__file__))
     ex_12 = Image.from_debian_base(python_version=(3, 12), install_flyte=False).with_source_file(Path(__file__))

--- a/tests/flyte/test_image.py
+++ b/tests/flyte/test_image.py
@@ -723,29 +723,22 @@ def test_image_uri_changes_when_dockerignore_content_changes(tmp_path):
     assert uri1 != img2.uri
 
 
-def test_with_dockerignore_missing_file_raises_image_build_error(tmp_path):
-    """A non-existent .dockerignore path must raise a clear ImageBuildError, not a raw FileNotFoundError."""
-    from flyte.errors import ImageBuildError
+def test_with_dockerignore_missing_file_does_not_raise_at_definition_time(tmp_path):
+    """Defining an image must not validate the .dockerignore path.
 
-    missing = tmp_path / ".dockerignore"  # never created
-    with pytest.raises(ImageBuildError, match="with_dockerignore"):
-        Image.from_debian_base(registry="localhost", name="test").with_dockerignore(missing)
-
-
-def test_with_dockerignore_resolves_to_absolute_path(tmp_path, monkeypatch):
-    """with_dockerignore must store an absolute path so the file is locatable from any cwd at build time."""
+    Image definitions are module-level code that also executes inside the container at task
+    runtime, where the developer's .dockerignore does not exist -- validating here would raise
+    spuriously. Validation belongs at build time instead.
+    """
     from flyte._image import DockerIgnore
 
-    di_file = tmp_path / ".dockerignore"
-    di_file.write_text("*.log\n")
-
-    # Reference the file via a relative path from tmp_path, then change cwd to simulate the builder.
-    monkeypatch.chdir(tmp_path)
-    img = Image.from_debian_base(registry="localhost", name="test").with_dockerignore(Path(".dockerignore"))
+    missing = tmp_path / ".dockerignore"  # never created
+    img = Image.from_debian_base(registry="localhost", name="test").with_dockerignore(missing)
 
     layer = next(layer for layer in img._layers if isinstance(layer, DockerIgnore))
-    assert Path(layer.path).is_absolute()
-    assert Path(layer.path).is_file()
+    assert layer.path == str(missing)
+    # The hash must also survive the file being absent (falls back to hashing the path string).
+    assert img.uri
 
 
 def test_ids_for_different_python_version():


### PR DESCRIPTION
## Problem

`Image.with_dockerignore(path)` stored the path as-is, and both build paths copied it into the build context with a bare `shutil.copy(layer.path, context_path)`. When the file wasn't there at build time — typically running `flyte deploy` from outside the project root — that raised a raw, uninformative `FileNotFoundError` which leaked to Sentry as if it were an SDK bug.

Sentry: **FLYTE-SDK-4Z** (`FileNotFoundError: [Errno 2] No such file or directory: '.dockerignore'`, observed on 2.4.4).

## Fix

Validate at **build time only** — in `remote_builder._get_layers_proto` and `docker_builder.DockerIgnoreHandler.handle`. Those are the only two places the file genuinely has to exist, and both raise a clear **`ImageBuildError`** (a `RuntimeUserError`, so it's shown to the user and filtered from Sentry) instead of the raw `FileNotFoundError`.

`with_dockerignore()` itself is unchanged from `main`.

### Why no check at definition time

An earlier revision validated inside `with_dockerignore()`. Per [@pingsutw's review](https://github.com/flyteorg/flyte-sdk/pull/1184#discussion_r3390319883), that was wrong: image definitions are module-level code that also executes **inside the container at task runtime**, where the developer's `.dockerignore` is absent — so a definition-time check would raise spuriously. `DockerIgnore.update_hash` already falls back to hashing the path string when the file is missing, confirming "may not exist" was the intended contract.

That revision also resolved the path to absolute. Dropped as well: it wasn't load-bearing. The Sentry stack shows the copy failing in `_get_layers_proto`, which runs client-side in the same process that defined the image, so there's no cwd mismatch to correct.

## Tests

- `tests/flyte/test_image.py` — a missing `.dockerignore` must **not** raise at definition time, and `img.uri` must still compute (locks in the contract above).
- `tests/flyte/imagebuild/test_docker_builder.py` — the build-time handler raises `ImageBuildError` for a missing file; happy-path copy still works.

`tests/flyte/test_image.py` + `tests/flyte/imagebuild/` → 184 passed. (`test_image_build_engine.py::test_persistent_cache_write_and_read` fails identically on `main` — pre-existing test-isolation issue, unrelated.)

fixes FLYTE-SDK-4Z

🤖 Generated with [Claude Code](https://claude.com/claude-code)
