### PR TITLE
fix(serde): merge task resources into pod template instead of overwri…

### DIFF
--- a/src/flyte/_internal/runtime/task_serde.py
+++ b/src/flyte/_internal/runtime/task_serde.py
@@ -406,10 +406,18 @@ def _get_k8s_pod(primary_container: tasks_pb2.Container, pod_template: PodTempla
             for resource in primary_container.resources.requests:
                 requests[_sanitize_resource_name(resource)] = resource.value
 
-            resource_requirements = V1ResourceRequirements(limits=limits, requests=requests)
             if len(limits) > 0 or len(requests) > 0:
-                # Important! Only copy over resource requirements if they are non-empty.
-                container.resources = resource_requirements
+                # Merge the task-declared resources (cpu/mem/gpu from Resources(...))
+                # into whatever the pod template's primary container already set,
+                # instead of replacing it. This preserves extended-resource requests
+                # (e.g. device-plugin resources like "smarter-devices/fuse") that can
+                # only be expressed through the pod template — replacing would silently
+                # drop them. Task-declared keys win on conflict. Mirrors the backend's
+                # flytek8s MergeResources behavior.
+                existing = container.resources or V1ResourceRequirements()
+                merged_limits = {**(existing.limits or {}), **limits}
+                merged_requests = {**(existing.requests or {}), **requests}
+                container.resources = V1ResourceRequirements(limits=merged_limits, requests=merged_requests)
 
             if primary_container.env is not None:
                 container.env = [V1EnvVar(name=e.key, value=e.value) for e in primary_container.env] + (

--- a/tests/user_api/test_pod_template.py
+++ b/tests/user_api/test_pod_template.py
@@ -62,6 +62,88 @@ def test_pod_template_to_k8s_pod_with_empty_container():
     assert k8s_pod is not None
 
 
+def _serialize_with_task_resources(pod_template, *, cpu=None, memory=None):
+    """Run a pod template through task_serde._get_k8s_pod with task-declared
+    cpu/memory, returning the rendered primary container's resources dict.
+    """
+    from flyteidl2.core import tasks_pb2
+
+    from flyte._internal.runtime.task_serde import _get_k8s_pod
+
+    primary = tasks_pb2.Container()
+    if cpu is not None:
+        primary.resources.requests.append(
+            tasks_pb2.Resources.ResourceEntry(name=tasks_pb2.Resources.ResourceName.CPU, value=cpu)
+        )
+    if memory is not None:
+        primary.resources.limits.append(
+            tasks_pb2.Resources.ResourceEntry(name=tasks_pb2.Resources.ResourceName.MEMORY, value=memory)
+        )
+    from google.protobuf.json_format import MessageToDict
+
+    k8s_pod = _get_k8s_pod(primary, pod_template)
+    pod_spec = MessageToDict(k8s_pod.pod_spec)
+    container = next(
+        c for c in pod_spec["containers"] if c["name"] == pod_template.primary_container_name
+    )
+    return container.get("resources", {})
+
+
+def test_extended_resource_in_pod_template_survives_task_resources():
+    """Extended resources (e.g. device-plugin resources) set on the pod template's
+    primary container must be merged with — not clobbered by — the task's declared
+    cpu/memory. Regression test for the overwrite that dropped them at serialization.
+    """
+    from kubernetes.client import V1Container, V1PodSpec, V1ResourceRequirements
+
+    pt = PodTemplate(
+        pod_spec=V1PodSpec(
+            containers=[
+                V1Container(
+                    name="primary",
+                    resources=V1ResourceRequirements(
+                        limits={"smarter-devices/fuse": "1"},
+                        requests={"smarter-devices/fuse": "1"},
+                    ),
+                )
+            ]
+        ),
+        primary_container_name="primary",
+    )
+
+    resources = _serialize_with_task_resources(pt, cpu="1", memory="1Gi")
+
+    # task-declared cpu/memory present...
+    assert resources["requests"]["cpu"] == "1"
+    assert resources["limits"]["memory"] == "1Gi"
+    # ...and the extended resource from the pod template survived on both sides.
+    assert resources["limits"]["smarter-devices/fuse"] == "1"
+    assert resources["requests"]["smarter-devices/fuse"] == "1"
+
+
+def test_task_resources_override_pod_template_same_key():
+    """When both the task and the pod template set the same resource key, the
+    task-declared value wins (merge precedence)."""
+    from kubernetes.client import V1Container, V1PodSpec, V1ResourceRequirements
+
+    pt = PodTemplate(
+        pod_spec=V1PodSpec(
+            containers=[
+                V1Container(
+                    name="primary",
+                    resources=V1ResourceRequirements(requests={"cpu": "8", "smarter-devices/fuse": "1"}),
+                )
+            ]
+        ),
+        primary_container_name="primary",
+    )
+
+    resources = _serialize_with_task_resources(pt, cpu="1")
+
+    assert resources["requests"]["cpu"] == "1"  # task wins
+    assert resources["requests"]["smarter-devices/fuse"] == "1"  # template-only key kept
+
+
 def test_pod_template_importable():
     assert flyte.PodTemplate is PodTemplate
 

--- a/tests/user_api/test_pod_template.py
+++ b/tests/user_api/test_pod_template.py
@@ -83,9 +83,7 @@ def _serialize_with_task_resources(pod_template, *, cpu=None, memory=None):
 
     k8s_pod = _get_k8s_pod(primary, pod_template)
     pod_spec = MessageToDict(k8s_pod.pod_spec)
-    container = next(
-        c for c in pod_spec["containers"] if c["name"] == pod_template.primary_container_name
-    )
+    container = next(c for c in pod_spec["containers"] if c["name"] == pod_template.primary_container_name)
     return container.get("resources", {})
 
 


### PR DESCRIPTION
…ting

`_get_k8s_pod` replaced the pod template primary container's resources with a fresh object built only from the task's `Resources(cpu/mem/gpu)`, silently dropping any extended-resource requests (e.g. device-plugin resources like `smarter-devices/fuse`) that can only be expressed through the pod template.

Merge key-wise instead, with task-declared keys winning on conflict — mirroring the backend flytek8s `MergeResources`. This lets device-plugin-backed features (e.g. unprivileged in-pod FUSE via /dev/fuse) carry their resource request all the way through serialization.