### PR TITLE
[Experimental] Async-only local execution in thread-less runtimes (Pyodide/WASM)

### DIFF
--- a/src/flyte/_utils/runtime_env.py
+++ b/src/flyte/_utils/runtime_env.py
@@ -1,0 +1,33 @@
+"""
+Runtime-capability detection for constrained execution environments.
+
+The primary motivating environment is Pyodide / WebAssembly (running flyte in the browser),
+where the host Python interpreter has **no thread support**. This module centralizes the
+detection so the rest of the SDK can opt into a thread-free, async-only execution mode.
+"""
+
+import os
+import sys
+
+from flyte._utils.helpers import str2bool
+
+# True when running under Pyodide / Emscripten (browser WASM). The CPython build there reports
+# ``sys.platform == "emscripten"`` and cannot start OS threads.
+IS_PYODIDE = sys.platform == "emscripten"
+
+
+def background_loop_disabled() -> bool:
+    """
+    Whether the syncify background event-loop thread must be skipped.
+
+    When True, flyte runs in an async-only mode: the synchronous (blocking) flyte API is
+    unavailable and callers must use the ``.aio()`` coroutine form, which is executed directly
+    in the caller's own running event loop instead of a dedicated background thread.
+
+    Controlled by ``FLYTE_DISABLE_BACKGROUND_LOOP`` (truthy/falsy string); when unset it
+    auto-enables under Pyodide so the browser case works without any configuration.
+    """
+    env = os.getenv("FLYTE_DISABLE_BACKGROUND_LOOP")
+    if env not in (None, ""):
+        return str2bool(env)
+    return IS_PYODIDE

--- a/src/flyte/io/_dataframe/dataframe.py
+++ b/src/flyte/io/_dataframe/dataframe.py
@@ -14,9 +14,19 @@ from typing import Any, Callable, ClassVar, Coroutine, Dict, Generic, List, Opti
 from flyteidl2.core import literals_pb2, types_pb2
 from fsspec.utils import get_protocol
 from mashumaro.types import SerializableType
-from obstore.exceptions import GenericError
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_serializer, model_validator
 from typing_extensions import Annotated, TypeAlias, get_args, get_origin
+
+try:
+    from obstore.exceptions import GenericError
+except ImportError:
+    # obstore is a native (Rust) dependency with no WASM wheel, so it is absent in constrained
+    # runtimes such as Pyodide. Importing this module must still succeed there (the type engine
+    # imports it eagerly for every task); the obstore-backed cloud IO paths below are unreachable
+    # without it, so the placeholder only needs to keep the ``except GenericError`` clause valid.
+    class GenericError(Exception):  # type: ignore[no-redef]
+        """Placeholder so ``except GenericError`` stays valid without obstore."""
+
 
 import flyte.storage as storage
 from flyte._logging import logger

--- a/src/flyte/storage/_parallel_reader.py
+++ b/src/flyte/storage/_parallel_reader.py
@@ -12,7 +12,14 @@ from typing import Any, Hashable, Protocol
 
 import aiofiles
 import aiofiles.os
-import obstore
+
+try:
+    import obstore
+except ImportError:
+    # Native dep absent in constrained runtimes (e.g. Pyodide). The obstore-backed readers in
+    # this module are only reached on cloud (s3/gs/abfs) paths, which are disabled without it;
+    # importing the module (e.g. for the pure-python DownloadQueueEmpty) must still succeed.
+    obstore = None  # type: ignore[assignment]
 
 from flyte._logging import logger
 

--- a/src/flyte/storage/_storage.py
+++ b/src/flyte/storage/_storage.py
@@ -9,12 +9,28 @@ from typing import AsyncGenerator, Optional
 from uuid import UUID
 
 import fsspec
-import obstore
 from fsspec.asyn import AsyncFileSystem
 from fsspec.utils import get_protocol
