### PR TITLE
feat(pod): unprivileged allow_fuse() via FUSE device plugin + volume examples

### DIFF
--- a/examples/volumes/bench.py
+++ b/examples/volumes/bench.py
@@ -1,0 +1,709 @@
+# /// script
+# requires-python = "==3.12"
+# dependencies = [
+#    "kubernetes",
+#    "flyte",
+#    "flyteplugins-union>=0.4.0",
+# ]
+#
+# [tool.uv.sources]
+# flyte = { path = "../..", editable = true }
+# ///
+"""
+Volume benchmark driver.
+
+Sweeps ``workload * engine * writeback`` and renders a multi-tab Flyte
+report with timing tables and inline-SVG bar charts. Each cell runs in
+its own sub-action with a fresh Volume; the driver fans the cells out
+with ``asyncio.gather`` so the matrix runs concurrently.
+
+Workloads (default set):
+
+* ``metadata_burst`` — touch N empty files; stresses metadata-write rate.
+* ``big_files`` — write K large blobs; stresses chunk-upload throughput.
+* ``small_files`` — write K small files with payload; mixed metadata+IO.
+* ``fork_burst`` — fork the base K times back-to-back; metadata snapshot
+  + upload cost only.
+
+Override the sweep at runtime, e.g.::
+
+    uv run flyte run examples/volumes/bench.py main \\
+        --workloads '["metadata_burst", "fork_burst"]'
+"""
+
+import asyncio
+import logging
+import math
+import os
+import time
+import uuid
+from pathlib import Path
+from statistics import mean, median, quantiles
+from typing import Awaitable, Callable, Dict, List, Optional, Tuple
+
+from flyteplugins.union.io import ROVolume, Volume, with_high_throughput_volume_deps
+
+import flyte
+import flyte.report
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+logger = logging.getLogger("bench")
+
+# The bench sweeps the "redis" engine explicitly, so it needs the
+# high-throughput image (which provisions redis-server); each cell passes
+# metadata_store_type= explicitly, so the image's UNION_VOLUME_METADATA_STORE=redis
+# default is overridden per-cell. The released flyteplugins-union package comes
+# from PyPI (juicefs is bundled in its platform wheels).
+base = (
+    flyte.Image.from_debian_base(install_flyte=False, name="volume-bench")
+    .with_pip_packages("flyteplugins-union>=0.4.0")
+    .with_local_v2()  # last, so the local dev SDK wins over the pip layer's flyte dep
+)
+image = with_high_throughput_volume_deps(base)
+
+env = flyte.TaskEnvironment(
+    name="vol-bench",
+    # Unprivileged FUSE via the cluster's FUSE device plugin: the pod template
+    # requests smarter-devices/fuse (kubelet injects /dev/fuse) + CAP_SYS_ADMIN
+    # for mount(2). No privileged container, no hostPath. The Union dataplane
+    # chart ships an opt-in fuseDevicePlugin DaemonSet that advertises it.
+    pod_template=flyte.PodTemplate().allow_fuse(),
+    image=image,
+    resources=flyte.Resources(cpu="2", memory="4Gi"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Workloads
+# ---------------------------------------------------------------------------
+# Each workload runs against an already-mounted Volume rooted at /workspace
+# and returns a dict of measurements. Keep them deterministic so cells are
+# comparable across cells.
+
+WorkloadFn = Callable[..., Awaitable[Dict[str, float]]]
+
+
+async def _metadata_burst(_vol: Volume, *, n: int) -> Dict[str, float]:
+    data = Path("/workspace/data")
+    data.mkdir(parents=True, exist_ok=True)
+    t0 = time.monotonic()
+    for i in range(n):
+        (data / f"f{i:08d}").touch()
+    return {"workload_ms": (time.monotonic() - t0) * 1000.0, "items": float(n)}
+
+
+async def _big_files(_vol: Volume, *, k: int, size_mib: float) -> Dict[str, float]:
+    nbytes = int(size_mib * 1024 * 1024)
+    payload = b"\0" * nbytes
+    t0 = time.monotonic()
+    for i in range(k):
+        Path(f"/workspace/blob_{i:03d}.bin").write_bytes(payload)
+    elapsed_ms = (time.monotonic() - t0) * 1000.0
+    return {
+        "workload_ms": elapsed_ms,
+        "items": float(k),
+        "throughput_mibs": (k * size_mib) / max(elapsed_ms / 1000.0, 1e-6),
+    }
+
+
+async def _small_files(_vol: Volume, *, k: int, size_bytes: int) -> Dict[str, float]:
+    payload = b"x" * size_bytes
+    data = Path("/workspace/small")
+    data.mkdir(parents=True, exist_ok=True)
+    t0 = time.monotonic()
+    for i in range(k):
+        (data / f"s{i:06d}").write_bytes(payload)
+    return {"workload_ms": (time.monotonic() - t0) * 1000.0, "items": float(k)}
+
+
+async def _fork_burst(vol: Volume, *, k: int, base_files: int = 100) -> Dict[str, float]:
+    data = Path("/workspace/data")
+    data.mkdir(parents=True, exist_ok=True)
+    for i in range(base_files):
+        (data / f"base_{i:04d}").write_text("x")
+
+    fork_ms: List[float] = []
+    for i in range(k):
+        t0 = time.monotonic()
+        await vol.fork(name=f"{vol.name}-fork-{i:04d}")
+        fork_ms.append((time.monotonic() - t0) * 1000.0)
+
+    p99 = quantiles(fork_ms, n=100, method="inclusive")[98] if len(fork_ms) >= 2 else fork_ms[0]
+    return {
+        "workload_ms": sum(fork_ms),
+        "items": float(k),
+        "fork_mean": mean(fork_ms),
+        "fork_p50": median(fork_ms),
+        "fork_p99": p99,
+    }
+
+
+# Self-managed workloads handle their own Volume lifecycle (no cell-level
+# mount/commit). Used by cold_fork, which deliberately forks an *unmounted*
+# Volume to exercise Volume.fork()'s cold path.
+async def _cold_fork(
+    *,
+    engine: str,
+    writeback: bool,
+    k: int,
+    base_files: int = 100,
+    base_bytes: int = 1024,
+) -> Tuple[ROVolume, Dict[str, float]]:
+    suffix = uuid.uuid4().hex[:6]
+    parent = Volume.new(name=f"bench-cold-fork-{engine}-{suffix}", metadata_store_type=engine)
+
+    t0 = time.monotonic()
+    await parent.mount(writeback=writeback)
+    mount_ms = (time.monotonic() - t0) * 1000.0
+
+    data = Path("/workspace/data")
+    data.mkdir(parents=True, exist_ok=True)
+    payload = "x" * base_bytes
+    for i in range(base_files):
+        (data / f"base_{i:04d}").write_text(payload)
+
+    t0 = time.monotonic()
+    committed = await parent.finalize()
+    commit_ms = (time.monotonic() - t0) * 1000.0
+
+    # Forks are issued on the *sealed* (unmounted) ROVolume → cold path.
+    fork_ms: List[float] = []
+    for i in range(k):
+        t0 = time.monotonic()
+        await committed.fork(name=f"{committed.name}-cold-{i:04d}")
+        fork_ms.append((time.monotonic() - t0) * 1000.0)
+
+    p99 = quantiles(fork_ms, n=100, method="inclusive")[98] if len(fork_ms) >= 2 else fork_ms[0]
+    return committed, {
+        "workload_ms": sum(fork_ms),
+        "items": float(k),
+        "fork_mean": mean(fork_ms),
+        "fork_p50": median(fork_ms),
+        "fork_p99": p99,
+        "mount_ms": mount_ms,
+        "commit_ms": commit_ms,
+        "index_bytes": 0.0,
+        "used_bytes": float(committed.used_bytes) if committed.used_bytes is not None else 0.0,
+        "inode_count": float(committed.inode_count) if committed.inode_count is not None else 0.0,
+    }
+
+
+WORKLOADS: Dict[str, Tuple[WorkloadFn, Dict[str, object]]] = {
+    "metadata_burst": (_metadata_burst, {"n": 10_000}),
+    "big_files": (_big_files, {"k": 5, "size_mib": 100}),
+    "small_files": (_small_files, {"k": 5_000, "size_bytes": 4096}),
+    "fork_burst": (_fork_burst, {"k": 25}),
+}
+
+# Workloads that manage their own Volume (skip the cell-level mount/commit).
+SELF_MANAGED: Dict[str, Tuple[Callable[..., Awaitable[Dict[str, float]]], Dict[str, object]]] = {
+    "cold_fork": (_cold_fork, {"k": 25, "base_files": 100, "base_bytes": 1024}),
+}
+
+ENGINES: List[str] = ["redis", "sqlite"]
+WRITEBACK: List[bool] = [True, False]
+
+# Dataset sweep: hold per-file size constant, vary count, plot one line per
+# engine. Counts capped at 100k (small) / 10k (big) so a full sweep stays
+# bounded in time and disk; bump in-place if you need to push further.
+DATASET_SMALL_COUNTS: List[int] = [10, 100, 1_000, 10_000, 100_000]
+DATASET_BIG_COUNTS: List[int] = [10, 100, 1_000, 10_000]
+DATASET_SMALL_SIZE_BYTES = 256
+DATASET_BIG_SIZE_KIB = 64
+DATASET_ENGINES: List[str] = ["redis", "sqlite"]
+
+
+# ---------------------------------------------------------------------------
+# Per-cell sub-action
+# ---------------------------------------------------------------------------
+
+
+@env.task
+async def run_cell(workload: str, engine: str, writeback: bool) -> Tuple[ROVolume, Dict[str, float]]:
+    """Run one matrix cell.
+
+    Returns ``(sealed_volume, stats)`` so the ROVolume's serialized
+    metadata (bucket, index path, parent, used_bytes, etc.) is visible
+    in the Flyte UI alongside the timing numbers.
+    """
+    if workload in SELF_MANAGED:
+        fn, params = SELF_MANAGED[workload]
+        return await fn(engine=engine, writeback=writeback, **params)
+
+    fn, params = WORKLOADS[workload]
+    suffix = uuid.uuid4().hex[:6]
+    # Volume names: alphanumerics and dashes only, 3-63 chars.
+    safe_workload = workload.replace("_", "-")
+    vol = Volume.new(
+        name=f"bench-{safe_workload}-{engine}-{int(writeback)}-{suffix}",
+        metadata_store_type=engine,
+    )
+
+    t0 = time.monotonic()
+    await vol.mount(writeback=writeback)
+    mount_ms = (time.monotonic() - t0) * 1000.0
+
+    result = await fn(vol, **params)
+
+    t0 = time.monotonic()
+    final = await vol.finalize()
+    commit_ms = (time.monotonic() - t0) * 1000.0
+
+    # Capture the index footprint *after* commit. Redis only writes its
+    # dump.rdb when SAVE runs (which commit() triggers); SQLite's index.db
+    # is mutated continuously but commit() WAL-checkpoints it. Either way,
+    # post-commit is the size of the file that actually gets uploaded.
+    index_bytes = 0.0
+    for p in ("/var/lib/flyte-volume/index.db", "/var/lib/flyte-volume/dump.rdb"):
+        if os.path.exists(p):
+            index_bytes = float(os.path.getsize(p))
+            break
+
+    # Volume-level stats populated by commit() (best-effort).
+    used_bytes = float(final.used_bytes) if final.used_bytes is not None else 0.0
+    inode_count = float(final.inode_count) if final.inode_count is not None else 0.0
+
+    logger.info(
+        "cell done: workload=%s engine=%s writeback=%s mount=%.0fms commit=%.0fms used=%.0f inodes=%.0f",
+        workload,
+        engine,
+        writeback,
+        mount_ms,
+        commit_ms,
+        used_bytes,
+        inode_count,
+    )
+
+    stats = {
+        **result,
+        "mount_ms": mount_ms,
+        "commit_ms": commit_ms,
+        "index_bytes": index_bytes,
+        "used_bytes": used_bytes,
+        "inode_count": inode_count,
+    }
+    return final, stats
+
+
+# ---------------------------------------------------------------------------
+# Dataset-sweep cell
+# ---------------------------------------------------------------------------
+
+
+@env.task
+async def run_dataset_cell(workload: str, engine: str, n: int) -> Tuple[ROVolume, Dict[str, float]]:
+    """One ``(workload, engine, n)`` point on the dataset sweep.
+
+    Holds per-file size constant (set by ``DATASET_SMALL_SIZE_BYTES`` /
+    ``DATASET_BIG_SIZE_KIB``) and varies ``n``. Always runs with
+    ``writeback=True`` so the curve isn't dominated by per-chunk upload
+    latency. Returns ``(sealed_volume, stats)`` so the ROVolume's
+    metadata is inspectable in the Flyte UI.
+    """
+    suffix = uuid.uuid4().hex[:6]
+    vol = Volume.new(
+        name=f"bench-ds-{workload.replace('_', '-')}-{engine}-{n}-{suffix}",
+        metadata_store_type=engine,
+    )
+
+    t0 = time.monotonic()
+    await vol.mount(writeback=True)
+    mount_ms = (time.monotonic() - t0) * 1000.0
+
+    if workload == "small_files":
+        result = await _small_files(vol, k=n, size_bytes=DATASET_SMALL_SIZE_BYTES)
+    elif workload == "big_files":
+        result = await _big_files(vol, k=n, size_mib=DATASET_BIG_SIZE_KIB / 1024.0)
+    else:
+        raise ValueError(f"unsupported dataset workload: {workload}")
+
+    t0 = time.monotonic()
+    final = await vol.finalize()
+    commit_ms = (time.monotonic() - t0) * 1000.0
+
+    return final, {**result, "mount_ms": mount_ms, "commit_ms": commit_ms}
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def _cell_label(engine: str, writeback: bool) -> str:
+    return f"{engine}/{'wb' if writeback else 'cold'}"
+
+
+def _bar_svg(title: str, labels: List[str], values: List[float], unit: str) -> str:
+    w, h = 480, 220
+    mL, mR, mT, mB = 60, 16, 32, 60
+    pw, ph = w - mL - mR, h - mT - mB
+    vmax = max([*values, 1.0])
+
+    n = max(len(values), 1)
+    slot = pw / n
+    bar_w = slot * 0.7
+
+    parts: List[str] = [
+        f'<svg viewBox="0 0 {w} {h}" xmlns="http://www.w3.org/2000/svg" '
+        'style="max-width:100%;height:auto;font-family:system-ui,sans-serif">',
+        f'<text x="{w / 2}" y="20" text-anchor="middle" font-size="13" font-weight="600">{title}</text>',
+        f'<line x1="{mL}" y1="{mT + ph}" x2="{mL + pw}" y2="{mT + ph}" stroke="#888"/>',
+        f'<line x1="{mL}" y1="{mT}" x2="{mL}" y2="{mT + ph}" stroke="#888"/>',
+        f'<text x="{mL - 6}" y="{mT + 4}" text-anchor="end" font-size="10">{vmax:,.0f}</text>',
+        f'<text x="{mL - 6}" y="{mT + ph + 4}" text-anchor="end" font-size="10">0</text>',
+        f'<text x="14" y="{mT + ph / 2}" font-size="10" '
+        f'transform="rotate(-90 14 {mT + ph / 2})" text-anchor="middle">{unit}</text>',
+    ]
+
+    # Lighter shades for the "cold" (writeback=off) variant so wb vs cold
+    # reads at a glance within an engine.
+    cold_shades = {"#1f6feb": "#94c7ff", "#fb8500": "#ffd6a3", "#0a8754": "#9ddfb8"}
+    for i, (lab, v) in enumerate(zip(labels, values)):
+        x = mL + i * slot + (slot - bar_w) / 2
+        bh = (v / vmax) * ph if vmax > 0 else 0.0
+        y = mT + ph - bh
+        engine = lab.split("/", 1)[0]
+        color = _ENGINE_COLORS.get(engine, "#666")
+        if lab.endswith("cold"):
+            color = cold_shades.get(color, color)
+        parts.append(f'<rect x="{x:.1f}" y="{y:.1f}" width="{bar_w:.1f}" height="{bh:.1f}" fill="{color}"/>')
+        parts.append(
+            f'<text x="{x + bar_w / 2:.1f}" y="{y - 4:.1f}" text-anchor="middle" font-size="10">{v:,.0f}</text>'
+        )
+        # Two-line x label (engine / mode), rotated for readability.
+        cx = x + bar_w / 2
+        parts.append(f'<text x="{cx:.1f}" y="{mT + ph + 14:.1f}" text-anchor="middle" font-size="10">{lab}</text>')
+
+    parts.append("</svg>")
+    return "".join(parts)
+
+
+_ENGINE_COLORS = {"redis": "#1f6feb", "sqlite": "#fb8500"}
+
+
+def _line_svg(
+    title: str,
+    series: Dict[str, List[Tuple[float, float]]],
+    x_label: str,
+    y_label: str,
+    *,
+    log_x: bool = True,
+    log_y: bool = True,
+) -> str:
+    """Log-log line plot with one series per name. ``series`` is ``{name: [(x, y), ...]}``.
+
+    Lifts log-scale plotting into pure SVG so the report stays self-contained
+    (no JS, no Plotly). One polyline + circles per series; right-side legend.
+    """
+    w, h = 560, 320
+    mL, mR, mT, mB = 70, 110, 36, 56
+    pw, ph = w - mL - mR, h - mT - mB
+
+    all_pts = [(x, y) for pts in series.values() for x, y in pts if x > 0 and y > 0]
+    if not all_pts:
+        return (
+            f'<svg viewBox="0 0 {w} {h}" xmlns="http://www.w3.org/2000/svg" '
+            f'style="max-width:100%;height:auto;font-family:system-ui,sans-serif">'
+            f'<text x="{w / 2}" y="{h / 2}" text-anchor="middle" font-size="13">no data</text></svg>'
+        )
+
+    def tx(v: float) -> float:
+        return math.log10(v) if log_x else v
+
+    def ty(v: float) -> float:
+        return math.log10(v) if log_y else v
+
+    xs = [tx(x) for x, _ in all_pts]
+    ys = [ty(y) for _, y in all_pts]
+    x_min, x_max = min(xs), max(xs)
+    y_min, y_max = min(ys), max(ys)
+    if log_x:
+        x_min, x_max = math.floor(x_min), math.ceil(x_max)
+    if log_y:
+        y_min, y_max = math.floor(y_min), math.ceil(y_max)
+    if x_min == x_max:
+        x_max = x_min + 1
+    if y_min == y_max:
+        y_max = y_min + 1
+
+    def px(v: float) -> float:
+        return mL + (tx(v) - x_min) / (x_max - x_min) * pw
+
+    def py(v: float) -> float:
+        return mT + ph - (ty(v) - y_min) / (y_max - y_min) * ph
+
+    parts: List[str] = [
+        f'<svg viewBox="0 0 {w} {h}" xmlns="http://www.w3.org/2000/svg" '
+        'style="max-width:100%;height:auto;font-family:system-ui,sans-serif">',
+        f'<text x="{w / 2}" y="20" text-anchor="middle" font-size="14" font-weight="600">{title}</text>',
+        f'<line x1="{mL}" y1="{mT + ph}" x2="{mL + pw}" y2="{mT + ph}" stroke="#666"/>',
+        f'<line x1="{mL}" y1="{mT}" x2="{mL}" y2="{mT + ph}" stroke="#666"/>',
+    ]
+
+    # Decade gridlines + tick labels.
+    if log_x:
+        for e in range(int(x_min), int(x_max) + 1):
+            v = 10**e
+            x = px(v)
+            parts.append(f'<line x1="{x:.1f}" y1="{mT}" x2="{x:.1f}" y2="{mT + ph}" stroke="#eee"/>')
+            parts.append(f'<text x="{x:.1f}" y="{mT + ph + 14}" text-anchor="middle" font-size="10">{int(v):,}</text>')
+    if log_y:
+        for e in range(int(y_min), int(y_max) + 1):
+            v = 10**e
+            y = py(v)
+            parts.append(f'<line x1="{mL}" y1="{y:.1f}" x2="{mL + pw}" y2="{y:.1f}" stroke="#eee"/>')
+            label = f"{int(v):,}" if v >= 1 else f"{v:.2g}"
+            parts.append(f'<text x="{mL - 6}" y="{y + 4:.1f}" text-anchor="end" font-size="10">{label}</text>')
+
+    parts.append(f'<text x="{mL + pw / 2}" y="{h - 12}" text-anchor="middle" font-size="11">{x_label}</text>')
+    parts.append(
+        f'<text x="14" y="{mT + ph / 2}" text-anchor="middle" font-size="11" '
+        f'transform="rotate(-90 14 {mT + ph / 2})">{y_label}</text>'
+    )
+
+    legend_y = mT
+    for name, points in series.items():
+        color = _ENGINE_COLORS.get(name, "#666")
+        pts = sorted(p for p in points if p[0] > 0 and p[1] > 0)
+        if pts:
+            polyline = " ".join(f"{px(x):.1f},{py(y):.1f}" for x, y in pts)
+            parts.append(f'<polyline points="{polyline}" fill="none" stroke="{color}" stroke-width="2"/>')
+            for x, y in pts:
+                parts.append(f'<circle cx="{px(x):.1f}" cy="{py(y):.1f}" r="3" fill="{color}"/>')
+        parts.append(f'<rect x="{mL + pw + 12}" y="{legend_y}" width="14" height="3" fill="{color}"/>')
+        parts.append(f'<text x="{mL + pw + 30}" y="{legend_y + 5}" font-size="11">{name}</text>')
+        legend_y += 18
+
+    parts.append("</svg>")
+    return "".join(parts)
+
+
+def _render_workload(name: str, rows: List[Dict[str, object]]) -> str:
+    engine_order = {e: i for i, e in enumerate(ENGINES)}
+
+    def sort_key(r: Dict[str, object]) -> Tuple[int, int]:
+        return (engine_order.get(str(r["engine"]), 99), 0 if r["writeback"] else 1)
+
+    rows = sorted(rows, key=sort_key)
+    if not rows:
+        return f"<h2>{name}</h2><p><em>no results</em></p>"
+
+    base_cols = [
+        "engine",
+        "writeback",
+        "items",
+        "workload_ms",
+        "mount_ms",
+        "commit_ms",
+        "index_bytes",
+        "used_bytes",
+        "inode_count",
+    ]
+    extra_cols = [c for c in ("throughput_mibs", "fork_mean", "fork_p50", "fork_p99") if c in rows[0]]
+    cols = base_cols + extra_cols
+
+    head = "<tr>" + "".join(f"<th>{c}</th>" for c in cols) + "</tr>"
+    body = ""
+    for r in rows:
+        cells = []
+        for c in cols:
+            v = r.get(c, "")
+            if isinstance(v, bool):
+                cells.append(f"<td>{'on' if v else 'off'}</td>")
+            elif isinstance(v, float):
+                cells.append(f"<td align=right>{v:,.1f}</td>")
+            elif isinstance(v, int):
+                cells.append(f"<td align=right>{v:,}</td>")
+            else:
+                cells.append(f"<td>{v}</td>")
+        body += "<tr>" + "".join(cells) + "</tr>"
+    table = f"<table border=1 cellpadding=6 cellspacing=0>{head}{body}</table>"
+
+    labels = [_cell_label(str(r["engine"]), bool(r["writeback"])) for r in rows]
+    charts = [
+        _bar_svg("workload time", labels, [float(r["workload_ms"]) for r in rows], "ms"),
+        _bar_svg("commit time", labels, [float(r["commit_ms"]) for r in rows], "ms"),
+        _bar_svg("index size", labels, [float(r["index_bytes"]) for r in rows], "bytes"),
+    ]
+    if "throughput_mibs" in rows[0]:
+        charts.append(_bar_svg("throughput", labels, [float(r["throughput_mibs"]) for r in rows], "MiB/s"))
+    if "fork_mean" in rows[0]:
+        charts.append(_bar_svg("fork mean", labels, [float(r["fork_mean"]) for r in rows], "ms"))
+
+    chart_html = "".join(f'<div style="flex:1 1 320px;min-width:320px">{c}</div>' for c in charts)
+    return f'<h2>{name}</h2>{table}<div style="display:flex;flex-wrap:wrap;gap:16px;margin-top:12px">{chart_html}</div>'
+
+
+def _render_overview(rows: List[Dict[str, object]], workloads: List[str]) -> str:
+    body = "".join(
+        "<tr>"
+        f"<td>{r['workload']}</td>"
+        f"<td>{r['engine']}</td>"
+        f"<td>{'on' if r['writeback'] else 'off'}</td>"
+        f"<td align=right>{float(r['workload_ms']):,.0f}</td>"
+        f"<td align=right>{float(r['mount_ms']):,.0f}</td>"
+        f"<td align=right>{float(r['commit_ms']):,.0f}</td>"
+        f"<td align=right>{int(r['index_bytes']):,}</td>"
+        f"<td align=right>{int(float(r.get('used_bytes', 0))):,}</td>"
+        f"<td align=right>{int(float(r.get('inode_count', 0))):,}</td>"
+        "</tr>"
+        for w in workloads
+        for r in (x for x in rows if x["workload"] == w)
+    )
+    head = (
+        "<tr><th>workload</th><th>engine</th><th>writeback</th>"
+        "<th>workload_ms</th><th>mount_ms</th><th>commit_ms</th>"
+        "<th>index_bytes</th><th>used_bytes</th><th>inodes</th></tr>"
+    )
+    return (
+        "<h1>Volume benchmark sweep</h1>"
+        "<p>Each row is one sub-action with a fresh <code>Volume</code>. "
+        "Sub-actions fan out concurrently via <code>asyncio.gather</code>.</p>"
+        f"<table border=1 cellpadding=6 cellspacing=0>{head}{body}</table>"
+    )
+
+
+def _render_dataset_sweep(
+    small_rows: List[Dict[str, object]],
+    big_rows: List[Dict[str, object]],
+) -> str:
+    """Two side-by-side line plots: small_files vs big_files, one line per engine."""
+
+    def _by_engine(rows: List[Dict[str, object]]) -> Dict[str, List[Tuple[float, float]]]:
+        by: Dict[str, List[Tuple[float, float]]] = {}
+        for r in rows:
+            by.setdefault(str(r["engine"]), []).append((float(r["n"]), float(r["workload_ms"])))
+        return by
+
+    small_chart = _line_svg(
+        title=f"small_files — {DATASET_SMALL_SIZE_BYTES} B per file",
+        series=_by_engine(small_rows),
+        x_label="file count",
+        y_label="workload_ms",
+    )
+    big_chart = _line_svg(
+        title=f"big_files — {DATASET_BIG_SIZE_KIB} KiB per file",
+        series=_by_engine(big_rows),
+        x_label="file count",
+        y_label="workload_ms",
+    )
+
+    def _table(rows: List[Dict[str, object]]) -> str:
+        rows = sorted(rows, key=lambda r: (str(r["engine"]), int(r["n"])))
+        head = "<tr><th>engine</th><th>n</th><th>workload_ms</th><th>mount_ms</th><th>commit_ms</th></tr>"
+        body = "".join(
+            "<tr>"
+            f"<td>{r['engine']}</td>"
+            f"<td align=right>{int(r['n']):,}</td>"
+            f"<td align=right>{float(r['workload_ms']):,.0f}</td>"
+            f"<td align=right>{float(r['mount_ms']):,.0f}</td>"
+            f"<td align=right>{float(r['commit_ms']):,.0f}</td>"
+            "</tr>"
+            for r in rows
+        )
+        return f"<table border=1 cellpadding=6 cellspacing=0>{head}{body}</table>"
+
+    return (
+        "<h1>Dataset size sweep</h1>"
+        "<p>Each cell is a fresh Volume with writeback enabled. "
+        "X-axis is the file count; y-axis is the workload time (ms). "
+        "Lines are metadata engines; both axes are log-scale.</p>"
+        '<div style="display:flex;flex-wrap:wrap;gap:24px;align-items:flex-start">'
+        f'<div style="flex:1 1 480px;min-width:480px">{small_chart}{_table(small_rows)}</div>'
+        f'<div style="flex:1 1 480px;min-width:480px">{big_chart}{_table(big_rows)}</div>'
+        "</div>"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+@env.task(report=True)
+async def volume_benchmark_driver(
+    workloads: Optional[List[str]] = None,
+    engines: Optional[List[str]] = None,
+    writeback: Optional[List[bool]] = None,
+    dataset_sweep: bool = False,
+) -> str:
+    all_workloads = {**WORKLOADS, **SELF_MANAGED}
+    selected_workloads = workloads or list(all_workloads.keys())
+    selected_engines = engines or ENGINES
+    selected_writeback = writeback if writeback is not None else WRITEBACK
+
+    unknown = [w for w in selected_workloads if w not in all_workloads]
+    if unknown:
+        raise ValueError(f"unknown workloads: {unknown}; available: {list(all_workloads)}")
+
+    keys: List[Tuple[str, str, bool]] = []
+    coros = []
+    for wname in selected_workloads:
+        for engine in selected_engines:
+            for wb in selected_writeback:
+                keys.append((wname, engine, wb))
+                short = f"{wname.replace('_', '-')}-{engine}-{'wb' if wb else 'cold'}"
+                coros.append(run_cell.override(short_name=short)(workload=wname, engine=engine, writeback=wb))
+
+    # Dataset-size sweep cells: (workload, engine, n). Same per-file size
+    # across a workload, varying count; one curve per engine.
+    ds_keys: List[Tuple[str, str, int]] = []
+    ds_coros = []
+    if dataset_sweep:
+        for engine in DATASET_ENGINES:
+            for n in DATASET_SMALL_COUNTS:
+                ds_keys.append(("small_files", engine, n))
+                ds_coros.append(
+                    run_dataset_cell.override(short_name=f"ds-small-{engine}-{n}")(
+                        workload="small_files", engine=engine, n=n
+                    )
+                )
+            for n in DATASET_BIG_COUNTS:
+                ds_keys.append(("big_files", engine, n))
+                ds_coros.append(
+                    run_dataset_cell.override(short_name=f"ds-big-{engine}-{n}")(
+                        workload="big_files", engine=engine, n=n
+                    )
+                )
+
+    logger.info(
+        "dispatching %d matrix cells + %d dataset cells across %d workloads",
+        len(coros),
+        len(ds_coros),
+        len(selected_workloads),
+    )
+    raw = await asyncio.gather(*coros, *ds_coros)
+    matrix_results = raw[: len(coros)]
+    ds_results = raw[len(coros) :]
+
+    rows: List[Dict[str, object]] = []
+    for (wname, engine, wb), (_vol, stats) in zip(keys, matrix_results):
+        rows.append({"workload": wname, "engine": engine, "writeback": wb, **stats})
+
+    ds_rows: List[Dict[str, object]] = []
+    for (wname, engine, n), (_vol, stats) in zip(ds_keys, ds_results):
+        ds_rows.append({"workload": wname, "engine": engine, "n": n, **stats})
+
+    overview_tab = flyte.report.get_tab("Overview")
+    overview_tab.log(_render_overview(rows, selected_workloads))
+
+    for wname in selected_workloads:
+        wrows = [r for r in rows if r["workload"] == wname]
+        tab = flyte.report.get_tab(wname)
+        tab.log(_render_workload(wname, wrows))
+
+    if dataset_sweep:
+        small_rows = [r for r in ds_rows if r["workload"] == "small_files"]
+        big_rows = [r for r in ds_rows if r["workload"] == "big_files"]
+        sweep_tab = flyte.report.get_tab("Dataset sweep")
+        sweep_tab.log(_render_dataset_sweep(small_rows, big_rows))
+
+    await flyte.report.flush.aio()
+    return f"{len(rows)} matrix cells + {len(ds_rows)} dataset cells across {len(selected_workloads)} workloads"
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(volume_benchmark_driver, dataset_sweep=True)
+    print(run.url)
+    run.wait()

--- a/examples/volumes/gcsfuse_example.py
+++ b/examples/volumes/gcsfuse_example.py
@@ -1,7 +1,6 @@
 # /// script
 # requires-python = "==3.12"
 # dependencies = [
-#    "kubernetes",
 #    "flyte",
 # ]
 # ///

--- a/examples/volumes/volume_cold_fork.py
+++ b/examples/volumes/volume_cold_fork.py
@@ -1,0 +1,107 @@
+# /// script
+# requires-python = "==3.12"
+# dependencies = [
+#    "flyte",
+#    "flyteplugins-union>=0.4.0",
+# ]
+#
+# [tool.uv.sources]
+# flyte = { path = "../..", editable = true }
+# ///
+"""
+Cold-fork correctness example.
+
+Exercises ``Volume.fork()`` on an *unmounted* Volume. The fork task never
+calls ``mount()`` on the parent — it just calls ``parent.fork(...)``,
+which downloads the index, snapshots it, and uploads. The fork task then
+mounts the *fork* and reads the marker the parent wrote, proving that
+cold-forked Volumes preserve the parent's namespace.
+
+Workflow:
+
+1. ``populate_parent`` creates a fresh ``RWVolume``, writes a marker, and
+   ``finalize()``s it into an immutable ``ROVolume``.
+2. ``cold_fork`` receives the sealed ``ROVolume``, forks it *without
+   mounting* (``ROVolume.fork() -> RWVolume``), then mounts the fork and
+   reads the marker back.
+3. ``main`` chains them and returns the marker contents.
+"""
+
+import logging
+import os
+import uuid
+from pathlib import Path
+
+from flyteplugins.union.io import ROVolume, Volume
+
+import flyte
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(name)s] %(levelname)s: %(message)s")
+logger = logging.getLogger("volume-cold-fork-demo")
+
+VOL_NAME = os.environ.get("VOL_NAME", "cold-fork-demo")
+MARKER_CONTENTS = "parent state — should be visible to cold fork\n"
+
+# A plain image + the released flyteplugins-union package is all Volumes need
+# (juicefs is bundled in the PyPI platform wheels).
+image = (
+    flyte.Image.from_debian_base(install_flyte=False, name="volume-cold-fork-demo")
+    .with_pip_packages("flyteplugins-union>=0.4.0")
+    .with_local_v2()  # last, so the local dev SDK wins over the pip layer's flyte dep
+)
+
+env = flyte.TaskEnvironment(
+    name="volume-cold-fork-demo",
+    # Unprivileged FUSE via the cluster's FUSE device plugin: the pod template
+    # requests smarter-devices/fuse (kubelet injects /dev/fuse) + CAP_SYS_ADMIN
+    # for mount(2). No privileged container, no hostPath. The Union dataplane
+    # chart ships an opt-in fuseDevicePlugin DaemonSet that advertises it.
+    pod_template=flyte.PodTemplate().allow_fuse(),
+    image=image,
+    resources=flyte.Resources(cpu="500m", memory="1Gi"),
+)
+
+
+@env.task
+async def populate_parent(volume_name: str) -> ROVolume:
+    """Format + populate a parent volume, then seal it into an ROVolume."""
+    logger.info("populate_parent: name=%s", volume_name)
+    # Default sqlite store is daemon-less and fork-capable, so the later
+    # cold fork (see `cold_fork_and_read`) works with no extra image deps.
+    # Volume.new() returns a writable RWVolume.
+    parent = Volume.new(name=volume_name)
+    await parent.mount()
+    Path("/workspace/marker.txt").write_text(MARKER_CONTENTS)
+    return await parent.finalize(message="parent marker")
+
+
+@env.task
+async def cold_fork_and_read(parent: ROVolume, fork_name: str) -> str:
+    """Fork *without* mounting the parent — the cold path — then mount the
+    fork and read the marker.
+    """
+    logger.info("cold_fork_and_read: parent=%s -> fork=%s (no parent mount)", parent.name, fork_name)
+    # Critical: no parent.mount() call. fork() must handle the cold path.
+    forked = await parent.fork(name=fork_name)
+    logger.info("cold_fork_and_read: forked, new index path=%s", forked.index.path if forked.index else None)
+
+    await forked.mount()
+    contents = Path("/workspace/marker.txt").read_text()
+    logger.info("cold_fork_and_read: read %d bytes from fork", len(contents))
+    if contents != MARKER_CONTENTS:
+        raise AssertionError(f"cold fork lost parent state: got {contents!r}, want {MARKER_CONTENTS!r}")
+    return contents
+
+
+@env.task
+async def main() -> str:
+    run_id = uuid.uuid4().hex[:8]
+    parent = await populate_parent(volume_name=f"{VOL_NAME}-{run_id}")
+    return await cold_fork_and_read(parent, fork_name=f"{VOL_NAME}-{run_id}-fork")
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(main)
+    print(run.url)
+    run.wait()

--- a/examples/volumes/volume_example.py
+++ b/examples/volumes/volume_example.py
@@ -1,0 +1,145 @@
+# /// script
+# requires-python = "==3.12"
+# dependencies = [
+#    "flyte",
+#    "flyteplugins-union>=0.4.0",
+# ]
+#
+# [tool.uv.sources]
+# flyte = { path = "../..", editable = true }
+# ///
+"""
+Volume example.
+
+``Volume`` lives in ``flyteplugins.union.io``, released to PyPI as
+``flyteplugins-union`` (>=0.4.0). The platform wheels bundle the juicefs
+binary, so the remote container image only needs a plain pip install.
+
+Demonstrates the typed Volume lifecycle (PRD §Core Concepts) flowing
+through a multi-task workflow. Tasks exchange immutable ``ROVolume``
+values; to mutate, a task forks one into a writable ``RWVolume``, writes,
+and ``finalize()``s back to an ``ROVolume``:
+
+1. ``init_volume`` creates a fresh ``RWVolume`` (``Volume.new``), writes a
+   file, and ``finalize()``s — drains writeback, unmounts, and publishes
+   an immutable ``ROVolume``.
+2. ``append`` ``fork()``s the incoming ``ROVolume`` into an ``RWVolume``,
+   appends to the file, and ``finalize()``s the new immutable version.
+3. ``branch`` ``fork()``s a volume into a named writable copy and
+   ``finalize()``s it — a cheap, namespace-isolated snapshot that shares
+   chunks in object storage.
+4. ``main`` chains them together so the run produces a lineage:
+   ``init -> appended -> fork``.
+
+Prereqs:
+- A bucket the cluster's service account can read/write.
+- Cluster nodes expose ``/dev/fuse``; pods can run privileged with
+  CAP_SYS_ADMIN so the primary container can FUSE-mount in-process.
+"""
+
+import logging
+import os
+import uuid
+from pathlib import Path
+
+from flyteplugins.union.io import ROVolume, Volume
+
+import flyte
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(name)s] %(levelname)s: %(message)s")
+logger = logging.getLogger("volume-demo")
+
+
+VOL_NAME = os.environ.get("VOL_NAME", "demo-vol")
+
+# A plain image + the released flyteplugins-union package is all Volumes need
+# (juicefs is bundled in the PyPI platform wheels; the default sqlite store
+# mounts via raw syscalls; enable FUSE with PodTemplate.allow_fuse()).
+image = (
+    flyte.Image.from_debian_base(install_flyte=False, name="volume-demo")
+    .with_pip_packages("flyteplugins-union>=0.4.0")
+    .with_local_v2()  # last, so the local dev SDK wins over the pip layer's flyte dep
+)
+
+env = flyte.TaskEnvironment(
+    name="volume-demo",
+    # Unprivileged FUSE via the cluster's FUSE device plugin: the pod template
+    # requests smarter-devices/fuse (kubelet injects /dev/fuse) + CAP_SYS_ADMIN
+    # for mount(2). No privileged container, no hostPath. The Union dataplane
+    # chart ships an opt-in fuseDevicePlugin DaemonSet that advertises it.
+    pod_template=flyte.PodTemplate().allow_fuse(),
+    image=image,
+    resources=flyte.Resources(cpu="500m", memory="1Gi"),
+)
+
+
+@env.task(cache="auto")
+async def init_volume(volume_name: str) -> ROVolume:
+    logger.info("init_volume: declaring fresh volume name=%s", volume_name)
+    # Volume.new() returns a writable RWVolume backed by the default sqlite
+    # store — daemon-less and fork-capable, so the later `branch`/`append`
+    # forks Just Work with no extra image deps.
+    vol = Volume.new(name=volume_name)
+    logger.info("init_volume: bucket resolved to %s", vol.bucket)
+    # mount_path is configurable; "/workspace" is the default.
+    await vol.mount(mount_path="/workspace")
+    Path("/workspace/hello.txt").write_text("hello from volume\n")
+    # finalize() drains writeback, unmounts, and returns an immutable ROVolume.
+    # Use commit() instead to flush without unmounting (keeps the volume live).
+    sealed = await vol.finalize(message="initial write")
+    logger.info("init_volume: sealed, index path=%s", sealed.index.path if sealed.index else None)
+    return sealed
+
+
+@env.task
+async def append(vol: ROVolume, line: str) -> ROVolume:
+    logger.info("append: forking immutable volume name=%s into a writable copy", vol.name)
+    # An ROVolume is immutable; fork it into an RWVolume to write.
+    rw = await vol.fork(name=f"{vol.name}-app")
+    await rw.mount()
+    with open("/workspace/hello.txt", "a") as f:  # noqa: ASYNC230
+        f.write(line + "\n")
+    sealed = await rw.finalize(message=f"append: {line!r}")
+    logger.info("append: sealed, new index path=%s", sealed.index.path if sealed.index else None)
+    return sealed
+
+
+@env.task
+async def branch(vol: ROVolume, name: str) -> ROVolume:
+    logger.info("branch: forking source volume name=%s into name=%s", vol.name, name)
+    rw = await vol.fork(name=name)
+    await rw.mount()
+    sealed = await rw.finalize(message="branch point")
+    logger.info("branch: sealed fork, new index path=%s", sealed.index.path if sealed.index else None)
+    return sealed
+
+
+@env.task
+async def read_all(vol: ROVolume) -> str:
+    logger.info("read_all: mounting volume name=%s (read-only)", vol.name)
+    await vol.mount()  # ROVolume always mounts read-only
+    contents = Path("/workspace/hello.txt").read_text()
+    logger.info("read_all: read %d bytes", len(contents))
+    return contents
+
+
+@env.task
+async def main() -> str:
+    # Unique volume name per run so the format step doesn't collide with
+    # chunks left in the bucket by earlier runs.
+    run_name = f"{VOL_NAME}-{uuid.uuid4().hex[:8]}"
+    logger.info("main: starting volume lineage demo with name=%s", run_name)
+    v0 = await init_volume(volume_name=run_name)
+    v1 = await append(v0, line="appended on main branch")
+    fork = await branch(v1, name=f"{run_name}-fork")
+    fork_after = await append(fork, line="only on the fork")
+    result = await read_all(fork_after)
+    logger.info("main: done, fork content len=%d", len(result))
+    return result
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(main)
+    print(run.url)
+    run.wait()

--- a/examples/volumes/volume_recover.py
+++ b/examples/volumes/volume_recover.py
@@ -1,0 +1,193 @@
+# /// script
+# requires-python = "==3.12"
+# dependencies = [
+#    "flyte",
+#    "flyteplugins-union>=0.4.0",
+# ]
+#
+# [tool.uv.sources]
+# flyte = { path = "../..", editable = true }
+# ///
+"""
+Volume checkpointing via ``@flyte.trace``.
+
+``Volume`` lives in ``flyteplugins.union.io``, released to PyPI as
+``flyteplugins-union`` (>=0.4.0). The platform wheels bundle the juicefs
+binary, so the remote container image only needs a plain pip install.
+
+The Volume type no longer ships built-in periodic checkpointing or crash
+recovery. This example reconstructs both with ``@flyte.trace``: a single
+long-running task mounts a writable volume once and runs one traced
+``run_epoch`` span per epoch. Each span commits the volume — a durable,
+immutable ``ROVolume`` snapshot — and returns it, so the run-details graph shows
+a ``version -> version`` lineage chain, and a crashed attempt resumes from the
+last committed epoch instead of restarting.
+
+Three design points worth understanding:
+
+**Mount once, commit many.** Mounting is expensive (FUSE format + mount), so we
+do it exactly once per attempt. ``run_epoch`` does *not* mount on the happy path
+— it calls :meth:`RWVolume.commit`, which drains writeback and uploads a fresh
+metadata index while **keeping the mount live**, so a checkpoint costs one index
+upload, not a remount.
+
+**No Volume crosses the trace boundary — it's captured, not passed.**
+``@flyte.trace`` serializes a function's *inputs* (to hash for the memo key) and
+its *output* (for lineage). Passing a Volume either way is a trap: a live
+``RWVolume`` would be drain+unmounted by the transformer's auto-finalize during
+input hashing, and even an immutable ``ROVolume`` doesn't serialize identically
+across the record/restore boundary (the transformer stamps
+``produced_by.output_name`` onto the recorded output but not onto the live
+value), so threading it would change the input hash on a retry and break
+memoization. So ``run_epoch`` takes **only the ``epoch`` int** — a stable key —
+and operates on the writable ``vol`` captured from the enclosing scope. The
+``version -> version`` lineage still threads through each committed Volume's own
+``parent_produced_by``.
+
+**Crash recovery is the trace memoization.** On a retry, every ``run_epoch`` span
+that already succeeded is replayed from its recorded output without re-running,
+so the first epoch that actually executes is the one past the last checkpoint.
+That epoch forks the last checkpoint into a writable working copy (``fork`` is
+the blessed RO->RW path and shares its chunks copy-on-write), resuming exactly
+where the crash hit. The example forces this path once via ``CRASH_AT_EPOCH``.
+
+Prereqs:
+- A bucket the cluster's service account can read/write.
+- Cluster nodes expose ``/dev/fuse``; pods can run privileged with
+  CAP_SYS_ADMIN so the primary container can FUSE-mount in-process.
+"""
+
+import asyncio
+import logging
+import os
+import uuid
+from pathlib import Path
+from typing import Optional
+
+from flyteplugins.union.io import ROVolume, Volume
+
+import flyte
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(name)s] %(levelname)s: %(message)s")
+logger = logging.getLogger("volume-checkpoint-demo")
+
+VOL_NAME = os.environ.get("VOL_NAME", "checkpoint-demo")
+EPOCHS = int(os.environ.get("EPOCHS", "6"))
+SECONDS_PER_EPOCH = float(os.environ.get("SECONDS_PER_EPOCH", "3"))
+# Force a one-time crash after this epoch, on the first attempt only, to exercise
+# the resume-from-checkpoint path. Set to a negative value to disable.
+CRASH_AT_EPOCH = int(os.environ.get("CRASH_AT_EPOCH", "2"))
+
+# A plain image + the released flyteplugins-union package is all Volumes need
+# (juicefs is bundled in the PyPI platform wheels; sqlite mounts via raw
+# syscalls under allow_fuse()).
+image = (
+    flyte.Image.from_debian_base(install_flyte=False, name="volume-checkpoint-demo")
+    .with_pip_packages("flyteplugins-union>=0.4.0")
+    .with_local_v2()  # last, so the local dev SDK wins over the pip layer's flyte dep
+)
+
+env = flyte.TaskEnvironment(
+    name="volume-checkpoint-demo",
+    # Unprivileged FUSE via the cluster's FUSE device plugin: the pod template
+    # requests smarter-devices/fuse (kubelet injects /dev/fuse) + CAP_SYS_ADMIN
+    # for mount(2). No privileged container, no hostPath. The Union dataplane
+    # chart ships an opt-in fuseDevicePlugin DaemonSet that advertises it.
+    pod_template=flyte.PodTemplate().allow_fuse(),
+    image=image,
+    resources=flyte.Resources(cpu="500m", memory="1Gi"),
+)
+
+
+@env.task(retries=2)
+async def train(volume_name: str, epochs: int) -> ROVolume:
+    """Mount a writable volume once, then checkpoint one ``@flyte.trace`` span
+    per epoch.
+
+    Each epoch commits the volume (a durable ``ROVolume`` snapshot) and returns
+    it, so on a retry the completed epochs are replayed from trace memoization
+    and the loop resumes from the last checkpoint — see the module docstring.
+    """
+    logger.info("train: volume_name=%s epochs=%d", volume_name, epochs)
+    # `vol` is the writable handle for this attempt — we mount it once and commit
+    # *it* on every epoch (RWVolume.commit keeps the mount live). It starts as a
+    # fresh empty volume; on a resume, run_epoch forks it from the checkpoint.
+    vol = Volume.new(name=volume_name)
+    # `current_vol` threads the latest immutable checkpoint through the loop and,
+    # across a retry, via @flyte.trace memoization. `mounted` is process-local so
+    # the live mount is stood up exactly once per attempt.
+    current_vol: Optional[ROVolume] = None
+    mounted = False
+
+    @flyte.trace
+    async def run_epoch(epoch: int) -> ROVolume:
+        nonlocal vol, mounted
+        # The body only executes for NON-cached epochs, so on a retry this runs at
+        # the first epoch past the last checkpoint. Stand the mount up once: if we
+        # fast-forwarded to a checkpoint (held in the closure `current_vol`), fork
+        # it into a writable working copy — fork() is the blessed RO->RW path, and
+        # it shares the checkpoint's chunks copy-on-write so we resume its files.
+        # The name is attempt-scoped so repeated retries don't collide. On a cold
+        # start `current_vol` is None and `vol` is the empty Volume.new above.
+        if not mounted:
+            if current_vol is not None:
+                attempt = int(os.environ.get("FLYTE_ATTEMPT_NUMBER", "0"))
+                vol = await current_vol.fork(name=f"{volume_name}-a{attempt}")
+            await vol.mount(mount_path="/workspace")
+            mounted = True
+        logger.info("train: epoch %d/%d working...", epoch, epochs)
+        await asyncio.sleep(SECONDS_PER_EPOCH)  # stand-in for real compute
+        # Write this epoch's "checkpoint" artifact into the live mount.
+        Path(f"/workspace/ckpt-{epoch:03d}.bin").write_bytes(b"\x00" * 1024)
+        with open("/workspace/epochs.log", "a") as f:  # noqa: ASYNC230
+            f.write(f"epoch {epoch} done\n")
+        # Commit the live RWVolume `vol`. RWVolume.commit drains writeback +
+        # uploads a fresh index and keeps the mount live, returning the new
+        # immutable version. (Never commit an ROVolume — it inherits the
+        # deprecated Volume.commit(), which drains+UNMOUNTS.)
+        return await vol.commit(message=f"epoch {epoch}")
+
+    for epoch in range(epochs):
+        current_vol = await run_epoch(epoch)
+        # Force one hard failure after a committed epoch (first attempt only) so
+        # the retry exercises the resume-from-checkpoint path. The completed
+        # run_epoch spans above are memoized on retry; the loop fast-forwards
+        # through them and the first live epoch remounts from the last commit.
+        if epoch == CRASH_AT_EPOCH and int(os.environ.get("FLYTE_ATTEMPT_NUMBER", "0")) == 0:
+            logger.error("train: simulating crash after epoch %d (attempt 0)", epoch)
+            raise RuntimeError(f"simulated crash after epoch {epoch}")
+
+    # finalize() drains writeback, unmounts, and publishes the terminal version.
+    # Finalize the live writable handle `vol` — `current_vol` is the last
+    # immutable ROVolume snapshot and has no finalize().
+    sealed = await vol.finalize(message=f"trained {epochs} epochs")
+    logger.info("train: sealed final index path=%s", sealed.index.path if sealed.index else None)
+    return sealed
+
+
+@env.task
+async def verify(vol: ROVolume, expected_epochs: int) -> str:
+    """Mount the sealed volume read-only and confirm every epoch landed."""
+    logger.info("verify: mounting %s read-only", vol.name)
+    await vol.mount()  # ROVolume always mounts read-only
+    log = Path("/workspace/epochs.log").read_text()
+    done = sum(1 for line in log.splitlines() if line.strip())
+    logger.info("verify: %d epochs recorded (expected %d)", done, expected_epochs)
+    if done != expected_epochs:
+        raise AssertionError(f"epoch mismatch: got {done}, want {expected_epochs}")
+    return log
+
+
+@env.task
+async def main() -> str:
+    run_name = f"{VOL_NAME}-{uuid.uuid4().hex[:8]}"
+    logger.info("main: starting checkpoint demo name=%s epochs=%d", run_name, EPOCHS)
+    trained = await train(volume_name=run_name, epochs=EPOCHS)
+    return await verify(trained, expected_epochs=EPOCHS)
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(main)
+    print(run.url)
+    run.wait()

