### PR TITLE
fix(runtime): surface load-time errors in task UI instead of empty message

### DIFF
--- a/examples/basics/module_not_found.py
+++ b/examples/basics/module_not_found.py
@@ -1,0 +1,95 @@
+# module_not_found.py
+#
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "kubernetes",
+# ]
+# ///
+#
+# Reproduces the "empty error message" problem from the support thread, with a custom
+# pod template on the task environment.
+#
+# When a task module imports something that exists locally but is NOT in the task's
+# container image, AND the import is at *module top level* (not inside the task body),
+# the container crashes while Flyte is still *loading* the task -- before the error-
+# capturing run wrapper exists. No `error.pb` gets written, so the backend has no error
+# document to show and the task UI displays only:
+#
+#     [primary] terminated with exit code (1). Reason [Error]. Message:
+#     .
+#
+# The real `ModuleNotFoundError` is buried at the very bottom of the task logs.
+#
+# Why top-level matters (this is the whole point of the repro):
+#   - Top-level import  -> fails in `_download_and_load_task` / `load_task`, which runs
+#     BEFORE `extract_download_run_upload`. `upload_error()` never runs, so no error.pb
+#     is uploaded -> the UI message is empty. (This is the bug we want to surface.)
+#   - In-body import    -> fails inside `convert_and_run`, which IS wrapped by the error
+#     handler, so error.pb is written and the UI correctly shows "No module named ...".
+#
+# The `[primary]` in the UI message is the pod's primary container name, set below via the
+# pod template (`primary_container_name="primary"`).
+#
+# To reproduce the empty message:
+#   1. Install the dependency LOCALLY so `flyte run` can import this file and submit the
+#      task:   pip install emoji
+#   2. Do NOT add `emoji` to the image, so the container lacks it at runtime.
+#   3. Run remotely:   flyte run module_not_found.py main
+#   4. Observe the empty error in the UI, and the real ModuleNotFoundError only at the
+#      bottom of the task logs.
+
+# This top-level import is present locally (step 1) but missing from the task image, so
+# the container dies while loading this module -- before Flyte can capture the error.
+import emoji
+from kubernetes.client import (
+    V1Container,
+    V1EnvVar,
+    V1PodSpec,
+)
+
+import flyte
+
+# A custom pod template on the environment. The primary container name shows up as
+# `[primary]` in the "terminated with exit code (1)" message in the UI.
+pod_template = flyte.PodTemplate(
+    primary_container_name="primary",
+    labels={"app": "module-not-found-repro"},
+    annotations={"flyte.org/example": "module_not_found"},
+    pod_spec=V1PodSpec(
+        containers=[
+            V1Container(
+                name="primary",
+                env=[V1EnvVar(name="EXAMPLE", value="module_not_found")],
+            )
+        ],
+    ),
+)
+
+# The default image deliberately does NOT install `emoji`. To make this pass (and prove
+# the asymmetry), build the image with the dependency instead:
+#
+#     image=flyte.Image.from_debian_base().with_pip_packages("emoji")
+#
+env = flyte.TaskEnvironment(
+    name="module_not_found",
+    resources=flyte.Resources(memory="250Mi"),
+    pod_template=pod_template,
+)
+
+
+@env.task
+def main(name: str = "world") -> str:
+    # `emoji` is used here, but the failure happens at import time above -- the container
+    # never reaches this line.
+    return emoji.emojize(f"Hello {name} :wave:")
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(main)
+    print(run.name)
+    print(run.url)
+    # The UI will show an empty "[primary] terminated with exit code (1)" message; the real
+    # `ModuleNotFoundError: No module named 'emoji'` is only at the bottom of the task logs.
+    run.wait()

--- a/src/flyte/_internal/runtime/entrypoints.py
+++ b/src/flyte/_internal/runtime/entrypoints.py
@@ -15,7 +15,8 @@ from flyte._task import TaskTemplate
 from flyte.models import ActionID, CheckpointPaths, CodeBundle, RawDataPath
 
 from ..._utils import adjust_sys_path
