### PR TITLE
fix: raise InitializationError for missing client credentials

### DIFF
--- a/src/flyte/remote/_client/auth/_authenticators/client_credentials.py
+++ b/src/flyte/remote/_client/auth/_authenticators/client_credentials.py
@@ -35,7 +35,17 @@ class ClientCredentialsAuthenticator(Authenticator):
         :param audience: Audience for the token
         """
         if not client_id or not client_credentials_secret:
-            raise ValueError("both client_id and client_credentials_secret are required.")
+            # Missing client_id / secret is a creds-config mistake, not an SDK crash.
+            # Raise a typed InitializationError so the Sentry filter (flyte/_sentry.py)
+            # skips it — otherwise it leaks as RuntimeError("SelectCluster failed...")
+            # -> RuntimeSystemError with no actionable signal (FLYTE-SDK-55).
+            from flyte.errors import InitializationError
+
+            raise InitializationError(
+                "InvalidClientCredentials",
+                "user",
+                "both client_id and client_credentials_secret are required.",
+            )
         self._client_id = client_id
         self._client_credentials_secret = client_credentials_secret
         super().__init__(**kwargs)

--- a/tests/flyte/remote/test_client_credentials_auth.py
+++ b/tests/flyte/remote/test_client_credentials_auth.py
@@ -1,0 +1,30 @@
+import pytest
+
+from flyte.errors import InitializationError
+from flyte.remote._client.auth._authenticators.client_credentials import ClientCredentialsAuthenticator
+
+
+@pytest.mark.parametrize(
+    "client_id,secret",
+    [
+        (None, None),
+        ("", ""),
+        ("client", None),
+        ("client", ""),
+        (None, "secret"),
+        ("", "secret"),
+    ],
+)
+def test_client_credentials_missing_creds_raises_initialization_error(client_id, secret):
+    """FLYTE-SDK-55: missing client_id / secret is a creds-config mistake. The
+    authenticator must raise a typed InitializationError (filtered from Sentry)
+    rather than a bare ValueError that leaks as RuntimeSystemError('Failed to get
+    signed url...')."""
+    with pytest.raises(InitializationError) as exc_info:
+        ClientCredentialsAuthenticator(
+            client_id=client_id,
+            client_credentials_secret=secret,
+            endpoint="dns:///example.com",
+        )
+
+    assert "client_id and client_credentials_secret are required" in str(exc_info.value)

--- a/tests/flyte/test_sentry.py
+++ b/tests/flyte/test_sentry.py
@@ -539,6 +539,24 @@ def test_capture_exception_skips_invalid_auth_mode_wrapped_as_system_error():
     init_mock.assert_not_called()
 
 
+def test_capture_exception_skips_invalid_client_credentials_wrapped_as_system_error():
+    """FLYTE-SDK-55: missing client_id / secret (creds misconfig) raised from the
+    ClientCredentialsAuthenticator is wrapped through RuntimeError('SelectCluster
+    failed...') -> RuntimeSystemError('Failed to get signed url...'). It's a
+    user-config mistake, so it must be filtered out of Sentry."""
+    from flyte.errors import InitializationError
+
+    inner = InitializationError(
+        "InvalidClientCredentials",
+        "user",
+        "both client_id and client_credentials_secret are required.",
+    )
+    err = _wrap_as_upload_system_error(inner)
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()
+
+
 def test_track_operation_counts_success():
     with mock.patch.object(_sentry, "count") as count_mock:
         with _sentry.track_operation("create_run"):


### PR DESCRIPTION
When `client_id` or `client_credentials_secret` is missing, `ClientCredentialsAuthenticator.__init__` raised a bare `ValueError("both client_id and client_credentials_secret are required.")`. On the SelectCluster path this is wrapped as `RuntimeError("SelectCluster failed...")` → `RuntimeSystemError` and leaks to Sentry as an SDK crash with no actionable signal (FLYTE-SDK-55).

Missing credentials is a user-config mistake. Raise a typed `InitializationError` (already in the `flyte/_sentry.py` user-error allowlist) so it is filtered — matching the invalid-auth-mode fix in #1194.

## Change
- `ClientCredentialsAuthenticator.__init__` raises `InitializationError("InvalidClientCredentials", "user", ...)` instead of `ValueError`.
- Added a constructor test (parametrized over missing/empty creds) and a Sentry-filter test covering the wrapped chain.

fixes FLYTE-SDK-55

🤖 Generated with [Claude Code](https://claude.com/claude-code)