--- a/plugins/redis/uv.lock
+++ b/plugins/redis/uv.lock
@@ -314,7 +314,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -376,7 +376,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.20" },
+    { name = "flyteidl2", specifier = "==2.0.23" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -443,7 +443,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.20"
+version = "2.0.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -452,7 +452,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/2d/7626f50a20fb11780455ca56ff092f1392ce89d5d124ccd130809c2e855a/flyteidl2-2.0.20-py3-none-any.whl", hash = "sha256:704e23484fa06f9be7b5e70322ad1a0787588338d926c6b3846382242d09dbcc", size = 344426, upload-time = "2026-06-01T17:55:29.215Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
 ]
 
 [[package]]
@@ -617,7 +617,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [

--- a/src/flyte/_pod.py
+++ b/src/flyte/_pod.py
@@ -12,10 +12,17 @@ if TYPE_CHECKING:
 _PRIMARY_CONTAINER_NAME_FIELD = "primary_container_name"
 _PRIMARY_CONTAINER_DEFAULT_NAME = "primary"
 
-# Name used for the hostPath volume and its volumeMount added by
-# ``PodTemplate.allow_fuse()``.
+# Name/path for the hostPath volume + volumeMount used by the legacy
+# ``allow_fuse(privileged=True)`` escape hatch.
 _FUSE_DEVICE_VOLUME_NAME = "fuse-device"
 _FUSE_DEVICE_PATH = "/dev/fuse"
+
+# Extended resource advertised by a FUSE device plugin (smarter-device-manager /
+# fuse-device-plugin DaemonSet). Requesting it makes kubelet inject /dev/fuse
+# into the container's devices-cgroup allowlist — granting an UNPRIVILEGED
+# container access to the device, which a hostPath cannot do. This is what the
+# default (device-plugin) path of ``PodTemplate.allow_fuse()`` uses.
+_FUSE_DEVICE_RESOURCE = "smarter-devices/fuse"
 
 # Every capability helper stamps ``flyte.org/capability-<name>: "true"`` on the
 # resulting template so the requested grant is auditable on the pod itself
@@ -95,44 +102,51 @@ class PodTemplate(object):
             annotations=dict(annotations) if annotations else None,
         )
 
