### PR TITLE
fix: filter OSError(EADDRINUSE) from PKCE callback bind as user environment error

### DIFF
--- a/src/flyte/_sentry.py
+++ b/src/flyte/_sentry.py
@@ -218,7 +218,7 @@ def _is_non_connect_endpoint_response(exc: BaseException) -> bool:
     return bool(content_type and content_type.group("received").strip().lower().startswith("text/"))
 
 
-_USER_ENVIRONMENT_OSERROR_ERRNOS: frozenset[int] = frozenset({errno.ENOSPC})
+_USER_ENVIRONMENT_OSERROR_ERRNOS: frozenset[int] = frozenset({errno.ENOSPC, errno.EADDRINUSE})
 
 
 def _is_user_environment_oserror(exc: BaseException) -> bool:
@@ -228,6 +228,14 @@ def _is_user_environment_oserror(exc: BaseException) -> bool:
     during `flyte deploy` bundle uploads when the user's machine is out of disk
     (FLYTE-SDK-32). Disk-full is a user environment problem, not something the
     SDK can fix, so it shouldn't be reported as a crash.
+
+    EADDRINUSE ("Address already in use") surfaces from asyncio.start_server in
+    the PKCE authenticator's local OAuth callback server (pkce.py
+    _create_callback_server) when the redirect-URI port is already bound — a
+    stale/concurrent login flow or another local process is holding it
+    (FLYTE-SDK-53 / FLYTE-SDK-57). The port comes from the backend's redirect_uri
+    config, so the SDK can't pick a different one; freeing the port is a
+    user-environment action, not an SDK bug.
     """
     if not isinstance(exc, OSError):
         return False

--- a/tests/flyte/test_sentry.py
+++ b/tests/flyte/test_sentry.py
@@ -326,9 +326,26 @@ def test_capture_exception_skips_gaierror_via_cause_chain():
     init_mock.assert_not_called()
 
 
+def test_capture_exception_skips_oserror_address_in_use():
+    """FLYTE-SDK-53/57: OSError(EADDRINUSE) from asyncio.start_server in the PKCE
+    authenticator's local OAuth callback server (the redirect-URI port is already
+    bound by a stale/concurrent login or another local process) is a user
+    environment problem, not an SDK bug. It can surface bare or wrapped through
+    RuntimeSystemError('Failed to get signed url...')."""
+    bare = OSError(
+        errno.EADDRINUSE,
+        "error while attempting to bind on address ('127.0.0.1', 53593): address already in use",
+    )
+    wrapped = _wrap_as_upload_system_error(OSError(errno.EADDRINUSE, "address already in use", "127.0.0.1"))
+    for err in (bare, wrapped):
+        with mock.patch.object(_sentry, "init") as init_mock:
+            _sentry.capture_exception(err)
+        init_mock.assert_not_called()
+
+
 def test_capture_exception_still_reports_other_oserror():
-    """OSError with errnos other than ENOSPC may legitimately indicate SDK bugs
-    and should still be reported to Sentry."""
+    """OSError with errnos other than the user-environment set (ENOSPC/EADDRINUSE)
+    may legitimately indicate SDK bugs and should still be reported to Sentry."""
     err = PermissionError(errno.EACCES, "Permission denied", "/some/path")
     with (
         mock.patch.object(_sentry, "init"),


### PR DESCRIPTION
The PKCE authenticator opens a local OAuth callback server (`pkce.py::_create_callback_server`) that binds the redirect-URI port via `asyncio.start_server`. When that port is already in use — a stale or concurrent login flow, or another local process holding it — bind raises `OSError(EADDRINUSE)` ("[Errno 98] address already in use"), which leaks to Sentry either bare or wrapped as `RuntimeSystemError("Failed to get signed url...")`.

The redirect-URI port comes from the backend config, so the SDK cannot pick a different one; freeing the port is a user-environment action, not an SDK bug.

## Change
- Add `errno.EADDRINUSE` to `_USER_ENVIRONMENT_OSERROR_ERRNOS` in `flyte/_sentry.py` so the cause-chain walk in `_is_user_error` filters it, same as `ENOSPC`.
- Test covers both the bare and `RuntimeSystemError`-wrapped chain.

fixes FLYTE-SDK-53
fixes FLYTE-SDK-57

🤖 Generated with [Claude Code](https://claude.com/claude-code)