### PR TITLE
feat: populate code_bundle_uri in Task and App serialization

### DIFF
--- a/plugins/anthropic/uv.lock
+++ b/plugins/anthropic/uv.lock
@@ -381,7 +381,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -448,7 +448,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -457,7 +457,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]

--- a/plugins/bigquery/uv.lock
+++ b/plugins/bigquery/uv.lock
@@ -451,7 +451,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -518,7 +518,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -527,7 +527,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]

--- a/plugins/codegen/uv.lock
+++ b/plugins/codegen/uv.lock
@@ -736,7 +736,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -803,7 +803,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -812,7 +812,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]

--- a/plugins/dask/uv.lock
+++ b/plugins/dask/uv.lock
@@ -607,7 +607,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -674,7 +674,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -683,7 +683,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]

--- a/plugins/databricks/uv.lock
+++ b/plugins/databricks/uv.lock
@@ -619,7 +619,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -686,7 +686,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -695,7 +695,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]

--- a/plugins/echo/uv.lock
+++ b/plugins/echo/uv.lock
@@ -344,7 +344,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -411,7 +411,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -420,7 +420,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]

--- a/plugins/gemini/uv.lock
+++ b/plugins/gemini/uv.lock
@@ -467,7 +467,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -534,7 +534,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -543,7 +543,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]

--- a/plugins/hitl/uv.lock
+++ b/plugins/hitl/uv.lock
@@ -377,7 +377,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -444,7 +444,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -453,7 +453,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]

--- a/plugins/huggingface/uv.lock
+++ b/plugins/huggingface/uv.lock
@@ -683,7 +683,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -750,7 +750,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -759,7 +759,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]

--- a/plugins/hydra/uv.lock
+++ b/plugins/hydra/uv.lock
@@ -473,7 +473,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -540,7 +540,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -549,7 +549,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]

--- a/plugins/jsonl/uv.lock
+++ b/plugins/jsonl/uv.lock
@@ -353,7 +353,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -420,7 +420,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -429,7 +429,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]

--- a/plugins/omegaconf/uv.lock
+++ b/plugins/omegaconf/uv.lock
@@ -359,7 +359,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -426,7 +426,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -435,7 +435,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]

--- a/plugins/openai/uv.lock
+++ b/plugins/openai/uv.lock
@@ -460,7 +460,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -527,7 +527,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -536,7 +536,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]

--- a/plugins/pandera/uv.lock
+++ b/plugins/pandera/uv.lock
@@ -573,7 +573,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -640,7 +640,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -649,7 +649,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]

--- a/plugins/polars/uv.lock
+++ b/plugins/polars/uv.lock
@@ -354,7 +354,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -421,7 +421,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -430,7 +430,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]

--- a/plugins/pytorch/uv.lock
+++ b/plugins/pytorch/uv.lock
@@ -388,7 +388,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -455,7 +455,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -464,7 +464,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]

--- a/plugins/ray/pyproject.toml
+++ b/plugins/ray/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.10,<3.13"
 dependencies = [
     "ray[default]",
     "flyte",
-    "flyteidl2==2.0.23",
+    "flyteidl2==2.0.24",
 ]
 
 [dependency-groups]

--- a/plugins/ray/uv.lock
+++ b/plugins/ray/uv.lock
@@ -523,7 +523,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -590,7 +590,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -599,7 +599,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]
@@ -621,7 +621,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "flyte", editable = "../../" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "ray", extras = ["default"] },
 ]
 

--- a/plugins/redis/uv.lock
+++ b/plugins/redis/uv.lock
@@ -376,7 +376,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -443,7 +443,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -452,7 +452,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]

--- a/plugins/sglang/uv.lock
+++ b/plugins/sglang/uv.lock
@@ -353,7 +353,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -420,7 +420,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -429,7 +429,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]

--- a/plugins/snowflake/uv.lock
+++ b/plugins/snowflake/uv.lock
@@ -497,7 +497,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -564,7 +564,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -573,7 +573,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]

--- a/plugins/spark/uv.lock
+++ b/plugins/spark/uv.lock
@@ -451,7 +451,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -518,7 +518,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -527,7 +527,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]

--- a/plugins/vllm/uv.lock
+++ b/plugins/vllm/uv.lock
@@ -353,7 +353,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -420,7 +420,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -429,7 +429,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]

