### PR TITLE
feat(debug): SSH-into-task debug over WebSocket

### DIFF
--- a/src/flyte/_bin/runtime.py
+++ b/src/flyte/_bin/runtime.py
@@ -22,6 +22,7 @@ ORG_NAME = "_U_ORG_NAME"
 ENDPOINT_OVERRIDE = "_U_EP_OVERRIDE"
 RUN_OUTPUT_BASE_DIR = "_U_RUN_BASE"
 FLYTE_ENABLE_VSCODE_KEY = "_F_E_VS"
+FLYTE_ENABLE_SSH_KEY = "_F_E_SSH"
 
 _UNION_EAGER_API_KEY_ENV_VAR = "_UNION_EAGER_API_KEY"
 _F_PATH_REWRITE = "_F_PATH_REWRITE"
@@ -154,7 +155,12 @@ def _run_action(
 
     logger.warning(f"Flyte runtime started for action {name} with run name {run_name}")
 
-    if debug and name == "a0":
+    ssh_debug = os.getenv(FLYTE_ENABLE_SSH_KEY, "").lower() in ("1", "true", "yes")
+    if ssh_debug and name == "a0":
+        from flyte._debug.ssh import _start_ssh_server
+
+        asyncio.run(_start_ssh_server(ctx))
+    elif debug and name == "a0":
         from flyte._debug.vscode import _start_vscode_server
 
         asyncio.run(_start_vscode_server(ctx))

--- a/src/flyte/_debug/constants.py
+++ b/src/flyte/_debug/constants.py
@@ -43,3 +43,35 @@ VSCODE_READY_MESSAGE = "Vscode server is ready"
 
 # Subprocess constants
 EXIT_CODE_SUCCESS = 0
+
+# ---------------------------------------------------------------------------
+# SSH-into-task debug over WebSocket (see prds/ssh-debug-wstunnel.md)
+#
+# Parallel to the code-server path: instead of a browser IDE we start an sshd
+# bound to loopback and an in-process WebSocket->sshd bridge on the same debug
+# port the dataplane already routes to (:6060). The bridge also answers the
+# code-server HTTP readiness probe so the pod goes Ready. Auth is two independent
+# gates: whatever gates the Cloudflare/Envoy route gates *reaching* the tunnel;
+# sshd key-auth gates *the shell*.
+# ---------------------------------------------------------------------------
+
+# Env var (parallel to _F_E_VS) that flips the a0 entrypoint into ssh-debug mode.
+FLYTE_ENABLE_SSH_KEY = "_F_E_SSH"
+# Env var carrying the user's SSH *public* key contents to authorize for login.
+FLYTE_SSH_PUBKEY_KEY = "_F_SSH_PK"
+# Optional override for the ssh login user name.
+FLYTE_SSH_USER_KEY = "_F_SSH_USER"
+
+# Loopback address + port the in-pod sshd listens on. Only reachable via the bridge.
+SSHD_BIND_HOST = "127.0.0.1"
+SSHD_PORT = 2222
+# The routed debug port the dataplane forwards to (same one code-server uses).
+WSTUNNEL_PORT = VSCODE_PORT  # 6060
+
+# Where ssh-debug scratch (host key, sshd_config, authorized_keys) is written.
+SSH_DEBUG_DIR = Path.home() / ".flyte-ssh-debug"
+
+# Printed in the cluster logs once sshd + the WS bridge are accepting connections.
+SSH_READY_MESSAGE = "SSH debug server is ready"
+# The login user defaults to whoever the container runs as.
+DEFAULT_SSH_USER = "root"

--- a/src/flyte/_debug/ssh.py
+++ b/src/flyte/_debug/ssh.py
@@ -1,0 +1,560 @@
+"""SSH-into-task debug over WebSocket.
+
+Pod-side counterpart to ``_debug/vscode.py``. Instead of a browser code-server
+this starts a real ``sshd`` bound to loopback and a small in-process server on
+the debug port the dataplane already routes to (:6060) that (a) answers the
+cluster's code-server HTTP readiness probe with 200 so the pod goes Ready, and
+(b) terminates incoming WebSockets and bridges them to the local sshd.
+
+```
+desktop ssh -> ws stdio proxy (ProxyCommand) -> wss:// -> Cloudflare
+   -> Envoy (per-pod :6060 route) -> pod: ws bridge -> 127.0.0.1:2222 sshd
+```
+
+We terminate the WebSocket in-process (rather than running ``wstunnel server``)
+because the dataplane rewrites the request path to ``/?target_port=6060``, which
+would clobber wstunnel's path-encoded tunnel addressing. The matching client is
+``flyteplugins.union.remote._ws_proxy`` (a standard-WebSocket stdio proxy).
+
+Triggered by the ``_F_E_SSH`` env var (parallel to ``_F_E_VS``); the user's
+public key arrives via ``_F_SSH_PK``. See ``prds/ssh-debug-wstunnel.md``.
+"""
+
+import asyncio
+import base64
+import getpass
+import hashlib
+import os
+import shutil
+import struct
+import subprocess
+import sys
+from contextlib import suppress
+from pathlib import Path
+from typing import Optional
+
+from flyte._debug.constants import (
+    DEFAULT_SSH_USER,
+    DEFAULT_UP_SECONDS,
+    FLYTE_SSH_PUBKEY_KEY,
+    FLYTE_SSH_USER_KEY,
+    SSH_DEBUG_DIR,
+    SSH_READY_MESSAGE,
+    SSHD_BIND_HOST,
+    SSHD_PORT,
+    WSTUNNEL_PORT,
+)
+from flyte._logging import logger
+
+# Largest WebSocket frame payload we'll accept from a client (defense-in-depth;
+# the peer is our own ws proxy behind the authenticated ingress). 64 MiB.
+_MAX_WS_FRAME = 64 * 1024 * 1024
+
+
+def _get_pubkey() -> str:
+    """Read the authorized public key from the environment."""
+    pubkey = os.getenv(FLYTE_SSH_PUBKEY_KEY)
+    if not pubkey or not pubkey.strip():
+        raise RuntimeError(
+            f"SSH debug mode requires a public key. Set {FLYTE_SSH_PUBKEY_KEY} to the contents of your "
+            "`~/.ssh/id_ed25519.pub` (e.g. via flyte.with_runcontext(env_vars=...))."
+        )
+    return pubkey.strip()
+
+
+def _get_ssh_user() -> str:
+    """The login user for the ssh shell (defaults to the container user)."""
+    override = os.getenv(FLYTE_SSH_USER_KEY)
+    if override:
+        return override
+    try:
+        return getpass.getuser()
+    except Exception:
+        return DEFAULT_SSH_USER
+
+
+class Sshd:
+    """Manages the in-pod sshd lifecycle: locate/install, configure, start, stop.
+
+    Everything sshd-specific lives here — finding (or apt-installing) the binary,
+    generating the host key, writing the authorized_keys + a minimal key-only
+    config, and running/terminating the daemon. Bound to loopback; only reachable
+    via the WebSocket bridge.
+    """
+
+    def __init__(
+        self,
+        pubkey: str,
+        *,
+        user: Optional[str] = None,
+        host: str = SSHD_BIND_HOST,
+        port: int = SSHD_PORT,
+        scratch_dir: Path = SSH_DEBUG_DIR,
+    ):
+        self.pubkey = pubkey.strip()
+        self.user = user or _get_ssh_user()
+        self.host = host
+        self.port = port
+        self.scratch = Path(scratch_dir)
+        self._proc: Optional[asyncio.subprocess.Process] = None
+
+    # -- setup ---------------------------------------------------------------
+
+    @staticmethod
+    def find_binary() -> str:
+        """Locate the sshd binary, attempting a best-effort install if missing."""
+        sshd = shutil.which("sshd")
+        if sshd is None:
+            for candidate in ("/usr/sbin/sshd", "/usr/local/sbin/sshd"):
+                if os.path.exists(candidate):
+                    sshd = candidate
+                    break
+        if sshd is not None:
+            return sshd
+
+        # Best-effort install on Debian/Ubuntu base images. Most images won't
+        # have openssh-server; bake it in for fast cold starts.
+        logger.info("sshd not found, attempting best-effort install of openssh-server...")
+        try:
+            subprocess.run(["apt-get", "update", "-y"], check=True, capture_output=True)
+            subprocess.run(
+                ["apt-get", "install", "-y", "--no-install-recommends", "openssh-server"],
+                check=True,
+                capture_output=True,
+            )
+        except Exception as e:
+            raise RuntimeError(
+                "sshd is not installed and automatic install failed. Bake `openssh-server` into the task "
+                f"image to use ssh debug. Underlying error: {e}"
+            )
+        sshd = shutil.which("sshd") or "/usr/sbin/sshd"
+        if not os.path.exists(sshd):
+            raise RuntimeError("sshd still not found after install attempt; bake `openssh-server` into the image.")
+        return sshd
+
+    def _write_authorized_keys(self) -> Path:
+        """Write the user's public key to an sshd-readable authorized_keys file."""
+        self.scratch.mkdir(parents=True, exist_ok=True)
+        auth_keys = self.scratch / "authorized_keys"
+        auth_keys.write_text(self.pubkey + "\n")
+        auth_keys.chmod(0o600)
+        return auth_keys
+
+    def _generate_host_key(self) -> Path:
+        """Generate an ed25519 host key for the in-pod sshd (idempotent)."""
+        host_key = self.scratch / "ssh_host_ed25519_key"
+        if not host_key.exists():
+            subprocess.run(
+                ["ssh-keygen", "-t", "ed25519", "-f", str(host_key), "-N", "", "-q"],
+                check=True,
+                capture_output=True,
+            )
+        host_key.chmod(0o600)
+        return host_key
+
+    def _render_config(self, host_key: Path, authorized_keys: Path) -> Path:
+        """Render a minimal, key-only sshd_config bound to loopback."""
+        config_path = self.scratch / "sshd_config"
+        pid_path = self.scratch / "sshd.pid"
+        # internal-sftp: required by VS Code Remote-SSH (no external sftp-server binary).
+        # StrictModes off avoids permission-mode failures on the scratch dir; key file is 0600.
+        config_path.write_text(
+            f"""\
+Port {self.port}
+ListenAddress {self.host}
+HostKey {host_key}
+PidFile {pid_path}
+AuthorizedKeysFile {authorized_keys}
+PasswordAuthentication no
+PubkeyAuthentication yes
+PermitRootLogin yes
+KbdInteractiveAuthentication no
+ChallengeResponseAuthentication no
+UsePAM no
+StrictModes no
+PrintMotd no
+X11Forwarding no
+AllowTcpForwarding yes
+PermitTunnel yes
+Subsystem sftp internal-sftp
+LogLevel INFO
+"""
+        )
+        return config_path
+
+    @staticmethod
+    def _ensure_privsep_dir() -> None:
+        """sshd needs a privilege-separation dir (/run/sshd) to exist."""
+        for d in ("/run/sshd", "/var/run/sshd"):
+            try:
+                os.makedirs(d, exist_ok=True)
+                os.chmod(d, 0o755)
+            except Exception as e:
+                logger.debug(f"Could not create privsep dir {d}: {e}")
+
+    # -- lifecycle -----------------------------------------------------------
+
+    async def start(self) -> None:
+        """Configure and launch sshd in the foreground as a child process."""
+        binary = self.find_binary()
+        self._ensure_privsep_dir()
+        authorized_keys = self._write_authorized_keys()
+        host_key = self._generate_host_key()
+        config = self._render_config(host_key, authorized_keys)
+        logger.info(f"Starting sshd ({binary}) on {self.host}:{self.port} for user {self.user!r}")
+        # -D foreground, -e log to stderr, -f config.
+        self._proc = await asyncio.create_subprocess_exec(binary, "-D", "-e", "-f", str(config))
+
+    @property
+    def returncode(self) -> Optional[int]:
+        return self._proc.returncode if self._proc else None
+
+    async def wait(self, timeout: Optional[float] = None) -> None:
+        """Block until sshd exits (or *timeout* elapses, raising TimeoutError)."""
+        if self._proc is None:
+            return
+        await asyncio.wait_for(self._proc.wait(), timeout=timeout)
+
+    async def stop(self) -> None:
+        """Terminate sshd and reap it (best-effort)."""
+        if self._proc is None or self._proc.returncode is not None:
+            return
+        self._proc.terminate()
+        with suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(self._proc.wait(), timeout=5)
+
+
+def _write_debug_helpers(ctx) -> Optional[str]:
+    """Drop debugger entrypoints into the workspace so you can pdb/VS Code the task.
+
+    Like the code-server path, the ssh server blocks the runtime *before* the
+    task body runs — so you attach a shell to a live pod and launch the task
+    yourself. This writes:
+
+    - ``.vscode/launch.json`` (reused from the code-server path) so VS Code
+      Remote-SSH can run "Interactive Debugging" with the exact entrypoint args.
+    - ``flyte-debug-task.sh`` — the same entrypoint under ``python -m pdb`` for a
+      plain terminal debugger.
+
+    Returns the path to the pdb helper script, or ``None`` if ctx is unavailable.
+    """
+    if ctx is None:
+        return None
+    try:
+        import sys as _sys
+        from pathlib import Path as _Path
+
+        from flyte._debug.vscode import prepare_launch_json
+
+        # Reuse the code-server launch.json generator (writes .vscode/launch.json).
+        prepare_launch_json(ctx, pid=0)
+
+        # Build the same program + args as the "Interactive Debugging" config and
+        # wrap them in `python -m pdb` for a terminal session.
+        launch_json = _Path(os.getcwd()) / ".vscode" / "launch.json"
+        import json as _json
+
+        cfg = _json.loads(launch_json.read_text())
+        interactive = next(c for c in cfg["configurations"] if c["name"] == "Interactive Debugging")
+        program = interactive["program"]
+        args = interactive["args"]
+        quoted = " ".join(f"'{a}'" for a in args)
+        script = SSH_DEBUG_DIR / "flyte-debug-task.sh"
+        script.write_text(
+            "#!/usr/bin/env bash\n"
+            "# Run the task entrypoint under pdb. Set a breakpoint() in your task,\n"
+            "# or step from the top. Same args VS Code's 'Interactive Debugging' uses.\n"
+            f"exec {_sys.executable} -m pdb {program} {quoted}\n"
+        )
+        script.chmod(0o755)
+        return str(script)
+    except Exception as e:
+        logger.debug(f"Could not write debug helpers: {e}")
+        return None
+
+
+_WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+
+def _ws_accept_key(client_key: str) -> str:
+    """RFC6455 Sec-WebSocket-Accept for a given Sec-WebSocket-Key."""
+    digest = hashlib.sha1((client_key + _WS_GUID).encode()).digest()
+    return base64.b64encode(digest).decode()
+
+
+def _ws_frame(payload: bytes, opcode: int = 0x2) -> bytes:
+    """Encode a server->client WebSocket frame (FIN set, unmasked)."""
+    out = bytearray([0x80 | opcode])
+    n = len(payload)
+    if n < 126:
+        out.append(n)
+    elif n < 65536:
+        out.append(126)
+        out += struct.pack(">H", n)
+    else:
+        out.append(127)
+        out += struct.pack(">Q", n)
+    out += payload
+    return bytes(out)
+
+
+async def _ws_read_frame(reader: asyncio.StreamReader):
+    """Read one client->server frame. Returns (opcode, payload) or None at EOF."""
+    try:
+        b0, b1 = await reader.readexactly(2)
+    except asyncio.IncompleteReadError:
+        return None
+    opcode = b0 & 0x0F
+    masked = b1 & 0x80
+    length = b1 & 0x7F
+    if length == 126:
+        length = struct.unpack(">H", await reader.readexactly(2))[0]
+    elif length == 127:
+        length = struct.unpack(">Q", await reader.readexactly(8))[0]
+    if length > _MAX_WS_FRAME:
+        raise ValueError(f"WebSocket frame too large: {length} bytes")
+    mask = await reader.readexactly(4) if masked else b""
+    payload = await reader.readexactly(length) if length else b""
+    if masked and payload:
+        # Unmask in place; the masked direction (client->server) is ssh *input*,
+        # which is small. Bulk output (server->client) is unmasked, so no cost there.
+        ba = bytearray(payload)
+        for i in range(length):
+            ba[i] ^= mask[i & 3]
+        payload = bytes(ba)
+    return opcode, payload
+
+
+async def _ws_to_tcp(reader: asyncio.StreamReader, tcp_writer: asyncio.StreamWriter, safe_send):
+    """Pump client WS frames -> sshd bytes; answer pings; stop on close/EOF."""
+    try:
+        while True:
+            frame = await _ws_read_frame(reader)
+            if frame is None:
+                break
+            opcode, payload = frame
+            if opcode == 0x8:  # close
+                break
+            if opcode == 0x9:  # ping -> must pong, or the client tears down the connection
+                await safe_send(_ws_frame(payload, opcode=0xA))
+                continue
+            if opcode == 0xA:  # pong -> ignore
+                continue
+            if opcode in (0x0, 0x1, 0x2):  # continuation / text / binary -> ssh bytes
+                tcp_writer.write(payload)
+                await tcp_writer.drain()
+    except Exception:
+        pass
+    finally:
+        try:
+            tcp_writer.close()
+        except Exception:
+            pass
+
+
+async def _tcp_to_ws(tcp_reader: asyncio.StreamReader, safe_send):
+    """Pump sshd bytes -> client WS binary frames; send a close frame at EOF."""
+    try:
+        while True:
+            chunk = await tcp_reader.read(65536)
+            if not chunk:
+                break
+            await safe_send(_ws_frame(chunk))
+    except Exception:
+        pass
+    finally:
+        try:
+            await safe_send(_ws_frame(b"", opcode=0x8))  # close frame
+        except Exception:
+            pass
+
+
+class WsBridge:
+    """Readiness endpoint + WebSocket->sshd bridge on the routed debug port.
+
+    Two jobs on the one port the dataplane routes to:
+      1. Plain HTTP GET (the cluster's code-server readiness probe) -> 200, so the
+         pod goes Ready and the dataplane actually routes to it (else 503).
+      2. WebSocket upgrade -> complete the handshake and bridge the WS payload to
+         the local sshd at ``sshd_host:sshd_port``.
+
+    We terminate the WebSocket here (rather than running ``wstunnel server``)
+    because the dataplane rewrites the request path to ``/?target_port=6060``,
+    which clobbers wstunnel's path-encoded tunnel addressing. A raw WS bridge
+    ignores the path entirely, so it survives the rewrite. The client side uses
+    any standard WS tunnel (e.g. websocat, or the bundled stdio proxy).
+    """
+
+    def __init__(
+        self,
+        *,
+        sshd_host: str = SSHD_BIND_HOST,
+        sshd_port: int = SSHD_PORT,
+        listen_port: int = WSTUNNEL_PORT,
+    ):
+        self.sshd_host = sshd_host
+        self.sshd_port = sshd_port
+        self.listen_port = listen_port
+        self._server: Optional[asyncio.AbstractServer] = None
+
+    async def start(self) -> None:
+        self._server = await asyncio.start_server(self._handle, "0.0.0.0", self.listen_port)
+        logger.info(
+            f"ws->sshd bridge + readiness on 0.0.0.0:{self.listen_port} -> sshd {self.sshd_host}:{self.sshd_port}"
+        )
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            with suppress(Exception):
+                await self._server.wait_closed()
+
+    async def _handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        # readuntil consumes exactly through the header terminator and leaves any
+        # bytes after it (e.g. a coalesced first WS frame) in the reader buffer,
+        # so the frame reader below doesn't lose them.
+        try:
+            head = await reader.readuntil(b"\r\n\r\n")
+        except Exception:
+            writer.close()
+            return
+
+        if b"upgrade: websocket" not in head.lower():
+            # Readiness probe (or any non-WS request) -> 200 so k8s marks Ready.
+            writer.write(
+                b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"
+            )
+            try:
+                await writer.drain()
+            finally:
+                writer.close()
+            return
+
+        # Parse Sec-WebSocket-Key and complete the handshake.
+        key = None
+        for line in head.split(b"\r\n"):
+            if line.lower().startswith(b"sec-websocket-key:"):
+                key = line.split(b":", 1)[1].strip().decode()
+                break
+        if not key:
+            writer.write(b"HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n")
+            await writer.drain()
+            writer.close()
+            return
+
+        accept = _ws_accept_key(key)
+        writer.write(
+            (
+                "HTTP/1.1 101 Switching Protocols\r\n"
+                "Upgrade: websocket\r\n"
+                "Connection: Upgrade\r\n"
+                f"Sec-WebSocket-Accept: {accept}\r\n\r\n"
+            ).encode()
+        )
+        await writer.drain()
+
+        # All frames to the client go through one lock: data, pong, and close can
+        # otherwise interleave from the two pumps and corrupt the WS stream.
+        write_lock = asyncio.Lock()
+
+        async def safe_send(frame: bytes):
+            async with write_lock:
+                writer.write(frame)
+                await writer.drain()
+
+        try:
+            tcp_reader, tcp_writer = await asyncio.open_connection(self.sshd_host, self.sshd_port)
+        except Exception as e:
+            logger.debug(f"ws bridge could not reach sshd: {e}")
+            writer.close()
+            return
+        try:
+            await asyncio.gather(
+                _ws_to_tcp(reader, tcp_writer, safe_send),
+                _tcp_to_ws(tcp_reader, safe_send),
+            )
+        finally:
+            try:
+                writer.close()
+            except Exception:
+                pass
+
+
+async def _prepare_workspace(ctx) -> Optional[str]:
+    """Download+extract the task code bundle and make login shells start there.
+
+    The ssh server blocks the entrypoint *before* the normal code-bundle download
+    runs, so — exactly like ``_start_vscode_server`` — we fetch it here. Otherwise
+    you ssh in and the task code isn't on disk. Returns the absolute code dir.
+    """
+    if ctx is None:
+        return None
+    tgz = ctx.params.get("tgz")
+    dest = ctx.params.get("dest") or "."
+    code_dir = os.path.abspath(dest)
+    if tgz:
+        try:
+            from flyte._internal.runtime.rusty import download_tgz
+
+            await download_tgz(dest, ctx.params["version"], tgz)
+            logger.info(f"Downloaded task code bundle into {code_dir}")
+        except Exception as e:
+            logger.warning(f"Could not download code bundle ({e}); the workspace may be empty.")
+
+    # Login shells default to the user's $HOME (e.g. /root); drop a profile hook
+    # so an interactive ssh session lands in the code dir instead.
+    _write_login_cd_hook(code_dir)
+    return code_dir
+
+
+def _write_login_cd_hook(code_dir: str):
+    """Make interactive login shells start in the task code directory."""
+    try:
+        os.makedirs("/etc/profile.d", exist_ok=True)
+        Path("/etc/profile.d/zz-flyte-debug.sh").write_text(f'cd "{code_dir}" 2>/dev/null || true\n')
+    except Exception as e:
+        logger.debug(f"Could not write login-shell cd hook: {e}")
+
+
+async def _start_ssh_server(ctx=None):
+    """Start sshd + the in-process WS bridge, then block until uptime/death.
+
+    ``ctx`` carries the runtime args (code bundle, dest, version) used to stage
+    the workspace and the debug helpers.
+    """
+    sshd = Sshd(_get_pubkey(), user=_get_ssh_user())
+
+    # Stage the task code (the entrypoint is blocked here before the normal
+    # download), and land interactive ssh sessions in that directory.
+    code_dir = await _prepare_workspace(ctx)
+
+    await sshd.start()
+
+    # The in-process WS bridge answers the readiness probe AND terminates the
+    # WebSocket, forwarding to the local sshd. No wstunnel server needed on the
+    # pod (the dataplane's path rewrite would break wstunnel's path addressing).
+    bridge = WsBridge(sshd_host=sshd.host, sshd_port=sshd.port)
+    await bridge.start()
+
+    # Drop a launch.json + pdb helper so you can debug the task once attached.
+    pdb_script = _write_debug_helpers(ctx)
+
+    logger.info(SSH_READY_MESSAGE)
+    if code_dir:
+        logger.info(f"Task code is at {code_dir} (ssh sessions start there; open this folder in VS Code).")
+    if pdb_script:
+        logger.info("Once connected, debug the task with pdb:")
+        logger.info(f"  ssh flyte-debug -t 'bash {pdb_script}'")
+        logger.info("…or open the folder in VS Code Remote-SSH and run 'Interactive Debugging' (F5).")
+
+    max_uptime = int(os.getenv("SSH_SERVER_MAX_UPTIME_SECONDS", str(DEFAULT_UP_SECONDS)))
+    try:
+        # Block until sshd exits or we hit the max-uptime ceiling.
+        await sshd.wait(timeout=max_uptime)
+        logger.info("sshd exited; shutting down SSH debug server.")
+    except asyncio.TimeoutError:
+        logger.info(f"SSH debug server exceeded max uptime ({max_uptime}s). Terminating...")
+    finally:
+        await bridge.stop()
+        await sshd.stop()
+    sys.exit()

--- a/tests/flyte/test_ssh_debug.py
+++ b/tests/flyte/test_ssh_debug.py
@@ -1,0 +1,219 @@
+"""Tests for the pod-side SSH-into-task debug server (flyte._debug.ssh).
+
+Covers the pure WebSocket framing helpers, the sshd config / authorized-keys
+rendering, and an end-to-end exercise of the in-process WS->sshd bridge against
+a fake echo "sshd".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import struct
+
+import pytest
+
+from flyte._debug import ssh
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _client_frame(payload: bytes, opcode: int = 0x2) -> bytes:
+    """Build a masked client->server WebSocket frame (clients MUST mask, RFC6455)."""
+    mask = os.urandom(4)
+    masked = bytes(payload[i] ^ mask[i % 4] for i in range(len(payload)))
+    n = len(payload)
+    hdr = bytearray([0x80 | opcode])
+    if n < 126:
+        hdr.append(0x80 | n)
+    elif n < 65536:
+        hdr.append(0x80 | 126)
+        hdr += struct.pack(">H", n)
+    else:
+        hdr.append(0x80 | 127)
+        hdr += struct.pack(">Q", n)
+    return bytes(hdr) + mask + masked
+
+
+# ---------------------------------------------------------------------------
+# WebSocket framing
+# ---------------------------------------------------------------------------
+
+
+class TestWsAcceptKey:
+    def test_rfc6455_vector(self):
+        # The canonical example from RFC 6455 section 1.3.
+        assert ssh._ws_accept_key("dGhlIHNhbXBsZSBub25jZQ==") == "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+
+
+class TestWsFrameRoundtrip:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("size", [0, 5, 125, 126, 200, 70000])
+    async def test_masked_client_frame_decodes(self, size):
+        payload = os.urandom(size)
+        reader = asyncio.StreamReader()
+        reader.feed_data(_client_frame(payload))
+        reader.feed_eof()
+        result = await ssh._ws_read_frame(reader)
+        assert result is not None
+        opcode, got = result
+        assert opcode == 0x2
+        assert got == payload
+
+    @pytest.mark.asyncio
+    async def test_server_frame_is_unmasked_and_roundtrips(self):
+        payload = b"hello-from-server"
+        frame = ssh._ws_frame(payload)
+        # MASK bit (0x80 of the 2nd byte) must be clear on server frames.
+        assert frame[1] & 0x80 == 0
+        reader = asyncio.StreamReader()
+        reader.feed_data(frame)
+        reader.feed_eof()
+        opcode, got = await ssh._ws_read_frame(reader)
+        assert opcode == 0x2
+        assert got == payload
+
+    @pytest.mark.asyncio
+    async def test_eof_returns_none(self):
+        reader = asyncio.StreamReader()
+        reader.feed_eof()
+        assert await ssh._ws_read_frame(reader) is None
+
+    @pytest.mark.asyncio
+    async def test_oversize_frame_rejected(self, monkeypatch):
+        monkeypatch.setattr(ssh, "_MAX_WS_FRAME", 10)
+        reader = asyncio.StreamReader()
+        reader.feed_data(_client_frame(b"x" * 50))
+        reader.feed_eof()
+        with pytest.raises(ValueError):
+            await ssh._ws_read_frame(reader)
+
+
+# ---------------------------------------------------------------------------
+# sshd config / authorized keys
+# ---------------------------------------------------------------------------
+
+
+class TestSshdConfigAndKeys:
+    def test_authorized_keys_written_0600(self, tmp_path):
+        sshd = ssh.Sshd("ssh-ed25519 AAAA... user@host", user="root", scratch_dir=tmp_path)
+        p = sshd._write_authorized_keys()
+        assert p.read_text() == "ssh-ed25519 AAAA... user@host\n"
+        assert (p.stat().st_mode & 0o777) == 0o600
+
+    def test_sshd_config_directives(self, tmp_path):
+        sshd = ssh.Sshd("pk", user="root", host="127.0.0.1", port=2222, scratch_dir=tmp_path)
+        cfg = sshd._render_config(tmp_path / "hostkey", tmp_path / "authorized_keys").read_text()
+        assert "Port 2222" in cfg
+        assert "ListenAddress 127.0.0.1" in cfg
+        assert "PasswordAuthentication no" in cfg
+        assert "PubkeyAuthentication yes" in cfg
+        # VS Code Remote-SSH needs sftp; ssh -L (debugpy) needs forwarding.
+        assert "Subsystem sftp internal-sftp" in cfg
+        assert "AllowTcpForwarding yes" in cfg
+
+    def test_user_defaults_to_container_user(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("_F_SSH_USER", "flyte")
+        assert ssh.Sshd("pk", scratch_dir=tmp_path).user == "flyte"
+
+    def test_find_binary_locates_sshd(self):
+        import shutil
+
+        if not (shutil.which("sshd") or any(__import__("os").path.exists(p) for p in ("/usr/sbin/sshd",))):
+            pytest.skip("sshd not installed")
+        assert ssh.Sshd.find_binary().endswith("sshd")
+
+    def test_get_ssh_user_env_override(self, monkeypatch):
+        monkeypatch.setenv("_F_SSH_USER", "flyte")
+        assert ssh._get_ssh_user() == "flyte"
+
+    def test_get_pubkey_missing_raises(self, monkeypatch):
+        monkeypatch.delenv("_F_SSH_PK", raising=False)
+        with pytest.raises(RuntimeError):
+            ssh._get_pubkey()
+
+
+# ---------------------------------------------------------------------------
+# WS -> sshd bridge (end to end against a fake echo "sshd")
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bridge_readiness_probe_returns_200():
+    bridge_port = _free_port()
+    # nothing listening on sshd_port; the probe path must not touch it
+    bridge = ssh.WsBridge(sshd_port=_free_port(), listen_port=bridge_port)
+    await bridge.start()
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", bridge_port)
+        writer.write(b"GET /healthz HTTP/1.1\r\nHost: x\r\n\r\n")
+        await writer.drain()
+        resp = await asyncio.wait_for(reader.read(200), timeout=5)
+        assert b"200 OK" in resp
+        writer.close()
+    finally:
+        await bridge.stop()
+
+
+@pytest.mark.asyncio
+async def test_bridge_websocket_to_sshd_echo():
+    sshd_port = _free_port()
+    bridge_port = _free_port()
+
+    # Fake "sshd": echo every byte back.
+    async def _echo(r, w):
+        while True:
+            chunk = await r.read(4096)
+            if not chunk:
+                break
+            w.write(chunk)
+            await w.drain()
+        w.close()
+
+    fake_sshd = await asyncio.start_server(_echo, "127.0.0.1", sshd_port)
+    bridge = ssh.WsBridge(sshd_host="127.0.0.1", sshd_port=sshd_port, listen_port=bridge_port)
+    await bridge.start()
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", bridge_port)
+        # Send a WS upgrade (path is irrelevant to the bridge, mirroring the dataplane rewrite).
+        writer.write(
+            b"GET /?target_port=6060 HTTP/1.1\r\n"
+            b"Host: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n"
+            b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n"
+        )
+        await writer.drain()
+        head = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=5)
+        assert b"101 Switching Protocols" in head
+        assert b"Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=" in head
+
+        # Push bytes through the WS; expect them echoed back inside a server frame.
+        writer.write(_client_frame(b"ping-through-tunnel"))
+        await writer.drain()
+        opcode, payload = await asyncio.wait_for(ssh._ws_read_frame(reader), timeout=5)
+        assert opcode == 0x2
+        assert payload == b"ping-through-tunnel"
+        writer.close()
+    finally:
+        await bridge.stop()
+        fake_sshd.close()
+
+
+@pytest.mark.asyncio
+async def test_wsbridge_start_stop_idempotent():
+    bridge = ssh.WsBridge(sshd_port=_free_port(), listen_port=_free_port())
+    await bridge.start()
+    # serving now; probe succeeds
+    reader, writer = await asyncio.open_connection("127.0.0.1", bridge.listen_port)
+    writer.write(b"GET / HTTP/1.1\r\n\r\n")
+    await writer.drain()
+    assert b"200 OK" in await asyncio.wait_for(reader.read(100), timeout=5)
+    writer.close()
+    await bridge.stop()
+    await bridge.stop()  # second stop is a no-op, must not raise


### PR DESCRIPTION
## SSH-into-task debug over WebSocket (pod side)

Adds an `_F_E_SSH` debug mode — a real-ssh sibling to the existing browser code-server `_F_E_VS` path. On the `a0` entrypoint it starts an `sshd` bound to `127.0.0.1:2222` and an in-process **WebSocket→sshd bridge** on the routed debug port (`:6060`), so a developer can attach plain `ssh`, `scp`/`rsync`, or **VS Code Remote-SSH** to a running task pod.

Enabled via the `_F_E_SSH` env var (the SSH public key is injected via `_F_SSH_PK`), e.g. through `flyte.with_runcontext(env_vars=...)`. This PR is the **pod-side server only**; the matching desktop client is provided separately.


### What's here
- **`Sshd`** class — daemon lifecycle: locate / best-effort apt-install the binary, generate the host key, write `authorized_keys` + a minimal key-only `sshd_config`, `start()` (asyncio subprocess) / `wait(timeout)` / `stop()`.
- **`WsBridge`** class — readiness endpoint + WebSocket↔sshd bridge: `start()`/`stop()`; handles concurrent connections, ping/pong keepalive, and serializes frame writes under a lock.
- key-only sshd with `internal-sftp` (VS Code Remote-SSH) and `AllowTcpForwarding` (`ssh -L` / debugpy).
- stages the code bundle and writes `.vscode/launch.json` + a `python -m pdb` helper; interactive shells land in the code dir.
- async-first throughout; `sys.exit()` after a max-uptime ceiling.

### Tests
`tests/flyte/test_ssh_debug.py` (19): WS frame roundtrip (masked/large/oversize), RFC6455 accept key, `Sshd` config/keys/`find_binary`, `WsBridge` start/stop, and an **end-to-end WS→sshd bridge echo**. ruff clean.

### Verified on cluster
Built the wheel, launched a debug run, resolved the route, then `ssh` → landed a root shell in `/home/flyte` with the task code present (connected first attempt).

