### PR TITLE
fix(imagebuild): install local wheel by path so dev pre-release isn't dropped

### DIFF
--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -245,32 +245,18 @@ class PythonWheelHandler:
         pip_install_args = layer.get_pip_install_args()
         secret_mounts = _get_secret_mounts_layer(layer.secret_mounts)
 
-        # First install: Install the wheel without dependencies using --no-deps
-        pip_install_args_no_deps = [
-            *pip_install_args,
-            *[
-                "--find-links",
-                "/dist",
-                "--no-deps",
-                "--no-index",
-                "--reinstall",
-                layer.package_name,
-            ],
-        ]
-
-        delta1 = UV_WHEEL_INSTALL_COMMAND_TEMPLATE.substitute(
-            PIP_INSTALL_ARGS=" ".join(pip_install_args_no_deps), SECRET_MOUNT=secret_mounts
+        # Install the local wheel directly by its file path (the glob is expanded by the build
+        # shell). Pointing uv at the file means there is no resolution contest for the package
+        # itself, so a locally-built pre-release wheel (e.g. ``2.5.2.dev1+g...``) is never swapped
+        # for a stable release on PyPI by PEP 440 pre-release exclusion -- which is what happened
+        # when the package name was passed unpinned. The wheel's dependencies still resolve from
+        # the index. ``package_name`` is already the underscore-normalized distribution name, so
+        # ``/dist/<package_name>-*.whl`` matches only this package's wheel (the trailing dash keeps
+        # ``flyte-*`` from matching ``flyteplugins_*``).
+        install_args = [*pip_install_args, f"/dist/{layer.package_name}-*.whl"]
+        dockerfile += UV_WHEEL_INSTALL_COMMAND_TEMPLATE.substitute(
+            PIP_INSTALL_ARGS=" ".join(install_args), SECRET_MOUNT=secret_mounts
         )
-        dockerfile += delta1
-
-        # Second install: Install dependencies from PyPI. Keep /dist as a findlink so the package
-        # itself resolves to the local wheel even when it isn't published to PyPI (e.g. a local
-        # plugin wheel); its dependencies still come from the index.
-        pip_install_args_deps = [*pip_install_args, "--find-links", "/dist", layer.package_name]
-        delta2 = UV_WHEEL_INSTALL_COMMAND_TEMPLATE.substitute(
-            PIP_INSTALL_ARGS=" ".join(pip_install_args_deps), SECRET_MOUNT=secret_mounts
-        )
-        dockerfile += delta2
 
         return dockerfile
 

--- a/tests/flyte/imagebuild/test_docker_builder.py
+++ b/tests/flyte/imagebuild/test_docker_builder.py
@@ -194,6 +194,60 @@ async def test_pip_package_handling_with_version_constraints():
 
 
 @pytest.mark.asyncio
+async def test_python_wheel_handler_installs_local_wheel_by_path():
+    """The local wheel must be installed directly by file path (not by bare package name).
+
+    Passing the bare name with ``--find-links`` lets uv discard a locally-built ``.dev``
+    pre-release wheel in favor of a stable release on PyPI (PEP 440 pre-release exclusion).
+    Pointing uv at the wheel file avoids that resolution contest, while dependencies still
+    resolve from the index. ``/dist`` may also hold other packages' wheels (e.g. plugins),
+    so the emitted glob must match only this package.
+    """
+    from flyte._image import PythonWheels
+    from flyte._internal.imagebuild.docker_builder import PythonWheelHandler
+
+    with tempfile.TemporaryDirectory() as tmp_wheels, tempfile.TemporaryDirectory() as tmp_context:
+        wheel_dir = Path(tmp_wheels)
+        # A local dev (pre-release) wheel plus an unrelated plugin wheel sharing the "flyte" prefix.
+        (wheel_dir / "flyte-2.5.2.dev1+gabcdef.d20260101-py3-none-any.whl").write_text("")
+        (wheel_dir / "flyteplugins_spark-2.5.2.dev1+gabcdef.d20260101-py3-none-any.whl").write_text("")
+
+        layer = PythonWheels(wheel_dir=wheel_dir, package_name="flyte")
+        docker_update = await PythonWheelHandler.handle(
+            layer=layer, context_path=Path(tmp_context), dockerfile=""
+        )
+
+        # Installs the local wheel by path via a glob anchored to this package's distribution name.
+        assert "/dist/flyte-*.whl" in docker_update
+        # A single install command -- no more two-step (no-deps + deps) dance.
+        assert docker_update.count("uv pip install") == 1
+        # None of the resolver work-arounds that caused the pre-release to be dropped remain.
+        for flag in ("--no-deps", "--no-index", "--reinstall", "--find-links"):
+            assert flag not in docker_update
+        # The trailing dash keeps the glob from matching the plugin wheel.
+        assert "/dist/flyteplugins" not in docker_update
+
+
+@pytest.mark.asyncio
+async def test_python_wheel_handler_glob_matches_normalized_plugin_name():
+    """Plugin layers pass an underscore-normalized ``package_name``; the glob must match it."""
+    from flyte._image import PythonWheels
+    from flyte._internal.imagebuild.docker_builder import PythonWheelHandler
+
+    with tempfile.TemporaryDirectory() as tmp_wheels, tempfile.TemporaryDirectory() as tmp_context:
+        wheel_dir = Path(tmp_wheels)
+        (wheel_dir / "flyteplugins_spark-2.5.2.dev1-py3-none-any.whl").write_text("")
+
+        layer = PythonWheels(wheel_dir=wheel_dir, package_name="flyteplugins_spark")
+        docker_update = await PythonWheelHandler.handle(
+            layer=layer, context_path=Path(tmp_context), dockerfile=""
+        )
+
+        assert "/dist/flyteplugins_spark-*.whl" in docker_update
+        assert docker_update.count("uv pip install") == 1
+
+
+@pytest.mark.asyncio
 async def test_requirements_handler(monkeypatch):
     secret_mounts = (Secret("my-secret"), Secret("my-secret2"))
     monkeypatch.setenv("MY_SECRET", "test-value")


### PR DESCRIPTION
## Why

`with_local_v2()` (used when building a dev image from a locally-modified `flyte`) stopped picking up the local build. The image would install the local wheel and then immediately replace it with a stable release from PyPI:

```
#18 [build] Install wheel flyte ...
 - flyte==2.5.1
 + flyte==2.5.2.dev1+g512b21d95.d20260617   # local wheel installed
#19 [build] Install dependencies for flyte ...
 - flyte==2.5.2.dev1+g512b21d95.d20260617
 + flyte==2.5.1                              # ...then silently swapped back
```

### Root cause

`PythonWheelHandler.handle` emitted **two** `uv pip install` commands per `PythonWheels` layer:

1. Install the wheel only: `uv pip install --find-links /dist --no-deps --no-index --reinstall <pkg>`
2. Install dependencies: `uv pip install --find-links /dist <pkg>`

Once step 2 drops `--no-index`, uv sees the package from two sources — the local `/dist` wheel (a `.dev` **pre-release**) and PyPI (a **stable** release). Per PEP 440, uv/pip ignore pre-releases when a stable version satisfies an unconstrained requirement, and no `--pre` is passed (`PipOption.pre` defaults to `False`). So step 2 resolves `<pkg>` to the stable PyPI version, uninstalls the local dev wheel, and reinstalls the stable one. `--find-links /dist` doesn't help: the local wheel is *available* but still loses as a pre-release.

This only surfaces once a competing **stable** release exists on PyPI, which is why it "used to work" and then regressed.

## What

Install the wheel **directly by file path** instead of by package name:

```
uv pip install <args> /dist/<package_name>-*.whl
```

Pointing uv at the file removes the resolution contest for the package itself (no pre-release exclusion), while its dependencies still resolve from the index. This also collapses the two commands into one.

- `package_name` is already the underscore-normalized distribution name (`_image.py` builds it via `plugin.replace("-", "_")`), so `/dist/<package_name>-*.whl` matches this package's wheel. The trailing dash anchors it (`flyte-*` does not match `flyteplugins_*`).
- The glob is expanded by the build shell (the `RUN` is emitted in shell form).
- Multiple-version ambiguity can't arise from the normal build: `make dist` runs `clean` (`rm -rf dist/`) and `make dist-plugins` runs `clean-plugins` (`rm -f dist/flyteplugins_*.whl`) first, so `dist/` holds at most one wheel per package.

## Tests

Added two unit tests in `tests/flyte/imagebuild/test_docker_builder.py`:

- `test_python_wheel_handler_installs_local_wheel_by_path` — asserts a single `uv pip install`, that it installs `/dist/flyte-*.whl`, that none of `--no-deps/--no-index/--reinstall/--find-links` remain, and that the glob doesn't match a sibling `flyteplugins_*` wheel.
- `test_python_wheel_handler_glob_matches_normalized_plugin_name` — asserts the glob matches an underscore-normalized plugin name.

Full `test_docker_builder.py` suite passes (37 passed, 1 skipped); `ruff` clean.

### Verification

Reproduced the swap and confirmed the fix locally with the real `flyte` dev wheel:

| command | result |
|---|---|
| `uv pip install --find-links ./dist flyte` (old, fresh resolve) | installs **stable** PyPI build, drops local dev wheel |
| `uv pip install ./dist/flyte-*.whl` (new) | installs **local dev wheel**, all deps resolved from PyPI |