### PR TITLE
fix File, Dir, DataFrame cli parsing with collections

### DIFF
--- a/src/flyte/cli/_params.py
+++ b/src/flyte/cli/_params.py
@@ -22,7 +22,7 @@ from google.protobuf.json_format import MessageToDict
 from mashumaro.codecs.json import JSONEncoder
 
 from flyte._logging import logger
-from flyte.io import Dir, File
+from flyte.io import DataFrame, Dir, File
 from flyte.types._pickle import FlytePickleTransformer
 
 # ---------------------------------------------------
@@ -105,6 +105,11 @@ class StructuredDatasetParamType(click.ParamType):
         # Check if we're in local mode (when run_args is available and local=True)
         run_args = getattr(ctx.obj, "run_args", None) if ctx and ctx.obj else None
         if run_args is not None and run_args.local:
+            if storage.is_remote(value):
+                format = "parquet"
+                if value.endswith(".csv"):
+                    format = "csv"
+                return io.DataFrame.from_existing_remote(remote_path=value, format=format)
             # In local mode, create DataFrame from the file path (not upload)
             path = pathlib.Path(value)
             if not path.exists():
@@ -464,7 +469,7 @@ class JsonParamType(click.ParamType):
         if converter is None:
             return value
 
-        if isinstance(value, (File, Dir)):
+        if isinstance(value, (File, Dir, DataFrame)):
             return value
 
         if isinstance(value, str):

--- a/src/flyte/cli/_params.py
+++ b/src/flyte/cli/_params.py
@@ -427,6 +427,149 @@ class JsonParamType(click.ParamType):
             except json.JSONDecodeError as e:
                 raise click.BadParameter(f"parameter {param} should be a valid json object, {value}, error: {e}")
 
