### PR TITLE
feat(container): add file_input_layout to ContainerTask

### DIFF
--- a/examples/advanced/named_dir_file_input.py
+++ b/examples/advanced/named_dir_file_input.py
@@ -1,0 +1,109 @@
+"""
+Preserve input filenames in a raw ContainerTask with ``file_input_layout``.
+
+By default (DIRECT) CoPilot stages a ``File`` input at an extensionless path
+(``/var/inputs/<var>`` for a File, ``/var/inputs/<var>/<index>`` for list[File]
+elements), which breaks tools that detect a file's format from its extension.
+
+``file_input_layout="NAMED_DIR"`` instead stages each input inside a per-input
+directory under its original basename, so names and extensions round-trip::
+
+    fasta : File        -> /var/inputs/fasta/genome.fasta
+    reads : list[File]  -> /var/inputs/reads/sample_R1.fastq.gz
+                           /var/inputs/reads/sample_R2.fastq.gz
+
+Consumers glob ``/var/inputs/<var>/*`` to read the input.
+
+    flyte run examples/advanced/named_dir_file_input.py main        # single File
+    flyte run examples/advanced/named_dir_file_input.py main_list   # list[File]
+"""
+
+from pathlib import Path
+
+import flyte
+from flyte.extras import ContainerTask
+from flyte.io import File
+
+# Single File: NAMED_DIR stages it at /var/inputs/fasta/<original-name>; the command
+# globs the dir and reports whether the .fasta extension survived.
+check_extension = ContainerTask(
+    name="check_extension",
+    image="alpine:3.20",
+    inputs={"fasta": File},
+    outputs={"name": str},
+    input_data_dir="/var/inputs",
+    output_data_dir="/var/outputs",
+    file_input_layout="NAMED_DIR",
+    command=[
+        "/bin/sh",
+        "-c",
+        "set -eu; "
+        "if [ -d /var/inputs/fasta ]; then f=$(ls /var/inputs/fasta/* | head -n1); else f=/var/inputs/fasta; fi; "
+        'echo "staged input: $f"; '
+        'case "$(basename "$f")" in '
+        '  *.fasta) echo "RESULT: extension preserved (NAMED_DIR)" ;; '
+        '  *) echo "RESULT: extension dropped (DIRECT)" ;; '
+        "esac; "
+        'printf \'%s\' "$(basename "$f")" | tee /var/outputs/name',
+    ],
+)
+
+# list[File]: each element keeps its original basename under /var/inputs/reads/
+# (e.g. sample_R1.fastq.gz) instead of the bare index 0/1.
+check_reads = ContainerTask(
+    name="check_reads",
+    image="alpine:3.20",
+    inputs={"reads": list[File]},
+    outputs={"names": str},
+    input_data_dir="/var/inputs",
+    output_data_dir="/var/outputs",
+    file_input_layout="NAMED_DIR",
+    command=[
+        "/bin/sh",
+        "-c",
+        "set -eu; "
+        "ok=1; "
+        "for f in /var/inputs/reads/*; do "
+        '  echo "staged input: $f"; '
+        '  case "$(basename "$f")" in '
+        "    *.fastq.gz) ;; "
+        "    *) ok=0 ;; "
+        "  esac; "
+        "done; "
+        'if [ "$ok" -eq 1 ]; then echo "RESULT: all reads kept their extension (NAMED_DIR)"; '
+        'else echo "RESULT: extensions dropped (DIRECT)"; fi; '
+        "(cd /var/inputs/reads && echo *) | tee /var/outputs/names",
+    ],
+)
+
+container_env = flyte.TaskEnvironment.from_task("named_dir_env", check_extension)
+list_env = flyte.TaskEnvironment.from_task("named_dir_list_env", check_reads)
+env = flyte.TaskEnvironment(name="named_dir_demo", depends_on=[container_env, list_env])
+
+
+@env.task
+async def main() -> str:
+    # The local basename must survive the upload -> stage round-trip.
+    local = Path("/tmp/genome.fasta")
+    local.write_text(">seq1\nACGTACGTACGT\n")
+    fasta = await File.from_local(str(local))
+    # Expect the task to print: "genome.fasta".
+    return await check_extension(fasta=fasta)
+
+
+@env.task
+async def main_list() -> str:
+    d = Path("/tmp/reads")
+    d.mkdir(exist_ok=True)
+    (d / "sample_R1.fastq.gz").write_bytes(b"@r1\nACGT\n+\nIIII\n")
+    (d / "sample_R2.fastq.gz").write_bytes(b"@r2\nTGCA\n+\nIIII\n")
+    r1 = await File.from_local(str(d / "sample_R1.fastq.gz"))
+    r2 = await File.from_local(str(d / "sample_R2.fastq.gz"))
+    # Expect the task to print: "sample_R1.fastq.gz sample_R2.fastq.gz".
+    return await check_reads(reads=[r1, r2])
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.with_runcontext(mode="remote").run(main)
+    print(run.url)

