### PR TITLE
docs(cli): repoint union plugin API-ref cross-link to union-plugin (DOC-1231)

### DIFF
--- a/src/flyte/cli/_gen.py
+++ b/src/flyte/cli/_gen.py
@@ -399,7 +399,7 @@ def markdown(cfg: common.CLIConfig, plugin_variants: str | None = None):
             "> (user management, RBAC, API keys).",
             "> Install it with `pip install flyteplugins-union`.",
             ">",
-            "> See the [flyteplugins.union API reference](../integrations/union/_index)",
+            "> See the [flyteplugins.union API reference](../union-plugin/_index)",
             "> for the programmatic interface.",
             "",
         ]


### PR DESCRIPTION
## DOC-1231 — repoint union plugin API-ref cross-link (docs-serving)

`flyte gen docs` emits a "flyteplugins.union API reference" link in the generated `flyte-cli.md` (`src/flyte/cli/_gen.py`). The Union plugin API-reference section moved from `api-reference/integrations/union/` up to a top-level `api-reference/union-plugin/`, so the generated link target is updated `../integrations/union/_index` → `../union-plugin/_index`.

**Docs-serving change only** — it changes the CLI-docs generator's *output*, not SDK behavior. Part of the DOC-1231 3-PR set (content + docs-infra + this). Linear: https://linear.app/unionai/issue/DOC-1231

> Authored by the docsy docs pipeline; **eng/owner reviews + merges** (not admin-merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