+    def _unwrap_field_type(self, tp: typing.Type) -> typing.Type:
+        from flyte.types._type_engine import get_underlying_type
+
+        tp = get_underlying_type(tp)
+        origin = typing.get_origin(tp)
+        args = get_args(tp)
+        if origin is typing.Union:
+            non_none = [a for a in args if a is not type(None)]
+            if len(non_none) == 1:
+                return self._unwrap_field_type(non_none[0])
+        return tp
+
+    def _blob_param_converter_for_type(self, field_type: typing.Type) -> typing.Optional[click.ParamType]:
+        from flyte.types._type_engine import TypeEngine
+
+        field_type = self._unwrap_field_type(field_type)
+        try:
+            lt = TypeEngine.to_literal_type(field_type)
+            converter = literal_type_to_click_type(lt, field_type)
+            if isinstance(converter, (FileParamType, DirParamType, StructuredDatasetParamType)):
+                return converter
+        except Exception:
+            pass
+        return None
+
+    def _convert_blob_value(
+        self,
+        value: typing.Any,
+        field_type: typing.Type,
+        param: typing.Optional[click.Parameter],
+        ctx: typing.Optional[click.Context],
+    ) -> typing.Any:
+        field_type = self._unwrap_field_type(field_type)
+        converter = self._blob_param_converter_for_type(field_type)
+        if converter is None:
+            return value
+
+        if isinstance(value, (File, Dir)):
+            return value
+
+        if isinstance(value, str):
+            return converter.convert(value, param, ctx)
+
+        if isinstance(value, dict) and isinstance(field_type, type):
+            from pydantic import BaseModel
+
+            if issubclass(field_type, BaseModel):
+                return field_type.model_validate(value)
+
+        return value
+
+    def _convert_blob_collection_elements(
+        self,
+        parsed_value: typing.Union[typing.List[typing.Any], typing.Dict[str, typing.Any]],
+        element_type: typing.Type,
+        param: typing.Optional[click.Parameter],
+        ctx: typing.Optional[click.Context],
+    ) -> typing.Optional[typing.Any]:
+        """Convert string paths in list/dict CLI JSON to File, Dir, or DataFrame objects."""
+        if self._blob_param_converter_for_type(element_type) is None:
+            return None
+
+        if isinstance(parsed_value, list):
+            return [self._convert_blob_value(v, element_type, param, ctx) for v in parsed_value]
+        return {k: self._convert_blob_value(v, element_type, param, ctx) for k, v in parsed_value.items()}
+
+    def _convert_blob_fields_in_value(
+        self,
+        value: typing.Any,
+        python_type: typing.Type,
+        param: typing.Optional[click.Parameter],
+        ctx: typing.Optional[click.Context],
+    ) -> typing.Any:
+        if value is None:
+            return None
+
+        python_type = self._unwrap_field_type(python_type)
+        origin = typing.get_origin(python_type)
+        args = get_args(python_type)
+
+        if dataclasses.is_dataclass(python_type) and isinstance(value, dict):
+            field_types = typing.get_type_hints(python_type, include_extras=True)
+            return {
+                k: self._convert_blob_fields_in_value(v, field_types.get(k, type(v)), param, ctx)
+                for k, v in value.items()
+            }
+
+        if origin is list and isinstance(value, list):
+            elem_type = args[0] if args else typing.Any
+            return [self._convert_blob_fields_in_value(v, elem_type, param, ctx) for v in value]
+
+        if origin is dict and isinstance(value, dict):
+            val_type = args[1] if len(args) >= 2 else typing.Any
+            return {k: self._convert_blob_fields_in_value(v, val_type, param, ctx) for k, v in value.items()}
+
+        return self._convert_blob_value(value, python_type, param, ctx)
+
+    def _instantiate_dataclass(self, python_type: typing.Type, value: typing.Any) -> typing.Any:
+        if not isinstance(value, dict):
+            return value
+
+        field_types = typing.get_type_hints(python_type, include_extras=True)
+        kwargs: dict[str, typing.Any] = {}
+        for field in dataclasses.fields(python_type):
+            if field.name not in value:
+                continue
+            v = value[field.name]
+            if v is None:
+                kwargs[field.name] = None
+                continue
+
+            field_type = self._unwrap_field_type(field_types.get(field.name, field.type))
+            if dataclasses.is_dataclass(field_type) and isinstance(v, dict):
+                kwargs[field.name] = self._instantiate_dataclass(field_type, v)
+                continue
+
+            origin = typing.get_origin(field_type)
+            inner_args = get_args(field_type)
+            if origin is list and isinstance(v, list):
+                elem_type = self._unwrap_field_type(inner_args[0] if inner_args else typing.Any)
+                if dataclasses.is_dataclass(elem_type):
+                    kwargs[field.name] = [
+                        self._instantiate_dataclass(elem_type, item) if isinstance(item, dict) else item for item in v
+                    ]
+                else:
+                    kwargs[field.name] = v
+                continue
+
+            if origin is dict and isinstance(v, dict):
+                val_type = self._unwrap_field_type(inner_args[1] if len(inner_args) >= 2 else typing.Any)
+                if dataclasses.is_dataclass(val_type):
+                    kwargs[field.name] = {
+                        k: self._instantiate_dataclass(val_type, item) if isinstance(item, dict) else item
+                        for k, item in v.items()
+                    }
+                else:
+                    kwargs[field.name] = v
+                continue
+
+            kwargs[field.name] = v
+
+        return python_type(**kwargs)
+
     def convert(
         self, value: typing.Any, param: typing.Optional[click.Parameter], ctx: typing.Optional[click.Context]
     ) -> typing.Any:
@@ -447,14 +590,34 @@ class JsonParamType(click.ParamType):
             # We don't support native list/dict types with nested dataclasses.
             if get_args(self._python_type) == ():
                 return parsed_value