-    def allow_fuse(self, privileged: bool = True) -> PodTemplate:
+    def allow_fuse(self, privileged: bool = False) -> PodTemplate:
         """
-        Return a copy of this template granted everything a container needs to
-        perform an in-process FUSE mount (e.g. for ``Volume`` support).
+        Return a copy of this template granted everything an **unprivileged**
+        container needs to perform an in-process FUSE mount (e.g. for ``Volume``
+        support).
 
-        Specifically, the copy:
+        By default (``privileged=False``) the copy:
 
-        * adds a ``hostPath`` volume named ``fuse-device`` pointing at
-          ``/dev/fuse`` on the node, mounted into the primary container;
-        * adds ``CAP_SYS_ADMIN`` to the primary container so the ``mount``
-          syscall is permitted;
-        * with ``privileged=True`` (the default), sets ``privileged: true`` on
-          the primary container; with ``privileged=False``, instead sets the
-          ``container.apparmor.security.beta.kubernetes.io/<primary>:
-          unconfined`` pod annotation (the default AppArmor profile would
-          otherwise block ``mount``);
+        * requests the ``smarter-devices/fuse`` extended resource (request +
+          limit) on the primary container, so the cluster's FUSE **device
+          plugin** (smarter-device-manager / fuse-device-plugin DaemonSet)
+          injects ``/dev/fuse`` into the container's devices-cgroup allowlist —
+          making the node device *usable* from an unprivileged container; and
+        * adds ``CAP_SYS_ADMIN`` to the primary container, required for the
+          ``mount(2)`` syscall that attaches the FUSE filesystem;
         * stamps the ``flyte.org/capability-fuse`` annotation for auditability.
 
-        Why privileged is the default: opening ``/dev/fuse`` is gated by the
-        container runtime's device-cgroup allowlist, which only ``privileged``
-        bypasses — there is no pod-spec field to whitelist a device for a
-        non-privileged container. Pass ``privileged=False`` **only** on
-        clusters that permit ``/dev/fuse`` for non-privileged containers (e.g.
-        via a FUSE device plugin or runtime device-allowlist configuration);
-        otherwise the pod deploys fine but ``open("/dev/fuse")`` fails with
-        ``EPERM`` at runtime. ``privileged=False`` composes with
-        ``allow_nested_sandboxing()``; ``privileged=True`` does not (Kubernetes
-        rejects privileged containers that set
-        ``allowPrivilegeEscalation: false``).
+        It does **not** set ``privileged: true`` and does **not** add a
+        ``/dev/fuse`` hostPath. A hostPath only makes the device *node* visible;
+        the devices cgroup still denies ``open()`` with ``EPERM`` — the device
+        plugin is what actually grants access. This default composes with
+        ``allow_nested_sandboxing()``. The cluster must run a FUSE device plugin
+        advertising ``smarter-devices/fuse`` (the Union dataplane chart ships an
+        opt-in ``fuseDevicePlugin`` DaemonSet for this).
+
+        ``privileged=True`` is a legacy escape hatch for clusters **without** a
+        FUSE device plugin: it instead adds a ``/dev/fuse`` hostPath volume +
+        mount and sets ``privileged: true`` on the primary container (the device
+        cgroup is bypassed by privilege). It does not compose with
+        ``allow_nested_sandboxing()`` (Kubernetes rejects privileged containers
+        that set ``allowPrivilegeEscalation: false``).
+
+        AppArmor note: on clusters that enforce a restrictive default AppArmor
+        profile, the ``mount`` syscall may additionally need the primary
+        container's profile set to ``unconfined`` — set that annotation on the
+        template yourself if needed; it is not applied by default to keep this
+        grant minimal.
 
         The original template is never mutated; existing volumes, mounts,
-        sidecars, labels, annotations, and unrelated security-context fields
-        are preserved. Re-applying with the same arguments is idempotent.
+        resources, sidecars, labels, annotations, and unrelated security-context
+        fields are preserved. Re-applying with the same arguments is idempotent.
 
-        Raises ``ValueError`` if the template already pins a conflicting
-        security posture (with ``privileged=True``: ``privileged: false`` or
-        ``allowPrivilegeEscalation: false`` pre-set; with ``privileged=False``:
-        a different AppArmor profile for the primary container).
+        Raises ``ValueError`` if the template already pins a conflicting security
+        posture (with ``privileged=True``: ``privileged: false`` or
+        ``allowPrivilegeEscalation: false`` pre-set).
         """
         return _apply_fuse(self, privileged=privileged)
 
