### PR TITLE
Downgrade path-rewrite fallback log to debug

### DIFF
--- a/src/flyte/_bin/runtime.py
+++ b/src/flyte/_bin/runtime.py
@@ -177,9 +177,10 @@ def main(
             path_rewrite = potential_path_rewrite
             logger.info(f"Path rewrite configured for {path_rewrite.new_prefix}")
         else:
-            logger.error(
-                f"Path rewrite failed for path {potential_path_rewrite.new_prefix}, "
-                f"not found, reverting to original path {potential_path_rewrite.old_prefix}"
+            # Mount absent = accelerated datasets not enabled on this cluster. Expected; use original path.
+            logger.debug(
+                f"Path rewrite target {potential_path_rewrite.new_prefix} not mounted, "
+                f"using original path {potential_path_rewrite.old_prefix}"
             )
 
     # Create a coroutine to load the task and run it


### PR DESCRIPTION
## Summary

The backend sets `_F_PATH_REWRITE` for every v2 task, but the `/union-persistent-data/` mount only exists on clusters with accelerated datasets enabled — which is none of the BYOC clusters today. So every v2 task in every BYOC cluster logs this at ERROR on startup:

```
ERROR runtime.py:141 - Path rewrite failed for path /union-persistent-data/, not found, reverting to original path s3://...
```

The SDK falls back to the original S3 path correctly — nothing breaks. But the ERROR level has surfaced as an alarming-looking line in customer logs. Each time someone on our side has had to explain that it's harmless.

Downgrade to DEBUG and reword: the fallback is the expected case when the feature isn't configured, not a failure.
