### PR TITLE
Create run with TaskId for lazy task

### DIFF
--- a/examples/run_deploy.py
+++ b/examples/run_deploy.py
@@ -1,0 +1,7 @@
+import flyte
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    task = flyte.remote.Task.get("named_fanout.fanout", auto_version="latest")
+    result = flyte.run(task, n1=2, n2=3, n3=4)
+    print(f"Result: {result}")

--- a/examples/run_deploy.py
+++ b/examples/run_deploy.py
@@ -1,7 +1,0 @@
-import flyte
-
-if __name__ == "__main__":
-    flyte.init_from_config()
-    task = flyte.remote.Task.get("named_fanout.fanout", auto_version="latest")
-    result = flyte.run(task, n1=2, n2=3, n3=4)
-    print(f"Result: {result}")

--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -182,12 +182,14 @@ class _Runner:
         domain = self._domain or cfg.domain
 
         task: TaskTemplate[P, R, F] | TaskDetails
+        task_id = None
         if isinstance(obj, (LazyEntity, TaskDetails)):
             if isinstance(obj, LazyEntity):
                 task = await obj.fetch.aio()
             else:
                 task = obj
             task_spec = task.pb2.spec
+            task_id = task.pb2.task_id
             inputs = await convert_from_native_to_inputs(
                 task.interface, *args, custom_context=self._custom_context, **kwargs
             )
@@ -352,14 +354,17 @@ class _Runner:
                 )
             # Fill in task id inside the task template if it's not provided.
             # Maybe this should be done here, or the backend.
-            if task_spec.task_template.id.project == "":
-                task_spec.task_template.id.project = project or ""
-            if task_spec.task_template.id.domain == "":
-                task_spec.task_template.id.domain = domain or ""
-            if task_spec.task_template.id.org == "":
-                task_spec.task_template.id.org = cfg.org or ""
-            if task_spec.task_template.id.version == "":
-                task_spec.task_template.id.version = version
+            # Only needed for locally-defined tasks; a fetched task (task_id set) already
+            # carries a fully-populated id and is sent by reference, not as a spec.
+            if task_id is None:
+                if task_spec.task_template.id.project == "":
+                    task_spec.task_template.id.project = project or ""
+                if task_spec.task_template.id.domain == "":
+                    task_spec.task_template.id.domain = domain or ""
+                if task_spec.task_template.id.org == "":
+                    task_spec.task_template.id.org = cfg.org or ""
+                if task_spec.task_template.id.version == "":
+                    task_spec.task_template.id.version = version
 
             kv_pairs: List[literals_pb2.KeyValuePair] = []
             for k, v in env.items():
@@ -399,10 +404,12 @@ class _Runner:
             try:
                 from flyteidl2.dataproxy import dataproxy_service_pb2
 
-                upload_req = dataproxy_service_pb2.UploadInputsRequest(
-                    inputs=inputs.proto_inputs,
-                    task_spec=task_spec,
-                )
+                upload_req = dataproxy_service_pb2.UploadInputsRequest(inputs=inputs.proto_inputs)
+                # Reference an already-registered task by id; otherwise upload the full spec.
+                if task_id is not None:
+                    upload_req.task_id.CopyFrom(task_id)
+                else:
+                    upload_req.task_spec.CopyFrom(task_spec)
                 if run_id is not None:
                     upload_req.run_id.CopyFrom(run_id)
                 else:
@@ -410,35 +417,40 @@ class _Runner:
 
                 upload_resp = await get_client().dataproxy_service.upload_inputs(upload_req)
 