-            elif isinstance(parsed_value, list) and dataclasses.is_dataclass(get_args(self._python_type)[0]):
-                j = JsonParamType(get_args(self._python_type)[0])
-                # turn object back into json string
-                return [j.convert(json.dumps(v), param, ctx) for v in parsed_value]
-            elif isinstance(parsed_value, dict) and dataclasses.is_dataclass(get_args(self._python_type)[1]):
-                j = JsonParamType(get_args(self._python_type)[1])
-                # turn object back into json string
-                return {k: j.convert(json.dumps(v), param, ctx) for k, v in parsed_value.items()}
+            elif isinstance(parsed_value, list):
+                element_type = get_args(self._python_type)[0]
+                converted = self._convert_blob_collection_elements(parsed_value, element_type, param, ctx)
+                if converted is not None:
+                    return converted
+                if dataclasses.is_dataclass(element_type):
+                    dc_type = typing.cast(type[typing.Any], element_type)
+                    return [
+                        self._instantiate_dataclass(
+                            dc_type,
+                            self._convert_blob_fields_in_value(v, dc_type, param, ctx),
+                        )
+                        for v in parsed_value
+                    ]
+            elif isinstance(parsed_value, dict):
+                value_type = get_args(self._python_type)[1]
+                converted = self._convert_blob_collection_elements(parsed_value, value_type, param, ctx)
+                if converted is not None:
+                    return converted
+                if dataclasses.is_dataclass(value_type):
+                    dc_type = typing.cast(type[typing.Any], value_type)
+                    return {
+                        k: self._instantiate_dataclass(
+                            dc_type,
+                            self._convert_blob_fields_in_value(v, dc_type, param, ctx),
+                        )
+                        for k, v in parsed_value.items()
+                    }
 
             return parsed_value
 
@@ -480,6 +643,10 @@ class JsonParamType(click.ParamType):
                 json.dumps(parsed_value), strict=False, context={"deserialize": True}
             )
         elif dataclasses.is_dataclass(self._python_type):
+            if isinstance(parsed_value, dict):
+                converted = self._convert_blob_fields_in_value(parsed_value, self._python_type, param, ctx)
+                return self._instantiate_dataclass(self._python_type, converted)
+
             from mashumaro.codecs.json import JSONDecoder
 
             decoder = JSONDecoder(self._python_type)

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -527,6 +527,215 @@ def test_json_param_type_accepts_dataclass_file_dict_format():
     assert result.flytedir.path == "s3://example-dir"
 
 