@@ -231,6 +245,18 @@ def _add_sys_admin(primary: "V1Container") -> None:
     primary.security_context = sc
 
 
+def _add_fuse_device_resource(primary: "V1Container") -> None:
+    """Request the FUSE device-plugin resource on the primary container, merging
+    into any resources the caller already set (request + limit, per the k8s rule
+    that extended resources must have request == limit)."""
+    from kubernetes.client import V1ResourceRequirements
+
+    resources = primary.resources or V1ResourceRequirements()
+    resources.requests = {**(resources.requests or {}), _FUSE_DEVICE_RESOURCE: "1"}
+    resources.limits = {**(resources.limits or {}), _FUSE_DEVICE_RESOURCE: "1"}
+    primary.resources = resources
+
+
 def _set_apparmor_unconfined(pt: PodTemplate, caller: str) -> None:
     """Set the AppArmor-unconfined annotation for the primary container.
 
@@ -248,40 +274,42 @@ def _set_apparmor_unconfined(pt: PodTemplate, caller: str) -> None:
     pt.annotations = annotations
 
 
-def _apply_fuse(pod_template: PodTemplate, *, privileged: bool = True) -> PodTemplate:
+def _apply_fuse(pod_template: PodTemplate, *, privileged: bool = False) -> PodTemplate:
     """Augmentor behind :meth:`PodTemplate.allow_fuse`."""
-    from kubernetes.client import V1HostPathVolumeSource, V1Volume, V1VolumeMount
-
     pt = _clone_with_primary(pod_template)
     primary = _get_primary_container(pt)
 
-    if privileged:
-        # Conflict checks: a privileged container cannot deny privilege
-        # escalation (Kubernetes rejects the combination), and an explicit
-        # privileged=False contradicts what this grant needs.
-        sc = primary.security_context
-        if sc is not None:
-            if sc.privileged is False:
-                raise ValueError(
-                    f"allow_fuse() requires privileged=true on the primary container "
-                    f"({pt.primary_container_name!r}), but the pod template explicitly sets privileged=false. "
-                    "On clusters that permit /dev/fuse for non-privileged containers, use "
-                    "allow_fuse(privileged=False)."
-                )
-            if sc.allow_privilege_escalation is False:
-                raise ValueError(
-                    "allow_fuse() makes the primary container privileged, which Kubernetes rejects when "
-                    "allowPrivilegeEscalation=false is set (e.g. after allow_nested_sandboxing()). On clusters "
-                    "that permit /dev/fuse for non-privileged containers, use allow_fuse(privileged=False), "
-                    "which composes with allow_nested_sandboxing()."
-                )
-    else:
-        # Non-privileged FUSE: mount needs CAP_SYS_ADMIN (added below) and an
-        # unconfined AppArmor profile; the cluster must separately permit
-        # /dev/fuse for non-privileged containers (device plugin or runtime
-        # device-allowlist config). Leaves privileged/allowPrivilegeEscalation
-        # untouched, so it composes with allow_nested_sandboxing().
-        _set_apparmor_unconfined(pt, "allow_fuse(privileged=False)")
+    if not privileged:
+        # Default device-plugin path: request smarter-devices/fuse so kubelet
+        # injects /dev/fuse into the devices cgroup; CAP_SYS_ADMIN for mount(2).
+        # No privileged, no hostPath. Composes with allow_nested_sandboxing()
+        # (SYS_ADMIN + allowPrivilegeEscalation=false is permitted).
+        _add_fuse_device_resource(primary)
+        _add_sys_admin(primary)
+        _stamp_capability(pt, "fuse")
+        return pt
+
+    # Legacy escape hatch (privileged=True): /dev/fuse hostPath + privileged, for
+    # clusters WITHOUT a FUSE device plugin (privilege bypasses the device cgroup).
+    from kubernetes.client import V1HostPathVolumeSource, V1Volume, V1VolumeMount
+
+    # Conflict checks: a privileged container cannot deny privilege escalation
+    # (Kubernetes rejects the combination), and an explicit privileged=False
+    # contradicts what this grant needs.
+    sc = primary.security_context
+    if sc is not None:
+        if sc.privileged is False:
+            raise ValueError(
+                f"allow_fuse(privileged=True) requires privileged=true on the primary container "
+                f"({pt.primary_container_name!r}), but the pod template explicitly sets privileged=false. "
+                "On clusters with a FUSE device plugin, use allow_fuse() (the unprivileged default)."
+            )
+        if sc.allow_privilege_escalation is False:
+            raise ValueError(
+                "allow_fuse(privileged=True) makes the primary container privileged, which Kubernetes rejects "
+                "when allowPrivilegeEscalation=false is set (e.g. after allow_nested_sandboxing()). Use the "
+                "unprivileged default allow_fuse(), which composes with allow_nested_sandboxing()."
+            )
 
     # Volume + volumeMount for /dev/fuse — idempotent: skip if already present.
     assert pt.pod_spec is not None  # _clone_with_primary guarantees it
@@ -300,11 +328,8 @@ def _apply_fuse(pod_template: PodTemplate, *, privileged: bool = True) -> PodTem
         mounts.append(V1VolumeMount(name=_FUSE_DEVICE_VOLUME_NAME, mount_path=_FUSE_DEVICE_PATH))
         primary.volume_mounts = mounts
 
-    # SecurityContext: CAP_SYS_ADMIN (+ privileged unless opted out). Preserve
-    # any other security-context fields the caller set.
     _add_sys_admin(primary)
-    if privileged:
-        primary.security_context.privileged = True
+    primary.security_context.privileged = True
 
     _stamp_capability(pt, "fuse")
     return pt

--- a/src/flyte/_pod.py
+++ b/src/flyte/_pod.py
@@ -345,7 +345,6 @@ def _apply_fuse_privileged(pt: PodTemplate, primary: "V1Container") -> None:
 
     primary.security_context = primary.security_context or V1SecurityContext()
     primary.security_context.privileged = True
-    return pt
 
 
 def _apply_sandboxing(pod_template: PodTemplate) -> PodTemplate:

--- a/src/flyte/_pod.py
+++ b/src/flyte/_pod.py
@@ -275,22 +275,35 @@ def _set_apparmor_unconfined(pt: PodTemplate, caller: str) -> None:
 
 
 def _apply_fuse(pod_template: PodTemplate, *, privileged: bool = False) -> PodTemplate:
-    """Augmentor behind :meth:`PodTemplate.allow_fuse`."""
+    """Augmentor behind :meth:`PodTemplate.allow_fuse`. Dispatches to one of two
+    clearly separate strategies; both grant CAP_SYS_ADMIN and stamp the fuse
+    capability annotation."""
     pt = _clone_with_primary(pod_template)
     primary = _get_primary_container(pt)
 
-    if not privileged:
-        # Default device-plugin path: request smarter-devices/fuse so kubelet
-        # injects /dev/fuse into the devices cgroup; CAP_SYS_ADMIN for mount(2).
-        # No privileged, no hostPath. Composes with allow_nested_sandboxing()
-        # (SYS_ADMIN + allowPrivilegeEscalation=false is permitted).
-        _add_fuse_device_resource(primary)
-        _add_sys_admin(primary)
-        _stamp_capability(pt, "fuse")
-        return pt
+    if privileged:
+        _apply_fuse_privileged(pt, primary)
+    else:
+        _apply_fuse_device_plugin(primary)
 
-    # Legacy escape hatch (privileged=True): /dev/fuse hostPath + privileged, for
-    # clusters WITHOUT a FUSE device plugin (privilege bypasses the device cgroup).
+    _add_sys_admin(primary)  # the mount(2) syscall needs it on both paths
+    _stamp_capability(pt, "fuse")
+    return pt
+
+
+def _apply_fuse_device_plugin(primary: "V1Container") -> None:
+    """Default, UNPRIVILEGED path: request the ``smarter-devices/fuse`` extended
+    resource so a FUSE device plugin makes kubelet inject ``/dev/fuse`` into the
+    container's devices-cgroup allowlist. No privileged, no hostPath — composes
+    with ``allow_nested_sandboxing()``. Requires a FUSE device plugin on the
+    cluster."""
+    _add_fuse_device_resource(primary)
+
+
+def _apply_fuse_privileged(pt: PodTemplate, primary: "V1Container") -> None:
+    """Legacy escape hatch for clusters WITHOUT a FUSE device plugin: a
+    ``/dev/fuse`` hostPath + ``privileged=true`` (privilege bypasses the device
+    cgroup that would otherwise deny ``open()``)."""
     from kubernetes.client import V1HostPathVolumeSource, V1Volume, V1VolumeMount
 
     # Conflict checks: a privileged container cannot deny privilege escalation
@@ -328,10 +341,10 @@ def _apply_fuse(pod_template: PodTemplate, *, privileged: bool = False) -> PodTe
         mounts.append(V1VolumeMount(name=_FUSE_DEVICE_VOLUME_NAME, mount_path=_FUSE_DEVICE_PATH))
         primary.volume_mounts = mounts
 
-    _add_sys_admin(primary)
-    primary.security_context.privileged = True
+    from kubernetes.client import V1SecurityContext
 
-    _stamp_capability(pt, "fuse")
+    primary.security_context = primary.security_context or V1SecurityContext()
+    primary.security_context.privileged = True
     return pt
 
 

--- a/tests/user_api/test_pod_template.py
+++ b/tests/user_api/test_pod_template.py
@@ -278,8 +278,59 @@ class TestCapabilityLaws:
 
 
 class TestAllowFuse:
-    def test_fuse_device_volume_and_mount(self):
+    """Default (unprivileged) device-plugin path."""
+
+    def test_requests_fuse_device_resource(self):
         pt = PodTemplate().allow_fuse()
+        primary = next(c for c in pt.pod_spec.containers if c.name == "primary")
+        assert primary.resources.requests["smarter-devices/fuse"] == "1"
+        assert primary.resources.limits["smarter-devices/fuse"] == "1"
+
+    def test_not_privileged_and_no_hostpath(self):
+        pt = PodTemplate().allow_fuse()
+        primary = next(c for c in pt.pod_spec.containers if c.name == "primary")
+        sc = primary.security_context
+        assert sc.privileged is not True
+        assert "SYS_ADMIN" in sc.capabilities.add
+        # composability: must not pin allowPrivilegeEscalation either way
+        assert sc.allow_privilege_escalation is None
+        # no /dev/fuse hostPath in the device-plugin path
+        assert not any(getattr(v, "name", None) == "fuse-device" for v in (pt.pod_spec.volumes or []))
+
+    def test_privileged_false_is_the_default(self):
+        assert PodTemplate().allow_fuse() == PodTemplate().allow_fuse(privileged=False)
+
+    def test_merges_with_existing_resources(self):
+        from kubernetes.client import V1Container, V1PodSpec, V1ResourceRequirements
+
+        pt = PodTemplate(
+            pod_spec=V1PodSpec(
+                containers=[V1Container(name="primary", resources=V1ResourceRequirements(requests={"cpu": "1"}))]
+            )
+        ).allow_fuse()
+        primary = next(c for c in pt.pod_spec.containers if c.name == "primary")
+        assert primary.resources.requests["cpu"] == "1"
+        assert primary.resources.requests["smarter-devices/fuse"] == "1"
+
+    def test_composes_with_sandboxing_in_both_orders(self):
+        a = PodTemplate().allow_fuse().allow_nested_sandboxing()
+        b = PodTemplate().allow_nested_sandboxing().allow_fuse()
+        assert a == b  # order-free law holds for the composable pair
+        primary = next(c for c in a.pod_spec.containers if c.name == "primary")
+        sc = primary.security_context
+        assert sc.capabilities.add == ["SYS_ADMIN"]
+        assert sc.allow_privilege_escalation is False
+        assert sc.privileged is not True
+        assert primary.resources.requests["smarter-devices/fuse"] == "1"
+        assert a.annotations["flyte.org/capability-fuse"] == "true"
+        assert a.annotations["flyte.org/capability-nested-sandboxing"] == "true"
+
+
+class TestAllowFusePrivileged:
+    """Legacy escape hatch (privileged=True): hostPath + privileged."""
+
+    def test_fuse_device_volume_and_mount(self):
+        pt = PodTemplate().allow_fuse(privileged=True)
         vol = next(v for v in pt.pod_spec.volumes if v.name == "fuse-device")
         assert vol.host_path.path == "/dev/fuse"
         assert vol.host_path.type == "CharDevice"
@@ -288,9 +339,10 @@ class TestAllowFuse:
         assert mount.mount_path == "/dev/fuse"
 
     def test_privileged(self):
-        pt = PodTemplate().allow_fuse()
+        pt = PodTemplate().allow_fuse(privileged=True)
         primary = next(c for c in pt.pod_spec.containers if c.name == "primary")
         assert primary.security_context.privileged is True
+        assert "SYS_ADMIN" in primary.security_context.capabilities.add
 
     def test_conflicts_with_explicit_unprivileged(self):
         from kubernetes.client import V1Container, V1PodSpec, V1SecurityContext
@@ -301,49 +353,11 @@ class TestAllowFuse:
             )
         )
         with pytest.raises(ValueError, match="privileged=false"):
-            pt.allow_fuse()
+            pt.allow_fuse(privileged=True)
 
     def test_conflicts_allow_nested_sandboxing(self):
         with pytest.raises(ValueError, match="allowPrivilegeEscalation"):
-            PodTemplate().allow_nested_sandboxing().allow_fuse()
-
-
-class TestAllowFuseUnprivileged:
-    def test_not_privileged(self):
-        pt = PodTemplate().allow_fuse(privileged=False)
-        primary = next(c for c in pt.pod_spec.containers if c.name == "primary")
-        sc = primary.security_context
-        assert sc.privileged is not True
-        assert "SYS_ADMIN" in sc.capabilities.add
-        # composability: must not pin allowPrivilegeEscalation either way
-        assert sc.allow_privilege_escalation is None
-
-    def test_device_volume_still_mounted(self):
-        pt = PodTemplate().allow_fuse(privileged=False)
-        assert any(v.name == "fuse-device" for v in pt.pod_spec.volumes)
-
-    def test_sets_apparmor_unconfined(self):
-        pt = PodTemplate(primary_container_name="worker").allow_fuse(privileged=False)
-        assert pt.annotations["container.apparmor.security.beta.kubernetes.io/worker"] == "unconfined"
-
-    def test_conflicts_with_other_apparmor_profile(self):
-        pt = PodTemplate(annotations={"container.apparmor.security.beta.kubernetes.io/primary": "runtime/default"})
-        with pytest.raises(ValueError, match="AppArmor"):
-            pt.allow_fuse(privileged=False)
-
-    def test_composes_with_sandboxing_in_both_orders(self):
-        a = PodTemplate().allow_fuse(privileged=False).allow_nested_sandboxing()
-        b = PodTemplate().allow_nested_sandboxing().allow_fuse(privileged=False)
-        assert a == b  # order-free law holds for the composable pair
-        primary = next(c for c in a.pod_spec.containers if c.name == "primary")
-        sc = primary.security_context
-        assert sc.capabilities.add == ["SYS_ADMIN"]
-        assert sc.allow_privilege_escalation is False
-        assert sc.privileged is not True
-        assert any(v.name == "fuse-device" for v in a.pod_spec.volumes)
-        assert a.annotations["container.apparmor.security.beta.kubernetes.io/primary"] == "unconfined"
-        assert a.annotations["flyte.org/capability-fuse"] == "true"
-        assert a.annotations["flyte.org/capability-nested-sandboxing"] == "true"
+            PodTemplate().allow_nested_sandboxing().allow_fuse(privileged=True)
 
 
 class TestAllowNestedSandboxing:
@@ -371,9 +385,15 @@ class TestAllowNestedSandboxing:
         with pytest.raises(ValueError, match="privileged=true"):
             pt.allow_nested_sandboxing()
 
-    def test_conflicts_allow_fuse(self):
-        with pytest.raises(ValueError, match="privileged"):
-            PodTemplate().allow_fuse().allow_nested_sandboxing()
+    def test_composes_with_default_allow_fuse(self):
+        # The default (device-plugin) allow_fuse is unprivileged, so it composes
+        # with nested sandboxing in either order.
+        PodTemplate().allow_fuse().allow_nested_sandboxing()
+        PodTemplate().allow_nested_sandboxing().allow_fuse()
+
+    def test_conflicts_allow_fuse_privileged(self):
+        with pytest.raises(ValueError, match="allowPrivilegeEscalation"):
+            PodTemplate().allow_nested_sandboxing().allow_fuse(privileged=True)
 
     def test_conflicts_with_other_apparmor_profile(self):
         pt = PodTemplate(annotations={"container.apparmor.security.beta.kubernetes.io/primary": "runtime/default"})


### PR DESCRIPTION
## What

Two things, together:

1. **`PodTemplate.allow_fuse()` now grants unprivileged FUSE via a device plugin by default** — `smarter-devices/fuse` resource request + `CAP_SYS_ADMIN`, no privileged container, no `/dev/fuse` hostPath. `allow_fuse(privileged=True)` is kept as a legacy escape hatch (hostPath + privileged) for clusters without a device plugin. The two paths are cleanly separated (`_apply_fuse_device_plugin` / `_apply_fuse_privileged`).
2. **JuiceFS `Volume` examples** (`examples/volumes/`) updated to use `pod_template=flyte.PodTemplate().allow_fuse()` instead of the old privileged/`enable_fuse_mount` approach.

## Why

The old `allow_fuse(privileged=False)` path used a `/dev/fuse` hostPath, which doesn't actually work: a hostPath surfaces the device node but the container's **devices cgroup** still denies `open()` with `EPERM`. Only `privileged` (or a device plugin) grants access. The device-plugin path is the real unprivileged solution — requesting `smarter-devices/fuse` makes kubelet inject `/dev/fuse` into the devices-cgroup allowlist; `CAP_SYS_ADMIN` covers `mount(2)`. Composes with `allow_nested_sandboxing()`.

The cluster must run a FUSE device plugin advertising `smarter-devices/fuse` — the Union dataplane chart ships an opt-in `fuseDevicePlugin` DaemonSet (unionai/helm-charts#443, unionai/cloud#16489).

## Validated end-to-end

On a real Union dataplane (dogfood, device plugin deployed): an unprivileged task pod built from `PodTemplate().allow_fuse()` (CAP_SYS_ADMIN + `smarter-devices/fuse`, not privileged, no hostPath) opened `/dev/fuse` and mounted an S3-backed **flyteplugins-union `Volume`** with a read/write round-trip. `CapEff=a82425fb` (SYS_ADMIN only).

## Tests

`TestAllowFuse` (device-plugin default) + `TestAllowFusePrivileged` (legacy hostPath escape hatch) + updated sandboxing-composition tests — 54 passed.
