### PR TITLE
fix: raise InitializationError for invalid auth mode

### DIFF
--- a/src/flyte/remote/_client/auth/_authenticators/factory.py
+++ b/src/flyte/remote/_client/auth/_authenticators/factory.py
@@ -163,8 +163,16 @@ def get_async_authenticator(
 
             return PassthroughAuthenticator(endpoint=endpoint, **kwargs)
         case _:
-            raise ValueError(
-                f"Invalid auth mode [{auth_type}] specified. Please update the creds config to use a valid value"
+            # An unrecognized auth mode is a user-config mistake, not an SDK crash.
+            # Raise a typed InitializationError so the Sentry filter (flyte/_sentry.py)
+            # skips it — otherwise it leaks as RuntimeError("SelectCluster failed...")
+            # -> RuntimeSystemError with no actionable signal (FLYTE-SDK-50).
+            from flyte.errors import InitializationError
+
+            raise InitializationError(
+                "InvalidAuthMode",
+                "user",
+                f"Invalid auth mode [{auth_type}] specified. Please update the creds config to use a valid value",
             )
 
 

--- a/src/flyte/remote/_client/auth/_authenticators/factory.py
+++ b/src/flyte/remote/_client/auth/_authenticators/factory.py
@@ -164,9 +164,6 @@ def get_async_authenticator(
             return PassthroughAuthenticator(endpoint=endpoint, **kwargs)
         case _:
             # An unrecognized auth mode is a user-config mistake, not an SDK crash.
-            # Raise a typed InitializationError so the Sentry filter (flyte/_sentry.py)
-            # skips it — otherwise it leaks as RuntimeError("SelectCluster failed...")
-            # -> RuntimeSystemError with no actionable signal (FLYTE-SDK-50).
             from flyte.errors import InitializationError
 
             raise InitializationError(

--- a/tests/flyte/remote/test_passthrough.py
+++ b/tests/flyte/remote/test_passthrough.py
@@ -250,3 +250,19 @@ def test_concurrent_auth_metadata_contexts_isolated_with_syncify(endpoint):
     # Verify thread3's metadata
     metadata3 = list(results["thread3"].headers.items())
     assert metadata3 == [("user", "charlie"), ("role", "guest")]
+
+
+@pytest.mark.parametrize("auth_type", [None, "Bogus", "pkce"])
+def test_get_async_authenticator_invalid_mode_raises_initialization_error(endpoint, auth_type):
+    """FLYTE-SDK-50: an unrecognized auth mode is a user-config mistake. The factory
+    must raise a typed InitializationError (filtered from Sentry) rather than a bare
+    ValueError that leaks as RuntimeSystemError('SelectCluster failed...')."""
+    from flyte.errors import InitializationError
+    from flyte.remote._client.auth._authenticators.factory import get_async_authenticator
+
+    with pytest.raises(InitializationError) as exc_info:
+        # cfg_store is unused on the invalid-mode branch, so None is fine here.
+        get_async_authenticator(endpoint, None, auth_type=auth_type)
+
+    assert "Invalid auth mode" in str(exc_info.value)
+    assert str(auth_type) in str(exc_info.value)

--- a/tests/flyte/test_sentry.py
+++ b/tests/flyte/test_sentry.py
@@ -520,6 +520,20 @@ def test_capture_exception_skips_wrapped_invalid_endpoint_error():
     chain = list(_sentry._iter_cause_chain(err))
     assert any(isinstance(c, InitializationError) for c in chain)
 
+
+def test_capture_exception_skips_invalid_auth_mode_wrapped_as_system_error():
+    """FLYTE-SDK-50: an unrecognized auth mode (creds misconfig) raised from the
+    authenticator factory is wrapped through RuntimeError('SelectCluster failed...')
+    -> RuntimeSystemError('Failed to get signed url...'). It's a user-config mistake,
+    so it must be filtered out of Sentry."""
+    from flyte.errors import InitializationError
+
+    inner = InitializationError(
+        "InvalidAuthMode",
+        "user",
+        "Invalid auth mode [None] specified. Please update the creds config to use a valid value",
+    )
+    err = _wrap_as_upload_system_error(inner)
     with mock.patch.object(_sentry, "init") as init_mock:
         _sentry.capture_exception(err)
     init_mock.assert_not_called()


### PR DESCRIPTION
## Problem

An unrecognized auth mode in the creds config raised a bare `ValueError` from the authenticator factory (`_authenticators/factory.py`). During `SelectCluster` it gets wrapped as `RuntimeError("SelectCluster failed...")` → `RuntimeSystemError` and leaked to Sentry as an SDK crash with no actionable signal — even though it's a user-config mistake.

Sentry: **FLYTE-SDK-50** — `RuntimeSystemError: ... Invalid auth mode [None] specified. Please update the creds config to use a valid value`

## Fix

Raise a typed `InitializationError` (a user-facing error already in the Sentry filter's allowlist) instead of a bare `ValueError`. The Sentry user-error filter walks the cause chain and now skips it, and the user still gets the clear 'update the creds config' message.

## Tests

- `test_get_async_authenticator_invalid_mode_raises_initialization_error` — factory raises `InitializationError` for `None`/bogus modes.
- `test_capture_exception_skips_invalid_auth_mode_wrapped_as_system_error` — the wrapped `RuntimeSystemError` chain is filtered from Sentry.

fixes FLYTE-SDK-50