-from .convert import Error, Inputs, Outputs
+from .convert import Error, Inputs, Outputs, convert_from_native_to_error
+from .io import upload_error
 from .taskrunner import (
     convert_and_run,
     extract_download_run_upload,
@@ -243,7 +244,24 @@ async def load_and_run_task(
     """
     sw = Stopwatch("load_and_run_task_total")
     sw.start()
-    task = await _download_and_load_task(code_bundle, resolver, resolver_args)
+    try:
+        task = await _download_and_load_task(code_bundle, resolver, resolver_args)
+    except Exception as e:
+        # Loading the task (downloading the bundle, importing the user module, running the
+        # resolver) happens *before* the contextual_run wrapper below, which is what writes
+        # the error document (error.pb) on failure. If loading raises -- e.g. a top-level
+        # `ModuleNotFoundError` because a dependency is missing from the image -- the process
+        # would crash with no error.pb, leaving the backend with no message to display. The
+        # UI then shows only an empty "terminated with exit code (1)" and the real cause is
+        # buried at the bottom of the task logs.
+        #
+        # Surface it: write the error document here so the actual failure reason shows up in
+        # the task UI, then re-raise so the process still exits non-zero.
+        logger.exception(f"Failed to load task before execution: {e}")
+        if output_path:
+            error = convert_from_native_to_error(e)
+            await upload_error(error.err, output_path, recoverable=error.recoverable)
+        raise
 
     await contextual_run(
         extract_download_run_upload,

--- a/src/flyte/_internal/runtime/entrypoints.py
+++ b/src/flyte/_internal/runtime/entrypoints.py
@@ -247,16 +247,8 @@ async def load_and_run_task(
     try:
         task = await _download_and_load_task(code_bundle, resolver, resolver_args)
     except Exception as e:
-        # Loading the task (downloading the bundle, importing the user module, running the
-        # resolver) happens *before* the contextual_run wrapper below, which is what writes
-        # the error document (error.pb) on failure. If loading raises -- e.g. a top-level
-        # `ModuleNotFoundError` because a dependency is missing from the image -- the process
-        # would crash with no error.pb, leaving the backend with no message to display. The
-        # UI then shows only an empty "terminated with exit code (1)" and the real cause is
-        # buried at the bottom of the task logs.
-        #
-        # Surface it: write the error document here so the actual failure reason shows up in
-        # the task UI, then re-raise so the process still exits non-zero.
+        # Import/load failures happen before the contextual_run wrapper below, so they must
+        # also be uploaded to the error file -- otherwise the UI shows an empty message.
         logger.exception(f"Failed to load task before execution: {e}")
         if output_path:
             error = convert_from_native_to_error(e)

--- a/src/flyte/_internal/runtime/entrypoints.py
+++ b/src/flyte/_internal/runtime/entrypoints.py
@@ -16,7 +16,6 @@ from flyte.models import ActionID, CheckpointPaths, CodeBundle, RawDataPath
 
 from ..._utils import adjust_sys_path
 from .convert import Error, Inputs, Outputs, convert_from_native_to_error
-from .io import upload_error
 from .taskrunner import (
     convert_and_run,
     extract_download_run_upload,
@@ -251,6 +250,8 @@ async def load_and_run_task(
         # also be uploaded to the error file -- otherwise the UI shows an empty message.
         logger.exception(f"Failed to load task before execution: {e}")
         if output_path:
+            from .io import upload_error
+
             error = convert_from_native_to_error(e)
             await upload_error(error.err, output_path, recoverable=error.recoverable)
         raise

--- a/tests/flyte/internal/runtime/test_entrypoints.py
+++ b/tests/flyte/internal/runtime/test_entrypoints.py
@@ -1,7 +1,11 @@
 import os
 import tempfile
+from unittest import mock
 
-from flyte._internal.runtime.entrypoints import _list_user_files
+import pytest
+
+from flyte._internal.runtime.entrypoints import _list_user_files, load_and_run_task
+from flyte.models import ActionID, RawDataPath
 
 
 def test_list_user_files_excludes_venv():
@@ -109,3 +113,70 @@ def test_list_user_files_empty_directory():
     with tempfile.TemporaryDirectory() as cwd:
         files = _list_user_files(cwd)
         assert files == []
+
+
+@pytest.mark.asyncio
+async def test_load_failure_uploads_error_document():
+    """A failure while loading the task (e.g. a missing module import) must write an error
+    document so the real reason is surfaced in the UI, instead of an empty
+    "terminated with exit code (1)" message. See entrypoints.load_and_run_task.
+    """
+    boom = ModuleNotFoundError("No module named 'emoji'")
+
+    with (
+        mock.patch(
+            "flyte._internal.runtime.entrypoints._download_and_load_task",
+            side_effect=boom,
+        ),
+        mock.patch(
+            "flyte._internal.runtime.entrypoints.upload_error",
+            new_callable=mock.AsyncMock,
+        ) as mock_upload_error,
+    ):
+        with pytest.raises(ModuleNotFoundError):
+            await load_and_run_task(
+                action=ActionID(name="a0", run_name="r0"),
+                raw_data_path=RawDataPath(path="/tmp/raw"),
+                output_path="s3://bucket/outputs",
+                run_base_dir="s3://bucket/run",
+                version="v1",
+                controller=None,
+                resolver="some.resolver",
+                resolver_args=["mod", "task"],
+            )
+
+    # The error document was uploaded to the task's output path before re-raising.
+    mock_upload_error.assert_awaited_once()
+    uploaded_err = mock_upload_error.call_args.args[0]
+    assert "emoji" in uploaded_err.message
+    assert uploaded_err.code == "ModuleNotFoundError"
+
+
+@pytest.mark.asyncio
+async def test_load_failure_without_output_path_still_raises():
+    """If there is no output path to write to, the load failure must still propagate."""
+    boom = ModuleNotFoundError("No module named 'emoji'")
+
+    with (
+        mock.patch(
+            "flyte._internal.runtime.entrypoints._download_and_load_task",
+            side_effect=boom,
+        ),
+        mock.patch(
+            "flyte._internal.runtime.entrypoints.upload_error",
+            new_callable=mock.AsyncMock,
+        ) as mock_upload_error,
+    ):
+        with pytest.raises(ModuleNotFoundError):
+            await load_and_run_task(
+                action=ActionID(name="a0", run_name="r0"),
+                raw_data_path=RawDataPath(path="/tmp/raw"),
+                output_path="",
+                run_base_dir="s3://bucket/run",
+                version="v1",
+                controller=None,
+                resolver="some.resolver",
+                resolver_args=["mod", "task"],
+            )
+
+    mock_upload_error.assert_not_awaited()

--- a/tests/flyte/internal/runtime/test_entrypoints.py
+++ b/tests/flyte/internal/runtime/test_entrypoints.py
@@ -129,7 +129,7 @@ async def test_load_failure_uploads_error_document():
             side_effect=boom,
         ),
         mock.patch(
-            "flyte._internal.runtime.entrypoints.upload_error",
+            "flyte._internal.runtime.io.upload_error",
             new_callable=mock.AsyncMock,
         ) as mock_upload_error,
     ):
@@ -163,7 +163,7 @@ async def test_load_failure_without_output_path_still_raises():
             side_effect=boom,
         ),
         mock.patch(
-            "flyte._internal.runtime.entrypoints.upload_error",
+            "flyte._internal.runtime.io.upload_error",
             new_callable=mock.AsyncMock,
         ) as mock_upload_error,
     ):


### PR DESCRIPTION
## Problem

When a task fails while **loading** — e.g. a top-level `ModuleNotFoundError` because a dependency is present in the local env but missing from the task image — the container dies in `_download_and_load_task`, which runs *before* the `contextual_run` wrapper that writes the error document (`error.pb`). With no `error.pb`, the backend has no error message to display, so the task UI shows only:

```
[primary] terminated with exit code (1). Reason [Error]. Message:
.
```

The real `ModuleNotFoundError` — including the nice diagnostics `load_task` already builds (cwd + file listing) — is buried at the very bottom of the task logs. This is the issue surfaced in the support thread.

### Root cause

`entrypoints.py` loads the task *before* the error-capturing wrapper:

```
task = await _download_and_load_task(...)        # raises here -> no error.pb
await contextual_run(extract_download_run_upload, ...)   # upload_error() lives in here
```

An import that fails **inside the task body** is caught by `convert_and_run` and written to `error.pb` (UI shows it correctly). An import that fails **at module top level** fails during load and bypasses that path entirely.

## Fix

Wrap the load step in `load_and_run_task`: on failure, convert the exception to an error document and `upload_error()` it to the task's output path, then re-raise (preserving the non-zero exit). The actual reason now appears in the UI's `Message:` field.

## Tests

- `test_load_failure_uploads_error_document` — load failure uploads an error document carrying the real message/code, then re-raises.
- `test_load_failure_without_output_path_still_raises` — no output path → still propagates, no upload attempted.

## Reproduction

`examples/basics/module_not_found.py` is a deliberate repro (top-level import missing from the image, custom pod template so the `[primary]` container name matches). Before this fix it yields the empty message above; with the fix the UI shows `ModuleNotFoundError: No module named 'emoji'`.

```
pip install emoji        # local-only, so the task can be submitted
flyte run examples/basics/module_not_found.py main
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)