### PR TITLE
Fix trigger example

### DIFF
--- a/examples/triggers/basic.py
+++ b/examples/triggers/basic.py
@@ -12,7 +12,7 @@ env = flyte.TaskEnvironment(
 )
 
 
-@env.task(triggers=flyte.Trigger.hourly())  # Every hour
+@env.task(triggers=flyte.Trigger.hourly("trigger_time"))  # Every hour, bind fire time -> trigger_time
 def example_task(trigger_time: datetime, x: int = 1) -> str:
     return f"Task executed at {trigger_time.isoformat()} with x={x}"
 


### PR DESCRIPTION
The example showed an hourly trigger that bound nothing, while the task required a trigger_time argument. On deploy failed with: missing inputs for variables [trigger_time].