-                resp = await get_client().run_service.create_run(
-                    run_service_pb2.CreateRunRequest(
-                        run_id=run_id,
-                        project_id=project_id,
-                        task_spec=task_spec,
-                        offloaded_input_data=upload_resp.offloaded_input_data,
-                        run_spec=run_pb2.RunSpec(
+                create_req = run_service_pb2.CreateRunRequest(
+                    run_id=run_id,
+                    project_id=project_id,
+                    offloaded_input_data=upload_resp.offloaded_input_data,
+                    run_spec=run_pb2.RunSpec(
+                        overwrite_cache=self._overwrite_cache,
+                        interruptible=wrappers_pb2.BoolValue(value=self._interruptible)
+                        if self._interruptible is not None
+                        else None,
+                        annotations=annotations,
+                        labels=labels,
+                        envs=env_kv,
+                        cluster=self._queue or task.queue,
+                        max_action_concurrency=self._max_action_concurrency or 0,
+                        raw_data_storage=raw_data_storage,
+                        security_context=security_context,
+                        cache_config=run_pb2.CacheConfig(
                             overwrite_cache=self._overwrite_cache,
-                            interruptible=wrappers_pb2.BoolValue(value=self._interruptible)
-                            if self._interruptible is not None
+                            cache_lookup_scope=_to_cache_lookup_scope(self._cache_lookup_scope)
+                            if self._cache_lookup_scope
                             else None,
-                            annotations=annotations,
-                            labels=labels,
-                            envs=env_kv,
-                            cluster=self._queue or task.queue,
-                            max_action_concurrency=self._max_action_concurrency or 0,
-                            raw_data_storage=raw_data_storage,
-                            security_context=security_context,
-                            cache_config=run_pb2.CacheConfig(
-                                overwrite_cache=self._overwrite_cache,
-                                cache_lookup_scope=_to_cache_lookup_scope(self._cache_lookup_scope)
-                                if self._cache_lookup_scope
-                                else None,
-                            ),
-                            notification_rule_name=notification_rule_name,
-                            notification_rules=notification_rules,
                         ),
+                        notification_rule_name=notification_rule_name,
+                        notification_rules=notification_rules,
                     ),
                 )
+                # Reference an already-registered task by id; otherwise send the full spec.
+                # The user should have Action_ACTION_REGISTER_FLYTE_INVENTORY permission while sending the full spec.
+                if task_id is not None:
+                    create_req.task_id.CopyFrom(task_id)
+                else:
+                    create_req.task_spec.CopyFrom(task_spec)
+
+                resp = await get_client().run_service.create_run(create_req)
                 return Run(pb2=resp.run, _preserve_original_types=self._preserve_original_types)
             except ConnectError as e:
                 if e.code == Code.UNAVAILABLE:

--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -449,7 +449,6 @@ class _Runner:
                     ),
                 )
                 # Reference an already-registered task by id; otherwise send the full spec.
-                # The user should have Action_ACTION_REGISTER_FLYTE_INVENTORY permission while sending the full spec.
                 if task_id is not None:
                     create_req.task_id.CopyFrom(task_id)
                 else:

--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -189,7 +189,11 @@ class _Runner:
             else:
                 task = obj
             task_spec = task.pb2.spec
-            task_id = task.pb2.task_id
+            # A fetched task is normally run by reference (task_id only). But if it was modified via
+            # `.override(...)`, the local spec no longer matches the registered task, so we must send
+            # the full spec instead. Setting task_id to None routes every downstream branch to the
+            # spec path.
+            task_id = None if task.overridden else task.pb2.task_id
             inputs = await convert_from_native_to_inputs(
                 task.interface, *args, custom_context=self._custom_context, **kwargs
             )
@@ -354,8 +358,9 @@ class _Runner:
                 )
             # Fill in task id inside the task template if it's not provided.
             # Maybe this should be done here, or the backend.
-            # Only needed for locally-defined tasks; a fetched task (task_id set) already
-            # carries a fully-populated id and is sent by reference, not as a spec.
+            # Only needed for locally-defined tasks; a fetched task sent by reference (task_id set)
+            # is skipped here. An overridden fetched task (task_id None) already carries a
+            # fully-populated id, so the `== ""` guards below leave it untouched.
             if task_id is None:
                 if task_spec.task_template.id.project == "":
                     task_spec.task_template.id.project = project or ""

--- a/src/flyte/remote/_task.py
+++ b/src/flyte/remote/_task.py
@@ -165,7 +165,7 @@ class TaskDetails(ToJSONMixin):
     pb2: task_definition_pb2.TaskDetails
     max_inline_io_bytes: int = 10 * 1024 * 1024  # 10 MB
     overriden_queue: Optional[str] = None
