### PR TITLE
examples(volumes): use PodTemplate().allow_fuse() instead of enable_fuse_mount

### DIFF
--- a/examples/volumes/bench.py
+++ b/examples/volumes/bench.py
@@ -63,8 +63,11 @@ image = with_high_throughput_volume_deps(base)
 
 env = flyte.TaskEnvironment(
     name="vol-bench",
-    # CAP_SYS_ADMIN + /dev/fuse come from this flag; no PodTemplate needed.
-    enable_fuse_mount=True,
+    # Unprivileged FUSE via the cluster's FUSE device plugin: the pod template
+    # requests smarter-devices/fuse (kubelet injects /dev/fuse) + CAP_SYS_ADMIN
+    # for mount(2). No privileged container, no hostPath. The Union dataplane
+    # chart ships an opt-in fuseDevicePlugin DaemonSet that advertises it.
+    pod_template=flyte.PodTemplate().allow_fuse(),
     image=image,
     resources=flyte.Resources(cpu="2", memory="4Gi"),
 )

--- a/examples/volumes/volume_cold_fork.py
+++ b/examples/volumes/volume_cold_fork.py
@@ -52,8 +52,11 @@ image = (
 
 env = flyte.TaskEnvironment(
     name="volume-cold-fork-demo",
-    # CAP_SYS_ADMIN + /dev/fuse come from this flag; no PodTemplate needed.
-    enable_fuse_mount=True,
+    # Unprivileged FUSE via the cluster's FUSE device plugin: the pod template
+    # requests smarter-devices/fuse (kubelet injects /dev/fuse) + CAP_SYS_ADMIN
+    # for mount(2). No privileged container, no hostPath. The Union dataplane
+    # chart ships an opt-in fuseDevicePlugin DaemonSet that advertises it.
+    pod_template=flyte.PodTemplate().allow_fuse(),
     image=image,
     resources=flyte.Resources(cpu="500m", memory="1Gi"),
 )

--- a/examples/volumes/volume_example.py
+++ b/examples/volumes/volume_example.py
@@ -54,7 +54,7 @@ VOL_NAME = os.environ.get("VOL_NAME", "demo-vol")
 
 # A plain image + the released flyteplugins-union package is all Volumes need
 # (juicefs is bundled in the PyPI platform wheels; the default sqlite store
-# mounts via raw syscalls under enable_fuse_mount).
+# mounts via raw syscalls; enable FUSE with PodTemplate.allow_fuse()).
 image = (
     flyte.Image.from_debian_base(install_flyte=False, name="volume-demo")
     .with_pip_packages("flyteplugins-union>=0.4.0")
@@ -63,8 +63,11 @@ image = (
 
 env = flyte.TaskEnvironment(
     name="volume-demo",
-    # CAP_SYS_ADMIN + /dev/fuse come from this flag; no PodTemplate needed.
-    enable_fuse_mount=True,
+    # Unprivileged FUSE via the cluster's FUSE device plugin: the pod template
+    # requests smarter-devices/fuse (kubelet injects /dev/fuse) + CAP_SYS_ADMIN
+    # for mount(2). No privileged container, no hostPath. The Union dataplane
+    # chart ships an opt-in fuseDevicePlugin DaemonSet that advertises it.
+    pod_template=flyte.PodTemplate().allow_fuse(),
     image=image,
     resources=flyte.Resources(cpu="500m", memory="1Gi"),
 )

--- a/examples/volumes/volume_recover.py
+++ b/examples/volumes/volume_recover.py
@@ -80,7 +80,7 @@ CRASH_AT_EPOCH = int(os.environ.get("CRASH_AT_EPOCH", "2"))
 
 # A plain image + the released flyteplugins-union package is all Volumes need
 # (juicefs is bundled in the PyPI platform wheels; sqlite mounts via raw
-# syscalls under enable_fuse_mount).
+# syscalls under allow_fuse()).
 image = (
     flyte.Image.from_debian_base(install_flyte=False, name="volume-checkpoint-demo")
     .with_pip_packages("flyteplugins-union>=0.4.0")
@@ -89,8 +89,11 @@ image = (
 
 env = flyte.TaskEnvironment(
     name="volume-checkpoint-demo",
-    # CAP_SYS_ADMIN + /dev/fuse come from this flag; no PodTemplate needed.
-    enable_fuse_mount=True,
+    # Unprivileged FUSE via the cluster's FUSE device plugin: the pod template
+    # requests smarter-devices/fuse (kubelet injects /dev/fuse) + CAP_SYS_ADMIN
+    # for mount(2). No privileged container, no hostPath. The Union dataplane
+    # chart ships an opt-in fuseDevicePlugin DaemonSet that advertises it.
+    pod_template=flyte.PodTemplate().allow_fuse(),
     image=image,
     resources=flyte.Resources(cpu="500m", memory="1Gi"),
 )


### PR DESCRIPTION
Switches the volume examples to `pod_template=flyte.PodTemplate().allow_fuse()`. With flyteorg/flyte-sdk#1205, `allow_fuse()` grants unprivileged FUSE via the device plugin (smarter-devices/fuse request + CAP_SYS_ADMIN, no privileged/hostPath), so the examples no longer need the `enable_fuse_mount` flag. Base is the volume-examples branch; rebase onto main once #1205 lands.