+pd = None
+try:
+    import pandas as pd
+except ImportError:
+    pass
+
+
+@pytest.fixture
+def temp_parquet_file_for_json_param_type():
+    """Create a temporary parquet file for JsonParamType DataFrame tests."""
+    if pd is None:
+        pytest.skip("pandas is not installed")
+
+    df = pd.DataFrame({"name": ["Alice"], "age": [25]})
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".parquet") as f:
+        df.to_parquet(f.name)
+        yield f.name
+    Path(f.name).unlink(missing_ok=True)
+
+
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
+def test_json_param_type_converts_list_of_dataframe_paths_to_dataframe_objects(
+    temp_parquet_file_for_json_param_type,
+):
+    """list[DataFrame] CLI JSON should convert string paths to DataFrame objects."""
+    import json
+    from unittest.mock import MagicMock
+
+    from flyte.cli._params import JsonParamType
+    from flyte.cli._run import RunArguments
+    from flyte.io import DataFrame
+
+    run_args = RunArguments(local=True)
+    mock_cli_obj = MagicMock()
+    mock_cli_obj.run_args = run_args
+
+    ctx = MagicMock()
+    ctx.obj = mock_cli_obj
+
+    param_type = JsonParamType(list[DataFrame])
+    result = param_type.convert(
+        json.dumps(["s3://example-path/data.parquet", temp_parquet_file_for_json_param_type]),
+        None,
+        ctx,
+    )
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert all(isinstance(df, DataFrame) for df in result)
+    assert result[0].uri == "s3://example-path/data.parquet"
+    assert result[1].uri == temp_parquet_file_for_json_param_type
+
+
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
+def test_json_param_type_converts_dataclass_with_dataframe_paths():
+    """Dataclass CLI JSON should convert string DataFrame paths to typed objects."""
+    import json
+    from dataclasses import dataclass
+    from typing import Optional
+    from unittest.mock import MagicMock
+
+    from flyte.cli._params import JsonParamType
+    from flyte.cli._run import RunArguments
+    from flyte.io import DataFrame
+
+    @dataclass
+    class DataFrameInput:
+        dataframe: Optional[DataFrame] = None
+
+    run_args = RunArguments(local=True)
+    mock_cli_obj = MagicMock()
+    mock_cli_obj.run_args = run_args
+
+    ctx = MagicMock()
+    ctx.obj = mock_cli_obj
+
+    param_type = JsonParamType(DataFrameInput)
+    result = param_type.convert(
+        json.dumps({"dataframe": "s3://example-path/data.parquet"}),
+        None,
+        ctx,
+    )
+
+    assert isinstance(result, DataFrameInput)
+    assert isinstance(result.dataframe, DataFrame)
+    assert result.dataframe.uri == "s3://example-path/data.parquet"
+
+
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
+def test_json_param_type_converts_nested_dataclass_with_dataframe_paths(
+    temp_parquet_file_for_json_param_type,
+):
+    """Nested dataclass CLI JSON should convert nested string DataFrame paths."""
+    import json
+    from dataclasses import dataclass
+    from typing import List
+    from unittest.mock import MagicMock
+
+    from flyte.cli._params import JsonParamType
+    from flyte.cli._run import RunArguments
+    from flyte.io import DataFrame
+
+    @dataclass
+    class Inner:
+        dataframe: DataFrame
+
+    @dataclass
+    class Outer:
+        inner: Inner
+        list_inner: List[Inner]
+
+    run_args = RunArguments(local=True)
+    mock_cli_obj = MagicMock()
+    mock_cli_obj.run_args = run_args
+
+    ctx = MagicMock()
+    ctx.obj = mock_cli_obj
+
+    param_type = JsonParamType(Outer)
+    result = param_type.convert(
+        json.dumps(
+            {
+                "inner": {"dataframe": temp_parquet_file_for_json_param_type},
+                "list_inner": [
+                    {"dataframe": "s3://example-path/data-1.parquet"},
+                    {"dataframe": "s3://example-path/data-2.parquet"},
+                ],
+            }
+        ),
+        None,
+        ctx,
+    )
+
+    assert isinstance(result.inner.dataframe, DataFrame)
+    assert result.inner.dataframe.uri == temp_parquet_file_for_json_param_type
+    assert len(result.list_inner) == 2
+    assert all(isinstance(item.dataframe, DataFrame) for item in result.list_inner)
+    assert result.list_inner[0].dataframe.uri == "s3://example-path/data-1.parquet"
+
+
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
+def test_json_param_type_accepts_dataclass_dataframe_dict_format(temp_parquet_file_for_json_param_type):
+    """Dataclass DataFrame fields still accept the structured dict JSON format."""
+    import json
+    from dataclasses import dataclass
+    from unittest.mock import MagicMock
+
+    from flyte.cli._params import JsonParamType
+    from flyte.cli._run import RunArguments
+    from flyte.io import DataFrame
+
+    @dataclass
+    class DataFrameInput:
+        dataframe: DataFrame
+
+    run_args = RunArguments(local=True)
+    mock_cli_obj = MagicMock()
+    mock_cli_obj.run_args = run_args
+
+    ctx = MagicMock()
+    ctx.obj = mock_cli_obj
+
+    param_type = JsonParamType(DataFrameInput)
+    result = param_type.convert(
+        json.dumps({"dataframe": {"uri": temp_parquet_file_for_json_param_type, "format": "parquet"}}),
+        None,
+        ctx,
+    )
+
+    assert isinstance(result.dataframe, DataFrame)
+    assert result.dataframe.uri == temp_parquet_file_for_json_param_type
+    assert result.dataframe.format == "parquet"
+
+
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
+def test_json_param_type_converts_dict_of_dataframe_paths(temp_parquet_file_for_json_param_type):
+    """dict[str, DataFrame] CLI JSON should convert string paths to DataFrame objects."""
+    import json
+    from unittest.mock import MagicMock
+
+    from flyte.cli._params import JsonParamType
+    from flyte.cli._run import RunArguments
+    from flyte.io import DataFrame
+
+    run_args = RunArguments(local=True)
+    mock_cli_obj = MagicMock()
+    mock_cli_obj.run_args = run_args
+
+    ctx = MagicMock()
+    ctx.obj = mock_cli_obj
+
+    param_type = JsonParamType(dict[str, DataFrame])
+    result = param_type.convert(
+        json.dumps(
+            {
+                "remote": "s3://example-path/data.parquet",
+                "local": temp_parquet_file_for_json_param_type,
+            }
+        ),
+        None,
+        ctx,
+    )
+
+    assert isinstance(result["remote"], DataFrame)
+    assert isinstance(result["local"], DataFrame)
+    assert result["remote"].uri == "s3://example-path/data.parquet"
+    assert result["local"].uri == temp_parquet_file_for_json_param_type
+
+
 # ============================================================================
 # Tests for DataFrame CLI inputs
 # ============================================================================

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -382,6 +382,151 @@ def test_dir_param_type_returns_dir_with_local_path_in_local_mode():
         assert result.path == tmp_dir
 
 