-    overridden: bool = False # Flag if the TaskDetails was overridden
+    overridden: bool = False  # Flag if the TaskDetails was overridden
 
     @classmethod
     def get(

--- a/src/flyte/remote/_task.py
+++ b/src/flyte/remote/_task.py
@@ -165,6 +165,7 @@ class TaskDetails(ToJSONMixin):
     pb2: task_definition_pb2.TaskDetails
     max_inline_io_bytes: int = 10 * 1024 * 1024  # 10 MB
     overriden_queue: Optional[str] = None
+    overridden: bool = False # Flag if the TaskDetails was overridden
 
     @classmethod
     def get(
@@ -487,6 +488,7 @@ class TaskDetails(ToJSONMixin):
             pb2,
             max_inline_io_bytes=max_inline_io_bytes or self.max_inline_io_bytes,
             overriden_queue=queue,
+            overridden=True,
         )
 
     def __rich_repr__(self) -> rich.repr.Result:

--- a/tests/flyte/remote/test_task.py
+++ b/tests/flyte/remote/test_task.py
@@ -223,6 +223,14 @@ class TestTaskDetailsOverrideResources:
         names = {e.name for e in tmpl.container.resources.requests}
         assert tasks_pb2.Resources.ResourceName.GPU in names
 
+    def test_override_marks_task_as_overridden(self):
+        # A freshly fetched task is run by reference; once overridden, the local spec no longer
+        # matches the registered task, so `_run.py` must send the full spec instead of the task_id.
+        td = self._container_task_details()
+        assert td.overridden is False
+        out = td.override(resources=flyte.Resources(cpu="2", memory="2Gi"))
+        assert out.overridden is True
+
     def test_cpu_only_override_clears_stale_accelerator(self):
         td = self._container_task_details()
         gpu = td.override(resources=flyte.Resources(cpu="4", memory="16Gi", gpu="L40s:1"))


### PR DESCRIPTION
## Goal
While creating runs with remote task(lazy task), we should create run request with TaskID instead of TaskSpec. Thus, the user only needs execution permission to do such an operation. 

p.s. While executing ephemeral runs(create runs with TaskSpec), the user must process write permission because the BE will create TaskSpec in the DB.

## Tests
Add log to see if we are creating run with TaskID or TaskSpec:
<img width="744" height="179" alt="Screenshot 2026-06-12 at 10 31 02 AM" src="https://github.com/user-attachments/assets/9216198f-ecb4-4bad-be97-70155bb13253" />

Test with this script to run remote task:
```
import flyte

if __name__ == "__main__":
    flyte.init_from_config()
    task = flyte.remote.Task.get("named_fanout.fanout", auto_version="latest")
    result = flyte.run(task, n1=2, n2=3, n3=4)
    print(f"Result: {result}")
```
The log shows we create run with TaskID
<img width="260" height="37" alt="Screenshot 2026-06-12 at 10 41 14 AM" src="https://github.com/user-attachments/assets/93935355-f783-4f9b-8809-6a9917e01660" />

Execute an ephemeral run, the log show we create run with TaskSpec:
<img width="360" height="62" alt="Screenshot 2026-06-12 at 10 43 04 AM" src="https://github.com/user-attachments/assets/a30c4df9-e286-4953-a57b-d320d726db79" />

Test if task override works by overriding the task Short_name:
```
import flyte

if __name__ == "__main__":
    flyte.init_from_config()
    task = flyte.remote.Task.get("named_fanout.fanout", auto_version="latest").override(short_name="overridden_my_task")
    result = flyte.run(task, n1=2, n2=3, n3=4)
    print(f"Result: {result}")
```

The name is overridden:
<img width="464" height="111" alt="Screenshot 2026-06-15 at 11 14 41 AM" src="https://github.com/user-attachments/assets/038c19d1-77f5-4744-bdfc-c6fff6e113de" />

## Rollout plan
The backend permission check changes is till processing. It is ok to merge this PR first as current BE authz logic will not block create run request with TaskID.