-from obstore.exceptions import GenericError
-from obstore.fsspec import register
-from obstore.store import ObjectStore
+
+try:
+    import obstore
+    from obstore.exceptions import GenericError
+    from obstore.fsspec import register
+    from obstore.store import ObjectStore
+
+    HAS_OBSTORE = True
+except ImportError:
+    # obstore is a native (Rust) dependency with no WASM wheel, so it is absent in constrained
+    # runtimes such as Pyodide. Local (file://) and other plain-fsspec protocols do not need it;
+    # only the cloud bypass fast-paths (s3/gs/abfs) do, and those are guarded by HAS_OBSTORE.
+    HAS_OBSTORE = False
+    obstore = None  # type: ignore[assignment]
+    register = None  # type: ignore[assignment]
+    ObjectStore = None  # type: ignore[assignment,misc]
+
+    class GenericError(Exception):  # type: ignore[no-redef]
+        """Placeholder so ``except (..., GenericError)`` clauses stay valid without obstore."""
+
 
 from flyte._initialize import get_storage
 from flyte._logging import logger
@@ -60,7 +76,7 @@ def _is_obstore_supported_protocol(protocol: str) -> bool:
     :param protocol: Protocol to check.
     :return: True if the protocol is supported, False otherwise.
     """
-    return protocol in _OBSTORE_SUPPORTED_PROTOCOLS
+    return HAS_OBSTORE and protocol in _OBSTORE_SUPPORTED_PROTOCOLS
 
 
 def is_remote(path: typing.Union[pathlib.Path | str]) -> bool:
@@ -582,5 +598,6 @@ def get_credentials_error(uri: str, protocol: str) -> str:
     raise ValueError(f"Unsupported protocol: {protocol}")
 
 
-register(_OBSTORE_SUPPORTED_PROTOCOLS, asynchronous=True)
+if HAS_OBSTORE:
+    register(_OBSTORE_SUPPORTED_PROTOCOLS, asynchronous=True)
 fsspec.register_implementation("flyte", FlyteFS, clobber=True)

--- a/src/flyte/syncify/_api.py
+++ b/src/flyte/syncify/_api.py
@@ -14,6 +14,7 @@ from typing import (
     Callable,
     Coroutine,
     Iterator,
+    Optional,
     ParamSpec,
     Protocol,
     TypeVar,
@@ -23,6 +24,7 @@ from typing import (
 )
 
 from flyte._logging import logger
+from flyte._utils.runtime_env import background_loop_disabled
 
 P = ParamSpec("P")
 
@@ -255,7 +257,7 @@ class _SyncWrapper:
     def __init__(
         self,
         fn: Any,
-        bg_loop: _BackgroundLoop,
+        bg_loop: Optional[_BackgroundLoop],
         underlying_obj: Any = None,
     ):
         self.fn = fn
@@ -283,6 +285,13 @@ class _SyncWrapper:
         return wrapper
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        if self._bg_loop is None:
+            # Async-only mode (no background-loop thread, e.g. Pyodide/WASM). The blocking sync
+            # API cannot be supported without a thread to drive the loop from a sync context.
+            raise RuntimeError(
+                f"The synchronous flyte API is unavailable in this runtime (no thread support); "
+                f"call `await {self.fn.__name__}.aio(...)` from an async context instead."
+            )
         if threading.current_thread().name == self._bg_loop.thread.name:
             # If we are already in the background loop thread, we can call the function directly
             raise AssertionError(
@@ -319,10 +328,16 @@ class _SyncWrapper:
             if inspect.isasyncgenfunction(fn):
                 # If the function is an async generator, we need to handle it differently
                 async_iter = fn(*args, **kwargs)
+                if self._bg_loop is None:
+                    # Async-only mode: yield directly in the caller's running event loop.
+                    return async_iter
                 return self._bg_loop.iterate_in_loop(async_iter)
             else:
                 # If we are already in the background loop, just return the coroutine
                 coro = fn(*args, **kwargs)
+                if self._bg_loop is None:
+                    # Async-only mode: the coroutine / async iterator runs in the caller's loop.
+                    return coro
                 if hasattr(coro, "__aiter__"):
                     # If the coroutine is an async iterator, we need to handle it differently
                     return self._bg_loop.iterate_in_loop(coro)
@@ -371,7 +386,10 @@ class Syncify:
     """
 
     def __init__(self, name: str = "flyte_syncify"):