+def test_json_param_type_converts_list_of_file_paths_to_file_objects():
+    """list[File] CLI JSON should convert string paths to File objects like FileParamType does."""
+    import json
+    from unittest.mock import MagicMock
+
+    from flyte.cli._params import JsonParamType
+    from flyte.cli._run import RunArguments
+    from flyte.io import File
+
+    run_args = RunArguments(local=True)
+    mock_cli_obj = MagicMock()
+    mock_cli_obj.run_args = run_args
+
+    ctx = MagicMock()
+    ctx.obj = mock_cli_obj
+
+    param_type = JsonParamType(list[File])
+    value = json.dumps(["s3://example-path", "s3://example-path2"])
+    result = param_type.convert(value, None, ctx)
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert all(isinstance(f, File) for f in result)
+    assert result[0].path == "s3://example-path"
+    assert result[1].path == "s3://example-path2"
+
+
+def test_json_param_type_converts_dataclass_with_file_and_dir_paths():
+    """Dataclass CLI JSON should convert string File/Dir paths to typed objects."""
+    import json
+    from dataclasses import dataclass
+    from typing import Optional
+    from unittest.mock import MagicMock
+
+    from flyte.cli._params import JsonParamType
+    from flyte.cli._run import RunArguments
+    from flyte.io import Dir, File
+
+    @dataclass
+    class FlyteTypes:
+        flytefile: Optional[File] = None
+        flytedir: Optional[Dir] = None
+
+    run_args = RunArguments(local=True)
+    mock_cli_obj = MagicMock()
+    mock_cli_obj.run_args = run_args
+
+    ctx = MagicMock()
+    ctx.obj = mock_cli_obj
+
+    param_type = JsonParamType(FlyteTypes)
+    result = param_type.convert(
+        json.dumps({"flytefile": "s3://example-path", "flytedir": "s3://example-dir"}),
+        None,
+        ctx,
+    )
+
+    assert isinstance(result, FlyteTypes)
+    assert isinstance(result.flytefile, File)
+    assert isinstance(result.flytedir, Dir)
+    assert result.flytefile.path == "s3://example-path"
+    assert result.flytedir.path == "s3://example-dir"
+
+
+def test_json_param_type_converts_nested_dataclass_with_file_paths():
+    """Nested dataclass CLI JSON should convert nested string File paths."""
+    import json
+    from dataclasses import dataclass
+    from typing import List, Optional
+    from unittest.mock import MagicMock
+
+    from flyte.cli._params import JsonParamType
+    from flyte.cli._run import RunArguments
+    from flyte.io import File
+
+    @dataclass
+    class Inner:
+        flytefile: File
+
+    @dataclass
+    class Outer:
+        inner: Inner
+        list_inner: Optional[List[Inner]] = None
+
+    run_args = RunArguments(local=True)
+    mock_cli_obj = MagicMock()
+    mock_cli_obj.run_args = run_args
+
+    ctx = MagicMock()
+    ctx.obj = mock_cli_obj
+
+    param_type = JsonParamType(Outer)
+    result = param_type.convert(
+        json.dumps(
+            {
+                "inner": {"flytefile": "s3://inner-path"},
+                "list_inner": [{"flytefile": "s3://list-path-1"}, {"flytefile": "s3://list-path-2"}],
+            }
+        ),
+        None,
+        ctx,
+    )
+
+    assert isinstance(result.inner.flytefile, File)
+    assert result.inner.flytefile.path == "s3://inner-path"
+    assert len(result.list_inner) == 2
+    assert all(isinstance(item.flytefile, File) for item in result.list_inner)
+    assert result.list_inner[0].flytefile.path == "s3://list-path-1"
+
+
+def test_json_param_type_accepts_dataclass_file_dict_format():
+    """Dataclass File/Dir fields still accept the structured dict JSON format."""
+    import json
+    from dataclasses import dataclass
+    from unittest.mock import MagicMock
+
+    from flyte.cli._params import JsonParamType
+    from flyte.cli._run import RunArguments
+    from flyte.io import Dir, File
+
+    @dataclass
+    class FlyteTypes:
+        flytefile: File
+        flytedir: Dir
+
+    run_args = RunArguments(local=True)
+    mock_cli_obj = MagicMock()
+    mock_cli_obj.run_args = run_args
+
+    ctx = MagicMock()
+    ctx.obj = mock_cli_obj
+
+    param_type = JsonParamType(FlyteTypes)
+    result = param_type.convert(
+        json.dumps({"flytefile": {"path": "s3://example-path"}, "flytedir": {"path": "s3://example-dir"}}),
+        None,
+        ctx,
+    )
+
+    assert isinstance(result.flytefile, File)
+    assert isinstance(result.flytedir, Dir)
+    assert result.flytefile.path == "s3://example-path"
+    assert result.flytedir.path == "s3://example-dir"
+
+
 # ============================================================================
 # Tests for DataFrame CLI inputs
 # ============================================================================