--- a/plugins/wandb/uv.lock
+++ b/plugins/wandb/uv.lock
@@ -447,7 +447,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -514,7 +514,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -523,7 +523,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "async-lru>=2.0.5",
     "mashumaro",
     "aiolimiter>=1.2.1",
-    "flyteidl2==2.0.23",
+    "flyteidl2==2.0.24",
     "packaging",
     "sentry-sdk>=2.0",
     "pyOpenSSL>=24.0.0",

--- a/rs_controller/Cargo.lock
+++ b/rs_controller/Cargo.lock
@@ -269,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.22"
+version = "2.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2972cbcd33f6d867c50f0ea0c4d5995d9637f1495562e3818c5990152a6875ee"
+checksum = "e71d2360eccb93eefd22ffbda2944e52967e132d634d239ef2efd4e027a1e8d8"
 dependencies = [
  "async-trait",
  "futures",

--- a/rs_controller/Cargo.toml
+++ b/rs_controller/Cargo.toml
@@ -34,7 +34,7 @@ async-trait = "0.1"
 thiserror = "1.0"
 # Uncomment this if you need to use local flyteidl2
 #flyteidl2 = { path = "/Users/ytong/go/src/github.com/flyteorg/flyte/gen/rust" }
-flyteidl2 = "=2.0.23"
+flyteidl2 = "=2.0.24"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/rs_controller/pyproject.toml
+++ b/rs_controller/pyproject.toml
@@ -9,7 +9,7 @@ description = "Rust controller for Union"
 requires-python = ">=3.10"
 classifiers = ["Programming Language :: Python", "Programming Language :: Rust"]
 dependencies = [
-    "flyteidl2==2.0.23",
+    "flyteidl2==2.0.24",
 ]
 [tool.maturin]
 module-name = "flyte_controller_base"

--- a/src/flyte/_internal/runtime/task_serde.py
+++ b/src/flyte/_internal/runtime/task_serde.py
@@ -265,6 +265,9 @@ def get_proto_task(
             is_entrypoint=task.entrypoint,
             log_links=log_links,
             image_build_run=image_build_run,
+            code_bundle_uri=serialize_context.code_bundle.tgz or serialize_context.code_bundle.pkl
+            if serialize_context.code_bundle
+            else None,
         ),
         interface=transform_native_to_typed_interface(task.native_interface),
         custom=custom if len(custom) > 0 else None,

--- a/src/flyte/_internal/runtime/task_serde.py
+++ b/src/flyte/_internal/runtime/task_serde.py
@@ -265,9 +265,7 @@ def get_proto_task(
             is_entrypoint=task.entrypoint,
             log_links=log_links,
             image_build_run=image_build_run,
-            code_bundle_uri=serialize_context.code_bundle.tgz or serialize_context.code_bundle.pkl
-            if serialize_context.code_bundle
-            else None,
+            code_bundle_uri=serialize_context.code_bundle.tgz if serialize_context.code_bundle else None,
         ),
         interface=transform_native_to_typed_interface(task.native_interface),
         custom=custom if len(custom) > 0 else None,

--- a/src/flyte/app/_runtime/app_serde.py
+++ b/src/flyte/app/_runtime/app_serde.py
@@ -14,6 +14,7 @@ from typing import List, Optional, Union
 from flyteidl2.app import app_definition_pb2
 from flyteidl2.common import runtime_version_pb2
 from flyteidl2.core import literals_pb2, tasks_pb2
+from flyteidl2.task import task_definition_pb2
 from google.protobuf.duration_pb2 import Duration
 
 import flyte
@@ -276,14 +277,14 @@ async def translate_parameters(parameters: List[Parameter]) -> app_definition_pb
 
 
 def _get_code_bundle_uri(serialization_context: SerializationContext) -> str | None:
+    # Only the tgz bundle is a downloadable source archive; the pkl is a pickled
+    # interactive bundle that the download-link feature cannot serve.
     if serialization_context.code_bundle is None:
         return None
-    return serialization_context.code_bundle.tgz or serialization_context.code_bundle.pkl or None
+    return serialization_context.code_bundle.tgz or None
 
 
-def _get_source_code() -> "task_definition_pb2.SourceCode | None":
-    from flyteidl2.task import task_definition_pb2
-
+def _get_source_code() -> task_definition_pb2.SourceCode | None:
     from flyte.git import GitStatus
 
     git_status = GitStatus.from_current_repo()

--- a/src/flyte/app/_runtime/app_serde.py
+++ b/src/flyte/app/_runtime/app_serde.py
@@ -275,6 +275,24 @@ async def translate_parameters(parameters: List[Parameter]) -> app_definition_pb
     return app_definition_pb2.InputList(items=parameters_list)
 
 
+def _get_code_bundle_uri(serialization_context: SerializationContext) -> str | None:
+    if serialization_context.code_bundle is None:
+        return None
+    return serialization_context.code_bundle.tgz or serialization_context.code_bundle.pkl or None
+
+
+def _get_source_code() -> "task_definition_pb2.SourceCode | None":
+    from flyteidl2.task import task_definition_pb2
+
+    from flyte.git import GitStatus
+
+    git_status = GitStatus.from_current_repo()
+    if not git_status.is_valid:
+        return None
+    url = f"{git_status.remote_url}/tree/{git_status.commit_sha}"
+    return task_definition_pb2.SourceCode(link=url)
+
+
 @syncify
 async def translate_app_env_to_idl(
     app_env: AppEnvironment,
@@ -384,6 +402,8 @@ async def translate_app_env_to_idl(
                 domain=serialization_context.domain,
                 name=app_env.name,
             ),
+            code_bundle_uri=_get_code_bundle_uri(serialization_context),
+            source_code=_get_source_code(),
         ),
         spec=app_definition_pb2.Spec(
             desired_state=desired_state,

--- a/uv.lock
+++ b/uv.lock
@@ -21,12 +21,12 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-06T19:01:20.271147Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P5D"
 
 [options.exclude-newer-package]
-flyteidl2 = { timestamp = "2026-06-11T19:01:20.271153Z", span = "PT0S" }
-flyte-controller-base = { timestamp = "2026-06-11T19:01:20.271156Z", span = "PT0S" }
+flyteidl2 = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+flyte-controller-base = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 
 [[package]]
 name = "aiofiles"
@@ -1188,7 +1188,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.23" },
+    { name = "flyteidl2", specifier = "==2.0.24" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -1262,11 +1262,11 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "flyteidl2", specifier = "==2.0.23" }]
+requires-dist = [{ name = "flyteidl2", specifier = "==2.0.24" }]
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.23"
+version = "2.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -1275,7 +1275,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/31/0f830765eb525e14319ae46d249bb00a3b663149419afed9cc4e033d8841/flyteidl2-2.0.23-py3-none-any.whl", hash = "sha256:c90d4414c27b31dd027807eb04e5443f9bc1ea521e57e12d31ce5661c6e9d903", size = 348528, upload-time = "2026-06-11T18:57:38.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/bf91bc584e29ca79487b3582f398c4fb7a4d011384e31fc32ceb216122fa/flyteidl2-2.0.24-py3-none-any.whl", hash = "sha256:67ff86490bb98cef0f4a984b83b67d792a2bbfeee63258ad58c9efb21a7e12fb", size = 349416, upload-time = "2026-06-18T18:05:45.019Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Tracking issue

## Why are the changes needed?

The UI uses `code_bundle_uri` to display the source code bundle for a task or app, and `source_code.link` to provide a GitHub link to the defining code. These fields existed in the IDL but were never populated during serialization.

## What changes were proposed in this pull request?

1. **`task_serde.py`**: Set `code_bundle_uri` in `TaskMetadata` to `serialize_context.code_bundle.tgz or .pkl` during task serialization.

2. **`app_serde.py`**: 
   - Set `code_bundle_uri` on `App.Meta` during app serialization (tgz or pkl bundle URI).
   - Set `source_code` on `App.Meta` with a GitHub tree URL (`<remote>/tree/<sha>`) constructed from `flyte.git.GitStatus`. Gracefully returns `None` when not in a git repo (`is_valid=False`).

## How was this patch tested?

The `code_bundle_uri` and `source_code` fields on `App.Meta` are added in companion PRs:

- https://github.com/flyteorg/flyte/pull/7549 — IDL adds `code_bundle_uri` and `source_code` to `App.Meta`
- https://github.com/unionai/cloud/pull/16585 — dataproxy reads `meta.code_bundle_uri` from App, falls back to container command args and pod primary container args for PodTemplate apps