### PR TITLE
fix(image): always install the local wheel for with_local_v2()

### DIFF
--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -245,7 +245,22 @@ class PythonWheelHandler:
         pip_install_args = layer.get_pip_install_args()
         secret_mounts = _get_secret_mounts_layer(layer.secret_mounts)
 
-        # First install: Install the wheel without dependencies using --no-deps
+        # First install: resolve and install the package's dependencies from the index. Keep /dist as
+        # a findlink so the package itself still resolves even when it isn't published to PyPI (e.g. a
+        # local plugin wheel); its dependencies come from the index. The exact local wheel is forced in
+        # the second step, so it does not matter which version of the package this step picks.
+        pip_install_args_deps = [*pip_install_args, "--find-links", "/dist", layer.package_name]
+        delta1 = UV_WHEEL_INSTALL_COMMAND_TEMPLATE.substitute(
+            PIP_INSTALL_ARGS=" ".join(pip_install_args_deps), SECRET_MOUNT=secret_mounts
+        )
+        dockerfile += delta1
+
+        # Second install (last): force the exact local wheel on top of whatever the dependency step
+        # installed. --no-index + --reinstall guarantees the local wheel wins and nothing re-resolves
+        # it to a published release afterwards. This must run after the dependency step: a full resolve
+        # can otherwise discard the local wheel in favor of a stable PyPI release -- e.g. when one of
+        # the local wheel's dependencies can't be satisfied, uv backtracks to the published version
+        # (silently swapping a `with_local_v2()` build back to the released package).
         pip_install_args_no_deps = [
             *pip_install_args,
             *[
@@ -257,18 +272,8 @@ class PythonWheelHandler:
                 layer.package_name,
             ],
         ]
-
-        delta1 = UV_WHEEL_INSTALL_COMMAND_TEMPLATE.substitute(
-            PIP_INSTALL_ARGS=" ".join(pip_install_args_no_deps), SECRET_MOUNT=secret_mounts
-        )
-        dockerfile += delta1
-
-        # Second install: Install dependencies from PyPI. Keep /dist as a findlink so the package
-        # itself resolves to the local wheel even when it isn't published to PyPI (e.g. a local
-        # plugin wheel); its dependencies still come from the index.
-        pip_install_args_deps = [*pip_install_args, "--find-links", "/dist", layer.package_name]
         delta2 = UV_WHEEL_INSTALL_COMMAND_TEMPLATE.substitute(
-            PIP_INSTALL_ARGS=" ".join(pip_install_args_deps), SECRET_MOUNT=secret_mounts
+            PIP_INSTALL_ARGS=" ".join(pip_install_args_no_deps), SECRET_MOUNT=secret_mounts
         )
         dockerfile += delta2
 

--- a/tests/flyte/imagebuild/test_docker_builder.py
+++ b/tests/flyte/imagebuild/test_docker_builder.py
@@ -8,7 +8,7 @@ import pytest
 import pytest_asyncio
 
 from flyte import Secret
-from flyte._image import AptPackages, Commands, Image, PipPackages, PoetryProject, Requirements, UVProject
+from flyte._image import AptPackages, Commands, Image, PipPackages, PoetryProject, PythonWheels, Requirements, UVProject
 from flyte._internal.imagebuild.docker_builder import (
     DOCKER_FILE_UV_BASE_TEMPLATE,
     CopyConfig,
@@ -16,6 +16,7 @@ from flyte._internal.imagebuild.docker_builder import (
     DockerImageBuilder,
     PipAndRequirementsHandler,
     PoetryProjectHandler,
+    PythonWheelHandler,
     UVProjectHandler,
     _get_secret_commands,
 )
@@ -175,6 +176,30 @@ async def test_pip_package_handling(monkeypatch):
         )
         assert "--mount=type=secret" in docker_update
         assert "uv pip install --python $UV_PYTHON pkg_a pkg_b" in docker_update
+
+
+@pytest.mark.asyncio
+async def test_python_wheel_handler_forces_local_wheel_last():
+    """The local wheel must be force-installed (--no-index --reinstall) *after* the dependency
+    resolution step. If the order is reversed, a full resolve can discard the local wheel in favor
+    of a stable PyPI release (e.g. when one of the wheel's deps can't be satisfied, uv backtracks to
+    the published version), silently undoing the local install."""
+    with tempfile.TemporaryDirectory() as wheel_dir, tempfile.TemporaryDirectory() as tmp_context:
+        # The handler copies wheel_dir into the build context, so it needs at least one file.
+        (Path(wheel_dir) / "flyte-2.5.2.dev1-py3-none-any.whl").write_text("")
+        context_path = Path(tmp_context)
+
+        layer = PythonWheels(wheel_dir=Path(wheel_dir), package_name="flyte")
+        docker_update = await PythonWheelHandler.handle(layer=layer, context_path=context_path, dockerfile="")
+
+        # Both install steps target the local wheel via --find-links /dist.
+        dep_step = "uv pip install --python $UV_PYTHON --find-links /dist flyte"
+        force_step = "uv pip install --python $UV_PYTHON --find-links /dist --no-deps --no-index --reinstall flyte"
+        assert dep_step in docker_update
+        assert force_step in docker_update
+
+        # The force-install step must come last so nothing re-resolves the package afterwards.
+        assert docker_update.index(force_step) > docker_update.index(dep_step)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

When building an image with `Image.from_*().with_local_v2()`, the locally-built `flyte` wheel can be **silently replaced by the published PyPI release**. A user modifying `flyte` locally ends up running the released version in the image without any error.

`PythonWheelHandler.handle` emits two `uv pip install` steps for a `PythonWheels` layer:

1. **force-install** the local wheel: `--no-deps --no-index --reinstall flyte`
2. **resolve dependencies** from the index: `--find-links /dist flyte`

The problem is the order: the dependency step runs **last** and does a full resolve of `flyte`. If the local wheel can't be fully satisfied during that resolve — most commonly when a dev wheel pins a dependency version that isn't published yet (e.g. after rebasing onto a branch that bumped an internal dep) — uv backtracks and installs the highest **satisfiable** version, i.e. the stable PyPI release. The result silently undoes step 1:

```
#19  - flyte==2.5.2.dev1+g512b21d95.d20260617
#19  + flyte==2.5.1
```

Note this is **not** specific to the `--find-links` that was recently added to step 2 — old and new code backtrack identically. The fix is structural.

## What

Swap the order so the **dependency step runs first** and the **force-install step runs last**. Because the force-install uses `--no-index --reinstall`, it can't be re-resolved away, so the exact local wheel is always the final state regardless of what the resolver picks for the package itself.

- Dependencies still come from the index (resolved in the first step).
- Packages not published to PyPI (local plugin wheels) still resolve via `--find-links /dist` in the first step.
- `with_local_v2()` now always installs exactly the local wheel.

Trade-off: the local wheel is force-installed with `--no-deps`, so a genuinely-missing dependency now surfaces at runtime (ImportError) instead of being masked by silently running the older published package. This is the intended behavior for `with_local_v2()` — you get your local code.

## Repro / verification

With a local dev wheel whose declared dependency can't be satisfied, the pre-fix sequence downgrades to the PyPI release; the reordered sequence keeps the local wheel:

```
[A] uv pip install --find-links /dist flyte                                  -> picks stable + deps
[B] uv pip install --no-deps --no-index --reinstall --find-links /dist flyte -> local dev wheel (final)
```

## Tests

Added `test_python_wheel_handler_forces_local_wheel_last` asserting the force-install step (`--no-index --reinstall`) is emitted **after** the dependency step in the generated Dockerfile.