--- a/src/flyte/extras/_container.py
+++ b/src/flyte/extras/_container.py
@@ -53,6 +53,9 @@ class ContainerTask(TaskTemplate):
     :param output_data_dir: The directory where the output data is stored. This is a string or a Path object.
     :param metadata_format: The format of the output file. This can be "JSON", "YAML", or "PROTO".
     :param local_logs: If True, logs will be printed to the console in the local execution.
+    :param file_input_layout: How CoPilot stages File / list[File] inputs on disk.
+        "DIRECT" (default) uses the bare path/index; "NAMED_DIR" preserves each input's
+        original basename (and extension), so extension-sniffing tools work.
     """
 
     MetadataFormat = Literal["JSON", "YAML", "PROTO"]
@@ -69,6 +72,7 @@ class ContainerTask(TaskTemplate):
         output_data_dir: str | pathlib.Path = "/var/outputs",
         metadata_format: MetadataFormat = "JSON",
         local_logs: bool = True,
+        file_input_layout: Literal["DIRECT", "NAMED_DIR"] = "DIRECT",
         **kwargs,
     ):
         super().__init__(
@@ -104,6 +108,7 @@ class ContainerTask(TaskTemplate):
         self._inputs = inputs
         self._outputs = outputs
         self.local_logs = local_logs
+        self._file_input_layout = file_input_layout
 
     def _render_command_and_volume_binding(self, cmd: str, **kwargs) -> Tuple[str, Dict[str, Dict[str, str]]]:
         """
@@ -324,12 +329,22 @@ class ContainerTask(TaskTemplate):
             "PROTO": tasks_pb2.DataLoadingConfig.PROTO,
         }
 
-        return tasks_pb2.DataLoadingConfig(
+        config = tasks_pb2.DataLoadingConfig(
             input_path=str(self._input_data_dir) if self._input_data_dir else None,
             output_path=str(self._output_data_dir) if self._output_data_dir else None,
             enabled=True,
             format=literal_to_protobuf.get(self._metadata_format, "JSON"),
         )
+        # NAMED_DIR preserves each input's original basename; DIRECT (default) leaves the
+        # field unset, so existing tasks keep working on older flyteidl2.
+        if self._file_input_layout == "NAMED_DIR":
+            if not hasattr(tasks_pb2.DataLoadingConfig, "NAMED_DIR"):
+                raise ValueError(
+                    "file_input_layout='NAMED_DIR' requires a newer flyteidl2 that includes "
+                    "DataLoadingConfig.file_input_layout; please upgrade flyteidl2."
+                )
+            config.file_input_layout = tasks_pb2.DataLoadingConfig.NAMED_DIR
+        return config
 
     def container_args(self, sctx: SerializationContext) -> List[str]:
         return self._cmd + (self._args or [])


### PR DESCRIPTION
## What

Adds a `file_input_layout` option to `ContainerTask`, exposing `DataLoadingConfig.file_input_layout`:

- `"DIRECT"` (default) — existing behavior; CoPilot stages a `File` at `/var/inputs/<var>` and `list[File]` elements at `/var/inputs/<var>/<index>` (extensionless).
- `"NAMED_DIR"` — CoPilot stages each input inside a per-input directory under its original basename, so names/extensions round-trip and tools that detect format by extension (e.g. salmon on `*.fastq.gz`) work.

It mirrors the existing `metadata_format` knob (a `Literal` mapped into the `DataLoadingConfig` proto) and defaults to `DIRECT`, so existing raw-container tasks are unaffected.

Includes `examples/advanced/named_dir_file_input.py` exercising both a single `File` and a `list[File]`.

## Dependency

`NAMED_DIR` requires the `DataLoadingConfig.file_input_layout` field in `flyteidl2` plus the CoPilot/executor support from the backend change. The `flyteidl2` pin must be bumped to a release that includes the field before `NAMED_DIR` can be selected; `DIRECT` tasks are unaffected and work with the current pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
