### PR TITLE
rename events to conditions

### DIFF
--- a/examples/advanced/conditions.py
+++ b/examples/advanced/conditions.py
@@ -1,10 +1,10 @@
-"""Examples of events with markdown prompts and webhook integration."""
+"""Examples of conditions with markdown prompts and webhook integration."""
 
 import time
 
 import flyte
 
-env = flyte.TaskEnvironment(name="events")
+env = flyte.TaskEnvironment(name="conditions")
 
 
 @env.task
@@ -13,22 +13,22 @@ async def next_task(value: int) -> int:
 
 
 # ---------------------------------------------------------------------------
-# 1. Basic event with a plain-text prompt
+# 1. Basic condition with a plain-text prompt
 # ---------------------------------------------------------------------------
 @env.task
-async def basic_event_task(x: int) -> int:
-    event = await flyte.new_event.aio(
+async def basic_condition_task(x: int) -> int:
+    condition = await flyte.new_condition.aio(
         "approval",
         prompt="Is it ok to continue?",
         data_type=bool,
     )
-    ev2 = await flyte.new_event.aio(
+    cond2 = await flyte.new_condition.aio(
         "review",
         prompt="Is it really ok to continue, again?",
         data_type=bool,
     )
-    if await event.wait.aio():
-        if await ev2.wait.aio():
+    if await condition.wait.aio():
+        if await cond2.wait.aio():
             return x + 1
     return -1
 
@@ -37,8 +37,8 @@ async def basic_event_task(x: int) -> int:
 # 2. Markdown prompt - renders rich text in the TUI / UI
 # ---------------------------------------------------------------------------
 @env.task
-async def markdown_event_task(x: int) -> int:
-    event = await flyte.new_event.aio(
+async def markdown_condition_task(x: int) -> int:
+    condition = await flyte.new_condition.aio(
         "review",
         prompt=(
             "## Review needed\n\n"
@@ -52,90 +52,90 @@ async def markdown_event_task(x: int) -> int:
         prompt_type="markdown",
         data_type=bool,
     )
-    approved = await event.wait.aio()
+    approved = await condition.wait.aio()
     if approved:
         return await next_task(x)
     return -1
 
 
 # ---------------------------------------------------------------------------
-# 3. Webhook - notify an external system when the event is created.
+# 3. Webhook - notify an external system when the condition is created.
 #    The external system can then POST back to {callback_uri} to signal it.
 # ---------------------------------------------------------------------------
 @env.task
 async def webhook_outbound_task(x: int) -> int:
-    event = await flyte.new_event.aio(
+    condition = await flyte.new_condition.aio(
         "external_approval",
         prompt="Waiting for external approval via webhook…",
         data_type=bool,
-        webhook=flyte.EventWebhook(
+        webhook=flyte.ConditionWebhook(
             url="https://example.com/hook",
             payload={
                 "callback": "{callback_uri}",
-                "event": "approval_needed",
+                "condition": "approval_needed",
                 "message": "Pipeline is waiting for approval",
             },
         ),
     )
     # The backend POSTs to the webhook URL with the payload above.
-    # An external service can then POST to the {callback_uri} to signal the event.
-    approved = await event.wait.aio()
+    # An external service can then POST to the {callback_uri} to signal the condition.
+    approved = await condition.wait.aio()
     if approved:
         return x + 1
     return -1
 
 
 # ---------------------------------------------------------------------------
-# 4. Signal an event programmatically from outside the workflow
+# 4. Signal a condition programmatically from outside the workflow
 #    (e.g. from a webhook handler, a script, or a CI job)
 # ---------------------------------------------------------------------------
-def signal_event_remotely(run_name: str, event_name: str, payload):
-    """Signal an event by name within a run.
+def signal_condition_remotely(run_name: str, condition_name: str, payload):
+    """Signal a condition by name within a run.
 
     Equivalent CLI form once you know the condition action id::
 
-        flyte signal event <run-name> <action-name> <value>
+        flyte signal condition <run-name> <action-name> <value>
     """
     import flyte.remote as remote
 
     flyte.init()
-    # Poll until the named event appears in the run.
-    while not (event := remote.Event.get(event_name, run_name=run_name)):
+    # Poll until the named condition appears in the run.
+    while not (condition := remote.Condition.get(condition_name, run_name=run_name)):
         time.sleep(5)
 
-    event.signal(payload)
+    condition.signal(payload)
 
 
 # ---------------------------------------------------------------------------
-# Main - trigger markdown_event_task and signal its "review" event
+# Main - trigger markdown_condition_task and signal its "review" condition
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":
     import flyte.remote as remote
 
     flyte.init_from_config()
 
-    # 1. Launch the run. markdown_event_task pauses on its "review" event.
-    r = flyte.run(markdown_event_task, x=10)
+    # 1. Launch the run. markdown_condition_task pauses on its "review" condition.
+    r = flyte.run(markdown_condition_task, x=10)
     print("run url:", r.url)
 
     # 2. Poll until the "review" condition shows up, then signal it with True.
-    EVENT_NAME = "review"
-    event = None
-    while event is None:
-        events = list(remote.Event.listall(run_name=r.name))
-        if events:
-            print("found events:", [(e.name, e.action_name, e.phase) for e in events])
-            # Prefer an exact name match; fall back to the only/first event.
-            event = next((e for e in events if e.name == EVENT_NAME), events[0])
+    CONDITION_NAME = "review"
+    condition = None
+    while condition is None:
+        conditions = list(remote.Condition.listall(run_name=r.name))
+        if conditions:
+            print("found conditions:", [(c.name, c.action_name, c.phase) for c in conditions])
+            # Prefer an exact name match; fall back to the only/first condition.
+            condition = next((c for c in conditions if c.name == CONDITION_NAME), conditions[0])
         else:
-            print("waiting for a condition event to be created…")
+            print("waiting for a condition to be created…")
             time.sleep(5)
 
-    print(f"signaling event '{event.name}' (action {event.action_name}, phase {event.phase}) with True")
-    event.signal(True)
+    print(f"signaling condition '{condition.name}' (action {condition.action_name}, phase {condition.phase}) with True")
+    condition.signal(True)
 
     # Equivalent CLI invocation (once you know the action id from the UI/logs):
-    #   flyte signal event <r.name> <event.action_name> true
+    #   flyte signal condition <r.name> <condition.action_name> true
 
     # 3. The task resumes; print its final output.
     print("outputs:", r.outputs())

--- a/src/flyte/__init__.py
+++ b/src/flyte/__init__.py
@@ -9,11 +9,11 @@ import sys
 from ._build import ImageBuild, build
 from ._cache import Cache, CachePolicy, CacheRequest
 from ._checkpoint import BaseCheckpoint, Checkpoint, latest_checkpoint
+from ._condition import ConditionWebhook, new_condition
 from ._context import ctx
 from ._custom_context import custom_context, get_custom_context
 from ._deploy import build_images, deploy
 from ._environment import Environment
-from ._event import EventWebhook, new_event
 from ._excepthook import custom_excepthook
 from ._group import group
 from ._image import Image
@@ -66,11 +66,11 @@ __all__ = [
     "CachePolicy",
     "CacheRequest",
     "Checkpoint",
+    "ConditionWebhook",
     "Cron",
     "Device",
     "DeviceClass",
     "Environment",
-    "EventWebhook",
     "FixedRate",
     "Image",
     "ImageBuild",
@@ -105,7 +105,7 @@ __all__ = [
     "latest_checkpoint",
     "logger",
     "map",
-    "new_event",
+    "new_condition",
     "run",
     "run_python_script",
     "serve",

--- a/src/flyte/_condition.py
+++ b/src/flyte/_condition.py
@@ -9,23 +9,23 @@ from flyte.syncify import syncify
 
 PromptType = Literal["text", "markdown"]
 
-EventType = typing.TypeVar("EventType", bool, int, float, str)
+ConditionType = typing.TypeVar("ConditionType", bool, int, float, str)
 
 
 @dataclass
-class EventWebhook:
-    """Webhook configuration for an event notification.
+class ConditionWebhook:
+    """Webhook configuration for a condition notification.
 
-    When specified, the backend will POST to the given URL when the event is created.
+    When specified, the backend will POST to the given URL when the condition is created.
     The ``payload`` dict may contain the template variable ``{callback_uri}`` in any
     string value — the backend replaces it with the actual URI that can be used to
-    signal the event.
+    signal the condition.
 
     Example::
 
-        EventWebhook(
+        ConditionWebhook(
             url="https://example.com/hook",
-            payload={"callback": "{callback_uri}", "event": "approval_needed"},
+            payload={"callback": "{callback_uri}", "condition": "approval_needed"},
         )
     """
 
@@ -35,21 +35,22 @@ class EventWebhook:
 
 @rich.repr.auto
 @dataclass
-class _Event(Generic[EventType]):
+class _Condition(Generic[ConditionType]):
     """
-    An event that can be awaited in a Run. Events can be used to pause Run until an external signal is received.
+    A condition that can be awaited in a Run. Conditions can be used to pause a Run until an external
+    signal is received.
 
     Examples:
 
     ```python
     import flyte
 
-    env = flyte.TaskEnvironment(name="events")
+    env = flyte.TaskEnvironment(name="conditions")
 
     @env.task
     async def my_task() -> Optional[int]:
-        event = await flyte.new_event(name="my_event", prompt="Is it ok to continue?", data_type=bool)
-        result = await event.wait()
+        condition = await flyte.new_condition(name="my_condition", prompt="Is it ok to continue?", data_type=bool)
+        result = await condition.wait()
         if result:
             return 42
         else:
@@ -60,10 +61,10 @@ class _Event(Generic[EventType]):
     name: str
     prompt: str = "Approve?"
     prompt_type: PromptType = "text"
-    data_type: Type[EventType] = bool  # type: ignore[assignment]
+    data_type: Type[ConditionType] = bool  # type: ignore[assignment]
     description: str = ""
     timeout: Union[timedelta, int, float, None] = None
-    webhook: Optional[EventWebhook] = None
+    webhook: Optional[ConditionWebhook] = None
 
     def __post_init__(self):
         valid_types = (bool, int, float, str)
@@ -80,9 +81,9 @@ class _Event(Generic[EventType]):
             self._timeout_seconds = None
 
     @syncify
-    async def wait(self) -> EventType:
+    async def wait(self) -> ConditionType:
         """
-        Await the event to be signaled.
+        Await the condition to be signaled.
 
         Blocks until the condition is resolved by the backend. The return value is
         converted to the ``data_type`` specified at creation time:
@@ -92,14 +93,14 @@ class _Event(Generic[EventType]):
         - ``float`` → Python ``float``
         - ``str`` → Python ``str``
 
-        **Protocol:** When running remotely, the event is backed by a *condition action*.
+        **Protocol:** When running remotely, the condition is backed by a *condition action*.
         The backend delivers the result as a ``Literal`` (protobuf scalar/primitive)
         directly in the ``ActionUpdate`` — no ``output_uri`` is used for conditions.
 
-        :return: The typed payload associated with the event when it is signaled.
-        :raises flyte.errors.EventTimedoutError: If the event is not signaled within the
+        :return: The typed payload associated with the condition when it is signaled.
+        :raises flyte.errors.ConditionTimedoutError: If the condition is not signaled within the
             specified ``timeout``.
-        :raises flyte.errors.EventFailedError: If the condition fails during execution.
+        :raises flyte.errors.ConditionFailedError: If the condition fails during execution.
         """
         from flyte._context import internal_ctx
 
@@ -111,52 +112,52 @@ class _Event(Generic[EventType]):
             from ._internal.controllers import get_controller
 
             controller = get_controller()
-            result = await controller.wait_for_event(self)
+            result = await controller.wait_for_condition(self)
             return result
         else:
-            raise RuntimeError("Events can only be awaited within a task context.")
+            raise RuntimeError("Conditions can only be awaited within a task context.")
 
 
 @syncify
-async def new_event(
+async def new_condition(
     name: str,
     /,
     prompt: str = "Approve?",
     prompt_type: PromptType = "text",
-    data_type: Type[EventType] = bool,  # type: ignore[assignment]
+    data_type: Type[ConditionType] = bool,  # type: ignore[assignment]
     description: str = "",
     timeout: Union[timedelta, int, float, None] = None,
-    webhook: Optional[EventWebhook] = None,
-) -> _Event:
+    webhook: Optional[ConditionWebhook] = None,
+) -> _Condition:
     """
-    Create an event that can be awaited in a workflow. Events can be used to pause workflow execution until
-    an external signal is received.
+    Create a condition that can be awaited in a workflow. Conditions can be used to pause workflow execution
+    until an external signal is received.
 
     **Condition protocol (remote execution):**
 
-    When running inside a task, ``new_event`` registers a *condition action* with the
-    backend. Calling ``event.wait()`` blocks until the condition is resolved. The backend
+    When running inside a task, ``new_condition`` registers a *condition action* with the
+    backend. Calling ``condition.wait()`` blocks until the condition is resolved. The backend
     delivers the result as an inline ``Literal`` (protobuf scalar/primitive) in the
     ``ActionUpdate`` stream — no ``output_uri`` is involved for conditions.
 
     - On success, ``wait()`` returns the value converted to ``data_type``
       (``True``/``False`` for bool, Python ``int``/``float``/``str`` for the others).
-    - If the condition times out, ``wait()`` raises ``flyte.errors.EventTimedoutError``.
-    - If the condition fails, ``wait()`` raises ``flyte.errors.EventFailedError``.
+    - If the condition times out, ``wait()`` raises ``flyte.errors.ConditionTimedoutError``.
+    - If the condition fails, ``wait()`` raises ``flyte.errors.ConditionFailedError``.
 
-    :param name: Name of the event
-    :param prompt: Prompt message for the event
-    :param data_type: Data type of the event payload — one of ``bool``, ``int``, ``float``, ``str``
+    :param name: Name of the condition
+    :param prompt: Prompt message for the condition
+    :param data_type: Data type of the condition payload — one of ``bool``, ``int``, ``float``, ``str``
     :param prompt_type: Type of prompt rendering - "text" or "markdown"
-    :param description: Description of the event
-    :param timeout: Optional timeout as a timedelta or number of seconds. If the event is not signaled
-        within this duration, ``wait()`` will raise ``flyte.errors.EventTimedoutError``.
+    :param description: Description of the condition
+    :param timeout: Optional timeout as a timedelta or number of seconds. If the condition is not signaled
+        within this duration, ``wait()`` will raise ``flyte.errors.ConditionTimedoutError``.
     :param webhook: Optional webhook configuration. When provided, the backend will POST to the
         given URL with the specified payload. The payload may use ``{callback_uri}`` as a template
-        variable — the backend replaces it with the URI that can be used to signal the event.
-    :return: An instance of _Event representing the created event
+        variable — the backend replaces it with the URI that can be used to signal the condition.
+    :return: An instance of _Condition representing the created condition
     """
-    event = _Event(
+    condition = _Condition(
         name=name,
         prompt=prompt,
         prompt_type=prompt_type,
@@ -175,7 +176,7 @@ async def new_event(
         from ._internal.controllers import get_controller
 
         controller = get_controller()
-        await controller.register_event(event)
+        await controller.register_condition(condition)
     else:
         pass
-    return event
+    return condition

--- a/src/flyte/_internal/controllers/__init__.py
+++ b/src/flyte/_internal/controllers/__init__.py
@@ -114,20 +114,20 @@ class Controller(Protocol):
         """
         ...
 
-    async def register_event(self, event: Any):
+    async def register_condition(self, condition: Any):
         """
-        Register an event that can be awaited. This is used to register events that can pause execution
+        Register a condition that can be awaited. This is used to register conditions that can pause execution
         until an external signal is received.
-        :param event: Event object to register
+        :param condition: Condition object to register
         :return:
         """
         ...
 
-    async def wait_for_event(self, event: Any) -> Any:
+    async def wait_for_condition(self, condition: Any) -> Any:
         """
-        Wait for an event to be signaled. This will block until the event receives data.
-        :param event: Event object to wait for
-        :return: The payload associated with the event when it is signaled
+        Wait for a condition to be signaled. This will block until the condition receives data.
+        :param condition: Condition object to wait for
+        :return: The payload associated with the condition when it is signaled
         """
         ...
 

--- a/src/flyte/_internal/controllers/_local_controller.py
+++ b/src/flyte/_internal/controllers/_local_controller.py
@@ -116,7 +116,7 @@ class LocalController(ControllerProtocol):
         self._runner_map: dict[str, _TaskRunner] = {}
         self._sequencer = TaskCallSequencer()
         self._recorder = RunRecorder()
-        self._registered_events: dict[str, Any] = {}
+        self._registered_conditions: dict[str, Any] = {}
 
     def set_recorder(self, recorder: RunRecorder) -> None:
         self._recorder = recorder
@@ -420,40 +420,40 @@ class LocalController(ControllerProtocol):
             f"Remote tasks cannot be executed locally, only remotely. Found remote task {_task.name}"
         )
 
-    async def register_event(self, event: Any):
+    async def register_condition(self, condition: Any):
         """
-        Register an event that can be awaited. Stores the event for later retrieval.
-        If the event has a webhook configured, fires it asynchronously.
+        Register a condition that can be awaited. Stores the condition for later retrieval.
+        If the condition has a webhook configured, fires it asynchronously.
 
-        :param event: Event object to register
+        :param condition: Condition object to register
         """
-        from flyte._event import _Event
+        from flyte._condition import _Condition
 
-        if not isinstance(event, _Event):
-            raise TypeError(f"Expected _Event, got {type(event)}")
+        if not isinstance(condition, _Condition):
+            raise TypeError(f"Expected _Condition, got {type(condition)}")
 
-        logger.debug(f"Registering event: {event.name}")
-        self._registered_events[event.name] = event
+        logger.debug(f"Registering condition: {condition.name}")
+        self._registered_conditions[condition.name] = condition
 
-        if event.webhook is not None:
-            await self._fire_event_webhook(event)
+        if condition.webhook is not None:
+            await self._fire_condition_webhook(condition)
 
-    async def _fire_event_webhook(self, event: Any):
-        """Fire the webhook associated with an event.
+    async def _fire_condition_webhook(self, condition: Any):
+        """Fire the webhook associated with a condition.
 
         Substitutes ``{callback_uri}`` in all string values of the payload, then
         POSTs the JSON body to the webhook URL.
         """
         import httpx
 
-        webhook = event.webhook
-        callback_uri = f"local://events/{event.name}/signal"
+        webhook = condition.webhook
+        callback_uri = f"local://conditions/{condition.name}/signal"
 
         payload = webhook.payload
         if payload is not None:
             payload = _substitute_callback_uri(payload, callback_uri)
 
-        logger.debug(f"Firing webhook for event '{event.name}' to {webhook.url}")
+        logger.debug(f"Firing webhook for condition '{condition.name}' to {webhook.url}")
         try:
             async with httpx.AsyncClient() as client:
                 resp = await client.post(
@@ -461,9 +461,9 @@ class LocalController(ControllerProtocol):
                     json=payload,
                     headers={"Content-Type": "application/json"},
                 )
-                logger.debug(f"Webhook response for event '{event.name}': {resp.status_code}")
+                logger.debug(f"Webhook response for condition '{condition.name}': {resp.status_code}")
         except Exception:
-            logger.exception(f"Failed to fire webhook for event '{event.name}'")
+            logger.exception(f"Failed to fire webhook for condition '{condition.name}'")
 
     def _get_current_action_id(self) -> str:
         ctx = internal_ctx()
@@ -474,66 +474,66 @@ class LocalController(ControllerProtocol):
         action = tctx.task_action or tctx.action
         return action.name
 
-    async def wait_for_event(self, event: Any) -> Any:
+    async def wait_for_condition(self, condition: Any) -> Any:
         """
-        Wait for an event to be signaled.
+        Wait for a condition to be signaled.
 
-        Each event is recorded as a *sub-action* of the waiting task: the prompt is its
-        input and the signaled value becomes its output, so resolved events stay visible
+        Each condition is recorded as a *sub-action* of the waiting task: the prompt is its
+        input and the signaled value becomes its output, so resolved conditions stay visible
         in the TUI tree (and the persisted run) after they are signaled.
 
-        In TUI mode, records a pending event so the TUI can render an input panel and
+        In TUI mode, records a pending condition so the TUI can render an input panel and
         blocks until the user submits a value. Without TUI, falls back to rich console prompts.
 
-        :param event: Event object to wait for
-        :return: The payload associated with the event when it is signaled
+        :param condition: Condition object to wait for
+        :return: The payload associated with the condition when it is signaled
         """
-        from flyte._event import _Event
+        from flyte._condition import _Condition
 
-        if not isinstance(event, _Event):
-            raise TypeError(f"Expected _Event, got {type(event)}")
+        if not isinstance(condition, _Condition):
+            raise TypeError(f"Expected _Condition, got {type(condition)}")
 
-        logger.info(f"Waiting for event: {event.name}")
+        logger.info(f"Waiting for condition: {condition.name}")
 
         parent_action_id = self._get_current_action_id()
-        event_seq = self._sequencer.next_seq(event, parent_action_id)
-        event_action_id = f"{parent_action_id}-evt-{event.name}-{event_seq}"
+        condition_seq = self._sequencer.next_seq(condition, parent_action_id)
+        condition_action_id = f"{parent_action_id}-cond-{condition.name}-{condition_seq}"
 
-        # Record the event as a sub-action of the waiting task. Only set the parent
-        # when it is tracked (mirrors `submit`), so a top-level event becomes a root.
+        # Record the condition as a sub-action of the waiting task. Only set the parent
+        # when it is tracked (mirrors `submit`), so a top-level condition becomes a root.
         parent_id = parent_action_id if self._recorder.get_action(parent_action_id) is not None else None
         self._recorder.record_start(
-            action_id=event_action_id,
-            task_name=event.name,
+            action_id=condition_action_id,
+            task_name=condition.name,
             parent_id=parent_id,
-            inputs={"prompt": event.prompt},
+            inputs={"prompt": condition.prompt},
         )
 
-        pending = self._recorder.record_event_waiting(
-            action_id=event_action_id,
-            event_name=event.name,
-            prompt=event.prompt,
-            prompt_type=event.prompt_type,
-            data_type=event.data_type,
-            description=event.description,
+        pending = self._recorder.record_condition_waiting(
+            action_id=condition_action_id,
+            condition_name=condition.name,
+            prompt=condition.prompt,
+            prompt_type=condition.prompt_type,
+            data_type=condition.data_type,
+            description=condition.description,
         )
 
-        timeout_seconds = event._timeout_seconds
+        timeout_seconds = condition._timeout_seconds
 
         if pending is not None:
-            # TUI mode: block until the TUI resolves the event
+            # TUI mode: block until the TUI resolves the condition
             loop = asyncio.get_event_loop()
             result = await loop.run_in_executor(None, pending.wait_for_result, timeout_seconds)
             if pending.timed_out:
-                msg = f"Event '{event.name}' was not signaled within {timeout_seconds} seconds."
-                self._recorder.record_failure(action_id=event_action_id, error=msg)
-                raise flyte.errors.EventTimedoutError(msg)
+                msg = f"Condition '{condition.name}' was not signaled within {timeout_seconds} seconds."
+                self._recorder.record_failure(action_id=condition_action_id, error=msg)
+                raise flyte.errors.ConditionTimedoutError(msg)
             if result is None:
                 self._recorder.record_failure(
-                    action_id=event_action_id, error=f"Event '{event.name}' was cancelled (TUI quit)."
+                    action_id=condition_action_id, error=f"Condition '{condition.name}' was cancelled (TUI quit)."
                 )
-                raise RuntimeError(f"Event '{event.name}' was cancelled (TUI quit).")
-            self._recorder.record_complete(action_id=event_action_id, outputs=result)
+                raise RuntimeError(f"Condition '{condition.name}' was cancelled (TUI quit).")
+            self._recorder.record_complete(action_id=condition_action_id, outputs=result)
             return result
 
         # Non-TUI mode: fall back to rich console prompts
@@ -541,43 +541,43 @@ class LocalController(ControllerProtocol):
             loop = asyncio.get_event_loop()
             try:
                 result = await asyncio.wait_for(
-                    loop.run_in_executor(None, self._prompt_event_console, event),
+                    loop.run_in_executor(None, self._prompt_condition_console, condition),
                     timeout=timeout_seconds,
                 )
             except asyncio.TimeoutError:
-                msg = f"Event '{event.name}' was not signaled within {timeout_seconds} seconds."
-                self._recorder.record_failure(action_id=event_action_id, error=msg)
-                raise flyte.errors.EventTimedoutError(msg)
+                msg = f"Condition '{condition.name}' was not signaled within {timeout_seconds} seconds."
+                self._recorder.record_failure(action_id=condition_action_id, error=msg)
+                raise flyte.errors.ConditionTimedoutError(msg)
         else:
-            result = self._prompt_event_console(event)
-        self._recorder.record_complete(action_id=event_action_id, outputs=result)
+            result = self._prompt_condition_console(condition)
+        self._recorder.record_complete(action_id=condition_action_id, outputs=result)
         return result
 
     @staticmethod
-    def _prompt_event_console(event: Any) -> Any:
+    def _prompt_condition_console(condition: Any) -> Any:
         from rich.console import Console
         from rich.prompt import Confirm, Prompt
 
         console = Console()
-        console.print(f"\n[bold cyan]Event:[/bold cyan] {event.name}")
-        if event.description:
-            console.print(f"[dim]{event.description}[/dim]")
+        console.print(f"\n[bold cyan]Condition:[/bold cyan] {condition.name}")
+        if condition.description:
+            console.print(f"[dim]{condition.description}[/dim]")
 
-        if event.data_type is bool:
-            result = Confirm.ask(event.prompt, console=console)
-        elif event.data_type in (int, float, str):
+        if condition.data_type is bool:
+            result = Confirm.ask(condition.prompt, console=console)
+        elif condition.data_type in (int, float, str):
             while True:
                 try:
-                    value = Prompt.ask(event.prompt, console=console)
-                    result = event.data_type(value)
+                    value = Prompt.ask(condition.prompt, console=console)
+                    result = condition.data_type(value)
                     break
                 except ValueError:
-                    type_name = event.data_type.__name__
+                    type_name = condition.data_type.__name__
                     console.print(f"[red]Please enter a valid {type_name}[/red]")
         else:
-            raise ValueError(f"Unsupported data type {event.data_type}")
+            raise ValueError(f"Unsupported data type {condition.data_type}")
 
-        logger.debug(f"Event {event.name} received value: {result}")
+        logger.debug(f"Condition {condition.name} received value: {result}")
         return result
 
 

--- a/src/flyte/_internal/controllers/remote/_action.py
+++ b/src/flyte/_internal/controllers/remote/_action.py
@@ -253,7 +253,7 @@ class Action:
         cls,
         parent_action_name: str,
         action_id: identifier_pb2.ActionIdentifier,
-        event_name: str,
+        condition_name: str,
         prompt: str,
         data_type: builtins.type,
         run_output_base: str,
@@ -266,14 +266,14 @@ class Action:
         # webhook_url: str | None = None,
         # webhook_payload: dict | None = None,
     ) -> Action:
-        """Create a condition action for an event.
+        """Create a condition action.
 
         ``inputs_uri`` is a placeholder path — conditions have no real inputs,
         but the EnqueueRequest validator requires a non-empty value.
         """
         simple_type = cls._DATA_TYPE_TO_SIMPLE.get(data_type)
         if simple_type is None:
-            raise TypeError(f"Unsupported event data_type {data_type}")
+            raise TypeError(f"Unsupported condition data_type {data_type}")
 
         literal_type = types_pb2.LiteralType(simple=simple_type)
 
@@ -281,12 +281,12 @@ class Action:
             action_id=action_id,
             parent_action_name=parent_action_name,
             type="condition",
-            friendly_name=event_name,
+            friendly_name=condition_name,
             group=group_data,
             inputs_uri=inputs_uri,
             run_output_base=run_output_base,
             condition=run_definition_pb2.ConditionAction(
-                name=event_name,
+                name=condition_name,
                 type=literal_type,
                 prompt=prompt,
                 description=description,

--- a/src/flyte/_internal/controllers/remote/_controller.py
+++ b/src/flyte/_internal/controllers/remote/_controller.py
@@ -137,7 +137,7 @@ class RemoteController(Controller):
         self._submit_loop: asyncio.AbstractEventLoop | None = None
         self._submit_thread: threading.Thread | None = None
         self._submit_init_lock = threading.Lock()
-        self._pending_events: dict[str, Action] = {}
+        self._pending_conditions: dict[str, Action] = {}
 
     def generate_task_call_sequence(self, task_obj: object, action_id: ActionID) -> int:
         """
@@ -615,17 +615,17 @@ class RemoteController(Controller):
         async with self._parent_action_semaphore[unique_action_name(task_action)]:
             return await self._submit_task_ref(task_call_seq, _task, *args, **kwargs)
 
-    async def register_event(self, event: Any):
+    async def register_condition(self, condition: Any):
         """
-        Register an event by submitting a condition action to the backend.
+        Register a condition by submitting a condition action to the backend.
         Returns immediately after the action is enqueued (fire-and-forget).
 
-        :param event: Event object to register
+        :param condition: Condition object to register
         """
-        from flyte._event import _Event
+        from flyte._condition import _Condition
 
-        if not isinstance(event, _Event):
-            raise TypeError(f"Expected _Event, got {type(event)}")
+        if not isinstance(condition, _Condition):
+            raise TypeError(f"Expected _Condition, got {type(condition)}")
 
         ctx = internal_ctx()
         tctx = ctx.data.task_context
@@ -635,14 +635,14 @@ class RemoteController(Controller):
             raise flyte.errors.RuntimeSystemError("BadContext", "Task action not initialized")
 
         current_action_id = tctx.action
-        # Condition actions nest under the real running task (task_action), so events fired inside a
+        # Condition actions nest under the real running task (task_action), so conditions fired inside a
         # @trace still parent to the task rather than the trace pseudo-action.
         task_action = tctx.task_action
-        invoke_seq = self.generate_task_call_sequence(event, current_action_id)
+        invoke_seq = self.generate_task_call_sequence(condition, current_action_id)
 
-        # Generate a deterministic action name from event name + sequence
+        # Generate a deterministic action name from condition name + sequence
         sub_action_id, sub_action_output_path = convert.generate_sub_action_id_and_output_path(
-            tctx, event.name, event.name, invoke_seq
+            tctx, condition.name, condition.name, invoke_seq
         )
 
         action = Action.from_condition(
@@ -656,62 +656,66 @@ class RemoteController(Controller):
                     org=current_action_id.org,
                 ),
             ),
-            event_name=event.name,
-            prompt=event.prompt,
-            data_type=event.data_type,
-            description=event.description,
+            condition_name=condition.name,
+            prompt=condition.prompt,
+            data_type=condition.data_type,
+            description=condition.description,
             group_data=tctx.group_data,
             run_output_base=tctx.run_base_dir,
             inputs_uri=io.inputs_path(sub_action_output_path),
         )
 
         logger.info(
-            f"Registering event '{event.name}' as condition action [{action.name}] "
+            f"Registering condition '{condition.name}' as condition action [{action.name}] "
             f"Run:[{action.run_name}], Parent:[{action.parent_action_name}]"
         )
 
-        # Store for wait_for_event to retrieve later
-        self._pending_events[event.name] = action
+        # Store for wait_for_condition to retrieve later
+        self._pending_conditions[condition.name] = action
 
         # Submit without waiting — returns immediately
         await self.start_action(action)
 
-    async def wait_for_event(self, event: Any) -> Any:
+    async def wait_for_condition(self, condition: Any) -> Any:
         """
-        Wait for a previously registered event to be signaled by the backend.
+        Wait for a previously registered condition to be signaled by the backend.
 
-        :param event: Event object to wait for
-        :return: The typed payload associated with the event when it is signaled.
-            For bool events, returns ``True`` or ``False``.
-        :raises flyte.errors.EventTimedoutError: If the condition times out before being signaled.
-        :raises flyte.errors.EventFailedError: If the condition fails during execution.
+        :param condition: Condition object to wait for
+        :return: The typed payload associated with the condition when it is signaled.
+            For bool conditions, returns ``True`` or ``False``.
+        :raises flyte.errors.ConditionTimedoutError: If the condition times out before being signaled.
+        :raises flyte.errors.ConditionFailedError: If the condition fails during execution.
         :raises flyte.errors.ActionAbortedError: If the condition action is externally aborted.
         """
-        from flyte._event import _Event
+        from flyte._condition import _Condition
 
-        if not isinstance(event, _Event):
-            raise TypeError(f"Expected _Event, got {type(event)}")
+        if not isinstance(condition, _Condition):
+            raise TypeError(f"Expected _Condition, got {type(condition)}")
 
-        if event.name not in self._pending_events:
-            raise RuntimeError(f"Event '{event.name}' was not registered. Call register_event first.")
+        if condition.name not in self._pending_conditions:
+            raise RuntimeError(f"Condition '{condition.name}' was not registered. Call register_condition first.")
 
-        action = self._pending_events.pop(event.name)
+        action = self._pending_conditions.pop(condition.name)
 
-        logger.info(f"Waiting for event '{event.name}' condition action [{action.name}]")
+        logger.info(f"Waiting for condition '{condition.name}' condition action [{action.name}]")
 
         n = await self.wait_for_action(action)
 
         if n.phase == phase_pb2.ACTION_PHASE_ABORTED:
-            raise flyte.errors.ActionAbortedError(f"Event '{event.name}' action {n.action_id.name} was aborted")
+            raise flyte.errors.ActionAbortedError(f"Condition '{condition.name}' action {n.action_id.name} was aborted")
 
         if n.phase == phase_pb2.ACTION_PHASE_TIMED_OUT:
-            raise flyte.errors.EventTimedoutError(f"Event '{event.name}' was not signaled within the timeout period.")
+            raise flyte.errors.ConditionTimedoutError(
+                f"Condition '{condition.name}' was not signaled within the timeout period."
+            )
 
         if n.has_error() or n.phase == phase_pb2.ACTION_PHASE_FAILED:
-            raise flyte.errors.EventFailedError(f"Event '{event.name}' condition action {n.action_id.name} failed.")
+            raise flyte.errors.ConditionFailedError(
+                f"Condition '{condition.name}' condition action {n.action_id.name} failed."
+            )
 
         # Condition actions deliver the signaled Literal inline via ActionUpdate.value
         # (no output_uri). Convert to the expected Python type.
         if n.condition_output is not None:
-            return Action.literal_to_python(n.condition_output, event.data_type)
+            return Action.literal_to_python(n.condition_output, condition.data_type)
         return None

--- a/src/flyte/_persistence/_recorder.py
+++ b/src/flyte/_persistence/_recorder.py
@@ -36,24 +36,25 @@ class RunRecorder:
         return None
 
     # ------------------------------------------------------------------
-    # Event waiting (called by LocalController for TUI interaction)
+    # Condition waiting (called by LocalController for TUI interaction)
     # ------------------------------------------------------------------
 
-    def record_event_waiting(
+    def record_condition_waiting(
         self,
         *,
         action_id: str,
-        event_name: str,
+        condition_name: str,
         prompt: str,
         prompt_type: str,
         data_type: type,
         description: str = "",
     ) -> Any:
-        """Record that an action is waiting for an event. Returns PendingEvent if tracker is present, else None."""
+        """Record that an action is waiting for a condition. Returns PendingCondition if tracker is present,
+        else None."""
         if self._tracker is not None:
-            return self._tracker.record_event_waiting(
+            return self._tracker.record_condition_waiting(
                 action_id=action_id,
-                event_name=event_name,
+                condition_name=condition_name,
                 prompt=prompt,
                 prompt_type=prompt_type,
                 data_type=data_type,

--- a/src/flyte/cli/_get.py
+++ b/src/flyte/cli/_get.py
@@ -257,7 +257,7 @@ def action(
 @click.argument("run_name", type=str, required=True)
 @click.argument("action_name", type=str, required=False)
 @click.pass_obj
-def event(
+def condition(
     cfg: common.CLIConfig,
     run_name: str,
     action_name: str | None = None,
@@ -265,21 +265,21 @@ def event(
     domain: str | None = None,
 ):
     """
-    List events (paused condition actions) for a run, optionally filtered to a
+    List conditions (paused condition actions) for a run, optionally filtered to a
     specific parent action.
 
-    Each event corresponds to a condition action registered via
-    ``flyte.new_event(...)`` from a workflow. Use ``flyte signal event`` to
+    Each condition corresponds to a condition action registered via
+    ``flyte.new_condition(...)`` from a workflow. Use ``flyte signal condition`` to
     resolve one.
     """
     cfg.init(project=project, domain=domain)
 
     console = common.get_console()
-    title = f"Events for {run_name}.{action_name}" if action_name else f"Events for {run_name}"
+    title = f"Conditions for {run_name}.{action_name}" if action_name else f"Conditions for {run_name}"
     console.print(
         common.format(
             title,
-            remote.Event.listall(run_name=run_name, action_name=action_name),
+            remote.Condition.listall(run_name=run_name, action_name=action_name),
             cfg.output_format,
         )
     )

--- a/src/flyte/cli/_signal.py
+++ b/src/flyte/cli/_signal.py
@@ -10,7 +10,7 @@ from flyte.cli import _common as common
 @click.group(name="signal")
 def signal():
     """
-    Signal an event waiting on a paused condition action.
+    Signal a paused condition action.
     """
 
 
@@ -19,7 +19,7 @@ def signal():
 @click.argument("action-name", type=str, required=True)
 @click.argument("value", type=str, required=False, default=None)
 @click.pass_obj
-def event(
+def condition(
     cfg: common.CLIConfig,
     run_name: str,
     action_name: str,
@@ -44,8 +44,8 @@ def event(
         raise click.ClickException(f"Action '{action_name}' in run '{run_name}' is not a signalable condition.")
     cond = details.pb2.condition
 
-    ev = remote.Event(pb2=action.pb2)
-    expected = ev.expected_type
+    cond_obj = remote.Condition(pb2=action.pb2)
+    expected = cond_obj.expected_type
     if expected is None:
         raise click.ClickException(f"Backend did not expose expected payload type for condition '{action_name}'.")
 
@@ -59,11 +59,11 @@ def event(
         console.print(f"signaling with: {payload!r}")
 
     with console.status(
-        f"Signaling event on action '{action_name}' (run '{run_name}')...",
+        f"Signaling condition on action '{action_name}' (run '{run_name}')...",
         spinner=common.safe_spinner("dots"),
     ):
-        ev.signal(payload)
-    console.print(f"Event on action '{action_name}' has been signaled.")
+        cond_obj.signal(payload)
+    console.print(f"Condition on action '{action_name}' has been signaled.")
 
 
 _BOOL_TRUE = {"true", "1", "yes", "y", "t"}

--- a/src/flyte/cli/_tui/_app.py
+++ b/src/flyte/cli/_tui/_app.py
@@ -15,7 +15,7 @@ from textual.widgets import Button, Footer, Header, Input, Markdown, RichLog, St
 from textual.widgets.tree import TreeNode
 from textual.worker import Worker, WorkerState
 
-from ._tracker import ActionNode, ActionStatus, ActionTracker, PendingEvent
+from ._tracker import ActionNode, ActionStatus, ActionTracker, PendingCondition
 
 _STATUS_ICON = {
     ActionStatus.RUNNING: ("●", "dodger_blue1"),
@@ -178,94 +178,94 @@ class _DetailBox(Static):
         super().__init__(*args, **kwargs)
 
 
-class EventInputPanel(Vertical):
-    """Interactive panel shown when a task is paused waiting for an event."""
+class ConditionInputPanel(Vertical):
+    """Interactive panel shown when a task is paused waiting for a condition."""
 
     DEFAULT_CSS = """
-    EventInputPanel {
+    ConditionInputPanel {
         height: auto;
         padding: 1;
     }
-    EventInputPanel .event-prompt {
+    ConditionInputPanel .condition-prompt {
         margin-bottom: 1;
     }
-    EventInputPanel .event-description {
+    ConditionInputPanel .condition-description {
         color: $text-muted;
         margin-bottom: 1;
     }
-    EventInputPanel .event-buttons {
+    ConditionInputPanel .condition-buttons {
         height: auto;
         layout: horizontal;
     }
-    EventInputPanel .event-buttons Button {
+    ConditionInputPanel .condition-buttons Button {
         margin-right: 1;
     }
-    EventInputPanel .event-input-row {
+    ConditionInputPanel .condition-input-row {
         height: auto;
         layout: horizontal;
     }
-    EventInputPanel .event-input-row Input {
+    ConditionInputPanel .condition-input-row Input {
         width: 1fr;
         margin-right: 1;
     }
-    EventInputPanel .event-validation-error {
+    ConditionInputPanel .condition-validation-error {
         color: red;
         height: auto;
     }
     """
 
     class Submitted(Message):
-        """Posted when the user submits a value for a pending event."""
+        """Posted when the user submits a value for a pending condition."""
 
         def __init__(self, action_id: str, value: Any) -> None:
             super().__init__()
             self.action_id = action_id
             self.value = value
 
-    def __init__(self, pending: PendingEvent, **kwargs: Any) -> None:
+    def __init__(self, pending: PendingCondition, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._pending = pending
 
     def compose(self) -> ComposeResult:
-        pe = self._pending
-        if pe.description:
-            yield Static(pe.description, classes="event-description")
+        pc = self._pending
+        if pc.description:
+            yield Static(pc.description, classes="condition-description")
 
-        if pe.prompt_type == "markdown":
-            yield Markdown(pe.prompt, classes="event-prompt")
+        if pc.prompt_type == "markdown":
+            yield Markdown(pc.prompt, classes="condition-prompt")
         else:
-            yield Static(pe.prompt, classes="event-prompt")
+            yield Static(pc.prompt, classes="condition-prompt")
 
-        if pe.data_type is bool:
-            with Horizontal(classes="event-buttons"):
-                yield Button("Yes", id="event-yes", variant="success")
-                yield Button("No", id="event-no", variant="error")
+        if pc.data_type is bool:
+            with Horizontal(classes="condition-buttons"):
+                yield Button("Yes", id="condition-yes", variant="success")
+                yield Button("No", id="condition-no", variant="error")
         else:
-            type_name = pe.data_type.__name__
-            with Horizontal(classes="event-input-row"):
-                yield Input(placeholder=f"Enter a {type_name} value...", id="event-input")
-                yield Button("Submit", id="event-submit", variant="primary")
-            yield Static("", id="event-validation-error", classes="event-validation-error")
+            type_name = pc.data_type.__name__
+            with Horizontal(classes="condition-input-row"):
+                yield Input(placeholder=f"Enter a {type_name} value...", id="condition-input")
+                yield Button("Submit", id="condition-submit", variant="primary")
+            yield Static("", id="condition-validation-error", classes="condition-validation-error")
 
-    @on(Button.Pressed, "#event-yes")
+    @on(Button.Pressed, "#condition-yes")
     def _on_yes(self) -> None:
         self.post_message(self.Submitted(self._pending.action_id, True))
 
-    @on(Button.Pressed, "#event-no")
+    @on(Button.Pressed, "#condition-no")
     def _on_no(self) -> None:
         self.post_message(self.Submitted(self._pending.action_id, False))
 
-    @on(Button.Pressed, "#event-submit")
+    @on(Button.Pressed, "#condition-submit")
     def _on_submit(self) -> None:
         self._try_submit()
 
-    @on(Input.Submitted, "#event-input")
+    @on(Input.Submitted, "#condition-input")
     def _on_input_submitted(self) -> None:
         self._try_submit()
 
     def _try_submit(self) -> None:
-        inp = self.query_one("#event-input", Input)
-        err_label = self.query_one("#event-validation-error", Static)
+        inp = self.query_one("#condition-input", Input)
+        err_label = self.query_one("#condition-validation-error", Static)
         raw = inp.value.strip()
         if not raw:
             err_label.update("Value cannot be empty.")
@@ -280,42 +280,42 @@ class EventInputPanel(Vertical):
         self.post_message(self.Submitted(self._pending.action_id, value))
 
 
-class EventResultPanel(Vertical):
-    """Read-only panel showing a resolved event's prompt and the submitted response."""
+class ConditionResultPanel(Vertical):
+    """Read-only panel showing a resolved condition's prompt and the submitted response."""
 
     DEFAULT_CSS = """
-    EventResultPanel {
+    ConditionResultPanel {
         height: auto;
         padding: 1;
     }
-    EventResultPanel .event-prompt {
+    ConditionResultPanel .condition-prompt {
         margin-bottom: 1;
     }
-    EventResultPanel .event-description {
+    ConditionResultPanel .condition-description {
         color: $text-muted;
         margin-bottom: 1;
     }
-    EventResultPanel .event-response {
+    ConditionResultPanel .condition-response {
         color: $success;
     }
     """
 
-    def __init__(self, pending: PendingEvent, value: Any, **kwargs: Any) -> None:
+    def __init__(self, pending: PendingCondition, value: Any, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._pending = pending
         self._value = value
 
     def compose(self) -> ComposeResult:
-        pe = self._pending
-        if pe.description:
-            yield Static(pe.description, classes="event-description")
+        pc = self._pending
+        if pc.description:
+            yield Static(pc.description, classes="condition-description")
 
-        if pe.prompt_type == "markdown":
-            yield Markdown(pe.prompt, classes="event-prompt")
+        if pc.prompt_type == "markdown":
+            yield Markdown(pc.prompt, classes="condition-prompt")
         else:
-            yield Static(pe.prompt, classes="event-prompt")
+            yield Static(pc.prompt, classes="condition-prompt")
 
-        yield Static(f"response: {self._value!r}", classes="event-response")
+        yield Static(f"response: {self._value!r}", classes="condition-response")
 
 
 class DetailPanel(VerticalScroll):
@@ -330,15 +330,15 @@ class DetailPanel(VerticalScroll):
     def __init__(self, tracker: ActionTracker, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._tracker = tracker
-        # Identifies the panel currently mounted in the event box:
+        # Identifies the panel currently mounted in the condition box:
         # "<action_id>|pending" or "<action_id>|resolved".
-        self._current_event_key: str | None = None
+        self._current_condition_key: str | None = None
         self._selected_attempts_by_action: dict[str, int] = {}
 
     def compose(self) -> ComposeResult:
         yield _DetailBox(id="box-attempt-controls")
         yield _DetailBox(id="box-task-details")
-        yield _DetailBox(id="box-event")
+        yield _DetailBox(id="box-condition")
         yield _DetailBox(id="box-report")
         yield _DetailBox(id="box-log-links")
         yield _DetailBox(id="box-inputs")
@@ -354,28 +354,30 @@ class DetailPanel(VerticalScroll):
     def refresh_detail(self) -> None:
         self._render_detail()
 
-    def _clear_event_box(self, event_box: _DetailBox) -> None:
-        """Remove any mounted event panel (interactive or read-only)."""
-        if self._current_event_key is not None:
-            for input_panel in event_box.query(EventInputPanel):
+    def _clear_condition_box(self, condition_box: _DetailBox) -> None:
+        """Remove any mounted condition panel (interactive or read-only)."""
+        if self._current_condition_key is not None:
+            for input_panel in condition_box.query(ConditionInputPanel):
                 input_panel.remove()
-            for result_panel in event_box.query(EventResultPanel):
+            for result_panel in condition_box.query(ConditionResultPanel):
                 result_panel.remove()
-            self._current_event_key = None
+            self._current_condition_key = None
 
-    def _hide_event_box(self, event_box: _DetailBox) -> None:
-        """Remove any mounted event panel and hide the event box."""
-        event_box.display = False
-        self._clear_event_box(event_box)
+    def _hide_condition_box(self, condition_box: _DetailBox) -> None:
+        """Remove any mounted condition panel and hide the condition box."""
+        condition_box.display = False
+        self._clear_condition_box(condition_box)
 
-    def _show_event_panel(self, event_box: _DetailBox, key: str, panel_factory: Callable[[], Any], title: str) -> None:
-        """Mount *panel_factory()* into the event box unless *key* is already shown."""
-        if self._current_event_key != key:
-            self._clear_event_box(event_box)
-            event_box.border_title = title
-            event_box.mount(panel_factory())
-            self._current_event_key = key
-        event_box.display = True
+    def _show_condition_panel(
+        self, condition_box: _DetailBox, key: str, panel_factory: Callable[[], Any], title: str
+    ) -> None:
+        """Mount *panel_factory()* into the condition box unless *key* is already shown."""
+        if self._current_condition_key != key:
+            self._clear_condition_box(condition_box)
+            condition_box.border_title = title
+            condition_box.mount(panel_factory())
+            self._current_condition_key = key
+        condition_box.display = True
 
     def _attempt_numbers_for_action(self, action_id: str) -> list[int]:
         node = self._tracker.get_action(action_id)
@@ -411,7 +413,7 @@ class DetailPanel(VerticalScroll):
         try:
             attempt_box = self.query_one("#box-attempt-controls", _DetailBox)
             task_box = self.query_one("#box-task-details", _DetailBox)
-            event_box = self.query_one("#box-event", _DetailBox)
+            condition_box = self.query_one("#box-condition", _DetailBox)
             report_box = self.query_one("#box-report", _DetailBox)
             log_links_box = self.query_one("#box-log-links", _DetailBox)
             inputs_box = self.query_one("#box-inputs", _DetailBox)
@@ -425,7 +427,7 @@ class DetailPanel(VerticalScroll):
             attempt_box.display = False
             task_box.update("Select an action to view details.")
             task_box.border_title = "Task Details"
-            self._hide_event_box(event_box)
+            self._hide_condition_box(condition_box)
             report_box.display = False
             log_links_box.display = False
             inputs_box.update("")
@@ -439,7 +441,7 @@ class DetailPanel(VerticalScroll):
         if node is None:
             attempt_box.display = False
             task_box.update(f"Action {aid} not found.")
-            self._hide_event_box(event_box)
+            self._hide_condition_box(condition_box)
             report_box.display = False
             log_links_box.display = False
             inputs_box.update("")
@@ -486,7 +488,7 @@ class DetailPanel(VerticalScroll):
             if elapsed:
                 details.append(f"duration:   {elapsed}")
             task_box.update("\n".join(details))
-            self._hide_event_box(event_box)
+            self._hide_condition_box(condition_box)
             report_box.display = False
             log_links_box.display = False
             inputs_box.display = False
@@ -518,18 +520,18 @@ class DetailPanel(VerticalScroll):
         details.append(f"cache:      {cache_str}")
         task_box.update("\n".join(details))
 
-        # -- Event box (interactive while paused) --
+        # -- Condition box (interactive while paused) --
         if node.status == ActionStatus.PAUSED:
-            pending = self._tracker.get_pending_event(aid)
+            pending = self._tracker.get_pending_condition(aid)
             if pending is not None:
-                self._show_event_panel(
-                    event_box,
+                self._show_condition_panel(
+                    condition_box,
                     f"{aid}|pending",
-                    functools.partial(EventInputPanel, pending),
-                    f"Event: {pending.event_name}",
+                    functools.partial(ConditionInputPanel, pending),
+                    f"Condition: {pending.condition_name}",
                 )
             else:
-                self._hide_event_box(event_box)
+                self._hide_condition_box(condition_box)
             # Hide other detail boxes when paused
             report_box.display = False
             log_links_box.display = False
@@ -538,18 +540,18 @@ class DetailPanel(VerticalScroll):
             outputs_box.display = False
             return
 
-        # -- Event box (read-only after the event was resolved) --
-        resolved = self._tracker.get_resolved_event(aid)
+        # -- Condition box (read-only after the condition was resolved) --
+        resolved = self._tracker.get_resolved_condition(aid)
         if resolved is not None:
-            pe, value = resolved
-            self._show_event_panel(
-                event_box,
+            pc, value = resolved
+            self._show_condition_panel(
+                condition_box,
                 f"{aid}|resolved",
-                lambda: EventResultPanel(pe, value),
-                f"Event: {pe.event_name} (signaled)",
+                lambda: ConditionResultPanel(pc, value),
+                f"Condition: {pc.condition_name} (signaled)",
             )
         else:
-            self._hide_event_box(event_box)
+            self._hide_condition_box(condition_box)
 
         # -- Report box (only when available) --
         if node.has_report and node.output_path:
@@ -677,17 +679,17 @@ class FlyteTUIApp(App[None]):
         height: auto;
         color: {_FLYTE_PURPLE_LIGHT};
     }}
-    EventInputPanel {{
+    ConditionInputPanel {{
         color: {_FLYTE_PURPLE_LIGHT};
     }}
-    EventInputPanel Button {{
+    ConditionInputPanel Button {{
         margin-right: 1;
     }}
-    EventInputPanel Input {{
+    ConditionInputPanel Input {{
         width: 1fr;
         margin-right: 1;
     }}
-    EventInputPanel .event-validation-error {{
+    ConditionInputPanel .condition-validation-error {{
         color: red;
     }}
     """
@@ -711,7 +713,7 @@ class FlyteTUIApp(App[None]):
         self._tracker = tracker
         self._execute_fn = execute_fn
         self._last_version: int = -1
-        self._seen_pending_event_ids: set[str] = set()
+        self._seen_pending_condition_ids: set[str] = set()
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -754,21 +756,21 @@ class FlyteTUIApp(App[None]):
             tree = self.query_one("#action-tree", ActionTreeWidget)
             tree.refresh_from_tracker()
             detail = self.query_one("#detail-panel", DetailPanel)
-            # Jump to a newly pending event's sub-action so its input panel is shown.
-            for pe in self._tracker.get_all_pending_events():
-                if pe.action_id not in self._seen_pending_event_ids:
-                    self._seen_pending_event_ids.add(pe.action_id)
-                    if tree.focus_action(pe.action_id):
-                        detail.action_id = pe.action_id
+            # Jump to a newly pending condition's sub-action so its input panel is shown.
+            for pc in self._tracker.get_all_pending_conditions():
+                if pc.action_id not in self._seen_pending_condition_ids:
+                    self._seen_pending_condition_ids.add(pc.action_id)
+                    if tree.focus_action(pc.action_id):
+                        detail.action_id = pc.action_id
             detail.refresh_detail()
 
     def on_tree_node_selected(self, event: Tree.NodeSelected[str]) -> None:
         detail = self.query_one("#detail-panel", DetailPanel)
         detail.action_id = event.node.data
 
-    @on(EventInputPanel.Submitted)
-    def _on_event_submitted(self, event: EventInputPanel.Submitted) -> None:
-        self._tracker.resolve_event(event.action_id, event.value)
+    @on(ConditionInputPanel.Submitted)
+    def _on_condition_submitted(self, event: ConditionInputPanel.Submitted) -> None:
+        self._tracker.resolve_condition(event.action_id, event.value)
 
     def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
         if event.state == WorkerState.SUCCESS:
@@ -777,9 +779,9 @@ class FlyteTUIApp(App[None]):
             self.sub_title = "failed"
 
     async def action_quit(self) -> None:
-        # Cancel all pending events so blocked threads don't hang
-        for pe in self._tracker.get_all_pending_events():
-            pe.set_result(None)
+        # Cancel all pending conditions so blocked threads don't hang
+        for pc in self._tracker.get_all_pending_conditions():
+            pc.set_result(None)
         self.exit()
         # The execution worker may be blocked on synchronous calls (via
         # syncify) that Textual's worker cancellation cannot interrupt.

--- a/src/flyte/cli/_tui/_tracker.py
+++ b/src/flyte/cli/_tui/_tracker.py
@@ -41,10 +41,10 @@ class ActionNode:
 
 
 @dataclass
-class PendingEvent:
-    """Represents an event that the TUI is waiting for the user to resolve."""
+class PendingCondition:
+    """Represents a condition that the TUI is waiting for the user to resolve."""
 
-    event_name: str
+    condition_name: str
     action_id: str
     prompt: str
     prompt_type: str  # "text" or "markdown"
@@ -95,8 +95,8 @@ class ActionTracker:
         self._root_ids: list[str] = []
         self._children: dict[str, list[str]] = {}
         self._version: int = 0
-        self._pending_events: dict[str, PendingEvent] = {}
-        self._resolved_events: dict[str, tuple[PendingEvent, Any]] = {}
+        self._pending_conditions: dict[str, PendingCondition] = {}
+        self._resolved_conditions: dict[str, tuple[PendingCondition, Any]] = {}
 
     @property
     def version(self) -> int:
@@ -249,9 +249,9 @@ class ActionTracker:
             node = self._nodes.get(action_id)
             if node is None:
                 return
-            # Drop any pending event (e.g. on timeout/cancel) so the TUI stops
+            # Drop any pending condition (e.g. on timeout/cancel) so the TUI stops
             # rendering its input panel.
-            self._pending_events.pop(action_id, None)
+            self._pending_conditions.pop(action_id, None)
             node.status = ActionStatus.FAILED
             if isinstance(error, Error):
                 node.error = error.err
@@ -286,18 +286,18 @@ class ActionTracker:
             if end_times:
                 group_node.end_time = max(end_times)
 
-    def record_event_waiting(
+    def record_condition_waiting(
         self,
         *,
         action_id: str,
-        event_name: str,
+        condition_name: str,
         prompt: str,
         prompt_type: str,
         data_type: type,
         description: str = "",
-    ) -> PendingEvent:
-        pe = PendingEvent(
-            event_name=event_name,
+    ) -> PendingCondition:
+        pc = PendingCondition(
+            condition_name=condition_name,
             action_id=action_id,
             prompt=prompt,
             prompt_type=prompt_type,
@@ -305,40 +305,40 @@ class ActionTracker:
             description=description,
         )
         with self._lock:
-            self._pending_events[action_id] = pe
+            self._pending_conditions[action_id] = pc
             node = self._nodes.get(action_id)
             if node is not None:
                 node.status = ActionStatus.PAUSED
             self._version += 1
-        return pe
+        return pc
 
-    def resolve_event(self, action_id: str, value: Any) -> None:
+    def resolve_condition(self, action_id: str, value: Any) -> None:
         with self._lock:
-            pe = self._pending_events.pop(action_id, None)
+            pc = self._pending_conditions.pop(action_id, None)
             node = self._nodes.get(action_id)
-            if pe is not None:
-                # Keep resolved events around so the TUI can keep rendering the
-                # prompt and the submitted response after the event is signaled.
-                self._resolved_events[action_id] = (pe, value)
+            if pc is not None:
+                # Keep resolved conditions around so the TUI can keep rendering the
+                # prompt and the submitted response after the condition is signaled.
+                self._resolved_conditions[action_id] = (pc, value)
             if node is not None:
                 # Transient; the controller records completion (with the value as
                 # the action's output) right after it unblocks.
                 node.status = ActionStatus.RUNNING
             self._version += 1
-        if pe is not None:
-            pe.set_result(value)
+        if pc is not None:
+            pc.set_result(value)
 
-    def get_pending_event(self, action_id: str) -> PendingEvent | None:
+    def get_pending_condition(self, action_id: str) -> PendingCondition | None:
         with self._lock:
-            return self._pending_events.get(action_id)
+            return self._pending_conditions.get(action_id)
 
-    def get_resolved_event(self, action_id: str) -> tuple[PendingEvent, Any] | None:
+    def get_resolved_condition(self, action_id: str) -> tuple[PendingCondition, Any] | None:
         with self._lock:
-            return self._resolved_events.get(action_id)
+            return self._resolved_conditions.get(action_id)
 
-    def get_all_pending_events(self) -> list[PendingEvent]:
+    def get_all_pending_conditions(self) -> list[PendingCondition]:
         with self._lock:
-            return list(self._pending_events.values())
+            return list(self._pending_conditions.values())
 
     def snapshot(self) -> tuple[list[str], dict[str, list[str]], dict[str, ActionNode]]:
         """Return (root_ids, children_map, all_nodes) — a consistent snapshot."""

--- a/src/flyte/errors.py
+++ b/src/flyte/errors.py
@@ -121,13 +121,13 @@ class TaskTimeoutError(RuntimeUserError):
         super().__init__("TaskTimeoutError", message, "user")
 
 
-class EventTimedoutError(RuntimeUserError):
+class ConditionTimedoutError(RuntimeUserError):
     """
-    This error is raised when an event is not signaled within its specified timeout.
+    This error is raised when a condition is not signaled within its specified timeout.
     """
 
     def __init__(self, message: str):
-        super().__init__("EventTimedoutError", message, "user")
+        super().__init__("ConditionTimedoutError", message, "user")
 
 
 class RetriesExhaustedError(RuntimeUserError):
@@ -348,31 +348,31 @@ class NonRecoverableError(RuntimeUserError):
         super().__init__(code, message)
 
 
-class EventAlreadyExistsError(RuntimeUserError):
+class ConditionAlreadyExistsError(RuntimeUserError):
     """
-    This error is raised when the user tries to create an event that already exists within the action.
+    This error is raised when the user tries to create a condition that already exists within the action.
     """
 
     def __init__(self, message: str):
-        super().__init__("EventAlreadyExistsError", message, "user")
+        super().__init__("ConditionAlreadyExistsError", message, "user")
 
 
-class EventFailedError(RuntimeUserError):
+class ConditionFailedError(RuntimeUserError):
     """
-    This error is raised when a condition event fails during execution.
+    This error is raised when a condition fails during execution.
 
     This can happen when the backend encounters an error while processing the condition,
-    or when the event is explicitly marked as failed by the system.
+    or when the condition is explicitly marked as failed by the system.
     """
 
     def __init__(self, message: str):
-        super().__init__("EventFailedError", message, "user")
+        super().__init__("ConditionFailedError", message, "user")
 
 
-class EventNotFoundError(RuntimeUserError):
+class ConditionNotFoundError(RuntimeUserError):
     """
-    This error is raised when the user tries to access an event that does not exist.
+    This error is raised when the user tries to access a condition that does not exist.
     """
 
     def __init__(self, message: str):
-        super().__init__("EventNotFoundError", message, "user")
+        super().__init__("ConditionNotFoundError", message, "user")

--- a/src/flyte/remote/__init__.py
+++ b/src/flyte/remote/__init__.py
@@ -8,7 +8,7 @@ __all__ = [
     "ActionInputs",
     "ActionOutputs",
     "App",
-    "Event",
+    "Condition",
     "Project",
     "Run",
     "RunDetails",
@@ -29,8 +29,8 @@ from ._action import Action, ActionDetails, ActionInputs, ActionOutputs
 from ._app import App
 from ._auth_metadata import auth_metadata
 from ._common import TimeFilter
+from ._condition import Condition
 from ._data import upload_dir, upload_file
-from ._event import Event
 from ._project import Project
 from ._run import Run, RunDetails
 from ._secret import Secret, SecretTypes

--- a/src/flyte/remote/_condition.py
+++ b/src/flyte/remote/_condition.py
@@ -13,20 +13,20 @@ from flyte.syncify import syncify
 from .._initialize import ensure_client, get_client, get_init_config
 from ._common import ToJSONMixin
 
-# The valid payload types for event signals, matching _event.EventType.
-EventPayload = Union[bool, int, float, str]
+# The valid payload types for condition signals, matching _condition.ConditionType.
+ConditionPayload = Union[bool, int, float, str]
 
 
 @dataclass
-class Event(ToJSONMixin):
+class Condition(ToJSONMixin):
     """
-    A remote Event registered within an action of a run.
+    A remote Condition registered within an action of a run.
 
-    Events pause a run until an external signal is delivered. On the backend an event is
-    backed by a *condition action*, so an ``Event`` simply wraps the condition
+    Conditions pause a run until an external signal is delivered. On the backend a condition is
+    backed by a *condition action*, so a ``Condition`` simply wraps the condition
     :class:`~flyteidl2.workflow.run_definition_pb2.Action` it represents.
 
-    Use :meth:`listall` to discover the events of a run, :meth:`get` to look one up by
+    Use :meth:`listall` to discover the conditions of a run, :meth:`get` to look one up by
     name, and :meth:`signal` to resolve one with a typed payload.
     """
 
@@ -34,19 +34,19 @@ class Event(ToJSONMixin):
 
     @property
     def name(self) -> str:
-        """The event name (the condition action's declared name)."""
+        """The condition name (the condition action's declared name)."""
         if self.pb2.metadata.HasField("condition"):
             return self.pb2.metadata.condition.name
         return self.pb2.id.name
 
     @property
     def action_name(self) -> str:
-        """The name of the condition action backing this event."""
+        """The name of the condition action backing this condition."""
         return self.pb2.id.name
 
     @property
     def run_name(self) -> str:
-        """The name of the run this event belongs to."""
+        """The name of the run this condition belongs to."""
         return self.pb2.id.run.name
 
     @property
@@ -90,17 +90,17 @@ class Event(ToJSONMixin):
         run_name: str,
         action_name: str | None = None,
         limit: int = 100,
-    ) -> AsyncIterator[Event]:
+    ) -> AsyncIterator[Condition]:
         """
-        List all Events for a run, optionally filtered to a specific parent action.
+        List all Conditions for a run, optionally filtered to a specific parent action.
 
-        Events are condition actions, so this lists the run's actions filtered (server
+        Conditions are condition actions, so this lists the run's actions filtered (server
         side) to ``ACTION_TYPE_CONDITION``.
 
-        :param run_name: The name of the Run to list events for (required).
-        :param action_name: Optionally narrow to events whose parent is this action.
-        :param limit: The maximum number of events to fetch per page.
-        :return: An async iterator of Event instances.
+        :param run_name: The name of the Run to list conditions for (required).
+        :param action_name: Optionally narrow to conditions whose parent is this action.
+        :param limit: The maximum number of conditions to fetch per page.
+        :return: An async iterator of Condition instances.
         """
         ensure_client()
         cfg = get_init_config()
@@ -146,31 +146,31 @@ class Event(ToJSONMixin):
         /,
         run_name: str,
         action_name: str | None = None,
-    ) -> Event | None:
+    ) -> Condition | None:
         """
-        Retrieve an existing Event by name within a run.
+        Retrieve an existing Condition by name within a run.
 
-        There is no dedicated get-event RPC, so this scans the run's condition actions
+        There is no dedicated get-condition RPC, so this scans the run's condition actions
         and returns the first whose name matches.
 
-        :param name: The name of the Event.
-        :param run_name: The name of the Run the event belongs to.
+        :param name: The name of the Condition.
+        :param run_name: The name of the Run the condition belongs to.
         :param action_name: Optionally narrow to a specific parent action within the run.
-        :return: An Event instance if found, otherwise None.
+        :return: A Condition instance if found, otherwise None.
         """
-        async for event in cls.listall.aio(run_name=run_name, action_name=action_name):
-            if event.name == name:
-                return event
+        async for condition in cls.listall.aio(run_name=run_name, action_name=action_name):
+            if condition.name == name:
+                return condition
         return None
 
     @syncify
-    async def signal(self, payload: EventPayload) -> None:
+    async def signal(self, payload: ConditionPayload) -> None:
         """
-        Signal the event with the provided payload.
+        Signal the condition with the provided payload.
 
         The payload must be one of: ``bool``, ``int``, ``float``, or ``str``.
 
-        :param payload: The value to signal the event with.
+        :param payload: The value to signal the condition with.
         :raises TypeError: If the payload is not a supported type.
         """
         if not isinstance(payload, (bool, int, float, str)):
@@ -187,7 +187,7 @@ class Event(ToJSONMixin):
         )
 
 
-def _encode_payload(value: EventPayload) -> Any:
+def _encode_payload(value: ConditionPayload) -> Any:
     """Encode a Python value into an EventPayload proto message."""
     # bool must be checked before int, since bool is a subclass of int.
     if isinstance(value, bool):

--- a/tests/internal/controllers/test_remote_conditions.py
+++ b/tests/internal/controllers/test_remote_conditions.py
@@ -1,8 +1,8 @@
-"""Tests for remote controller event registration and waiting.
+"""Tests for remote controller condition registration and waiting.
 
 These tests cover:
-- register_event: validates event, creates condition action, submits to backend (fire-and-forget)
-- wait_for_event: waits for condition action completion, returns typed payload
+- register_condition: validates condition, creates condition action, submits to backend (fire-and-forget)
+- wait_for_condition: waits for condition action completion, returns typed payload
 - Various data types (bool, int, float, str)
 - Error/failure/abort/timeout terminal phases
 - Integration with core controller start_action / wait_for_action split
@@ -22,8 +22,8 @@ from flyteidl2.task import task_definition_pb2
 import flyte
 import flyte.errors
 import flyte.report
+from flyte._condition import ConditionWebhook, _Condition
 from flyte._context import internal_ctx
-from flyte._event import EventWebhook, _Event
 from flyte._internal.controllers.remote._action import Action
 from flyte._internal.controllers.remote._controller import RemoteController
 from flyte._internal.controllers.remote._core import Controller
@@ -51,8 +51,8 @@ def _make_task_context(**overrides) -> TaskContext:
     return TaskContext(**defaults)
 
 
-def _make_event(name="approval", data_type=bool, **kwargs) -> _Event:
-    return _Event(name=name, data_type=data_type, **kwargs)
+def _make_condition(name="approval", data_type=bool, **kwargs) -> _Condition:
+    return _Condition(name=name, data_type=data_type, **kwargs)
 
 
 async def _make_client() -> ClientSet:
@@ -169,14 +169,14 @@ async def test_submit_and_wait_combines_both():
     assert result.phase == phase_pb2.ACTION_PHASE_SUCCEEDED
 
 
-# ── RemoteController: register_event ──────────────────────────────────────
+# ── RemoteController: register_condition ──────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_register_event_bool():
-    """register_event with bool data_type should submit a condition action and return immediately."""
+async def test_register_condition_bool():
+    """register_condition with bool data_type should submit a condition action and return immediately."""
     await flyte.init.aio()
-    event = _make_event(name="approve", data_type=bool, prompt="Approve deployment?")
+    condition = _make_condition(name="approve", data_type=bool, prompt="Approve deployment?")
 
     with patch("flyte._initialize.get_init_config") as mock_config:
         mock_config.return_value.root_dir = pathlib.Path(__file__).parent
@@ -187,17 +187,17 @@ async def test_register_event_bool():
             controller = _make_controller()
 
             with patch.object(controller, "start_action", new_callable=AsyncMock) as mock_start:
-                await controller.register_event(event)
+                await controller.register_condition(condition)
                 mock_start.assert_called_once()
                 action = mock_start.call_args[0][0]
                 assert action.type == "condition"
 
 
 @pytest.mark.asyncio
-async def test_register_event_str():
-    """register_event with str data_type."""
+async def test_register_condition_str():
+    """register_condition with str data_type."""
     await flyte.init.aio()
-    event = _make_event(name="user_input", data_type=str, prompt="Enter value:")
+    condition = _make_condition(name="user_input", data_type=str, prompt="Enter value:")
 
     with patch("flyte._initialize.get_init_config") as mock_config:
         mock_config.return_value.root_dir = pathlib.Path(__file__).parent
@@ -208,17 +208,17 @@ async def test_register_event_str():
             controller = _make_controller()
 
             with patch.object(controller, "start_action", new_callable=AsyncMock) as mock_start:
-                await controller.register_event(event)
+                await controller.register_condition(condition)
                 mock_start.assert_called_once()
                 action = mock_start.call_args[0][0]
                 assert action.type == "condition"
 
 
 @pytest.mark.asyncio
-async def test_register_event_int():
-    """register_event with int data_type."""
+async def test_register_condition_int():
+    """register_condition with int data_type."""
     await flyte.init.aio()
-    event = _make_event(name="count", data_type=int, prompt="How many?")
+    condition = _make_condition(name="count", data_type=int, prompt="How many?")
 
     with patch("flyte._initialize.get_init_config") as mock_config:
         mock_config.return_value.root_dir = pathlib.Path(__file__).parent
@@ -229,15 +229,15 @@ async def test_register_event_int():
             controller = _make_controller()
 
             with patch.object(controller, "start_action", new_callable=AsyncMock) as mock_start:
-                await controller.register_event(event)
+                await controller.register_condition(condition)
                 mock_start.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_register_event_float():
-    """register_event with float data_type."""
+async def test_register_condition_float():
+    """register_condition with float data_type."""
     await flyte.init.aio()
-    event = _make_event(name="threshold", data_type=float, prompt="Set threshold:")
+    condition = _make_condition(name="threshold", data_type=float, prompt="Set threshold:")
 
     with patch("flyte._initialize.get_init_config") as mock_config:
         mock_config.return_value.root_dir = pathlib.Path(__file__).parent
@@ -248,24 +248,24 @@ async def test_register_event_float():
             controller = _make_controller()
 
             with patch.object(controller, "start_action", new_callable=AsyncMock) as mock_start:
-                await controller.register_event(event)
+                await controller.register_condition(condition)
                 mock_start.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_register_event_rejects_non_event():
-    """register_event should raise TypeError for non-_Event objects."""
+async def test_register_condition_rejects_non_condition():
+    """register_condition should raise TypeError for non-_Condition objects."""
     controller = _make_controller()
-    with pytest.raises(TypeError, match="Expected _Event"):
-        await controller.register_event("not_an_event")
+    with pytest.raises(TypeError, match="Expected _Condition"):
+        await controller.register_condition("not_a_condition")
 
 
 @pytest.mark.asyncio
-async def test_register_event_with_webhook():
-    """register_event should work with webhook-configured events."""
+async def test_register_condition_with_webhook():
+    """register_condition should work with webhook-configured conditions."""
     await flyte.init.aio()
-    webhook = EventWebhook(url="https://example.com/hook", payload={"cb": "{callback_uri}"})
-    event = _make_event(name="webhook_event", webhook=webhook)
+    webhook = ConditionWebhook(url="https://example.com/hook", payload={"cb": "{callback_uri}"})
+    condition = _make_condition(name="webhook_condition", webhook=webhook)
 
     with patch("flyte._initialize.get_init_config") as mock_config:
         mock_config.return_value.root_dir = pathlib.Path(__file__).parent
@@ -276,15 +276,15 @@ async def test_register_event_with_webhook():
             controller = _make_controller()
 
             with patch.object(controller, "start_action", new_callable=AsyncMock) as mock_start:
-                await controller.register_event(event)
+                await controller.register_condition(condition)
                 mock_start.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_register_event_with_timeout():
-    """register_event should work with timeout-configured events."""
+async def test_register_condition_with_timeout():
+    """register_condition should work with timeout-configured conditions."""
     await flyte.init.aio()
-    event = _make_event(name="timed_event", timeout=timedelta(seconds=30))
+    condition = _make_condition(name="timed_condition", timeout=timedelta(seconds=30))
 
     with patch("flyte._initialize.get_init_config") as mock_config:
         mock_config.return_value.root_dir = pathlib.Path(__file__).parent
@@ -295,15 +295,15 @@ async def test_register_event_with_timeout():
             controller = _make_controller()
 
             with patch.object(controller, "start_action", new_callable=AsyncMock) as mock_start:
-                await controller.register_event(event)
+                await controller.register_condition(condition)
                 mock_start.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_register_event_with_description():
-    """register_event should pass description through to the condition action."""
+async def test_register_condition_with_description():
+    """register_condition should pass description through to the condition action."""
     await flyte.init.aio()
-    event = _make_event(name="described_event", description="This needs human review")
+    condition = _make_condition(name="described_condition", description="This needs human review")
 
     with patch("flyte._initialize.get_init_config") as mock_config:
         mock_config.return_value.root_dir = pathlib.Path(__file__).parent
@@ -314,18 +314,18 @@ async def test_register_event_with_description():
             controller = _make_controller()
 
             with patch.object(controller, "start_action", new_callable=AsyncMock) as mock_start:
-                await controller.register_event(event)
+                await controller.register_condition(condition)
                 mock_start.assert_called_once()
 
 
-# ── RemoteController: wait_for_event ──────────────────────────────────────
+# ── RemoteController: wait_for_condition ──────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_wait_for_event_bool_succeeded():
-    """wait_for_event should return bool payload on successful completion."""
+async def test_wait_for_condition_bool_succeeded():
+    """wait_for_condition should return bool payload on successful completion."""
     await flyte.init.aio()
-    event = _make_event(name="approve", data_type=bool)
+    condition = _make_condition(name="approve", data_type=bool)
 
     succeeded_action = Action(
         action_id=identifier_pb2.ActionIdentifier(
@@ -346,7 +346,7 @@ async def test_wait_for_event_bool_succeeded():
         with ctx.replace_task_context(tctx):
             controller = _make_controller()
 
-            # Simulate that register_event was called first
+            # Simulate that register_condition was called first
             with (
                 patch.object(controller, "start_action", new_callable=AsyncMock),
                 patch.object(
@@ -356,16 +356,16 @@ async def test_wait_for_event_bool_succeeded():
                     return_value=succeeded_action,
                 ) as mock_wait,
             ):
-                await controller.register_event(event)
-                await controller.wait_for_event(event)
+                await controller.register_condition(condition)
+                await controller.wait_for_condition(condition)
                 mock_wait.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_wait_for_event_str_succeeded():
-    """wait_for_event should return str payload on successful completion."""
+async def test_wait_for_condition_str_succeeded():
+    """wait_for_condition should return str payload on successful completion."""
     await flyte.init.aio()
-    event = _make_event(name="user_input", data_type=str)
+    condition = _make_condition(name="user_input", data_type=str)
 
     succeeded_action = Action(
         action_id=identifier_pb2.ActionIdentifier(
@@ -395,15 +395,15 @@ async def test_wait_for_event_str_succeeded():
                     return_value=succeeded_action,
                 ),
             ):
-                await controller.register_event(event)
-                await controller.wait_for_event(event)
+                await controller.register_condition(condition)
+                await controller.wait_for_condition(condition)
 
 
 @pytest.mark.asyncio
-async def test_wait_for_event_int_succeeded():
-    """wait_for_event should return int payload on successful completion."""
+async def test_wait_for_condition_int_succeeded():
+    """wait_for_condition should return int payload on successful completion."""
     await flyte.init.aio()
-    event = _make_event(name="count", data_type=int)
+    condition = _make_condition(name="count", data_type=int)
 
     succeeded_action = Action(
         action_id=identifier_pb2.ActionIdentifier(
@@ -433,15 +433,15 @@ async def test_wait_for_event_int_succeeded():
                     return_value=succeeded_action,
                 ),
             ):
-                await controller.register_event(event)
-                await controller.wait_for_event(event)
+                await controller.register_condition(condition)
+                await controller.wait_for_condition(condition)
 
 
 @pytest.mark.asyncio
-async def test_wait_for_event_float_succeeded():
-    """wait_for_event should return float payload on successful completion."""
+async def test_wait_for_condition_float_succeeded():
+    """wait_for_condition should return float payload on successful completion."""
     await flyte.init.aio()
-    event = _make_event(name="threshold", data_type=float)
+    condition = _make_condition(name="threshold", data_type=float)
 
     succeeded_action = Action(
         action_id=identifier_pb2.ActionIdentifier(
@@ -471,19 +471,19 @@ async def test_wait_for_event_float_succeeded():
                     return_value=succeeded_action,
                 ),
             ):
-                await controller.register_event(event)
-                await controller.wait_for_event(event)
+                await controller.register_condition(condition)
+                await controller.wait_for_condition(condition)
 
 
 @pytest.mark.asyncio
-async def test_wait_for_event_failed_phase():
-    """wait_for_event should raise EventFailedError when the condition action fails."""
+async def test_wait_for_condition_failed_phase():
+    """wait_for_condition should raise ConditionFailedError when the condition action fails."""
     await flyte.init.aio()
-    event = _make_event(name="fail_event", data_type=bool)
+    condition = _make_condition(name="fail_condition", data_type=bool)
 
     failed_action = Action(
         action_id=identifier_pb2.ActionIdentifier(
-            name="condition-fail_event",
+            name="condition-fail_condition",
             run=identifier_pb2.RunIdentifier(name="test_run"),
         ),
         parent_action_name="parent_action",
@@ -509,20 +509,20 @@ async def test_wait_for_event_failed_phase():
                     return_value=failed_action,
                 ),
             ):
-                await controller.register_event(event)
-                with pytest.raises(flyte.errors.EventFailedError):
-                    await controller.wait_for_event(event)
+                await controller.register_condition(condition)
+                with pytest.raises(flyte.errors.ConditionFailedError):
+                    await controller.wait_for_condition(condition)
 
 
 @pytest.mark.asyncio
-async def test_wait_for_event_aborted_phase():
-    """wait_for_event should raise ActionAbortedError when the condition action is aborted."""
+async def test_wait_for_condition_aborted_phase():
+    """wait_for_condition should raise ActionAbortedError when the condition action is aborted."""
     await flyte.init.aio()
-    event = _make_event(name="abort_event", data_type=bool)
+    condition = _make_condition(name="abort_condition", data_type=bool)
 
     aborted_action = Action(
         action_id=identifier_pb2.ActionIdentifier(
-            name="condition-abort_event",
+            name="condition-abort_condition",
             run=identifier_pb2.RunIdentifier(name="test_run"),
         ),
         parent_action_name="parent_action",
@@ -547,20 +547,20 @@ async def test_wait_for_event_aborted_phase():
                     return_value=aborted_action,
                 ),
             ):
-                await controller.register_event(event)
+                await controller.register_condition(condition)
                 with pytest.raises(flyte.errors.ActionAbortedError):
-                    await controller.wait_for_event(event)
+                    await controller.wait_for_condition(condition)
 
 
 @pytest.mark.asyncio
-async def test_wait_for_event_timed_out_phase():
-    """wait_for_event should raise EventTimedoutError when the condition action times out."""
+async def test_wait_for_condition_timed_out_phase():
+    """wait_for_condition should raise ConditionTimedoutError when the condition action times out."""
     await flyte.init.aio()
-    event = _make_event(name="timeout_event", data_type=bool, timeout=10)
+    condition = _make_condition(name="timeout_condition", data_type=bool, timeout=10)
 
     timed_out_action = Action(
         action_id=identifier_pb2.ActionIdentifier(
-            name="condition-timeout_event",
+            name="condition-timeout_condition",
             run=identifier_pb2.RunIdentifier(name="test_run"),
         ),
         parent_action_name="parent_action",
@@ -585,24 +585,24 @@ async def test_wait_for_event_timed_out_phase():
                     return_value=timed_out_action,
                 ),
             ):
-                await controller.register_event(event)
-                with pytest.raises(flyte.errors.EventTimedoutError):
-                    await controller.wait_for_event(event)
+                await controller.register_condition(condition)
+                with pytest.raises(flyte.errors.ConditionTimedoutError):
+                    await controller.wait_for_condition(condition)
 
 
 @pytest.mark.asyncio
-async def test_wait_for_event_rejects_non_event():
-    """wait_for_event should raise TypeError for non-_Event objects."""
+async def test_wait_for_condition_rejects_non_condition():
+    """wait_for_condition should raise TypeError for non-_Condition objects."""
     controller = _make_controller()
-    with pytest.raises(TypeError, match="Expected _Event"):
-        await controller.wait_for_event("not_an_event")
+    with pytest.raises(TypeError, match="Expected _Condition"):
+        await controller.wait_for_condition("not_a_condition")
 
 
 @pytest.mark.asyncio
-async def test_wait_for_event_without_register_raises():
-    """wait_for_event should raise if event was not previously registered."""
+async def test_wait_for_condition_without_register_raises():
+    """wait_for_condition should raise if condition was not previously registered."""
     await flyte.init.aio()
-    event = _make_event(name="unregistered")
+    condition = _make_condition(name="unregistered")
 
     with patch("flyte._initialize.get_init_config") as mock_config:
         mock_config.return_value.root_dir = pathlib.Path(__file__).parent
@@ -612,7 +612,7 @@ async def test_wait_for_event_without_register_raises():
         with ctx.replace_task_context(tctx):
             controller = _make_controller()
             with pytest.raises((RuntimeError, KeyError)):
-                await controller.wait_for_event(event)
+                await controller.wait_for_condition(condition)
 
 
 # ── Action.from_condition ──────────────────────────────────────────────────
@@ -627,7 +627,7 @@ def test_action_from_condition_creates_condition_type():
     action = Action.from_condition(
         parent_action_name="parent",
         action_id=action_id,
-        event_name="test_event",
+        condition_name="test_condition",
         prompt="Approve?",
         data_type=bool,
         run_output_base="/run_base",
@@ -648,7 +648,7 @@ def test_action_from_condition_with_description():
     action = Action.from_condition(
         parent_action_name="parent",
         action_id=action_id,
-        event_name="desc_event",
+        condition_name="desc_condition",
         prompt="Review?",
         data_type=str,
         description="Needs human review",
@@ -669,7 +669,7 @@ def test_action_from_condition_all_data_types(data_type):
     action = Action.from_condition(
         parent_action_name="parent",
         action_id=action_id,
-        event_name=f"event_{data_type.__name__}",
+        condition_name=f"condition_{data_type.__name__}",
         prompt="Enter value:",
         data_type=data_type,
         run_output_base="/run_base",
@@ -761,10 +761,10 @@ async def test_record_trace_uses_submit_and_wait():
 
 
 @pytest.mark.asyncio
-async def test_wait_for_event_failed_raises_event_failed_error():
-    """wait_for_event should raise EventFailedError (not generic Exception) on FAILED phase."""
+async def test_wait_for_condition_failed_raises_condition_failed_error():
+    """wait_for_condition should raise ConditionFailedError (not generic Exception) on FAILED phase."""
     await flyte.init.aio()
-    event = _make_event(name="fail_cond", data_type=str)
+    condition = _make_condition(name="fail_cond", data_type=str)
 
     failed_action = Action(
         action_id=identifier_pb2.ActionIdentifier(
@@ -793,16 +793,16 @@ async def test_wait_for_event_failed_raises_event_failed_error():
                     return_value=failed_action,
                 ),
             ):
-                await controller.register_event(event)
-                with pytest.raises(flyte.errors.EventFailedError, match="fail_cond"):
-                    await controller.wait_for_event(event)
+                await controller.register_condition(condition)
+                with pytest.raises(flyte.errors.ConditionFailedError, match="fail_cond"):
+                    await controller.wait_for_condition(condition)
 
 
 @pytest.mark.asyncio
-async def test_wait_for_event_failed_with_client_err_raises_event_failed():
-    """wait_for_event should raise EventFailedError even when client_err is set."""
+async def test_wait_for_condition_failed_with_client_err_raises_condition_failed():
+    """wait_for_condition should raise ConditionFailedError even when client_err is set."""
     await flyte.init.aio()
-    event = _make_event(name="fail_client", data_type=int)
+    condition = _make_condition(name="fail_client", data_type=int)
 
     failed_action = Action(
         action_id=identifier_pb2.ActionIdentifier(
@@ -832,18 +832,18 @@ async def test_wait_for_event_failed_with_client_err_raises_event_failed():
                     return_value=failed_action,
                 ),
             ):
-                await controller.register_event(event)
-                with pytest.raises(flyte.errors.EventFailedError):
-                    await controller.wait_for_event(event)
+                await controller.register_condition(condition)
+                with pytest.raises(flyte.errors.ConditionFailedError):
+                    await controller.wait_for_condition(condition)
 
 
 @pytest.mark.asyncio
-async def test_wait_for_event_timed_out_raises_event_timedout():
-    """wait_for_event should raise EventTimedoutError on TIMED_OUT phase for all data types."""
+async def test_wait_for_condition_timed_out_raises_condition_timedout():
+    """wait_for_condition should raise ConditionTimedoutError on TIMED_OUT phase for all data types."""
     await flyte.init.aio()
 
     for dt in (bool, int, float, str):
-        event = _make_event(name=f"timeout_{dt.__name__}", data_type=dt, timeout=5)
+        condition = _make_condition(name=f"timeout_{dt.__name__}", data_type=dt, timeout=5)
 
         timed_out_action = Action(
             action_id=identifier_pb2.ActionIdentifier(
@@ -872,9 +872,9 @@ async def test_wait_for_event_timed_out_raises_event_timedout():
                         return_value=timed_out_action,
                     ),
                 ):
-                    await controller.register_event(event)
-                    with pytest.raises(flyte.errors.EventTimedoutError):
-                        await controller.wait_for_event(event)
+                    await controller.register_condition(condition)
+                    with pytest.raises(flyte.errors.ConditionTimedoutError):
+                        await controller.wait_for_condition(condition)
 
 
 # ── Action.literal_to_python ─────────────────────────────────────────────────
@@ -1017,12 +1017,12 @@ def test_merge_state_ignores_value_for_non_condition():
         (str, {"string_value": "hello"}, "hello"),
     ],
 )
-async def test_wait_for_event_returns_signaled_value(data_type, primitive_kwargs, expected):
-    """wait_for_event should return the Python value carried in ActionUpdate.value."""
+async def test_wait_for_condition_returns_signaled_value(data_type, primitive_kwargs, expected):
+    """wait_for_condition should return the Python value carried in ActionUpdate.value."""
     from flyteidl2.core.literals_pb2 import Literal, Primitive, Scalar
 
     await flyte.init.aio()
-    event = _make_event(name=f"signal_{data_type.__name__}", data_type=data_type)
+    condition = _make_condition(name=f"signal_{data_type.__name__}", data_type=data_type)
 
     succeeded_action = Action(
         action_id=identifier_pb2.ActionIdentifier(
@@ -1052,17 +1052,17 @@ async def test_wait_for_event_returns_signaled_value(data_type, primitive_kwargs
                     return_value=succeeded_action,
                 ),
             ):
-                await controller.register_event(event)
-                result = await controller.wait_for_event(event)
+                await controller.register_condition(condition)
+                result = await controller.wait_for_condition(condition)
                 assert result == expected
                 assert isinstance(result, data_type)
 
 
 @pytest.mark.asyncio
-async def test_wait_for_event_returns_none_when_value_absent():
-    """wait_for_event should return None if the action succeeded without a value."""
+async def test_wait_for_condition_returns_none_when_value_absent():
+    """wait_for_condition should return None if the action succeeded without a value."""
     await flyte.init.aio()
-    event = _make_event(name="no_value", data_type=bool)
+    condition = _make_condition(name="no_value", data_type=bool)
 
     succeeded_action = Action(
         action_id=identifier_pb2.ActionIdentifier(
@@ -1091,20 +1091,20 @@ async def test_wait_for_event_returns_none_when_value_absent():
                     return_value=succeeded_action,
                 ),
             ):
-                await controller.register_event(event)
-                result = await controller.wait_for_event(event)
+                await controller.register_condition(condition)
+                result = await controller.wait_for_condition(condition)
                 assert result is None
 
 
-# ── register_event parent lineage (task_action) ──────────────────────────────
+# ── register_condition parent lineage (task_action) ──────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_register_event_parent_is_action_for_regular_task():
+async def test_register_condition_parent_is_action_for_regular_task():
     """For a regular task (no @trace), task_action defaults to action, so the condition action
     parents under tctx.action.name."""
     await flyte.init.aio()
-    event = _make_event(name="approve", data_type=bool)
+    condition = _make_condition(name="approve", data_type=bool)
 
     with patch("flyte._initialize.get_init_config") as mock_config:
         mock_config.return_value.root_dir = pathlib.Path(__file__).parent
@@ -1115,18 +1115,18 @@ async def test_register_event_parent_is_action_for_regular_task():
         with ctx.replace_task_context(tctx):
             controller = _make_controller()
             with patch.object(controller, "start_action", new_callable=AsyncMock) as mock_start:
-                await controller.register_event(event)
+                await controller.register_condition(condition)
                 action = mock_start.call_args[0][0]
                 assert action.type == "condition"
                 assert action.parent_action_name == "parent_action"
 
 
 @pytest.mark.asyncio
-async def test_register_event_reparents_to_task_action_inside_trace():
-    """When tctx.action has been swapped by @trace, a registered event must parent under
+async def test_register_condition_reparents_to_task_action_inside_trace():
+    """When tctx.action has been swapped by @trace, a registered condition must parent under
     tctx.task_action.name (the real running task), not the trace pseudo-action."""
     await flyte.init.aio()
-    event = _make_event(name="approve", data_type=bool)
+    condition = _make_condition(name="approve", data_type=bool)
 
     with patch("flyte._initialize.get_init_config") as mock_config:
         mock_config.return_value.root_dir = pathlib.Path(__file__).parent
@@ -1141,7 +1141,7 @@ async def test_register_event_reparents_to_task_action_inside_trace():
         with ctx.replace_task_context(tctx):
             controller = _make_controller()
             with patch.object(controller, "start_action", new_callable=AsyncMock) as mock_start:
-                await controller.register_event(event)
+                await controller.register_condition(condition)
                 action = mock_start.call_args[0][0]
                 assert action.type == "condition"
                 assert action.parent_action_name == "real_container_action"

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -1,6 +1,6 @@
 """
-Tests for the event system: _event.py, remote/_event.py, local controller event
-methods, and PendingEvent.
+Tests for the condition system: _condition.py, remote/_condition.py, local controller
+condition methods, and PendingCondition.
 """
 
 from __future__ import annotations
@@ -12,110 +12,110 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import flyte.errors
-from flyte._event import EventWebhook, _Event, new_event
+from flyte._condition import ConditionWebhook, _Condition, new_condition
 from flyte._internal.controllers._local_controller import _substitute_callback_uri
-from flyte.cli._tui._tracker import PendingEvent
-from flyte.remote._event import Event, _encode_payload
+from flyte.cli._tui._tracker import PendingCondition
+from flyte.remote._condition import Condition, _encode_payload
 
 # ---------------------------------------------------------------------------
-# _Event dataclass
+# _Condition dataclass
 # ---------------------------------------------------------------------------
 
 
-class TestEventCreation:
+class TestConditionCreation:
     def test_defaults(self):
-        e = _Event(name="ev1")
-        assert e.name == "ev1"
-        assert e.prompt == "Approve?"
-        assert e.prompt_type == "text"
-        assert e.data_type is bool
-        assert e.description == ""
-        assert e.timeout is None
-        assert e._timeout_seconds is None
+        c = _Condition(name="cond1")
+        assert c.name == "cond1"
+        assert c.prompt == "Approve?"
+        assert c.prompt_type == "text"
+        assert c.data_type is bool
+        assert c.description == ""
+        assert c.timeout is None
+        assert c._timeout_seconds is None
 
     def test_custom_fields(self):
-        e = _Event(
-            name="ev2",
+        c = _Condition(
+            name="cond2",
             prompt="Continue?",
             prompt_type="markdown",
             data_type=str,
             description="some desc",
         )
-        assert e.prompt == "Continue?"
-        assert e.prompt_type == "markdown"
-        assert e.data_type is str
-        assert e.description == "some desc"
+        assert c.prompt == "Continue?"
+        assert c.prompt_type == "markdown"
+        assert c.data_type is str
+        assert c.description == "some desc"
 
     @pytest.mark.parametrize("dt", [bool, int, float, str])
     def test_valid_data_types(self, dt):
-        e = _Event(name="ev", data_type=dt)
-        assert e.data_type is dt
+        c = _Condition(name="cond", data_type=dt)
+        assert c.data_type is dt
 
     @pytest.mark.parametrize("dt", [list, dict, bytes, object])
     def test_invalid_data_types(self, dt):
         with pytest.raises(TypeError, match="Invalid data_type"):
-            _Event(name="ev", data_type=dt)
+            _Condition(name="cond", data_type=dt)
 
 
-class TestEventTimeout:
+class TestConditionTimeout:
     def test_timeout_int_seconds(self):
-        e = _Event(name="ev", timeout=30)
-        assert e._timeout_seconds == 30.0
+        c = _Condition(name="cond", timeout=30)
+        assert c._timeout_seconds == 30.0
 
     def test_timeout_float_seconds(self):
-        e = _Event(name="ev", timeout=1.5)
-        assert e._timeout_seconds == 1.5
+        c = _Condition(name="cond", timeout=1.5)
+        assert c._timeout_seconds == 1.5
 
     def test_timeout_timedelta(self):
-        e = _Event(name="ev", timeout=timedelta(minutes=2))
-        assert e._timeout_seconds == 120.0
+        c = _Condition(name="cond", timeout=timedelta(minutes=2))
+        assert c._timeout_seconds == 120.0
 
     def test_timeout_none(self):
-        e = _Event(name="ev", timeout=None)
-        assert e._timeout_seconds is None
+        c = _Condition(name="cond", timeout=None)
+        assert c._timeout_seconds is None
 
     def test_timeout_zero_raises(self):
         with pytest.raises(ValueError, match="timeout must be positive"):
-            _Event(name="ev", timeout=0)
+            _Condition(name="cond", timeout=0)
 
     def test_timeout_negative_raises(self):
         with pytest.raises(ValueError, match="timeout must be positive"):
-            _Event(name="ev", timeout=-5)
+            _Condition(name="cond", timeout=-5)
 
     def test_timeout_negative_timedelta_raises(self):
         with pytest.raises(ValueError, match="timeout must be positive"):
-            _Event(name="ev", timeout=timedelta(seconds=-1))
+            _Condition(name="cond", timeout=timedelta(seconds=-1))
 
 
-class TestEventWait:
+class TestConditionWait:
     @pytest.mark.asyncio
     async def test_wait_outside_task_context_raises(self):
-        e = _Event(name="ev")
-        with pytest.raises(RuntimeError, match="Events can only be awaited within a task context"):
-            await e.wait.aio()
+        c = _Condition(name="cond")
+        with pytest.raises(RuntimeError, match="Conditions can only be awaited within a task context"):
+            await c.wait.aio()
 
 
 # ---------------------------------------------------------------------------
-# new_event factory
+# new_condition factory
 # ---------------------------------------------------------------------------
 
 
-class TestNewEvent:
+class TestNewCondition:
     @pytest.mark.asyncio
-    async def test_new_event_outside_context(self):
-        """Outside task context, new_event still returns an _Event (no-op registration)."""
-        e = await new_event.aio("my_event", prompt="Go?", data_type=int, timeout=10)
-        assert isinstance(e, _Event)
-        assert e.name == "my_event"
-        assert e.prompt == "Go?"
-        assert e.data_type is int
-        assert e._timeout_seconds == 10.0
+    async def test_new_condition_outside_context(self):
+        """Outside task context, new_condition still returns a _Condition (no-op registration)."""
+        c = await new_condition.aio("my_condition", prompt="Go?", data_type=int, timeout=10)
+        assert isinstance(c, _Condition)
+        assert c.name == "my_condition"
+        assert c.prompt == "Go?"
+        assert c.data_type is int
+        assert c._timeout_seconds == 10.0
 
     @pytest.mark.asyncio
-    async def test_new_event_registers_in_task_context(self):
-        """In a task context, new_event calls controller.register_event."""
+    async def test_new_condition_registers_in_task_context(self):
+        """In a task context, new_condition calls controller.register_condition."""
         mock_controller = MagicMock()
-        mock_controller.register_event = AsyncMock()
+        mock_controller.register_condition = AsyncMock()
 
         mock_ctx = MagicMock()
         mock_ctx.is_task_context.return_value = True
@@ -124,51 +124,51 @@ class TestNewEvent:
             patch("flyte._context.internal_ctx", return_value=mock_ctx),
             patch("flyte._internal.controllers.get_controller", return_value=mock_controller),
         ):
-            e = await new_event.aio("reg_event")
+            c = await new_condition.aio("reg_condition")
 
-        assert e.name == "reg_event"
-        mock_controller.register_event.assert_awaited_once_with(e)
+        assert c.name == "reg_condition"
+        mock_controller.register_condition.assert_awaited_once_with(c)
 
     @pytest.mark.asyncio
-    async def test_new_event_with_timeout_timedelta(self):
-        e = await new_event.aio("td_event", timeout=timedelta(seconds=45))
-        assert e._timeout_seconds == 45.0
+    async def test_new_condition_with_timeout_timedelta(self):
+        c = await new_condition.aio("td_condition", timeout=timedelta(seconds=45))
+        assert c._timeout_seconds == 45.0
 
 
 # ---------------------------------------------------------------------------
-# PendingEvent (TUI tracker)
+# PendingCondition (TUI tracker)
 # ---------------------------------------------------------------------------
 
 
-class TestPendingEvent:
+class TestPendingCondition:
     def test_set_and_wait(self):
-        pe = PendingEvent(
-            event_name="ev",
+        pc = PendingCondition(
+            condition_name="cond",
             action_id="act-1",
             prompt="ok?",
             prompt_type="text",
             data_type=bool,
         )
-        pe.set_result(True)
-        result = pe.wait_for_result()
+        pc.set_result(True)
+        result = pc.wait_for_result()
         assert result is True
-        assert pe.timed_out is False
+        assert pc.timed_out is False
 
     def test_timeout_expires(self):
-        pe = PendingEvent(
-            event_name="ev",
+        pc = PendingCondition(
+            condition_name="cond",
             action_id="act-1",
             prompt="ok?",
             prompt_type="text",
             data_type=bool,
         )
-        result = pe.wait_for_result(timeout=0.05)
+        result = pc.wait_for_result(timeout=0.05)
         assert result is None
-        assert pe.timed_out is True
+        assert pc.timed_out is True
 
     def test_result_before_timeout(self):
-        pe = PendingEvent(
-            event_name="ev",
+        pc = PendingCondition(
+            condition_name="cond",
             action_id="act-1",
             prompt="ok?",
             prompt_type="text",
@@ -176,19 +176,19 @@ class TestPendingEvent:
         )
 
         def signal():
-            pe.set_result(42)
+            pc.set_result(42)
 
         t = threading.Timer(0.02, signal)
         t.start()
-        result = pe.wait_for_result(timeout=2.0)
+        result = pc.wait_for_result(timeout=2.0)
         assert result == 42
-        assert pe.timed_out is False
+        assert pc.timed_out is False
         t.join()
 
     def test_no_timeout(self):
         """Without timeout, wait blocks until signaled."""
-        pe = PendingEvent(
-            event_name="ev",
+        pc = PendingCondition(
+            condition_name="cond",
             action_id="act-1",
             prompt="ok?",
             prompt_type="text",
@@ -196,22 +196,22 @@ class TestPendingEvent:
         )
 
         def signal():
-            pe.set_result("hello")
+            pc.set_result("hello")
 
         t = threading.Timer(0.02, signal)
         t.start()
-        result = pe.wait_for_result(timeout=None)
+        result = pc.wait_for_result(timeout=None)
         assert result == "hello"
-        assert pe.timed_out is False
+        assert pc.timed_out is False
         t.join()
 
 
 # ---------------------------------------------------------------------------
-# Local controller: register_event / wait_for_event
+# Local controller: register_condition / wait_for_condition
 # ---------------------------------------------------------------------------
 
 
-class TestLocalControllerEvents:
+class TestLocalControllerConditions:
     @pytest.fixture
     def controller(self):
         """Create a LocalController with mocked dependencies."""
@@ -219,41 +219,41 @@ class TestLocalControllerEvents:
         from flyte._internal.controllers._local_controller import LocalController
 
         mock_recorder = MagicMock()
-        mock_recorder.record_event_waiting.return_value = None  # non-TUI mode
+        mock_recorder.record_condition_waiting.return_value = None  # non-TUI mode
         controller = LocalController.__new__(LocalController)
-        controller._registered_events = {}
+        controller._registered_conditions = {}
         controller._recorder = mock_recorder
         controller._sequencer = TaskCallSequencer()
         return controller
 
     @pytest.mark.asyncio
-    async def test_register_event(self, controller):
-        e = _Event(name="ev1")
-        await controller.register_event(e)
-        assert "ev1" in controller._registered_events
-        assert controller._registered_events["ev1"] is e
+    async def test_register_condition(self, controller):
+        c = _Condition(name="cond1")
+        await controller.register_condition(c)
+        assert "cond1" in controller._registered_conditions
+        assert controller._registered_conditions["cond1"] is c
 
     @pytest.mark.asyncio
-    async def test_register_non_event_raises(self, controller):
-        with pytest.raises(TypeError, match="Expected _Event"):
-            await controller.register_event("not-an-event")
+    async def test_register_non_condition_raises(self, controller):
+        with pytest.raises(TypeError, match="Expected _Condition"):
+            await controller.register_condition("not-a-condition")
 
     @pytest.mark.asyncio
-    async def test_wait_non_event_raises(self, controller):
-        with pytest.raises(TypeError, match="Expected _Event"):
-            await controller.wait_for_event("not-an-event")
+    async def test_wait_non_condition_raises(self, controller):
+        with pytest.raises(TypeError, match="Expected _Condition"):
+            await controller.wait_for_condition("not-a-condition")
 
     @pytest.mark.asyncio
-    async def test_wait_for_event_tui_mode(self, controller):
-        """TUI mode: PendingEvent is returned by recorder, result comes from set_result."""
-        pe = PendingEvent(
-            event_name="ev",
+    async def test_wait_for_condition_tui_mode(self, controller):
+        """TUI mode: PendingCondition is returned by recorder, result comes from set_result."""
+        pc = PendingCondition(
+            condition_name="cond",
             action_id="act-1",
             prompt="ok?",
             prompt_type="text",
             data_type=bool,
         )
-        controller._recorder.record_event_waiting.return_value = pe
+        controller._recorder.record_condition_waiting.return_value = pc
 
         mock_ctx = MagicMock()
         mock_tctx = MagicMock()
@@ -261,31 +261,31 @@ class TestLocalControllerEvents:
         mock_tctx.task_action = None
         mock_ctx.data.task_context = mock_tctx
 
-        # Signal the event from another thread
+        # Signal the condition from another thread
         def signal():
-            pe.set_result(True)
+            pc.set_result(True)
 
         t = threading.Timer(0.02, signal)
         t.start()
 
-        e = _Event(name="ev")
+        c = _Condition(name="cond")
         with patch("flyte._internal.controllers._local_controller.internal_ctx", return_value=mock_ctx):
-            result = await controller.wait_for_event(e)
+            result = await controller.wait_for_condition(c)
 
         assert result is True
         t.join()
 
     @pytest.mark.asyncio
-    async def test_wait_for_event_tui_timeout(self, controller):
-        """TUI mode: timeout triggers EventTimedoutError."""
-        pe = PendingEvent(
-            event_name="ev",
+    async def test_wait_for_condition_tui_timeout(self, controller):
+        """TUI mode: timeout triggers ConditionTimedoutError."""
+        pc = PendingCondition(
+            condition_name="cond",
             action_id="act-1",
             prompt="ok?",
             prompt_type="text",
             data_type=bool,
         )
-        controller._recorder.record_event_waiting.return_value = pe
+        controller._recorder.record_condition_waiting.return_value = pc
 
         mock_ctx = MagicMock()
         mock_tctx = MagicMock()
@@ -293,16 +293,16 @@ class TestLocalControllerEvents:
         mock_tctx.task_action = None
         mock_ctx.data.task_context = mock_tctx
 
-        e = _Event(name="ev", timeout=0.05)
+        c = _Condition(name="cond", timeout=0.05)
 
         with patch("flyte._internal.controllers._local_controller.internal_ctx", return_value=mock_ctx):
-            with pytest.raises(flyte.errors.EventTimedoutError, match="not signaled within"):
-                await controller.wait_for_event(e)
+            with pytest.raises(flyte.errors.ConditionTimedoutError, match="not signaled within"):
+                await controller.wait_for_condition(c)
 
     @pytest.mark.asyncio
-    async def test_wait_for_event_console_timeout(self, controller):
-        """Non-TUI mode with timeout: timeout triggers EventTimedoutError."""
-        controller._recorder.record_event_waiting.return_value = None  # non-TUI
+    async def test_wait_for_condition_console_timeout(self, controller):
+        """Non-TUI mode with timeout: timeout triggers ConditionTimedoutError."""
+        controller._recorder.record_condition_waiting.return_value = None  # non-TUI
 
         mock_ctx = MagicMock()
         mock_tctx = MagicMock()
@@ -313,25 +313,25 @@ class TestLocalControllerEvents:
         stop = threading.Event()
 
         # Make console prompt block until stop is set (so the thread can be cleaned up)
-        def blocking_prompt(event):
+        def blocking_prompt(condition):
             stop.wait()
             return True
 
-        e = _Event(name="ev", timeout=0.05)
+        c = _Condition(name="cond", timeout=0.05)
 
         try:
             with (
                 patch("flyte._internal.controllers._local_controller.internal_ctx", return_value=mock_ctx),
-                patch.object(controller, "_prompt_event_console", side_effect=blocking_prompt),
+                patch.object(controller, "_prompt_condition_console", side_effect=blocking_prompt),
             ):
-                with pytest.raises(flyte.errors.EventTimedoutError, match="not signaled within"):
-                    await controller.wait_for_event(e)
+                with pytest.raises(flyte.errors.ConditionTimedoutError, match="not signaled within"):
+                    await controller.wait_for_condition(c)
         finally:
             stop.set()  # unblock the executor thread so it can exit
 
 
 # ---------------------------------------------------------------------------
-# remote Event — _encode_payload
+# remote Condition — _encode_payload
 # ---------------------------------------------------------------------------
 
 
@@ -358,12 +358,12 @@ class TestEncodePayload:
 
 
 # ---------------------------------------------------------------------------
-# remote Event — get / listall / signal
+# remote Condition — get / listall / signal
 # ---------------------------------------------------------------------------
 
 
 def _mock_condition_action(name: str, parent: str = "", run_name: str = "run1") -> MagicMock:
-    """Build a mock condition Action whose Event.name resolves to ``name``.
+    """Build a mock condition Action whose Condition.name resolves to ``name``.
 
     ``id`` is a real ActionIdentifier so ``signal`` can build a real SignalEventRequest.
     """
@@ -405,65 +405,65 @@ def _mock_cfg() -> MagicMock:
     return cfg
 
 
-class TestRemoteEventGet:
+class TestRemoteConditionGet:
     @pytest.mark.asyncio
-    async def test_get_returns_event(self):
-        target = _mock_condition_action("my_event", parent="act1")
+    async def test_get_returns_condition(self):
+        target = _mock_condition_action("my_condition", parent="act1")
         mock_client = _mock_list_actions_client([_mock_condition_action("other"), target])
 
         with (
-            patch("flyte.remote._event.ensure_client"),
-            patch("flyte.remote._event.get_client", return_value=mock_client),
-            patch("flyte.remote._event.get_init_config", return_value=_mock_cfg()),
+            patch("flyte.remote._condition.ensure_client"),
+            patch("flyte.remote._condition.get_client", return_value=mock_client),
+            patch("flyte.remote._condition.get_init_config", return_value=_mock_cfg()),
         ):
-            result = await Event.get.aio("my_event", run_name="run1", action_name="act1")
+            result = await Condition.get.aio("my_condition", run_name="run1", action_name="act1")
 
         assert result is not None
         assert result.pb2 is target
-        assert result.name == "my_event"
+        assert result.name == "my_condition"
 
     @pytest.mark.asyncio
     async def test_get_not_found_returns_none(self):
         mock_client = _mock_list_actions_client([_mock_condition_action("something_else")])
 
         with (
-            patch("flyte.remote._event.ensure_client"),
-            patch("flyte.remote._event.get_client", return_value=mock_client),
-            patch("flyte.remote._event.get_init_config", return_value=_mock_cfg()),
+            patch("flyte.remote._condition.ensure_client"),
+            patch("flyte.remote._condition.get_client", return_value=mock_client),
+            patch("flyte.remote._condition.get_init_config", return_value=_mock_cfg()),
         ):
-            result = await Event.get.aio("missing", run_name="run1")
+            result = await Condition.get.aio("missing", run_name="run1")
 
         assert result is None
 
 
-class TestRemoteEventListall:
+class TestRemoteConditionListall:
     @pytest.mark.asyncio
     async def test_listall_filters_by_parent_action(self):
-        match = _mock_condition_action("e1", parent="act1")
-        other = _mock_condition_action("e2", parent="act2")
+        match = _mock_condition_action("c1", parent="act1")
+        other = _mock_condition_action("c2", parent="act2")
         mock_client = _mock_list_actions_client([match, other])
 
         with (
-            patch("flyte.remote._event.ensure_client"),
-            patch("flyte.remote._event.get_client", return_value=mock_client),
-            patch("flyte.remote._event.get_init_config", return_value=_mock_cfg()),
+            patch("flyte.remote._condition.ensure_client"),
+            patch("flyte.remote._condition.get_client", return_value=mock_client),
+            patch("flyte.remote._condition.get_init_config", return_value=_mock_cfg()),
         ):
-            events = [e async for e in Event.listall.aio(run_name="run1", action_name="act1")]
+            conditions = [c async for c in Condition.listall.aio(run_name="run1", action_name="act1")]
 
-        assert [e.pb2 for e in events] == [match]
+        assert [c.pb2 for c in conditions] == [match]
 
     @pytest.mark.asyncio
     async def test_listall_filters_condition_actions_server_side(self):
         mock_client = _mock_list_actions_client([])
 
         with (
-            patch("flyte.remote._event.ensure_client"),
-            patch("flyte.remote._event.get_client", return_value=mock_client),
-            patch("flyte.remote._event.get_init_config", return_value=_mock_cfg()),
+            patch("flyte.remote._condition.ensure_client"),
+            patch("flyte.remote._condition.get_client", return_value=mock_client),
+            patch("flyte.remote._condition.get_init_config", return_value=_mock_cfg()),
         ):
-            events = [e async for e in Event.listall.aio(run_name="run1")]
+            conditions = [c async for c in Condition.listall.aio(run_name="run1")]
 
-        assert events == []
+        assert conditions == []
         mock_client.run_service.list_actions.assert_awaited_once()
         # The request must carry a server-side action_type == CONDITION (3) filter.
         req = mock_client.run_service.list_actions.await_args.args[0]
@@ -473,50 +473,50 @@ class TestRemoteEventListall:
 
     @pytest.mark.asyncio
     async def test_listall_pagination(self):
-        ev1 = _mock_condition_action("e1")
-        ev2 = _mock_condition_action("e2")
-        mock_client = _mock_list_actions_client([ev1], [ev2])
+        c1 = _mock_condition_action("c1")
+        c2 = _mock_condition_action("c2")
+        mock_client = _mock_list_actions_client([c1], [c2])
 
         with (
-            patch("flyte.remote._event.ensure_client"),
-            patch("flyte.remote._event.get_client", return_value=mock_client),
-            patch("flyte.remote._event.get_init_config", return_value=_mock_cfg()),
+            patch("flyte.remote._condition.ensure_client"),
+            patch("flyte.remote._condition.get_client", return_value=mock_client),
+            patch("flyte.remote._condition.get_init_config", return_value=_mock_cfg()),
         ):
-            events = [e async for e in Event.listall.aio(run_name="run1")]
+            conditions = [c async for c in Condition.listall.aio(run_name="run1")]
 
-        assert [e.pb2 for e in events] == [ev1, ev2]
+        assert [c.pb2 for c in conditions] == [c1, c2]
         assert mock_client.run_service.list_actions.await_count == 2
 
 
-class TestRemoteEventSignal:
+class TestRemoteConditionSignal:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("payload", [True, "go ahead", 42, 3.14])
     async def test_signal_sends_signal_event(self, payload):
         mock_client = MagicMock()
         mock_client.run_service.signal_event = AsyncMock()
 
-        event = Event(pb2=_mock_condition_action("e1", parent="act1"))
+        condition = Condition(pb2=_mock_condition_action("c1", parent="act1"))
 
         with (
-            patch("flyte.remote._event.ensure_client"),
-            patch("flyte.remote._event.get_client", return_value=mock_client),
+            patch("flyte.remote._condition.ensure_client"),
+            patch("flyte.remote._condition.get_client", return_value=mock_client),
         ):
-            await event.signal.aio(payload)
+            await condition.signal.aio(payload)
 
         mock_client.run_service.signal_event.assert_awaited_once()
         req = mock_client.run_service.signal_event.await_args.args[0]
-        assert req.action_id == event.pb2.id
+        assert req.action_id == condition.pb2.id
         assert req.parent_action_name == "act1"
 
     @pytest.mark.asyncio
     async def test_signal_invalid_type_raises(self):
-        event = Event(pb2=MagicMock())
+        condition = Condition(pb2=MagicMock())
         with pytest.raises(TypeError, match="payload must be bool, int, float, or str"):
-            await event.signal.aio([1, 2])
+            await condition.signal.aio([1, 2])
 
 
 # ---------------------------------------------------------------------------
-# Event.expected_type (auto-discovered from ActionMetadata.condition.type)
+# Condition.expected_type (auto-discovered from ActionMetadata.condition.type)
 # ---------------------------------------------------------------------------
 
 
@@ -542,7 +542,7 @@ def _mock_pb2_with_type(simple: int | None, has_condition: bool = True) -> Magic
     return pb
 
 
-class TestRemoteEventRichRepr:
+class TestRemoteConditionRichRepr:
     def test_yields_core_fields(self):
         from flyteidl2.common import identifier_pb2
         from flyteidl2.workflow import run_definition_pb2
@@ -558,7 +558,7 @@ class TestRemoteEventRichRepr:
                 parent="a0",
             ),
         )
-        pairs = dict(Event(pb2=action).__rich_repr__())
+        pairs = dict(Condition(pb2=action).__rich_repr__())
         assert pairs["name"] == "approve"
         assert pairs["action"] == "cond-hash"
         assert pairs["run"] == "run1"
@@ -567,7 +567,7 @@ class TestRemoteEventRichRepr:
         assert "type" not in pairs
 
 
-class TestRemoteEventExpectedType:
+class TestRemoteConditionExpectedType:
     @pytest.mark.parametrize(
         "simple_value, py_type",
         [
@@ -581,15 +581,15 @@ class TestRemoteEventExpectedType:
         from flyteidl2.core import types_pb2
 
         pb = _mock_pb2_with_type(getattr(types_pb2, simple_value))
-        assert Event(pb2=pb).expected_type is py_type
+        assert Condition(pb2=pb).expected_type is py_type
 
     def test_expected_type_no_condition_metadata(self):
         pb = _mock_pb2_with_type(simple=None, has_condition=False)
-        assert Event(pb2=pb).expected_type is None
+        assert Condition(pb2=pb).expected_type is None
 
     def test_expected_type_condition_without_type_field(self):
         pb = _mock_pb2_with_type(simple=None, has_condition=True)
-        assert Event(pb2=pb).expected_type is None
+        assert Condition(pb2=pb).expected_type is None
 
     def test_expected_type_proto_stub_missing_type_field(self):
         """When flyteidl2 stubs don't yet know about ConditionActionMetadata.type,
@@ -598,17 +598,17 @@ class TestRemoteEventExpectedType:
         pb = MagicMock()
         pb.metadata.HasField.return_value = True  # has 'condition'
         pb.metadata.condition.HasField.side_effect = ValueError("no field 'type'")
-        assert Event(pb2=pb).expected_type is None
+        assert Condition(pb2=pb).expected_type is None
 
     def test_expected_type_unsupported_simple_returns_none(self):
         from flyteidl2.core import types_pb2
 
         pb = _mock_pb2_with_type(types_pb2.DATETIME)
-        assert Event(pb2=pb).expected_type is None
+        assert Condition(pb2=pb).expected_type is None
 
 
 # ---------------------------------------------------------------------------
-# CLI: flyte signal event ...
+# CLI: flyte signal condition ...
 # ---------------------------------------------------------------------------
 
 
@@ -724,58 +724,58 @@ class TestSignalCliPromptForValue:
 
 
 # ---------------------------------------------------------------------------
-# EventWebhook dataclass
+# ConditionWebhook dataclass
 # ---------------------------------------------------------------------------
 
 
-class TestEventWebhook:
+class TestConditionWebhook:
     def test_basic_creation(self):
-        wh = EventWebhook(url="https://example.com/hook")
+        wh = ConditionWebhook(url="https://example.com/hook")
         assert wh.url == "https://example.com/hook"
         assert wh.payload is None
 
     def test_with_payload(self):
-        wh = EventWebhook(
+        wh = ConditionWebhook(
             url="https://example.com/hook",
-            payload={"callback": "{callback_uri}", "event": "approval"},
+            payload={"callback": "{callback_uri}", "condition": "approval"},
         )
         assert wh.url == "https://example.com/hook"
-        assert wh.payload == {"callback": "{callback_uri}", "event": "approval"}
+        assert wh.payload == {"callback": "{callback_uri}", "condition": "approval"}
 
-    def test_event_with_webhook(self):
-        wh = EventWebhook(url="https://example.com/hook")
-        e = _Event(name="ev", webhook=wh)
-        assert e.webhook is wh
+    def test_condition_with_webhook(self):
+        wh = ConditionWebhook(url="https://example.com/hook")
+        c = _Condition(name="cond", webhook=wh)
+        assert c.webhook is wh
 
-    def test_event_webhook_defaults_none(self):
-        e = _Event(name="ev")
-        assert e.webhook is None
+    def test_condition_webhook_defaults_none(self):
+        c = _Condition(name="cond")
+        assert c.webhook is None
 
 
-class TestNewEventWebhook:
+class TestNewConditionWebhook:
     @pytest.mark.asyncio
-    async def test_new_event_with_webhook(self):
-        wh = EventWebhook(url="https://example.com/hook", payload={"cb": "{callback_uri}"})
-        e = await new_event.aio("wh_event", webhook=wh)
-        assert e.webhook is wh
+    async def test_new_condition_with_webhook(self):
+        wh = ConditionWebhook(url="https://example.com/hook", payload={"cb": "{callback_uri}"})
+        c = await new_condition.aio("wh_condition", webhook=wh)
+        assert c.webhook is wh
 
     @pytest.mark.asyncio
-    async def test_new_event_registers_with_webhook_in_task_context(self):
+    async def test_new_condition_registers_with_webhook_in_task_context(self):
         mock_controller = MagicMock()
-        mock_controller.register_event = AsyncMock()
+        mock_controller.register_condition = AsyncMock()
 
         mock_ctx = MagicMock()
         mock_ctx.is_task_context.return_value = True
 
-        wh = EventWebhook(url="https://example.com/hook")
+        wh = ConditionWebhook(url="https://example.com/hook")
         with (
             patch("flyte._context.internal_ctx", return_value=mock_ctx),
             patch("flyte._internal.controllers.get_controller", return_value=mock_controller),
         ):
-            e = await new_event.aio("wh_reg_event", webhook=wh)
+            c = await new_condition.aio("wh_reg_condition", webhook=wh)
 
-        assert e.webhook is wh
-        mock_controller.register_event.assert_awaited_once_with(e)
+        assert c.webhook is wh
+        mock_controller.register_condition.assert_awaited_once_with(c)
 
 
 # ---------------------------------------------------------------------------
@@ -819,143 +819,150 @@ class TestSubstituteCallbackUri:
 
 
 # ---------------------------------------------------------------------------
-# Local controller: webhook firing
+# Condition wait() protocol
 # ---------------------------------------------------------------------------
 
 
-class TestEventWaitConditionProtocol:
-    """Tests for the event wait() condition protocol: timeout, failure, and output handling."""
+class TestConditionWaitProtocol:
+    """Tests for the condition wait() protocol: timeout, failure, and output handling."""
 
     @pytest.mark.asyncio
-    async def test_wait_raises_event_timedout_error(self):
-        """wait() should raise EventTimedoutError when the controller reports timeout."""
+    async def test_wait_raises_condition_timedout_error(self):
+        """wait() should raise ConditionTimedoutError when the controller reports timeout."""
         mock_controller = MagicMock()
-        mock_controller.wait_for_event = AsyncMock(
-            side_effect=flyte.errors.EventTimedoutError("Event 'ev' was not signaled within the timeout period.")
+        mock_controller.wait_for_condition = AsyncMock(
+            side_effect=flyte.errors.ConditionTimedoutError(
+                "Condition 'cond' was not signaled within the timeout period."
+            )
         )
 
         mock_ctx = MagicMock()
         mock_ctx.is_task_context.return_value = True
 
-        e = _Event(name="ev", data_type=bool, timeout=10)
+        c = _Condition(name="cond", data_type=bool, timeout=10)
 
         with (
             patch("flyte._context.internal_ctx", return_value=mock_ctx),
             patch("flyte._internal.controllers.get_controller", return_value=mock_controller),
         ):
-            with pytest.raises(flyte.errors.EventTimedoutError, match="not signaled within"):
-                await e.wait.aio()
+            with pytest.raises(flyte.errors.ConditionTimedoutError, match="not signaled within"):
+                await c.wait.aio()
 
     @pytest.mark.asyncio
-    async def test_wait_raises_event_failed_error(self):
-        """wait() should raise EventFailedError when the controller reports failure."""
+    async def test_wait_raises_condition_failed_error(self):
+        """wait() should raise ConditionFailedError when the controller reports failure."""
         mock_controller = MagicMock()
-        mock_controller.wait_for_event = AsyncMock(
-            side_effect=flyte.errors.EventFailedError("Event 'ev' condition action failed.")
+        mock_controller.wait_for_condition = AsyncMock(
+            side_effect=flyte.errors.ConditionFailedError("Condition 'cond' condition action failed.")
         )
 
         mock_ctx = MagicMock()
         mock_ctx.is_task_context.return_value = True
 
-        e = _Event(name="ev", data_type=str)
+        c = _Condition(name="cond", data_type=str)
 
         with (
             patch("flyte._context.internal_ctx", return_value=mock_ctx),
             patch("flyte._internal.controllers.get_controller", return_value=mock_controller),
         ):
-            with pytest.raises(flyte.errors.EventFailedError, match="failed"):
-                await e.wait.aio()
+            with pytest.raises(flyte.errors.ConditionFailedError, match="failed"):
+                await c.wait.aio()
 
     @pytest.mark.asyncio
     async def test_wait_returns_bool_true(self):
-        """wait() should return True for a bool event signaled with True."""
+        """wait() should return True for a bool condition signaled with True."""
         mock_controller = MagicMock()
-        mock_controller.wait_for_event = AsyncMock(return_value=True)
+        mock_controller.wait_for_condition = AsyncMock(return_value=True)
 
         mock_ctx = MagicMock()
         mock_ctx.is_task_context.return_value = True
 
-        e = _Event(name="approve", data_type=bool)
+        c = _Condition(name="approve", data_type=bool)
 
         with (
             patch("flyte._context.internal_ctx", return_value=mock_ctx),
             patch("flyte._internal.controllers.get_controller", return_value=mock_controller),
         ):
-            result = await e.wait.aio()
+            result = await c.wait.aio()
             assert result is True
 
     @pytest.mark.asyncio
     async def test_wait_returns_bool_false(self):
-        """wait() should return False for a bool event signaled with False."""
+        """wait() should return False for a bool condition signaled with False."""
         mock_controller = MagicMock()
-        mock_controller.wait_for_event = AsyncMock(return_value=False)
+        mock_controller.wait_for_condition = AsyncMock(return_value=False)
 
         mock_ctx = MagicMock()
         mock_ctx.is_task_context.return_value = True
 
-        e = _Event(name="approve", data_type=bool)
+        c = _Condition(name="approve", data_type=bool)
 
         with (
             patch("flyte._context.internal_ctx", return_value=mock_ctx),
             patch("flyte._internal.controllers.get_controller", return_value=mock_controller),
         ):
-            result = await e.wait.aio()
+            result = await c.wait.aio()
             assert result is False
 
     @pytest.mark.asyncio
     async def test_wait_returns_int(self):
-        """wait() should return an int for an int event."""
+        """wait() should return an int for an int condition."""
         mock_controller = MagicMock()
-        mock_controller.wait_for_event = AsyncMock(return_value=42)
+        mock_controller.wait_for_condition = AsyncMock(return_value=42)
 
         mock_ctx = MagicMock()
         mock_ctx.is_task_context.return_value = True
 
-        e = _Event(name="count", data_type=int)
+        c = _Condition(name="count", data_type=int)
 
         with (
             patch("flyte._context.internal_ctx", return_value=mock_ctx),
             patch("flyte._internal.controllers.get_controller", return_value=mock_controller),
         ):
-            result = await e.wait.aio()
+            result = await c.wait.aio()
             assert result == 42
             assert isinstance(result, int)
 
     @pytest.mark.asyncio
     async def test_wait_returns_float(self):
-        """wait() should return a float for a float event."""
+        """wait() should return a float for a float condition."""
         mock_controller = MagicMock()
-        mock_controller.wait_for_event = AsyncMock(return_value=3.14)
+        mock_controller.wait_for_condition = AsyncMock(return_value=3.14)
 
         mock_ctx = MagicMock()
         mock_ctx.is_task_context.return_value = True
 
-        e = _Event(name="threshold", data_type=float)
+        c = _Condition(name="threshold", data_type=float)
 
         with (
             patch("flyte._context.internal_ctx", return_value=mock_ctx),
             patch("flyte._internal.controllers.get_controller", return_value=mock_controller),
         ):
-            result = await e.wait.aio()
+            result = await c.wait.aio()
             assert abs(result - 3.14) < 1e-6
 
     @pytest.mark.asyncio
     async def test_wait_returns_str(self):
-        """wait() should return a str for a str event."""
+        """wait() should return a str for a str condition."""
         mock_controller = MagicMock()
-        mock_controller.wait_for_event = AsyncMock(return_value="go ahead")
+        mock_controller.wait_for_condition = AsyncMock(return_value="go ahead")
 
         mock_ctx = MagicMock()
         mock_ctx.is_task_context.return_value = True
 
-        e = _Event(name="input", data_type=str)
+        c = _Condition(name="input", data_type=str)
 
         with (
             patch("flyte._context.internal_ctx", return_value=mock_ctx),
             patch("flyte._internal.controllers.get_controller", return_value=mock_controller),
         ):
-            result = await e.wait.aio()
+            result = await c.wait.aio()
             assert result == "go ahead"
+
+
+# ---------------------------------------------------------------------------
+# Local controller: webhook firing
+# ---------------------------------------------------------------------------
 
 
 class TestLocalControllerWebhook:
@@ -964,36 +971,36 @@ class TestLocalControllerWebhook:
         from flyte._internal.controllers._local_controller import LocalController
 
         mock_recorder = MagicMock()
-        mock_recorder.record_event_waiting.return_value = None
+        mock_recorder.record_condition_waiting.return_value = None
         controller = LocalController.__new__(LocalController)
-        controller._registered_events = {}
+        controller._registered_conditions = {}
         controller._recorder = mock_recorder
         return controller
 
     @pytest.mark.asyncio
-    async def test_register_event_without_webhook_does_not_fire(self, controller):
-        e = _Event(name="ev_no_wh")
-        with patch.object(controller, "_fire_event_webhook", new_callable=AsyncMock) as mock_fire:
-            await controller.register_event(e)
+    async def test_register_condition_without_webhook_does_not_fire(self, controller):
+        c = _Condition(name="cond_no_wh")
+        with patch.object(controller, "_fire_condition_webhook", new_callable=AsyncMock) as mock_fire:
+            await controller.register_condition(c)
         mock_fire.assert_not_awaited()
-        assert "ev_no_wh" in controller._registered_events
+        assert "cond_no_wh" in controller._registered_conditions
 
     @pytest.mark.asyncio
-    async def test_register_event_with_webhook_fires(self, controller):
-        wh = EventWebhook(url="https://example.com/hook", payload={"cb": "{callback_uri}"})
-        e = _Event(name="ev_wh", webhook=wh)
-        with patch.object(controller, "_fire_event_webhook", new_callable=AsyncMock) as mock_fire:
-            await controller.register_event(e)
-        mock_fire.assert_awaited_once_with(e)
-        assert "ev_wh" in controller._registered_events
+    async def test_register_condition_with_webhook_fires(self, controller):
+        wh = ConditionWebhook(url="https://example.com/hook", payload={"cb": "{callback_uri}"})
+        c = _Condition(name="cond_wh", webhook=wh)
+        with patch.object(controller, "_fire_condition_webhook", new_callable=AsyncMock) as mock_fire:
+            await controller.register_condition(c)
+        mock_fire.assert_awaited_once_with(c)
+        assert "cond_wh" in controller._registered_conditions
 
     @pytest.mark.asyncio
-    async def test_fire_event_webhook_posts_with_substituted_payload(self, controller):
-        wh = EventWebhook(
+    async def test_fire_condition_webhook_posts_with_substituted_payload(self, controller):
+        wh = ConditionWebhook(
             url="https://example.com/hook",
-            payload={"callback": "{callback_uri}", "event": "test"},
+            payload={"callback": "{callback_uri}", "condition": "test"},
         )
-        e = _Event(name="my_ev", webhook=wh)
+        c = _Condition(name="my_cond", webhook=wh)
 
         mock_resp = MagicMock()
         mock_resp.status_code = 200
@@ -1004,18 +1011,18 @@ class TestLocalControllerWebhook:
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch("httpx.AsyncClient", return_value=mock_client):
-            await controller._fire_event_webhook(e)
+            await controller._fire_condition_webhook(c)
 
         mock_client.post.assert_awaited_once_with(
             "https://example.com/hook",
-            json={"callback": "local://events/my_ev/signal", "event": "test"},
+            json={"callback": "local://conditions/my_cond/signal", "condition": "test"},
             headers={"Content-Type": "application/json"},
         )
 
     @pytest.mark.asyncio
-    async def test_fire_event_webhook_no_payload(self, controller):
-        wh = EventWebhook(url="https://example.com/hook")
-        e = _Event(name="ev_nopayload", webhook=wh)
+    async def test_fire_condition_webhook_no_payload(self, controller):
+        wh = ConditionWebhook(url="https://example.com/hook")
+        c = _Condition(name="cond_nopayload", webhook=wh)
 
         mock_resp = MagicMock()
         mock_resp.status_code = 200
@@ -1026,7 +1033,7 @@ class TestLocalControllerWebhook:
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch("httpx.AsyncClient", return_value=mock_client):
-            await controller._fire_event_webhook(e)
+            await controller._fire_condition_webhook(c)
 
         mock_client.post.assert_awaited_once_with(
             "https://example.com/hook",
@@ -1035,10 +1042,10 @@ class TestLocalControllerWebhook:
         )
 
     @pytest.mark.asyncio
-    async def test_fire_event_webhook_exception_logged_not_raised(self, controller):
-        wh = EventWebhook(url="https://example.com/hook")
-        e = _Event(name="ev_fail", webhook=wh)
+    async def test_fire_condition_webhook_exception_logged_not_raised(self, controller):
+        wh = ConditionWebhook(url="https://example.com/hook")
+        c = _Condition(name="cond_fail", webhook=wh)
 
         with patch("httpx.AsyncClient", side_effect=Exception("connection error")):
             # Should not raise
-            await controller._fire_event_webhook(e)
+            await controller._fire_condition_webhook(c)


### PR DESCRIPTION
This pull request refactors the event-based workflow pausing mechanism to use the new "condition" terminology throughout the codebase and examples. The update includes renaming classes, functions, and variables from "event" to "condition", updating documentation and usage examples, and ensuring the new API is exposed at the package level. This improves clarity and aligns the API with its intended semantics.

**API and Core Functionality Updates:**

* Replaced all references to `EventWebhook`, `new_event`, and the `Event` class with `ConditionWebhook`, `new_condition`, and the `Condition` class, respectively, in both the implementation (`src/flyte/_condition.py`, previously `_event.py`) and the package exports (`src/flyte/__init__.py`).
* Updated the controller interface and internal logic to use `register_condition` and `wait_for_condition` instead of their event-based counterparts.

**Documentation and Example Updates:**

* Renamed the advanced example file from `events.py` to `conditions.py` and updated all code, comments, and documentation within to use the new "condition" terminology, including function names, variable names, CLI instructions, and webhook payloads.

These changes provide a more accurate and consistent API for pausing workflows based on external input, making the codebase easier to understand and maintain.