### PR TITLE
[Image Build] Enable setting platform in `from_base` and switch to `flyte` user only if exists

### DIFF
--- a/examples/plugins/pandera/pyspark_sql_schema.py
+++ b/examples/plugins/pandera/pyspark_sql_schema.py
@@ -33,8 +33,13 @@ import flyte
 import flyte.io
 
 image = (
-    flyte.Image.from_base("apache/spark-py:v3.4.0", platform=("linux/amd64", "linux/arm64"))
-    .clone(name="pandera-pyspark-sql", python_version=(3, 10), extendable=True)
+    flyte.Image.from_base("apache/spark-py:v3.4.0")
+    .clone(
+        name="pandera-pyspark-sql",
+        python_version=(3, 10),
+        extendable=True,
+        platform=("linux/amd64", "linux/arm64"),
+    )
     .with_pip_packages(
         "flyteplugins-spark==2.0.9",
         "pandera[pyspark]",

--- a/examples/plugins/pandera/pyspark_sql_schema.py
+++ b/examples/plugins/pandera/pyspark_sql_schema.py
@@ -33,7 +33,7 @@ import flyte
 import flyte.io
 
 image = (
-    flyte.Image.from_base("apache/spark-py:v3.4.0")
+    flyte.Image.from_base("apache/spark-py:v3.4.0", platform=("linux/amd64", "linux/arm64"))
     .clone(name="pandera-pyspark-sql", python_version=(3, 10), extendable=True)
     .with_pip_packages(
         "flyteplugins-spark==2.0.9",

--- a/examples/plugins/spark_dataframe_example.py
+++ b/examples/plugins/spark_dataframe_example.py
@@ -9,8 +9,14 @@ import flyte
 from flyte.io import File
 
 image = (
-    flyte.Image.from_base("apache/spark-py:v3.4.0", platform=("linux/amd64", "linux/arm64"))
-    .clone(name="spark", python_version=(3, 10), registry="ghcr.io/flyteorg", extendable=True)
+    flyte.Image.from_base("apache/spark-py:v3.4.0")
+    .clone(
+        name="spark",
+        python_version=(3, 10),
+        registry="ghcr.io/flyteorg",
+        extendable=True,
+        platform=("linux/amd64", "linux/arm64"),
+    )
     .with_pip_packages("flyteplugins-spark")
     .with_pip_packages("pandas", "pyarrow")
 )

--- a/examples/plugins/spark_dataframe_example.py
+++ b/examples/plugins/spark_dataframe_example.py
@@ -9,7 +9,7 @@ import flyte
 from flyte.io import File
 
 image = (
-    flyte.Image.from_base("apache/spark-py:v3.4.0")
+    flyte.Image.from_base("apache/spark-py:v3.4.0", platform=("linux/amd64", "linux/arm64"))
     .clone(name="spark", python_version=(3, 10), registry="ghcr.io/flyteorg", extendable=True)
     .with_pip_packages("flyteplugins-spark")
     .with_pip_packages("pandas", "pyarrow")

--- a/examples/plugins/spark_example.py
+++ b/examples/plugins/spark_example.py
@@ -8,8 +8,14 @@ from flyteplugins.spark.task import Spark
 import flyte.remote
 
 image = (
-    flyte.Image.from_base("apache/spark-py:v3.4.0", platform=("linux/amd64", "linux/arm64"))
-    .clone(name="spark", python_version=(3, 10), registry="ghcr.io/flyteorg", extendable=True)
+    flyte.Image.from_base("apache/spark-py:v3.4.0")
+    .clone(
+        name="spark",
+        python_version=(3, 10),
+        registry="ghcr.io/flyteorg",
+        extendable=True,
+        platform=("linux/amd64", "linux/arm64"),
+    )
     .with_pip_packages("flyteplugins-spark>=2.0.0")
 )
 

--- a/examples/plugins/spark_example.py
+++ b/examples/plugins/spark_example.py
@@ -8,7 +8,7 @@ from flyteplugins.spark.task import Spark
 import flyte.remote
 
 image = (
-    flyte.Image.from_base("apache/spark-py:v3.4.0")
+    flyte.Image.from_base("apache/spark-py:v3.4.0", platform=("linux/amd64", "linux/arm64"))
     .clone(name="spark", python_version=(3, 10), registry="ghcr.io/flyteorg", extendable=True)
     .with_pip_packages("flyteplugins-spark>=2.0.0")
 )

--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -736,7 +736,11 @@ class Image:
         return base_image
 
     @classmethod
-    def from_base(cls, image_uri: str) -> Image:
+    def from_base(
+        cls,
+        image_uri: str,
+        platform: Union[Architecture, Tuple[Architecture, ...], None] = None,
+    ) -> Image:
         """
         Use this method to start with a pre-built base image. This image must already exist in the registry of course.
 
@@ -753,9 +757,15 @@ class Image:
         for the full pattern.
 
         :param image_uri: The full URI of the image, in the format <registry>/<name>:<tag>
+        :param platform: Architecture(s) to build for, default is ``("linux/amd64",)``. Pass a tuple for
+            multi-arch builds, e.g. ``("linux/amd64", "linux/arm64")``. The base image must publish a
+            manifest for each requested platform.
         :return:
         """
-        img = cls._new(base_image=image_uri)
+        kwargs: dict[str, Any] = {"base_image": image_uri}
+        if platform is not None:
+            kwargs["platform"] = _ensure_tuple(platform)
+        img = cls._new(**kwargs)
         return img
 
     @classmethod
@@ -847,6 +857,7 @@ class Image:
         python_version: Optional[Tuple[int, int]] = None,
         addl_layer: Optional[Layer] = None,
         extendable: Optional[bool] = None,
+        platform: Union[Architecture, Tuple[Architecture, ...], None] = None,
     ) -> Image:
         """
         Clone an existing image, optionally with a new name or registry.
@@ -865,6 +876,8 @@ class Image:
          image for other images, and additional layers can be added on top of it. If False, the image cannot be
           used as a base image for other images, and additional layers cannot be added on top of it. If None (default),
           defaults to False for safety.
+        :param platform: Architecture(s) to build for. If not specified, the cloned image keeps the original's
+            platform. Pass a tuple for multi-arch builds, e.g. ``("linux/amd64", "linux/arm64")``.
         :return:
         """
         from flyte import Secret
@@ -895,7 +908,7 @@ class Image:
             dockerfile=self.dockerfile,
             registry=registry,
             name=name,
-            platform=self.platform,
+            platform=_ensure_tuple(platform) if platform else self.platform,
             python_version=python_version or self.python_version,
             extendable=extendable if extendable is not None else self.extendable,
             _is_cloned=True,

--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -741,7 +741,6 @@ class Image:
     def from_base(
         cls,
         image_uri: str,
-        platform: Union[Architecture, Tuple[Architecture, ...], None] = None,
     ) -> Image:
         """
         Use this method to start with a pre-built base image. This image must already exist in the registry of course.
@@ -759,15 +758,9 @@ class Image:
         for the full pattern.
 
         :param image_uri: The full URI of the image, in the format <registry>/<name>:<tag>
-        :param platform: Architecture(s) to build for, default is ``("linux/amd64",)``. Pass a tuple for
-            multi-arch builds, e.g. ``("linux/amd64", "linux/arm64")``. The base image must publish a
-            manifest for each requested platform.
         :return:
         """
-        kwargs: dict[str, Any] = {"base_image": image_uri}
-        if platform is not None:
-            kwargs["platform"] = _ensure_tuple(platform)
-        img = cls._new(**kwargs)
+        img = cls._new(base_image=image_uri)
         return img
 
     @classmethod

--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -468,6 +468,16 @@ _LOCALHOST_REGISTRY = "localhost:30000"
 _DEFAULT_IMAGE_NAME = "flyte"
 _DEFAULT_IMAGE_REF_NAME = "default"
 
+# Shell command that creates the non-root `flyte` runtime user. Only the `from_debian_base`
+# path adds this (as a Commands layer); `from_base`/`from_dockerfile` intentionally do not.
+_CREATE_FLYTE_USER_CMD = (
+    "if ! id -u flyte >/dev/null 2>&1; then"
+    " useradd --create-home --shell /bin/bash flyte; fi &&"
+    " mkdir -p /home/flyte &&"
+    " chown -R flyte:flyte /home/flyte &&"
+    " chown -R flyte:flyte /root"
+)
+
 
 def _get_base_registry() -> str:
     """
@@ -643,15 +653,7 @@ class Image:
         # Use Commands + WorkDir (rather than _DockerLines) so both the local docker
         # builder and the remote builder pick up the flyte user setup, since the
         # remote builder protobuf IDL only understands Layer types like Commands.
-        create_flyte_user = Commands(
-            commands=(
-                "if ! id -u flyte >/dev/null 2>&1; then"
-                " useradd --create-home --shell /bin/bash flyte; fi &&"
-                " mkdir -p /home/flyte &&"
-                " chown -R flyte:flyte /home/flyte &&"
-                " chown -R flyte:flyte /root",
-            ),
-        )
+        create_flyte_user = Commands(commands=(_CREATE_FLYTE_USER_CMD,))
         image = image.clone(addl_layer=labels)
         image = image.clone(addl_layer=create_flyte_user)
         image = image.clone(addl_layer=WorkDir(workdir="/home/flyte"))

--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -15,6 +15,7 @@ from flyte import Secret
 from flyte._code_bundle._ignore import STANDARD_IGNORE_PATTERNS
 from flyte._code_bundle._utils import copy_code_bundle_to_context
 from flyte._image import (
+    _CREATE_FLYTE_USER_CMD,
     AptPackages,
     CodeBundleLayer,
     Commands,
@@ -31,7 +32,6 @@ from flyte._image import (
     UVProject,
     UVScript,
     WorkDir,
-    _CREATE_FLYTE_USER_CMD,
     _DockerLines,
     _ensure_tuple,
 )
@@ -183,8 +183,8 @@ SHELL ["/bin/bash", "-c"]
 """)
 
 # Switches the runtime user/workdir to the non-root `flyte` user. Appended only when the
-# image created that flyte user. `from_base` and `from_dockerfile` images intentionally 
-# run as whatever USER their base declares, so forcing `USER flyte` on them would point 
+# image created that flyte user. `from_base` and `from_dockerfile` images intentionally
+# run as whatever USER their base declares, so forcing `USER flyte` on them would point
 # at a nonexistent user.
 DOCKER_FILE_FLYTE_USER_FOOTER = """\
 USER flyte
@@ -194,9 +194,7 @@ WORKDIR /home/flyte
 
 def _image_creates_flyte_user(image: Image) -> bool:
     """True if the image creates the non-root `flyte` user."""
-    return any(
-        isinstance(layer, Commands) and _CREATE_FLYTE_USER_CMD in layer.commands for layer in image._layers
-    )
+    return any(isinstance(layer, Commands) and _CREATE_FLYTE_USER_CMD in layer.commands for layer in image._layers)
 
 
 class Handler(Protocol):

--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -31,6 +31,7 @@ from flyte._image import (
     UVProject,
     UVScript,
     WorkDir,
+    _CREATE_FLYTE_USER_CMD,
     _DockerLines,
     _ensure_tuple,
 )
@@ -178,10 +179,24 @@ ENV PATH="$$PATH:/usr/local/nvidia/bin:/usr/local/cuda/bin" \
 # This gets added on to the end of the dockerfile
 DOCKER_FILE_BASE_FOOTER = Template("""\
 ENV _F_IMG_ID=$F_IMG_ID
-USER flyte
-WORKDIR /home/flyte
 SHELL ["/bin/bash", "-c"]
 """)
+
+# Switches the runtime user/workdir to the non-root `flyte` user. Appended only when the
+# image created that flyte user. `from_base` and `from_dockerfile` images intentionally 
+# run as whatever USER their base declares, so forcing `USER flyte` on them would point 
+# at a nonexistent user.
+DOCKER_FILE_FLYTE_USER_FOOTER = """\
+USER flyte
+WORKDIR /home/flyte
+"""
+
+
+def _image_creates_flyte_user(image: Image) -> bool:
+    """True if the image creates the non-root `flyte` user."""
+    return any(
+        isinstance(layer, Commands) and _CREATE_FLYTE_USER_CMD in layer.commands for layer in image._layers
+    )
 
 
 class Handler(Protocol):
@@ -767,6 +782,13 @@ class DockerImageBuilder(ImageBuilder):
 
             for layer in image._layers:
                 dockerfile = await _process_layer(layer, tmp_path, dockerfile, docker_ignore_patterns)
+
+            # Only switch to the `flyte` user for images that actually created it (the
+            # `from_debian_base` path adds the create-flyte-user command layer). Doing this
+            # unconditionally breaks `from_base`/`from_dockerfile` images whose base never
+            # created that user — containerd then fails with "no users found".
+            if _image_creates_flyte_user(image):
+                dockerfile += DOCKER_FILE_FLYTE_USER_FOOTER
 
             dockerfile += DOCKER_FILE_BASE_FOOTER.substitute(F_IMG_ID=image.uri)
 

--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -783,10 +783,6 @@ class DockerImageBuilder(ImageBuilder):
             for layer in image._layers:
                 dockerfile = await _process_layer(layer, tmp_path, dockerfile, docker_ignore_patterns)
 
-            # Only switch to the `flyte` user for images that actually created it (the
-            # `from_debian_base` path adds the create-flyte-user command layer). Doing this
-            # unconditionally breaks `from_base`/`from_dockerfile` images whose base never
-            # created that user — containerd then fails with "no users found".
             if _image_creates_flyte_user(image):
                 dockerfile += DOCKER_FILE_FLYTE_USER_FOOTER
 

--- a/tests/flyte/imagebuild/test_docker_builder.py
+++ b/tests/flyte/imagebuild/test_docker_builder.py
@@ -999,15 +999,37 @@ async def test_build_from_dockerfile_uses_custom_builder_from_env(monkeypatch):
     assert cmd[builder_idx + 1] == "my-custom-builder"
 
 
-def test_dockerfile_footer_switches_to_flyte_user():
-    """The footer should switch the runtime user to flyte and set the workdir to /home/flyte."""
+def test_dockerfile_base_footer_always_applies():
+    """The base footer carries the image id and bash shell for every image, but must NOT
+    force a runtime user — that is added separately only for images that create it."""
     from flyte._internal.imagebuild.docker_builder import DOCKER_FILE_BASE_FOOTER
 
     rendered = DOCKER_FILE_BASE_FOOTER.substitute(F_IMG_ID="some-image-id")
 
-    assert "USER flyte" in rendered
-    assert "WORKDIR /home/flyte" in rendered
     assert "ENV _F_IMG_ID=some-image-id" in rendered
+    assert "USER flyte" not in rendered
+    assert "WORKDIR /home/flyte" not in rendered
+
+
+def test_dockerfile_flyte_user_footer_switches_user():
+    """The flyte-user footer switches the runtime user and workdir to the flyte user."""
+    from flyte._internal.imagebuild.docker_builder import DOCKER_FILE_FLYTE_USER_FOOTER
+
+    assert "USER flyte" in DOCKER_FILE_FLYTE_USER_FOOTER
+    assert "WORKDIR /home/flyte" in DOCKER_FILE_FLYTE_USER_FOOTER
+
+
+def test_image_creates_flyte_user_only_for_debian_base():
+    """`from_debian_base` creates the flyte user, so its image gets the user footer;
+    `from_base` does not, so forcing `USER flyte` on it would break at runtime."""
+    import flyte
+    from flyte._internal.imagebuild.docker_builder import _image_creates_flyte_user
+
+    debian = flyte.Image.from_debian_base()
+    assert _image_creates_flyte_user(debian) is True
+
+    external = flyte.Image.from_base("apache/spark:3.5.8-python3")
+    assert _image_creates_flyte_user(external) is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

This PR fixes:

1. Enable setting `platform` when using `from_base`, otherwise only `linux/amd` image is built and cannot run on devbox in macOS
2. Only switch to `USER flyte` only if being created, to prevent `no users found` error

<img width="3812" height="298" alt="image" src="https://github.com/user-attachments/assets/d879efa4-e9e0-405e-8142-c8f71703fdb9" />
