### PR TITLE
fix: raise CodeBundleError for bad Environment.include paths

### DIFF
--- a/src/flyte/_code_bundle/_utils.py
+++ b/src/flyte/_code_bundle/_utils.py
@@ -170,7 +170,9 @@ def ls_files(
             else:
                 matched = glob.glob(str(p))
                 if not matched:
-                    raise ValueError(f"include path {entry!r} is not a file, directory, or matching glob pattern.")
+                    from flyte.errors import CodeBundleError
+
+                    raise CodeBundleError(f"include path {entry!r} is not a file, directory, or matching glob pattern.")
                 extra_paths.extend(m for m in matched if pathlib.Path(m).is_file())
 
         existing = set(all_files)
@@ -182,7 +184,13 @@ def ls_files(
             try:
                 rel = resolved.relative_to(resolved_source)
             except ValueError as exc:
-                raise ValueError(
+                from flyte.errors import CodeBundleError
+
+                # An include path that resolves outside the bundle root is a user
+                # configuration problem (the message tells them how to fix it), not an SDK
+                # bug. Raise a typed user error so it is filtered from crash reporting instead
+                # of leaking as a raw ValueError (FLYTE-SDK-5M).
+                raise CodeBundleError(
                     f"include path {extra!r} is outside the bundle root {source_path!s}. "
                     f"Pass --root-dir (or configure it) one level up so every include lives under the root."
                 ) from exc

--- a/src/flyte/_code_bundle/_utils.py
+++ b/src/flyte/_code_bundle/_utils.py
@@ -231,7 +231,13 @@ def ls_relative_files(relative_paths: list[str], source_path: pathlib.Path) -> t
                 # Filter out directories from glob results
                 all_files.extend([str(f) for f in glob_files if pathlib.Path(f).is_file()])
             else:
-                raise ValueError(f"File {path} is not a valid file, directory, or glob pattern")
+                from flyte.errors import CodeBundleError
+
+                # Same user error as the `additional_files` branch of `ls_files` above,
+                # reached by the `copy_style="none"` bundle path: the entry came from the
+                # user's `Environment.include`, so a path that matches nothing is their
+                # configuration, not an SDK bug (FLYTE-SDK-5M).
+                raise CodeBundleError(f"include path {str(path)!r} is not a file, directory, or glob pattern.")
 
     all_files.sort()
     abs_source = os.path.abspath(str(source_path))

--- a/tests/flyte/code_bundle/test_build_code_bundle.py
+++ b/tests/flyte/code_bundle/test_build_code_bundle.py
@@ -28,6 +28,7 @@ from flyte._code_bundle.bundle import (
     build_code_bundle,
     build_code_bundle_from_relative_paths,
 )
+from flyte.errors import CodeBundleError
 
 TESTDATA_ROOT = Path(__file__).parent / "testdata"
 
@@ -430,7 +431,7 @@ async def test_build_code_bundle_include_outside_source_raises():
         outside_file = Path(tmp_outside) / "stray.txt"
         outside_file.write_text("oops")
 
-        with pytest.raises(ValueError, match="outside the bundle root"):
+        with pytest.raises(CodeBundleError, match="outside the bundle root"):
             await build_code_bundle(
                 from_dir=layout,
                 dryrun=True,

--- a/tests/flyte/code_bundle/test_build_code_bundle.py
+++ b/tests/flyte/code_bundle/test_build_code_bundle.py
@@ -457,6 +457,28 @@ async def test_build_code_bundle_include_outside_source_raises():
 
 
 @pytest.mark.asyncio
+async def test_build_code_bundle_copy_style_none_missing_include_raises():
+    """
+    A ``copy_style='none'`` include that matches nothing must fail with the same
+    typed user error as the ``copy_style='all'`` path. This route reaches
+    ``ls_relative_files`` instead of ``ls_files``, and used to raise a bare
+    ``ValueError`` that was crash-reported as an SDK bug.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        layout = _copy_layout("single_file", tmp_dir)
+
+        with pytest.raises(CodeBundleError, match="is not a file, directory, or glob pattern"):
+            await build_code_bundle(
+                from_dir=layout,
+                dryrun=True,
+                copy_style="none",
+                additional_files=(str(layout / "does_not_exist.yaml"),),
+                copy_bundle_to=_bundle_out(tmp_dir),
+            )
+
+
+@pytest.mark.asyncio
 async def test_build_code_bundle_empty_source_raises(tmp_path):
     """An empty source directory with copy_style='all' surfaces a clear error."""
     empty = tmp_path / "empty"

--- a/tests/flyte/code_bundle/test_build_code_bundle.py
+++ b/tests/flyte/code_bundle/test_build_code_bundle.py
@@ -442,6 +442,28 @@ async def test_build_code_bundle_include_outside_source_raises():
 
 
 @pytest.mark.asyncio
+async def test_build_code_bundle_copy_style_none_missing_include_raises():
+    """
+    A ``copy_style='none'`` include that matches nothing must fail with the same
+    typed user error as the ``copy_style='all'`` path. This route reaches
+    ``ls_relative_files`` instead of ``ls_files``, and used to raise a bare
+    ``ValueError`` that was crash-reported as an SDK bug.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        layout = _copy_layout("single_file", tmp_dir)
+
+        with pytest.raises(CodeBundleError, match="is not a file, directory, or glob pattern"):
+            await build_code_bundle(
+                from_dir=layout,
+                dryrun=True,
+                copy_style="none",
+                additional_files=(str(layout / "does_not_exist.yaml"),),
+                copy_bundle_to=_bundle_out(tmp_dir),
+            )
+
+
+@pytest.mark.asyncio
 async def test_build_code_bundle_empty_source_raises(tmp_path):
     """An empty source directory with copy_style='all' surfaces a clear error."""
     empty = tmp_path / "empty"

--- a/tests/flyte/code_bundle/test_build_code_bundle.py
+++ b/tests/flyte/code_bundle/test_build_code_bundle.py
@@ -25,6 +25,7 @@ from typing import Callable, Iterator
 import pytest
 
 from flyte._code_bundle.bundle import build_code_bundle
+from flyte.errors import CodeBundleError
 
 TESTDATA_ROOT = Path(__file__).parent / "testdata"
 
@@ -445,7 +446,7 @@ async def test_build_code_bundle_include_outside_source_raises():
         outside_file = Path(tmp_outside) / "stray.txt"
         outside_file.write_text("oops")
 
-        with pytest.raises(ValueError, match="outside the bundle root"):
+        with pytest.raises(CodeBundleError, match="outside the bundle root"):
             await build_code_bundle(
                 from_dir=layout,
                 dryrun=True,

--- a/tests/flyte/code_bundle/test_code_bundle.py
+++ b/tests/flyte/code_bundle/test_code_bundle.py
@@ -234,7 +234,9 @@ def test_ls_relative_files_with_mixed_inputs():
 
 
 def test_ls_relative_files_invalid_path():
-    """Test ls_relative_files raises ValueError for invalid paths."""
+    """Test ls_relative_files raises CodeBundleError for invalid paths."""
+    from flyte.errors import CodeBundleError
+
     with tempfile.TemporaryDirectory() as tmpdir:
         test_dir = pathlib.Path(tmpdir)
 
@@ -242,7 +244,7 @@ def test_ls_relative_files_invalid_path():
         (test_dir / "main.py").write_text("print('hello')")
 
         # Test with non-existent path that doesn't match any glob
-        with pytest.raises(ValueError, match="is not a valid file, directory, or glob pattern"):
+        with pytest.raises(CodeBundleError, match="is not a file, directory, or glob pattern"):
             ls_relative_files(["nonexistent.py"], test_dir)
 
 

--- a/tests/flyte/code_bundle/test_includes.py
+++ b/tests/flyte/code_bundle/test_includes.py
@@ -25,6 +25,7 @@ import flyte
 from flyte._code_bundle._includes import collect_env_include_files
 from flyte._code_bundle._utils import ls_files
 from flyte._code_bundle.bundle import build_code_bundle
+from flyte.errors import CodeBundleError
 
 
 def _make_env_at(tmp_dir: Path, name: str, include: tuple[str, ...]) -> flyte.TaskEnvironment:
@@ -96,7 +97,7 @@ def test_ls_files_rejects_path_outside_source():
         outside_file.write_text("nope")
 
         with tempfile.TemporaryDirectory() as inside:
-            with pytest.raises(ValueError, match="outside the bundle root"):
+            with pytest.raises(CodeBundleError, match="outside the bundle root"):
                 ls_files(
                     Path(inside),
                     copy_file_detection="all",


### PR DESCRIPTION
## Problem
An `Environment.include` path that resolves **outside the bundle root**, or that matches **no file / directory / glob**, raised a bare `ValueError` from `flyte._code_bundle._utils` that leaked as a crash report:
- **FLYTE-SDK-5M** — "include path '…/_path_setup.py' is outside the bundle root … Pass --root-dir …"
- **FLYTE-SDK-5Y** — "include path '…' is not a file, directory, or matching glob pattern."

Both messages are already user-actionable; neither should have been an unhandled SDK crash.

## Fix
Convert all three include-path validation `ValueError`s in `_utils.py` to `CodeBundleError` — a `RuntimeUserError` that keeps the same helpful message and is filtered from crash reporting via the `_is_user_error` allowlist:

1. `ls_files` — include path resolves outside the bundle root (FLYTE-SDK-5M).
2. `ls_files` — include path matches no file, directory or glob (FLYTE-SDK-5Y).
3. `ls_relative_files` — same no-match case on the `copy_style="none"` route (`build_code_bundle` → `build_code_bundle_from_relative_paths` → `list_relative_files_to_bundle`). This is the same user error reached through a different code path; it had no Sentry issue of its own yet only because `copy_style="none"` is rarer. Its message is also reworded from "File … is not a valid file, directory, or glob pattern" to "include path …", naming the thing the user actually typed and matching its sibling in `ls_files`.

## Tests
- `test_ls_files_rejects_path_outside_source`, `test_build_code_bundle_include_outside_source_raises` and `test_ls_relative_files_invalid_path` now expect `CodeBundleError`.
- New `test_build_code_bundle_copy_style_none_missing_include_raises` covers the third site end-to-end through the public `build_code_bundle` API. Verified failing on unpatched `src/`, passing with the fix.

fixes FLYTE-SDK-5M
fixes FLYTE-SDK-5Y

**Update (2026-09-15):** the same leak has since fired again as **FLYTE-SDK-8M** (2 events, release 2.6.13+muka.1) — byte-for-byte the `outside the bundle root` message this PR converts, from the same `ls_files` line. This PR fixes it as-is; no code change needed.

fixes FLYTE-SDK-8M