### PR TITLE
fix(ray): merge requests/limits into head/worker pod_template instead of replacing it

### DIFF
--- a/plugins/ray/src/flyteplugins/ray/task.py
+++ b/plugins/ray/src/flyteplugins/ray/task.py
@@ -1,4 +1,5 @@
 import base64
+import copy
 import json
 import os
 import typing
@@ -26,6 +27,68 @@ if typing.TYPE_CHECKING:
 
 _RAY_HEAD_CONTAINER_NAME = "ray-head"
 _RAY_WORKER_CONTAINER_NAME = "ray-worker"
+
+
+def _build_node_pod_template(
+    primary_container_name: str,
+    pod_template: Optional[PodTemplate],
+    requests: Optional[Resources],
+    limits: Optional[Resources],
+) -> Optional[PodTemplate]:
+    """
+    Build the K8s pod template for a Ray head/worker group.
+
+    When ``requests``/``limits`` are set they are *merged* into the primary container of the
+    user-supplied ``pod_template`` rather than replacing it, so custom fields such as
+    ``args``/``command``/``env``/volumes set on the template are preserved. Resource keys derived
+    from ``requests``/``limits`` take precedence over any already present on the primary container.
+
+    If no ``pod_template`` is provided, a pod spec is built from the resources alone. If neither
+    ``requests`` nor ``limits`` is set, the ``pod_template`` is returned unchanged.
+    """
+    if not requests and not limits:
+        return pod_template
+
+    from kubernetes.client import V1Container, V1ResourceRequirements
+
+    # Resource requirements derived from the structured Resources (handles the nvidia.com/gpu key,
+    # singular-resource validation and request/limit mirroring) for the primary container.
+    resource_pod_spec = pod_spec_from_resources(
+        primary_container_name=primary_container_name,
+        requests=requests,
+        limits=limits,
+    )
+    resource_requirements = resource_pod_spec.containers[0].resources
+
+    # No user-supplied spec to merge into: fall back to the resource-only pod spec, preserving any
+    # labels/annotations/primary_container_name carried by the template.
+    if pod_template is None or pod_template.pod_spec is None:
+        return PodTemplate(
+            pod_spec=resource_pod_spec,
+            primary_container_name=pod_template.primary_container_name if pod_template else primary_container_name,
+            labels=pod_template.labels if pod_template else None,
+            annotations=pod_template.annotations if pod_template else None,
+        )
+
+    merged = copy.deepcopy(pod_template)
+    containers = list(merged.pod_spec.containers or [])
+
+    # Locate the container the resources belong to: prefer the Ray container name, otherwise the
+    # sole container, otherwise append a new one.
+    primary = next((c for c in containers if c.name == primary_container_name), None)
+    if primary is None and len(containers) == 1:
+        primary = containers[0]
+    if primary is None:
+        primary = V1Container(name=primary_container_name)
+        containers.append(primary)
+        merged.pod_spec.containers = containers
+
+    existing = primary.resources or V1ResourceRequirements()
+    primary.resources = V1ResourceRequirements(
+        requests={**(existing.requests or {}), **(resource_requirements.requests or {})} or None,
+        limits={**(existing.limits or {}), **(resource_requirements.limits or {})} or None,
+    )
+    return merged
 
 
 @dataclass
@@ -91,16 +154,12 @@ class RayFunctionTask(AsyncFunctionTaskTemplate):
 
         head_group_spec = None
         if cfg.head_node_config:
