### PR TITLE
fix: raise InitializationError for malformed API key

### DIFF
--- a/src/flyte/remote/_client/auth/_auth_utils.py
+++ b/src/flyte/remote/_client/auth/_auth_utils.py
@@ -1,15 +1,36 @@
 from __future__ import annotations
 
 import base64
+import binascii
 from typing import Literal
 
 
 def decode_api_key(encoded_str: str) -> tuple[str, str, str, str | Literal["None"]]:
     """Decode encoded base64 string into app credentials. endpoint, client_id, client_secret, org"""
+    from flyte.errors import InitializationError
+
     # Split with maxsplit=3 to handle endpoints with colons (e.g., dns:///endpoint.com)
-    parts = base64.b64decode(encoded_str.encode("utf-8")).decode("utf-8").split(":", 3)
+    try:
+        decoded = base64.b64decode(encoded_str.encode("utf-8")).decode("utf-8")
+    except (binascii.Error, ValueError, UnicodeDecodeError) as e:
+        # A malformed/garbled API key (e.g. truncated or hand-edited) is user input, not an
+        # SDK bug. Raise a typed user error so it surfaces with a clear message and is filtered
+        # from crash reporting instead of leaking as a raw base64/binascii error (FLYTE-SDK-5C).
+        raise InitializationError(
+            "InvalidApiKey",
+            "user",
+            "Invalid API key: the value is not a valid base64-encoded key. "
+            "Re-copy the API key from the Union console and try again.",
+        ) from e
+
+    parts = decoded.split(":", 3)
     if len(parts) != 4:
-        raise ValueError(f"Invalid API key format. Expected 4 parts separated by ':', got {len(parts)}")
+        raise InitializationError(
+            "InvalidApiKey",
+            "user",
+            f"Invalid API key format. Expected 4 parts separated by ':', got {len(parts)}. "
+            "Re-copy the API key from the Union console and try again.",
+        )
 
     endpoint, client_id, client_secret, org = parts
     # For consistency, let's make sure org is always a non-empty string

--- a/tests/flyte/internal/test_auth_utils.py
+++ b/tests/flyte/internal/test_auth_utils.py
@@ -1,5 +1,8 @@
+import base64
+
 import pytest
 
+from flyte.errors import InitializationError
 from flyte.remote._client.auth._auth_utils import decode_api_key
 
 
@@ -9,3 +12,33 @@ def test_decode():
     assert endpoint == "dogfood-gcp.cloud-staging.union.ai"
     assert org == "None"
     assert client_id == "dogfood-gcp-EAGER_API_KEY"
+
+
+def test_decode_valid_api_key():
+    raw = "example.union.ai:my-client-id:my-secret:my-org"
+    encoded = base64.b64encode(raw.encode("utf-8")).decode("utf-8")
+    endpoint, client_id, client_secret, org = decode_api_key(encoded)
+    assert endpoint == "example.union.ai"
+    assert client_id == "my-client-id"
+    assert client_secret == "my-secret"
+    assert org == "my-org"
+
+
+def test_decode_malformed_base64_raises_initialization_error():
+    """A garbled API key (invalid base64) must raise a typed user error, not leak a raw
+    binascii error as a crash report (FLYTE-SDK-5C)."""
+    # 5 data characters -> count is 1 more than a multiple of 4 -> binascii.Error
+    with pytest.raises(InitializationError) as exc_info:
+        decode_api_key("AAAAA")
+    assert exc_info.value.kind == "user"
+    assert exc_info.value.code == "InvalidApiKey"
+
+
+def test_decode_wrong_part_count_raises_initialization_error():
+    """A well-formed base64 value that does not contain 4 ':'-separated parts is also user
+    input error, surfaced as the same typed user error."""
+    encoded = base64.b64encode(b"only-one-part").decode("utf-8")
+    with pytest.raises(InitializationError) as exc_info:
+        decode_api_key(encoded)
+    assert exc_info.value.kind == "user"
+    assert exc_info.value.code == "InvalidApiKey"


### PR DESCRIPTION
## Problem
A garbled / truncated API key (invalid base64) caused `decode_api_key` to leak a raw `binascii.Error` ("Invalid base64-encoded string: number of data characters … cannot be 1 more than a multiple of 4") as a crash report — surfaced in Sentry as **FLYTE-SDK-5C** (via `flyte.cli._common.initialize_config` → `decode_api_key` → `base64.b64decode`). This is bad user input, not an SDK bug.

## Fix
Wrap the base64 decode (and the existing part-count check) in a typed `InitializationError(code="InvalidApiKey", kind="user")`:
- Clear, actionable message ("Re-copy the API key from the Union console").
- `InitializationError` is in the `_is_user_error` allowlist (`_sentry.py`), so it is filtered from crash reporting instead of leaking.

## Tests
Added `test_auth_utils` cases for a valid key, malformed base64, and wrong part count.

fixes FLYTE-SDK-5C