### PR TITLE
ci: signal unionai-docs to regenerate API docs on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -300,15 +300,30 @@ jobs:
     # live on PyPI). Mirrors the always()+result gating used by the image job.
     if: always() && github.event_name == 'release' && needs.flyte-pypi.result == 'success'
     runs-on: ubuntu-latest
+    # Job-level env so the App id is referenceable in step `if:` (secrets aren't).
+    env:
+      DOCSY_BOT_APP_ID: ${{ secrets.DOCSY_BOT_APP_ID }}
     steps:
+      # Authenticate as the "docsy-bot" GitHub App and mint a short-lived token
+      # scoped to unionai/unionai-docs (where the App is installed). The App is
+      # NOT installed on this repo — we only hold its credentials as secrets to
+      # request a cross-org installation token. Skipped until the secrets exist.
+      - name: Mint docsy-bot App token for unionai-docs
+        id: app-token
+        if: ${{ env.DOCSY_BOT_APP_ID != '' }}
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DOCSY_BOT_APP_ID }}
+          private-key: ${{ secrets.DOCSY_BOT_PRIVATE_KEY }}
+          owner: unionai
+          repositories: unionai-docs
+
       - name: Send repository_dispatch to unionai/unionai-docs
         env:
-          # Fine-grained token with `contents:write` (repository_dispatch) on
-          # unionai/unionai-docs. Cross-org, so it lives in this repo's secrets.
-          GH_TOKEN: ${{ secrets.UNIONAI_DOCS_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           if [ -z "${GH_TOKEN}" ]; then
-            echo "::warning title=docs regen signal skipped::UNIONAI_DOCS_DISPATCH_TOKEN is not set — skipping the unionai-docs regen signal. Set the secret to enable it."
+            echo "::warning title=docs regen signal skipped::docsy-bot App not configured (DOCSY_BOT_APP_ID / DOCSY_BOT_PRIVATE_KEY) — skipping the unionai-docs regen signal. Set the secrets to enable it."
             exit 0
           fi
           VERSION="${GITHUB_REF#refs/tags/v}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -291,3 +291,28 @@ jobs:
           FLYTE_DOCKER_BUILDER_CACHE_TO: "type=gha,mode=max"
         run: |
           uv run python maint_tools/build_default_image.py --type connector
+
+  notify-docs:
+    name: Signal unionai-docs to regenerate API docs
+    needs: [flyte-pypi, plugin-pypi]
+    # Fire only on a real release once the core `flyte` package is on PyPI.
+    # Tolerates partial plugin-publish failures (docs regen picks up whatever is
+    # live on PyPI). Mirrors the always()+result gating used by the image job.
+    if: always() && github.event_name == 'release' && needs.flyte-pypi.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send repository_dispatch to unionai/unionai-docs
+        env:
+          # Fine-grained token with `contents:write` (repository_dispatch) on
+          # unionai/unionai-docs. Cross-org, so it lives in this repo's secrets.
+          GH_TOKEN: ${{ secrets.UNIONAI_DOCS_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::warning title=docs regen signal skipped::UNIONAI_DOCS_DISPATCH_TOKEN is not set — skipping the unionai-docs regen signal. Set the secret to enable it."
+            exit 0
+          fi
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "Signaling unionai/unionai-docs to regenerate API docs for flyte ${VERSION}"
+          gh api repos/unionai/unionai-docs/dispatches \
+            -f event_type=sdk-release \
+            -f 'client_payload[version]='"${VERSION}"


### PR DESCRIPTION
## What

Adds a `notify-docs` job to `publish.yml` that, after a release publishes `flyte` + plugins to PyPI, sends a `repository_dispatch` (`sdk-release`) to **`unionai/unionai-docs`**.

## Why

The Union.ai docs site builds its API reference from **this SDK's docstrings**. Today that regen is manual, so the published API docs lag new SDK releases. With this hook, a release automatically triggers `unionai-docs`'s `regen-api-docs.yml` workflow, which regenerates the reference and opens a **draft PR** for the docs team to review — no manual step, nothing auto-merged.

This is the **producer** side of the signal; the **consumer** workflow ([unionai-docs#1114](https://github.com/unionai/unionai-docs/pull/1114)) is **already merged** and listening for `repository_dispatch(sdk-release)` (verified green via manual dispatch).

## How auth works (GitHub App, not a PAT)

The job authenticates as the **docsy-bot GitHub App** and mints a short-lived, scoped token via `actions/create-github-app-token` (`owner: unionai, repositories: unionai-docs`). The App is **installed only on `unionai/unionai-docs`** — **not** on this repo or the flyteorg org. This repo only holds the App's credentials as secrets to request that cross-org token. (App over PAT: no expiry/rotation, scoped short-lived tokens, org-owned identity rather than a person's.)

## Behavior / safety

- **Release-only**, and only after `flyte-pypi` succeeds (`needs: [flyte-pypi, plugin-pypi]`). Tolerates partial plugin-publish failures — the docs regen picks up whatever is live on PyPI.
- **No-ops with a warning if the App secrets are absent** — the token-mint step is skipped and the job exits 0, so it can never fail a release.
- One added job; no change to any existing publish step. **No GitHub App is installed on this repo.**

## Setup status — ✅ secrets already added

The required repository secrets are **already in place on `flyteorg/flyte-sdk`**:

- **`DOCSY_BOT_APP_ID`** — the docsy-bot App's App ID ✅
- **`DOCSY_BOT_PRIVATE_KEY`** — the App's `.pem` private key ✅

(Same App is installed + configured on `unionai/unionai-docs`.) No app installation in flyteorg is needed. **So once this PR merges, the release→docs loop is fully live** — the next SDK release will auto-open a regenerated API-docs PR on `unionai-docs`.

## Provenance

Docs-pipeline plumbing authored by **docsy** (Union.ai docs automation). Left for **flyte-sdk maintainers to review + merge** (docsy does not self-merge here). Tracking: DOC-1044.

🤖 Generated with [Claude Code](https://claude.com/claude-code)