### PR TITLE
Fix secrets pagination

### DIFF
--- a/src/flyte/remote/_secret.py
+++ b/src/flyte/remote/_secret.py
@@ -144,22 +144,23 @@ class Secret(ToJSONMixin):
         cfg = get_init_config()
         project, domain = _resolve_scope(cfg, cluster_pool, op="listing")
         svc = await _secrets_service_for(cluster_pool, cfg.org)
-        per_cluster_tokens = None
+        # The secret service paginates with a single continuation token (the underlying k8s list
+        # "continue" cursor): each response carries the cursor for the next page in `token`, and we
+        # pass it back until it comes back empty. (`per_cluster_tokens` is unused by the backend.)
+        token = None
         while True:
             request = payload_pb2.ListSecretsRequest(
                 organization=cfg.org,
                 project=project,
                 domain=domain,
-                per_cluster_tokens=per_cluster_tokens,
+                token=token,
                 limit=limit,
             )
             resp = await svc.list_secrets(request=request)  # type: ignore
-            per_cluster_tokens = resp.per_cluster_tokens
-            round_items = [v for _, v in per_cluster_tokens.items() if v]
-            has_next = any(round_items)
             for r in resp.secrets:
                 yield cls(r)
-            if not has_next:
+            token = resp.token
+            if not token:
                 break
 
     @syncify

--- a/tests/flyte/remote/test_secret_listall.py
+++ b/tests/flyte/remote/test_secret_listall.py
@@ -11,9 +11,7 @@ from flyte.remote._secret import Secret
 @pytest.mark.asyncio
 async def test_listall_paginates_via_scalar_token():
     # Page 1 returns a continuation token; page 2 returns an empty token (end).
-    page1 = payload_pb2.ListSecretsResponse(
-        secrets=[definition_pb2.Secret(), definition_pb2.Secret()], token="t1"
-    )
+    page1 = payload_pb2.ListSecretsResponse(secrets=[definition_pb2.Secret(), definition_pb2.Secret()], token="t1")
     page2 = payload_pb2.ListSecretsResponse(secrets=[definition_pb2.Secret()], token="")
     svc = MagicMock()
     svc.list_secrets = AsyncMock(side_effect=[page1, page2])

--- a/tests/flyte/remote/test_secret_listall.py
+++ b/tests/flyte/remote/test_secret_listall.py
@@ -1,0 +1,52 @@
+"""Tests for Secret.listall pagination (uses the scalar continuation token)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from flyteidl2.secret import definition_pb2, payload_pb2
+
+from flyte.remote._secret import Secret
+
+
+@pytest.mark.asyncio
+async def test_listall_paginates_via_scalar_token():
+    # Page 1 returns a continuation token; page 2 returns an empty token (end).
+    page1 = payload_pb2.ListSecretsResponse(
+        secrets=[definition_pb2.Secret(), definition_pb2.Secret()], token="t1"
+    )
+    page2 = payload_pb2.ListSecretsResponse(secrets=[definition_pb2.Secret()], token="")
+    svc = MagicMock()
+    svc.list_secrets = AsyncMock(side_effect=[page1, page2])
+    cfg = MagicMock(org="o", project="p", domain="d")
+
+    with (
+        patch("flyte.remote._secret.ensure_client"),
+        patch("flyte.remote._secret.get_init_config", return_value=cfg),
+        patch("flyte.remote._secret._secrets_service_for", AsyncMock(return_value=svc)),
+    ):
+        results = [s async for s in Secret.listall.aio(limit=2)]
+
+    # All secrets across both pages are yielded — not just the first page.
+    assert len(results) == 3
+    # Two requests were made, and the cursor from page 1 was passed back on request 2.
+    assert svc.list_secrets.await_count == 2
+    assert svc.list_secrets.await_args_list[0].kwargs["request"].token == ""
+    assert svc.list_secrets.await_args_list[1].kwargs["request"].token == "t1"
+
+
+@pytest.mark.asyncio
+async def test_listall_single_page_stops_when_token_empty():
+    page = payload_pb2.ListSecretsResponse(secrets=[definition_pb2.Secret()], token="")
+    svc = MagicMock()
+    svc.list_secrets = AsyncMock(return_value=page)
+    cfg = MagicMock(org="o", project="p", domain="d")
+
+    with (
+        patch("flyte.remote._secret.ensure_client"),
+        patch("flyte.remote._secret.get_init_config", return_value=cfg),
+        patch("flyte.remote._secret._secrets_service_for", AsyncMock(return_value=svc)),
+    ):
+        results = [s async for s in Secret.listall.aio(limit=2)]
+
+    assert len(results) == 1
+    assert svc.list_secrets.await_count == 1


### PR DESCRIPTION
With the introduction of `ClusterAwareSecretService` we stopped aggregating secrets across clusters. In fact, org wide secrets now require an explicit `--cluster-pool` arg for CRUD operations (https://github.com/flyteorg/flyte-sdk/pull/991) and for other operations (per-project or per-domain based) we only ever look at one cluster now.

We use the correct cursor (`token`) for the single cluster case instead of the now defunct `per_cluster_tokens`

This fix also allows us to now align secrets listall behavior with other objects in the SDK. 

Tested locally for a cluster with > 10 secrets