### PR DESCRIPTION
This pull request significantly enhances the Flyte CLI's support for structured data types (such as `File`, `Dir`, and `DataFrame`) when passing parameters via JSON, especially for dataclasses and collections. It introduces robust recursive conversion of string paths within lists, dictionaries, and nested dataclasses into their appropriate Flyte types, ensuring a more seamless and type-safe CLI experience. Comprehensive tests are also added to validate these behaviors.

### Core Improvements to Parameter Handling

* Refactored the `JsonParamType` in `src/flyte/cli/_params.py` to recursively convert string paths in lists, dicts, and dataclasses to proper `File`, `Dir`, and `DataFrame` objects, both for top-level and nested structures. This includes handling optional types and unions, and supports both path strings and structured dict formats.
* Added logic to handle remote DataFrame paths in local mode, automatically inferring the format (CSV or Parquet) and creating a `DataFrame` object accordingly.

### Testing Enhancements

* Introduced a comprehensive suite of tests in `tests/cli/test_run.py` to verify:
  - Conversion of lists and dicts of file/dataframe paths to Flyte objects.
  - Proper handling of dataclasses (including nested and optional fields) with `File`, `Dir`, and `DataFrame` fields.
  - Acceptance of both string and structured dict formats for these types.
  - Support for local and remote paths, and for both CSV and Parquet DataFrames.

These changes make the CLI parameter parsing much more robust and user-friendly, especially for complex input types in Flyte workflows.