-        self._bg_loop = _BackgroundLoop(name=name)
+        # In constrained runtimes without thread support (e.g. Pyodide/WASM), do not start the
+        # background event-loop thread. flyte then operates in async-only mode: synchronous calls
+        # raise, and ``.aio()`` runs coroutines directly in the caller's own running event loop.
+        self._bg_loop: Optional[_BackgroundLoop] = None if background_loop_disabled() else _BackgroundLoop(name=name)
 
     @overload
     def __call__(self, func: Callable[P, Awaitable[R_co]]) -> SyncFunction[P, R_co]: ...


### PR DESCRIPTION
> ⚠️ **Experimental / Draft.** Opt-in, off by default. Targets running flyte in the browser (Pyodide/WASM) for *authoring + local async execution* only. Not intended for production paths.

## Motivation

Running `flyte` in Pyodide (browser WASM) fails for two independent reasons, neither of which is the `obstore` install error users first see:

1. **No threads at import.** `flyte.syncify` starts a background event-loop **thread at import time** (`syncify/__init__.py` → `_api.py` `thread.start()`). Pyodide has no thread support → `RuntimeError: can't start new thread` on `import flyte`.
2. **Eager native import.** `obstore` (a Rust dep with no WASM wheel) is imported eagerly in `storage/_storage.py` and `register(...)` runs at module import, so `import flyte.storage` — which local execution needs — crashes with `ModuleNotFoundError: obstore`.

This PR makes both opt-in skippable so `import flyte` + `await flyte.run.aio(async_task, ...)` works in a thread-less runtime. **Async-only by design** — the synchronous (`@syncify` blocking) API is intentionally disabled in this mode.

## Changes

- **New** `flyte/_utils/runtime_env.py`: `IS_PYODIDE` (`sys.platform == "emscripten"`) and `background_loop_disabled()` — auto-on under Pyodide, overridable via `FLYTE_DISABLE_BACKGROUND_LOOP` for testing on a normal machine.
- **`syncify/_api.py`**: when the background loop is disabled, `Syncify` starts no thread; `.aio()` runs coroutines directly in the caller's running loop (mirrors the existing `is_in_loop()` short-circuit); blocking sync calls raise a clear "use `.aio()`" error.
- **`storage/_storage.py`**: guard `obstore` with the existing `HAS_X` idiom (cf. `HAS_AIOSQLITE`). `_is_obstore_supported_protocol` returns `False` without it, so local/`file://` IO uses the plain-fsspec fallback in `get`/`put`/`put_stream`/`get_stream`. `register(...)` is guarded too.
- **`storage/_parallel_reader.py`**: same defensive `try/except` guard on the eager `obstore` import.

## Scope / non-goals

Unsupported in this mode (by design): synchronous API, `def` (non-async) tasks, conditions/human-input, cloud-URI IO, and `DataFrame` types. A plain `pip install flyte` in Pyodide still needs the `deps=False` install dance — the native deps remain unbuildable for WASM; this PR only fixes import + async execution.

## Verification

- `tests/flyte/syncify` — all 32 pass (no behavior change with flag off).
- Flag-on (`FLYTE_DISABLE_BACKGROUND_LOOP=1`) on a normal machine: `import flyte` starts no thread; `await flyte.run.aio(add, 41)` → `ActionOutputs(o0=42)`; a blocking sync call raises the clear async-only error.
- `obstore` import blocked (simulating Pyodide): `import flyte.storage` succeeds with `HAS_OBSTORE = False`; local `put_stream`/`get_stream` round-trips via fsspec.
- A Node+Pyodide harness reproduces the original failures and confirms the real (un-stubbed) browser path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)