### PR TITLE
Add labels to create run and list runs

### DIFF
--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -912,7 +912,8 @@ def with_runcontext(
     :param project: Optional The project to use for the run
     :param domain: Optional The domain to use for the run
     :param env_vars: Optional Environment variables to set for the run
-    :param labels: Optional Labels to set for the run
+    :param labels: Optional user-defined labels to attach to the run as KEY=VALUE pairs, used for
+        filtering and organizing runs (e.g. ``flyte get run --with-label team=ml``)
     :param annotations: Optional Annotations to set for the run
     :param interruptible: Optional If true, the run can be scheduled on interruptible instances and false implies
         that all tasks in the run should only be scheduled on non-interruptible instances. If not specified the

--- a/src/flyte/cli/_get.py
+++ b/src/flyte/cli/_get.py
@@ -87,6 +87,22 @@ def project(cfg: common.CLIConfig, name: str | None = None, archived: bool = Fal
 @click.option(
     "--updated-before", type=_params.DateTimeType(), default=None, help="Show runs updated before this datetime (UTC)."
 )
+@click.option(
+    "--with-label",
+    "with_label",
+    type=str,
+    multiple=True,
+    default=(),
+    help="Filter runs that have this label key=value. Can be specified multiple times (AND semantics).",
+)
+@click.option(
+    "--with-label-key",
+    "with_label_key",
+    type=str,
+    multiple=True,
+    default=(),
+    help="Filter runs that have this label key present (existence check). Can be specified multiple times.",
+)
 @click.pass_obj
 def run(
     cfg: common.CLIConfig,
@@ -102,6 +118,8 @@ def run(
     created_before: dt.datetime | None = None,
     updated_after: dt.datetime | None = None,
     updated_before: dt.datetime | None = None,
+    with_label: Tuple[str, ...] = (),
+    with_label_key: Tuple[str, ...] = (),
 ):
     """
     Get a list of all runs, or details of a specific run by name.
@@ -115,6 +133,13 @@ def run(
     ```bash
     $ flyte get run --task-name my_task
     $ flyte get run --task-name my_task --task-version v1.0
+    ```
+
+    You can filter runs by their user-defined labels:
+
+    ```bash
+    $ flyte get run --with-label team=ml --with-label env=prod
+    $ flyte get run --with-label-key team
     ```
     """
 
@@ -147,6 +172,17 @@ def run(
             else None
         )
 
+        parsed_with_labels: dict[str, str] | None = None
+        if with_label:
+            parsed_with_labels = {}
+            for item in with_label:
+                if "=" not in item:
+                    raise click.BadParameter(f"Invalid --with-label value {item!r}: expected KEY=VALUE.")
+                k, v = item.split("=", 1)
+                if not k:
+                    raise click.BadParameter(f"Invalid --with-label value {item!r}: key must not be empty.")
+                parsed_with_labels[k] = v
+
         console.print(
             common.format(
                 "Runs",
@@ -158,6 +194,8 @@ def run(
                     task_version=task_version,
                     created_at=created_at,
                     updated_at=updated_at,
+                    with_labels=parsed_with_labels,
+                    with_label_keys=list(with_label_key) or None,
                 ),
                 cfg.output_format,
             )

--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -277,6 +277,18 @@ class RunArguments:
             )
         },
     )
+    label: List[str] = field(
+        default_factory=list,
+        metadata={
+            "click.option": click.Option(
+                ["--label"],
+                type=str,
+                multiple=True,
+                help="User-defined label to attach to the run. Format: KEY=VALUE. "
+                "Can be specified multiple times, e.g. `--label team=ml --label env=prod`.",
+            )
+        },
+    )
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> RunArguments:
@@ -294,6 +306,20 @@ class RunArguments:
             key, value = item.split("=", 1)
             if not key:
                 raise click.BadParameter(f"Invalid --env value {item!r}: key must not be empty.")
+            parsed[key] = value
+        return parsed
+
+    def parsed_labels(self) -> Dict[str, str] | None:
+        """Parse ``--label KEY=VALUE`` entries into a dict (returns None if none provided)."""
+        if not self.label:
+            return None
+        parsed: Dict[str, str] = {}
+        for item in self.label:
+            if "=" not in item:
+                raise click.BadParameter(f"Invalid --label value {item!r}: expected KEY=VALUE.")
+            key, value = item.split("=", 1)
+            if not key:
+                raise click.BadParameter(f"Invalid --label value {item!r}: key must not be empty.")
             parsed[key] = value
         return parsed
 
@@ -374,6 +400,7 @@ Missing required parameter(s): {", ".join(f"--{p[0]} (type: {p[1]})" for p in mi
                 debug=self.run_args.debug,
                 env_vars=self.run_args.parsed_env_vars(),
                 max_action_concurrency=self.run_args.max_action_concurrency,
+                labels=self.run_args.parsed_labels(),
             )
             result = await execution_context.run.aio(self.obj, **ctx.params)
         except Exception as e:
@@ -437,6 +464,7 @@ Missing required parameter(s): {", ".join(f"--{p[0]} (type: {p[1]})" for p in mi
                 reset_root_logger=config.reset_root_logger,
                 debug=self.run_args.debug,
                 env_vars=self.run_args.parsed_env_vars(),
+                labels=self.run_args.parsed_labels(),
                 _tracker=tracker,
             )
             return await execution_context.run.aio(self.obj, **ctx.params)
@@ -597,6 +625,7 @@ Missing required parameter(s): {", ".join(f"--{p[0]} (type: {p[1]})" for p in mi
                 debug=self.run_args.debug,
                 env_vars=self.run_args.parsed_env_vars(),
                 max_action_concurrency=self.run_args.max_action_concurrency,
+                labels=self.run_args.parsed_labels(),
             )
             result = await execution_context.run.aio(task, **ctx.params)
         except Exception as e:

--- a/src/flyte/remote/_run.py
+++ b/src/flyte/remote/_run.py
@@ -54,6 +54,8 @@ class Run(ToJSONMixin):
         domain: str | None = None,
         created_at: TimeFilter | None = None,
         updated_at: TimeFilter | None = None,
+        with_labels: dict[str, str] | None = None,
+        with_label_keys: list[str] | None = None,
     ) -> AsyncIterator[Run]:
         """
         Get all runs for the current project and domain.
@@ -68,6 +70,8 @@ class Run(ToJSONMixin):
         :param domain: The domain to list runs for. Defaults to the globally configured domain.
         :param created_at: Filter runs by creation time range.
         :param updated_at: Filter runs by last-update time range.
+        :param with_labels: Filter runs whose labels include all of these key=value pairs (AND semantics).
+        :param with_label_keys: Filter runs that have all of these label keys present (existence check).
         :return: An iterator of runs.
         """
         ensure_client()
@@ -122,6 +126,27 @@ class Run(ToJSONMixin):
             filters.extend(time_filtering("created_at", created_at))
         if updated_at:
             filters.extend(time_filtering("updated_at", updated_at))
+
+        # Label filters are expressed through the generic filter mechanism using a ``labels.<key>``
+        # field convention: ``--with-label k=v`` becomes an EQUAL match, ``--with-label-key k`` an
+        # EXISTS match. Multiple label filters are ANDed together with the other filters.
+        if with_labels:
+            for k, v in with_labels.items():
+                filters.append(
+                    list_pb2.Filter(
+                        function=list_pb2.Filter.Function.EQUAL,
+                        field=f"labels.{k}",
+                        values=[v],
+                    ),
+                )
+        if with_label_keys:
+            for k in with_label_keys:
+                filters.append(
+                    list_pb2.Filter(
+                        function=list_pb2.Filter.Function.EXISTS,
+                        field=f"labels.{k}",
+                    ),
+                )
 
         cfg = get_init_config()
         i = 0
@@ -337,6 +362,7 @@ class Run(ToJSONMixin):
         Rich representation of the Run object.
         """
         yield "url", f"[blue bold][link={self.url}]link[/link][/blue bold]"
+        yield "labels", dict(self.pb2.labels) if self.pb2.labels else {}
         yield from _action_rich_repr(self.pb2.action)
 
     def __repr__(self) -> str:


### PR DESCRIPTION
## What

Adds user-defined **run labels** to the SDK and CLI:

- `flyte run --label KEY=VALUE` — attach labels to a run (repeatable):
  ```bash
  flyte run --label team=ml --label env=prod my_workflow.py main
  ```
- `flyte get run --with-label KEY=VALUE` / `--with-label-key KEY` — filter runs by labels:
  ```bash
  flyte get run --with-label team=ml --with-label env=prod
  flyte get run --with-label-key team
  ```
- Runs now surface their labels in the rich representation.

This rebases @afbrock's #1140 (`adam/labels-part-1`) onto current `main`.

## Notes on the rebase

`main` diverged from the original PR's base, so a few adaptations were needed:

- **Single labels concept.** The current proto exposes only one labels field (`RunSpec.labels`), so the `--label` flag now feeds the existing `labels` parameter on `with_runcontext`/`_Runner` instead of introducing a parallel `run_labels` param. The original PR's `CreateRunRequest.labels` top-level field no longer exists.
- **List filtering via the generic filter API.** The proto no longer has `LabelSelector`/`label_selector`. Label filters are now expressed through the existing `list_pb2.Filter` mechanism using a `labels.<key>` field convention (`EQUAL` for `--with-label k=v`, `EXISTS` for `--with-label-key k`), ANDed with the other filters. **Backend support for the `labels.<key>` filter field should be confirmed.**

## Checks

- `make fmt` — clean
- `make mypy` — `Success: no issues found in 289 source files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