-            if cfg.head_node_config.requests or cfg.head_node_config.limits:
-                head_pod_template = PodTemplate(
-                    pod_spec=pod_spec_from_resources(
-                        primary_container_name=_RAY_HEAD_CONTAINER_NAME,
-                        requests=cfg.head_node_config.requests,
-                        limits=cfg.head_node_config.limits,
-                    )
-                )
-            else:
-                head_pod_template = cfg.head_node_config.pod_template
+            head_pod_template = _build_node_pod_template(
+                primary_container_name=_RAY_HEAD_CONTAINER_NAME,
+                pod_template=cfg.head_node_config.pod_template,
+                requests=cfg.head_node_config.requests,
+                limits=cfg.head_node_config.limits,
+            )
 
             head_group_spec = HeadGroupSpec(
                 ray_start_params=cfg.head_node_config.ray_start_params,
@@ -110,16 +169,12 @@ class RayFunctionTask(AsyncFunctionTaskTemplate):
 
         worker_group_spec: typing.List[WorkerGroupSpec] = []
         for c in cfg.worker_node_config:
-            if c.requests or c.limits:
-                worker_pod_template = PodTemplate(
-                    pod_spec=pod_spec_from_resources(
-                        primary_container_name=_RAY_WORKER_CONTAINER_NAME,
-                        requests=c.requests,
-                        limits=c.limits,
-                    )
-                )
-            else:
-                worker_pod_template = c.pod_template
+            worker_pod_template = _build_node_pod_template(
+                primary_container_name=_RAY_WORKER_CONTAINER_NAME,
+                pod_template=c.pod_template,
+                requests=c.requests,
+                limits=c.limits,
+            )
 
             worker_group_spec.append(
                 WorkerGroupSpec(

--- a/plugins/ray/tests/test_task.py
+++ b/plugins/ray/tests/test_task.py
@@ -2,11 +2,12 @@ from pathlib import Path
 
 import flyte
 import pytest
-from flyte import Resources
+from flyte import PodTemplate, Resources
 from flyte.models import SerializationContext
 from flyteidl2.core import tasks_pb2
 from flyteidl2.plugins.ray_pb2 import RayJob
-from google.protobuf.json_format import ParseDict
+from google.protobuf.json_format import MessageToDict, ParseDict
+from kubernetes.client import V1Container, V1PodSpec, V1ResourceRequirements
 
 from flyteplugins.ray.task import HeadNodeConfig, RayJobConfig, WorkerNodeConfig
 
@@ -34,6 +35,12 @@ def _build_ray_task(ray_config: RayJobConfig):
 
 def _to_ray_job(custom_config: dict) -> RayJob:
     return ParseDict(custom_config, RayJob())
+
+
+def _primary_container(k8s_pod) -> dict:
+    """Return the first container of a serialized k8s_pod as a plain dict."""
+    pod_spec = MessageToDict(k8s_pod.pod_spec)
+    return pod_spec["containers"][0]
 
 
 def test_head_node_extended_resources(sctx):
@@ -84,3 +91,121 @@ def test_extended_resources_absent_without_gpu(sctx):
 
     assert not ray_job.ray_cluster.head_group_spec.HasField("extended_resources")
     assert not ray_job.ray_cluster.worker_group_spec[0].HasField("extended_resources")
+
+
+def _wut_pod_template(container_name: str) -> PodTemplate:
+    """A pod template that sets a custom entrypoint and cpu/memory resources."""
+    return PodTemplate(
+        pod_spec=V1PodSpec(
+            containers=[
+                V1Container(
+                    name=container_name,
+                    args=["wut update-aws-credentials-file default"],
+                    resources=V1ResourceRequirements(
+                        requests={"cpu": "15000m", "memory": "45Gi"},
+                        limits={"cpu": "15000m", "memory": "45Gi"},
+                    ),
+                )
+            ]
+        )
+    )
+
+
+def test_worker_pod_template_merged_with_requests(sctx):
+    """requests/limits must merge into the worker pod_template instead of replacing it.
+
+    Regression test: previously, setting requests/limits caused the SDK to build a
+    fresh pod spec from resources and drop the user's PodTemplate (losing custom
+    args/command/env and cpu/memory).
+    """
+    ray_config = RayJobConfig(
+        worker_node_config=[
+            WorkerNodeConfig(
+                group_name="workers",
+                replicas=2,
+                requests=Resources(gpu="A10G:1"),
+                pod_template=_wut_pod_template("ray-worker"),
+            ),
+        ],
+    )
+    ray_task = _build_ray_task(ray_config)
+
+    ray_job = _to_ray_job(ray_task.custom_config(sctx))
+
+    worker_spec = ray_job.ray_cluster.worker_group_spec[0]
+    container = _primary_container(worker_spec.k8s_pod)
+
+    # Custom entrypoint from the pod_template is preserved.
+    assert container["args"] == ["wut update-aws-credentials-file default"]
+    # cpu/memory from the pod_template AND the gpu from requests are both present.
+    assert container["resources"]["requests"]["cpu"] == "15000m"
+    assert container["resources"]["requests"]["memory"] == "45Gi"
+    assert container["resources"]["limits"]["nvidia.com/gpu"] == "1"
+    # extended_resources still reflects the requested accelerator type.
+    assert worker_spec.extended_resources.gpu_accelerator.device == "nvidia-a10g"
+
+
+def test_head_pod_template_merged_with_requests(sctx):
+    """requests/limits must merge into the head pod_template instead of replacing it."""
+    ray_config = RayJobConfig(
+        head_node_config=HeadNodeConfig(
+            requests=Resources(gpu="T4:1"),
+            pod_template=_wut_pod_template("ray-head"),
+        ),
+        worker_node_config=[WorkerNodeConfig(group_name="grp", replicas=1)],
+    )
+    ray_task = _build_ray_task(ray_config)
+
+    ray_job = _to_ray_job(ray_task.custom_config(sctx))
+
+    head_spec = ray_job.ray_cluster.head_group_spec
+    container = _primary_container(head_spec.k8s_pod)
+
+    assert container["args"] == ["wut update-aws-credentials-file default"]
+    assert container["resources"]["requests"]["cpu"] == "15000m"
+    assert container["resources"]["limits"]["nvidia.com/gpu"] == "1"
+    assert head_spec.extended_resources.gpu_accelerator.device == "nvidia-tesla-t4"
+
+
+def test_requests_take_precedence_over_pod_template_resources(sctx):
+    """Resource keys from requests/limits override the same keys on the pod_template."""
+    ray_config = RayJobConfig(
+        worker_node_config=[
+            WorkerNodeConfig(
+                group_name="workers",
+                replicas=1,
+                requests=Resources(cpu="8000m", memory="32Gi"),
+                pod_template=_wut_pod_template("ray-worker"),
+            ),
+        ],
+    )
+    ray_task = _build_ray_task(ray_config)
+
+    ray_job = _to_ray_job(ray_task.custom_config(sctx))
+
+    container = _primary_container(ray_job.ray_cluster.worker_group_spec[0].k8s_pod)
+    # requests=Resources(cpu="8000m", memory="32Gi") overrides the template's 15000m/45Gi.
+    assert container["resources"]["requests"]["cpu"] == "8000m"
+    assert container["resources"]["requests"]["memory"] == "32Gi"
+    # The custom entrypoint is still preserved.
+    assert container["args"] == ["wut update-aws-credentials-file default"]
+
+
+def test_pod_template_without_resources_is_unchanged(sctx):
+    """A pod_template with no requests/limits passes through untouched (existing behavior)."""
+    ray_config = RayJobConfig(
+        worker_node_config=[
+            WorkerNodeConfig(
+                group_name="workers",
+                replicas=1,
+                pod_template=_wut_pod_template("ray-worker"),
+            ),
+        ],
+    )
+    ray_task = _build_ray_task(ray_config)
+
+    ray_job = _to_ray_job(ray_task.custom_config(sctx))
+
+    container = _primary_container(ray_job.ray_cluster.worker_group_spec[0].k8s_pod)
+    assert container["args"] == ["wut update-aws-credentials-file default"]
+    assert container["resources"]["requests"]["cpu"] == "15000m"


### PR DESCRIPTION
## Summary

When a Ray `HeadNodeConfig`/`WorkerNodeConfig` set **both** `requests`/`limits` **and** a custom `pod_template`, `custom_config` built a fresh pod spec from the resources alone and dropped the user's `PodTemplate` during serialization. This silently discarded custom container fields (e.g. `args`/`command`/`env` used for BYOK auth entrypoints) and the cpu/memory declared on the template — only `nvidia.com/gpu` survived.

`custom_config` now merges the resource requirements into the primary container of the user's `pod_template` instead of replacing it:

- locates the container by the Ray container name (`ray-head`/`ray-worker`), falling back to the sole container, then appends one if absent;
- overlays the `requests`/`limits`-derived resource keys onto the container's existing resources (structured resources win on key collisions), preserving `args`/`command`/`env`/volumes and everything else;
- `extended_resources` (the GPU accelerator node selector) is unchanged.

### Before

```python
if c.requests or c.limits:
    worker_pod_template = PodTemplate(pod_spec=pod_spec_from_resources(...))  # fresh spec, template dropped
else:
    worker_pod_template = c.pod_template
```

For a config that sets `requests=Resources(gpu="A10G:1")` plus a `pod_template` with `args=[wut_cmd]` and cpu/memory, the serialized worker container ended up with only `nvidia.com/gpu: 1` and `args=None`.

### After

The worker container keeps the `wut` auth args **and** `15000m`/`45Gi` cpu/memory **and** `nvidia.com/gpu: 1`, with `extended_resources` still reporting `nvidia-a10g`.

## Test plan

- Added regression tests: head merge, worker merge, request precedence over template resources, and no-resource pass-through.
- `pytest plugins/ray/tests/test_task.py` → 7 passed.
- `ruff check` / `ruff format --check` clean.

Reported in [Slack](https://unionai.slack.com/archives/C08UPCCFSUV/p1781214787678229?thread_ts=1780336118.001079&cid=C08UPCCFSUV).