### PR TITLE
Clustered-task examples + end-to-end validation on the demo cluster

### DIFF
--- a/examples/clustered/bad_spec.py
+++ b/examples/clustered/bad_spec.py
@@ -1,5 +1,5 @@
 """
-Bad-spec fast-fail (§9 exit-criterion #4).
+Bad-spec fast-fail.
 
 A misconfigured clustered task must FAIL FAST with a clear diagnosis instead of looping restarts
 forever. There are two distinct guards, at two different layers:

--- a/examples/clustered/bad_spec.py
+++ b/examples/clustered/bad_spec.py
@@ -1,0 +1,71 @@
+"""
+Bad-spec fast-fail (§9 exit-criterion #4).
+
+A misconfigured clustered task must FAIL FAST with a clear diagnosis instead of looping restarts
+forever. There are two distinct guards, at two different layers:
+
+  (A) Runtime / cluster errors (this example, runnable): the pod can't even start — e.g. an image
+      that doesn't exist. On the backend, the plugin runs ``DemystifyFailedOrPendingPod`` against
+      rank-0 (``<jobset>-workers-0-0``) and, once pod-0 has been Pending/Failed past the grace
+      window, surfaces ``BadTaskSpecification`` (a non-retryable error) rather than counting the
+      failure against ``max_restarts`` and retrying indefinitely.
+
+  (B) SDK validation errors (compile-time, NOT runnable): caught in
+      ``ClusteredTaskEnvironment.__post_init__`` before anything is submitted — e.g.
+      ``nproc_per_node`` greater than the GPU count, ``replicas < 1``, an unknown ``runtime``. These
+      raise ``ValueError`` / ``TypeError`` locally. See the commented block at the bottom and the
+      corresponding asserts in ``tests/flyte/clustered/test_env.py``.
+
+Run (expect a fast BadTaskSpecification, no retry storm):
+    uv run python examples/clustered/bad_spec.py
+"""
+
+from __future__ import annotations
+
+import flyte
+from flyte.clustered import ClusteredTaskEnvironment, ClusterFailurePolicy, TorchRun
+
+# An image reference that will never pull — the pods go ImagePullBackOff and rank-0 never starts.
+# (Use a clearly bogus tag so it can't accidentally resolve to a real image.)
+BOGUS_IMAGE = "ghcr.io/unionai/this-image-does-not-exist:never-built-deadbeef"
+
+env = ClusteredTaskEnvironment(
+    name="bad_spec_env",
+    image=BOGUS_IMAGE,
+    resources=flyte.Resources(cpu=(1, 2), memory=("1Gi", "2Gi")),
+    replicas=2,
+    nproc_per_node=1,
+    runtime=TorchRun(rdzv_backend="static", max_restarts=0),
+    # Even with a generous restart budget, image-pull failures should NOT consume it — the plugin
+    # short-circuits to BadTaskSpecification once pod-0 is stuck.
+    failure_policy=ClusterFailurePolicy(max_restarts=3),
+)
+
+
+@env.task
+async def never_runs() -> str:
+    """This body is never reached — the container image fails to pull first."""
+    return "unreachable"
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(never_runs)
+    print("Run URL:", run.url)
+    run.wait()
+    # Expect a failed phase with a BadTaskSpecification-style reason, reached quickly (no retry loop).
+    print("Final phase:", run.phase)
+
+
+# --- (B) SDK validation guards — these raise locally at construction time, before any submission. --
+# Uncomment any of these to see the immediate error (they never reach the cluster):
+#
+#   # nproc_per_node (2) exceeds the GPU count (1):
+#   ClusteredTaskEnvironment(
+#       name="bad", image="x", replicas=1, nproc_per_node=2,
+#       resources=flyte.Resources(gpu="A10G:1"),
+#   )  # -> ValueError: resources.gpu (1) must be >= nproc_per_node (2)
+#
+#   # replicas must be >= 1:
+#   ClusteredTaskEnvironment(name="bad", image="x", replicas=0, nproc_per_node=1)
+#   # -> ValueError: replicas must be >= 1

--- a/examples/clustered/compose_pretrain_eval.py
+++ b/examples/clustered/compose_pretrain_eval.py
@@ -1,5 +1,5 @@
 """
-Composability: pretrain -> evaluate, two sequential JobSets (§9 exit-criterion #6).
+Composability: pretrain -> evaluate, two sequential JobSets.
 
 A realistic pipeline chains a distributed pretrain step into a distributed evaluate step. Each
 clustered task emits its OWN JobSet, and they run sequentially when one awaits the other.

--- a/examples/clustered/compose_pretrain_eval.py
+++ b/examples/clustered/compose_pretrain_eval.py
@@ -1,0 +1,151 @@
+"""
+Composability: pretrain -> evaluate, two sequential JobSets (§9 exit-criterion #6).
+
+A realistic pipeline chains a distributed pretrain step into a distributed evaluate step. Each
+clustered task emits its OWN JobSet, and they run sequentially when one awaits the other.
+
+THE IMPORTANT CONSTRAINT: a clustered task runs with NO controller (the torchrun worker calls the
+runtime with ``controller_enabled=False``), so it **cannot enqueue subtasks**. The orchestration
+must therefore live in a *regular* ``flyte.TaskEnvironment`` task — the ``driver`` below — which
+awaits the two clustered tasks. Putting the ``await``s inside a clustered task would fail at
+runtime; that boundary is documented and asserted in the unit tests.
+
+Topology:
+    driver (plain task, has a controller)
+      ├─ await pretrain()    -> JobSet #1 (N pods)
+      └─ await evaluate(...)  -> JobSet #2 (N pods)
+
+    uv run python examples/clustered/compose_pretrain_eval.py
+"""
+
+from __future__ import annotations
+
+import flyte
+from flyte._image import DIST_FOLDER, PythonWheels
+from flyte.clustered import ClusteredTaskEnvironment, ClusterFailurePolicy, TorchRun
+
+image = (
+    flyte.Image.from_debian_base(name="compose_clustered")
+    .clone(addl_layer=PythonWheels(wheel_dir=DIST_FOLDER, package_name="flyte"))
+    .with_pip_packages("torch")
+)
+
+# --- Knobs ---------------------------------------------------------------------------------------
+USE_GPU = True
+GPU_DEVICE = "L4"  # one of flyte._resources.Accelerators device names; match the cluster's GPUs
+REPLICAS = 2  # pods (== nodes)
+NPROC_PER_NODE = 1  # processes (one per GPU) per pod  => world_size = REPLICAS * NPROC_PER_NODE
+
+_BACKEND = "nccl" if USE_GPU else "gloo"
+
+_clustered_resources = (
+    flyte.Resources(cpu=(2, 4), memory=("4Gi", "8Gi"), gpu=f"{GPU_DEVICE}:{NPROC_PER_NODE}")
+    if USE_GPU
+    else flyte.Resources(cpu=(1, 2), memory=("1Gi", "2Gi"))
+)
+
+# Both clustered steps share ONE ClusteredTaskEnvironment (UC7): each @task on it emits a JobSet.
+clustered_env = ClusteredTaskEnvironment(
+    name="compose_clustered_env",
+    image=image,
+    resources=_clustered_resources,
+    replicas=REPLICAS,
+    nproc_per_node=NPROC_PER_NODE,
+    runtime=TorchRun(rdzv_backend="static", max_restarts=0),
+    failure_policy=ClusterFailurePolicy(max_restarts=1),
+)
+
+# The driver is a PLAIN environment — it is the only one allowed to launch subtasks. It must declare
+# depends_on=[clustered_env] so the clustered env's image is registered in the image cache the driver
+# sees at runtime; otherwise awaiting pretrain()/evaluate() fails with "Environment ... not found in
+# image cache".
+driver_env = flyte.TaskEnvironment(
+    name="compose_driver_env",
+    image=image,
+    resources=flyte.Resources(cpu=1, memory="1Gi"),
+    depends_on=[clustered_env],
+)
+
+
+@clustered_env.task
+async def pretrain(steps: int = 20) -> float:
+    """Distributed 'pretrain' step — emits its own JobSet. Returns a final loss."""
+    import torch
+    import torch.distributed as dist
+    import torch.nn as nn
+    from torch.nn.parallel import DistributedDataParallel as DDP
+
+    ctx = flyte.ctx()
+
+    # Bind this rank to its local GPU BEFORE init_process_group so NCCL binds the right device.
+    if _BACKEND == "nccl" and torch.cuda.is_available():
+        torch.cuda.set_device(ctx.local_rank or 0)
+        device = torch.device(f"cuda:{ctx.local_rank or 0}")
+    else:
+        device = torch.device("cpu")
+
+    dist.init_process_group(backend=_BACKEND)
+    print(f"[pretrain rank {ctx.rank}/{ctx.world_size}] device={device} starting", flush=True)
+
+    torch.manual_seed(0)
+    ddp = DDP(nn.Linear(4, 1).to(device), device_ids=[device.index] if device.type == "cuda" else None)
+    opt = torch.optim.SGD(ddp.parameters(), lr=0.05)
+    loss_fn = nn.MSELoss()
+    x = torch.randn(64, 4, generator=torch.Generator().manual_seed(ctx.rank or 0)).to(device)
+    y = x.sum(dim=1, keepdim=True)
+
+    last = 0.0
+    for _ in range(steps):
+        opt.zero_grad()
+        loss = loss_fn(ddp(x), y)
+        loss.backward()
+        opt.step()
+        last = float(loss.detach())
+
+    dist.barrier()
+    dist.destroy_process_group()
+    print(f"[pretrain rank {ctx.rank}] done — loss {last:.5f}", flush=True)
+    return last
+
+
+@clustered_env.task
+async def evaluate(trained_loss: float) -> float:
+    """Distributed 'evaluate' step — emits a SECOND JobSet. Returns a synthetic eval metric."""
+    import torch
+    import torch.distributed as dist
+
+    ctx = flyte.ctx()
+
+    # Bind this rank to its local GPU BEFORE init_process_group so NCCL binds the right device.
+    if _BACKEND == "nccl" and torch.cuda.is_available():
+        torch.cuda.set_device(ctx.local_rank or 0)
+    dist.init_process_group(backend=_BACKEND)
+    print(
+        f"[evaluate rank {ctx.rank}/{ctx.world_size}] evaluating with train_loss={trained_loss:.5f}",
+        flush=True,
+    )
+
+    # Stand-in metric; in a real pipeline you'd load the pretrain checkpoint and run a held-out set.
+    metric = 1.0 / (1.0 + trained_loss)
+
+    dist.barrier()
+    dist.destroy_process_group()
+    print(f"[evaluate rank {ctx.rank}] done — metric {metric:.5f}", flush=True)
+    return metric
+
+
+@driver_env.task
+async def pretrain_then_eval(steps: int = 20) -> float:
+    """Plain orchestrator: await pretrain (JobSet #1), then evaluate (JobSet #2), sequentially."""
+    loss = await pretrain(steps=steps)
+    metric = await evaluate(trained_loss=loss)
+    print(f"[driver] pretrain_loss={loss:.5f} eval_metric={metric:.5f}", flush=True)
+    return metric
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(pretrain_then_eval, steps=20)
+    print("Run URL:", run.url)
+    run.wait()
+    print("Final phase:", run.phase)

--- a/examples/clustered/cpu_kill_rank.py
+++ b/examples/clustered/cpu_kill_rank.py
@@ -1,0 +1,111 @@
+"""
+Kill a single rank mid-training and watch the whole-set restart (CPU / gloo).
+
+The "same stuff" as ``ddp_train.py`` — real PyTorch DDP — but with a deliberate failure injected
+into one rank so you can SEE the cluster's failure handling. The core fact of distributed training:
+when one rank dies, every other rank blocks forever in the next collective, so the only safe fix is
+to kill them all and restart the whole set. The clustered runtime makes that happen:
+
+    one rank fails  ->  torchrun on that pod tears down its siblings, pod exits != 0
+      ->  Job fails immediately (backoffLimit=0)
+      ->  JobSet restarts ALL pods with a fresh rendezvous id (RDZV_ID rotates)
+      ->  ctx.restart_attempt increments; training resumes
+
+Pick the rank, the step, and the FAILURE MODE to compare signatures:
+  * "exit"      — os._exit(1): a hard, uncatchable death (closest to a real crash / OOM-killer).
+  * "exception" — raise RuntimeError: the a0 runtime catches it, writes a typed error, exits != 0.
+
+Unlike ``failure_cascade.py`` (which adds checkpoint-resume and exhausts the restart budget to force
+a RetryableFailure), this one is the minimal "watch the kill propagate and the set recover" demo.
+
+    uv run python examples/clustered/cpu_kill_rank.py
+"""
+
+from __future__ import annotations
+
+import flyte
+from flyte._image import DIST_FOLDER, PythonWheels
+from flyte.clustered import ClusteredTaskEnvironment, ClusterFailurePolicy, TorchRun
+
+# --- Knobs ---------------------------------------------------------------------------------------
+KILL_RANK = 2  # which global rank dies (0..world_size-1). With the env below, world_size = 4.
+KILL_AT_STEP = 20  # ~mid-run, given the 1s/step pacing below
+KILL_MODE = "exit"  # "exit" (hard os._exit) or "exception" (clean raise)
+
+image = (
+    flyte.Image.from_debian_base(name="cpu_kill_rank1")
+    .clone(addl_layer=PythonWheels(wheel_dir=DIST_FOLDER, package_name="flyte"))
+    .with_pip_packages("torch", "numpy")
+)
+
+env = ClusteredTaskEnvironment(
+    name="cpu_kill_rank_env",
+    image=image,
+    resources=flyte.Resources(cpu=(1, 2), memory=("1Gi", "2Gi")),
+    replicas=2,
+    # world_size = replicas * nproc_per_node = 4 (ranks 0-3): pod 0 holds ranks 0-1, pod 1 holds
+    # ranks 2-3. So KILL_RANK=2 dies on pod 1 (a cross-pod kill); use KILL_RANK<2 to kill on pod 0.
+    nproc_per_node=2,
+    runtime=TorchRun(rdzv_backend="static", max_restarts=0),  # no in-pod retries; restart the set
+    # Allow a couple of whole-set restarts so you can watch it recover rather than fail outright.
+    failure_policy=ClusterFailurePolicy(max_restarts=2),
+)
+
+
+@env.task
+async def train_and_kill(steps: int = 40, lr: float = 0.05) -> float:
+    """Run DDP; on the FIRST attempt, KILL_RANK dies at KILL_AT_STEP. Later attempts run clean."""
+    import asyncio
+    import os
+
+    import torch
+    import torch.distributed as dist
+    import torch.nn as nn
+    from torch.nn.parallel import DistributedDataParallel as DDP
+
+    ctx = flyte.ctx()
+    attempt = ctx.restart_attempt or 0
+    rank = ctx.rank or 0
+
+    dist.init_process_group(backend="gloo")
+    world_size = dist.get_world_size()
+    print(f"[rank {rank}/{world_size}] restart_attempt={attempt} node_rank={ctx.node_rank}", flush=True)
+
+    torch.manual_seed(0)
+    ddp = DDP(nn.Linear(4, 1))
+    opt = torch.optim.SGD(ddp.parameters(), lr=lr)
+    loss_fn = nn.MSELoss()
+    x = torch.randn(64, 4, generator=torch.Generator().manual_seed(rank))
+    y = x.sum(dim=1, keepdim=True)
+
+    last_loss = 0.0
+    for step in range(steps):
+        opt.zero_grad()
+        loss = loss_fn(ddp(x), y)
+        loss.backward()
+        opt.step()
+        last_loss = float(loss.detach())
+        await asyncio.sleep(1)  # pace the run so the kill lands mid-training and is observable
+
+        if rank == 0 and step % 10 == 0:
+            print(f"[rank 0] step {step:3d}  loss {last_loss:.5f}  (attempt {attempt})", flush=True)
+
+        # Inject the failure on the first attempt only, so the restart succeeds and you see recovery.
+        if attempt == 0 and rank == KILL_RANK and step == KILL_AT_STEP:
+            print(f"[rank {rank}] KILLING SELF at step {step} via mode={KILL_MODE!r}", flush=True)
+            if KILL_MODE == "exception":
+                raise RuntimeError(f"injected failure on rank {rank} at step {step}")
+            os._exit(1)  # default: hard exit, uncatchable
+
+    dist.barrier()
+    dist.destroy_process_group()
+    print(f"[rank {rank}] completed {steps} steps on attempt {attempt} — final loss {last_loss:.5f}", flush=True)
+    return last_loss
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(train_and_kill, steps=40)
+    print("Run URL:", run.url)
+    run.wait()
+    print("Final phase:", run.phase)

--- a/examples/clustered/ddp_train.py
+++ b/examples/clustered/ddp_train.py
@@ -4,8 +4,8 @@ End-to-end DDP training on a ClusteredTaskEnvironment.
 Trains a tiny linear-regression model with PyTorch DistributedDataParallel across
 ``replicas x nproc_per_node`` workers. The workers are bootstrapped by ``torchrun``
 via the dedicated ``clustered`` runtime entrypoint, which the Go ``clustered`` plugin
-wires into a Kubernetes JobSet. Backend is ``gloo`` (CPU) so it needs no GPUs — swap to
-``nccl`` + ``resources.gpu`` for real GPU training.
+wires into a Kubernetes JobSet. Defaults to ``nccl`` + ``resources.gpu`` (one GPU per pod);
+flip ``USE_GPU = False`` to smoke on ``gloo`` (CPU) with no GPUs.
 
 This exercises the full path:
     ClusteredTaskEnvironment  ->  task_serde (type=clustered-task, args -> `clustered`)
@@ -25,17 +25,31 @@ from flyte.clustered import ClusteredTaskEnvironment, ClusterFailurePolicy, Torc
 # Image carries the LOCAL flyte build (so the container has the `clustered` runtime
 # entrypoint and the clustered runtime fixes), plus torch for the actual DDP workload.
 image = (
-    flyte.Image.from_debian_base(name="ddp_train8")
+    flyte.Image.from_debian_base(name="ddp_train9")
     .clone(addl_layer=PythonWheels(wheel_dir=DIST_FOLDER, package_name="flyte"))
     .with_pip_packages("torch", "numpy")
+)
+
+# --- Knobs ---------------------------------------------------------------------------------------
+USE_GPU = True
+GPU_DEVICE = "L4"  # one of flyte._resources.Accelerators device names; match the cluster's GPUs
+REPLICAS = 2  # pods (== nodes)
+NPROC_PER_NODE = 1  # processes (one per GPU) per pod  => world_size = REPLICAS * NPROC_PER_NODE
+
+_BACKEND = "nccl" if USE_GPU else "gloo"
+
+resources = (
+    flyte.Resources(cpu=(2, 4), memory=("4Gi", "8Gi"), gpu=f"{GPU_DEVICE}:{NPROC_PER_NODE}")
+    if USE_GPU
+    else flyte.Resources(cpu=(1, 2), memory=("1Gi", "2Gi"))
 )
 
 env = ClusteredTaskEnvironment(
     name="ddp_env",
     image=image,
-    resources=flyte.Resources(cpu=(1, 2), memory=("1Gi", "2Gi")),
-    replicas=2,  # 2 pods (== 2 nodes)
-    nproc_per_node=2,  # 2 worker processes per pod  => world_size = 4
+    resources=resources,
+    replicas=REPLICAS,
+    nproc_per_node=NPROC_PER_NODE,
     runtime=TorchRun(rdzv_backend="static", max_restarts=0),
     failure_policy=ClusterFailurePolicy(max_restarts=1),
 )
@@ -51,26 +65,33 @@ async def train_ddp(steps: int = 50, lr: float = 0.05) -> float:
 
     ctx = flyte.ctx()
 
+    # Bind this rank to its local GPU BEFORE init_process_group so NCCL binds the right device.
+    if _BACKEND == "nccl" and torch.cuda.is_available():
+        torch.cuda.set_device(ctx.local_rank or 0)
+        device = torch.device(f"cuda:{ctx.local_rank or 0}")
+    else:
+        device = torch.device("cpu")
+
     # torchrun has already populated RANK / WORLD_SIZE / MASTER_ADDR / MASTER_PORT.
-    dist.init_process_group(backend="gloo")
+    dist.init_process_group(backend=_BACKEND)
     rank = dist.get_rank()
     world_size = dist.get_world_size()
     print(
-        f"[rank {rank}/{world_size}] ctx.rank={ctx.rank} ctx.world_size={ctx.world_size} "
+        f"[rank {rank}/{world_size}] device={device} ctx.rank={ctx.rank} ctx.world_size={ctx.world_size} "
         f"ctx.node_rank={ctx.node_rank} ctx.nnodes={ctx.nnodes} master_addr={ctx.master_addr}",
         flush=True,
     )
 
     # Tiny model the workers train cooperatively: learn y = x · [1,1,1,1].
     torch.manual_seed(0)
-    model = nn.Linear(4, 1)
-    ddp = DDP(model)
+    model = nn.Linear(4, 1).to(device)
+    ddp = DDP(model, device_ids=[device.index] if device.type == "cuda" else None)
     opt = torch.optim.SGD(ddp.parameters(), lr=lr)
     loss_fn = nn.MSELoss()
 
     # Each rank trains on its own shard of synthetic data.
     g = torch.Generator().manual_seed(rank)
-    x = torch.randn(64, 4, generator=g)
+    x = torch.randn(64, 4, generator=g).to(device)
     y = x.sum(dim=1, keepdim=True)
 
     last_loss = 0.0

--- a/examples/clustered/ddp_train_gpu.py
+++ b/examples/clustered/ddp_train_gpu.py
@@ -1,0 +1,109 @@
+"""
+Multi-node GPU DDP training on a ClusteredTaskEnvironment (NCCL backend).
+
+The GPU sibling of ``ddp_train.py`` (which uses CPU/gloo). Trains a tiny linear-regression model
+with PyTorch DistributedDataParallel across ``replicas x nproc_per_node`` GPU workers, each pinned
+to its local GPU. The workers are bootstrapped by ``torchrun`` via the dedicated ``clustered``
+runtime entrypoint, which the Go ``clustered`` plugin wires into a Kubernetes JobSet.
+
+This doubles as the §9 exit-criteria GPU smoke (#1 1x1, #2 2x1): assert a JobSet is created, the
+gang lands, ``torchrun`` -> ``clustered`` workers rendezvous over NCCL, ``world_size`` matches, and
+only rank-0 uploads outputs.
+
+Set GPU_DEVICE / REPLICAS / NPROC_PER_NODE to match your cluster's GPU capacity, then run on a GPU
+cluster (e.g. dogfood, domain=development):
+    uv run python examples/clustered/ddp_train_gpu.py
+"""
+
+from __future__ import annotations
+
+import flyte
+from flyte._image import DIST_FOLDER, PythonWheels
+from flyte.clustered import ClusteredTaskEnvironment, ClusterFailurePolicy, TorchRun
+
+# --- Knobs ---------------------------------------------------------------------------------------
+GPU_DEVICE = "L4"  # one of flyte._resources.Accelerators device names; match the cluster's GPUs
+REPLICAS = 2  # pods (== nodes). Set to 1 for the 1x1 smoke, 2 for 2x1.
+NPROC_PER_NODE = 1  # GPUs (processes) per pod; must be <= the GPU count on the device
+
+# Image carries the LOCAL flyte build (so the container has the `clustered` runtime entrypoint),
+# plus torch. The PyPI `torch` wheel bundles CUDA + NCCL, so this same image runs on GPU nodes —
+# no separate CUDA base image needed.
+image = (
+    flyte.Image.from_debian_base(name="ddp_train_gpu")
+    .clone(addl_layer=PythonWheels(wheel_dir=DIST_FOLDER, package_name="flyte"))
+    .with_pip_packages("torch", "numpy")
+)
+
+env = ClusteredTaskEnvironment(
+    name="ddp_gpu_env",
+    image=image,
+    resources=flyte.Resources(cpu=(2, 4), memory=("4Gi", "8Gi"), gpu=f"{GPU_DEVICE}:{NPROC_PER_NODE}"),
+    replicas=REPLICAS,
+    nproc_per_node=NPROC_PER_NODE,  # world_size = REPLICAS * NPROC_PER_NODE
+    runtime=TorchRun(rdzv_backend="static", max_restarts=0),
+    failure_policy=ClusterFailurePolicy(max_restarts=1),
+)
+
+
+@env.task
+async def train_ddp_gpu(steps: int = 50, lr: float = 0.05) -> float:
+    """Run NCCL DDP training on GPUs and return the final (rank-0) training loss."""
+    import torch
+    import torch.distributed as dist
+    import torch.nn as nn
+    from torch.nn.parallel import DistributedDataParallel as DDP
+
+    ctx = flyte.ctx()
+    assert torch.cuda.is_available(), "no CUDA device visible — is this running on a GPU node?"
+
+    # torchrun has already populated RANK / WORLD_SIZE / MASTER_ADDR / MASTER_PORT. Pin this rank
+    # to its local GPU BEFORE init_process_group so NCCL binds to the right device.
+    local_rank = ctx.local_rank or 0
+    torch.cuda.set_device(local_rank)
+    device = torch.device(f"cuda:{local_rank}")
+    dist.init_process_group(backend="nccl")
+
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    print(
+        f"[rank {rank}/{world_size}] device={device} ctx.rank={ctx.rank} "
+        f"ctx.local_rank={ctx.local_rank} ctx.world_size={ctx.world_size} "
+        f"ctx.node_rank={ctx.node_rank} ctx.nnodes={ctx.nnodes} master_addr={ctx.master_addr}",
+        flush=True,
+    )
+
+    # Tiny model the workers train cooperatively: learn y = x · [1,1,1,1].
+    torch.manual_seed(0)
+    model = nn.Linear(4, 1).to(device)
+    ddp = DDP(model, device_ids=[local_rank])
+    opt = torch.optim.SGD(ddp.parameters(), lr=lr)
+    loss_fn = nn.MSELoss()
+
+    # Each rank trains on its own shard of synthetic data.
+    g = torch.Generator().manual_seed(rank)
+    x = torch.randn(64, 4, generator=g).to(device)
+    y = x.sum(dim=1, keepdim=True)
+
+    last_loss = 0.0
+    for step in range(steps):
+        opt.zero_grad()
+        loss = loss_fn(ddp(x), y)
+        loss.backward()
+        opt.step()
+        last_loss = float(loss.detach())
+        if rank == 0 and step % 10 == 0:
+            print(f"[rank 0] step {step:3d}  loss {last_loss:.5f}", flush=True)
+
+    dist.barrier()
+    dist.destroy_process_group()
+    print(f"[rank {rank}] done — final loss {last_loss:.5f}", flush=True)
+    return last_loss
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(train_ddp_gpu, steps=50)
+    print("Run URL:", run.url)
+    run.wait()
+    print("Final phase:", run.phase)

--- a/examples/clustered/ddp_train_restart.py
+++ b/examples/clustered/ddp_train_restart.py
@@ -32,12 +32,26 @@ image = (
     .with_pip_packages("torch", "numpy")
 )
 
+# --- Knobs ---------------------------------------------------------------------------------------
+USE_GPU = True
+GPU_DEVICE = "L4"  # one of flyte._resources.Accelerators device names; match the cluster's GPUs
+REPLICAS = 2  # pods (== nodes)
+NPROC_PER_NODE = 1  # processes (one per GPU) per pod  => world_size = REPLICAS * NPROC_PER_NODE
+
+_BACKEND = "nccl" if USE_GPU else "gloo"
+
+resources = (
+    flyte.Resources(cpu=(2, 4), memory=("4Gi", "8Gi"), gpu=f"{GPU_DEVICE}:{NPROC_PER_NODE}")
+    if USE_GPU
+    else flyte.Resources(cpu=(1, 2), memory=("1Gi", "2Gi"))
+)
+
 env = ClusteredTaskEnvironment(
     name="ddp_restart_env",
     image=image,
-    resources=flyte.Resources(cpu=(1, 2), memory=("1Gi", "2Gi")),
-    replicas=2,
-    nproc_per_node=2,
+    resources=resources,
+    replicas=REPLICAS,
+    nproc_per_node=NPROC_PER_NODE,
     runtime=TorchRun(rdzv_backend="static", max_restarts=0),
     failure_policy=ClusterFailurePolicy(max_restarts=1),  # allow ONE JobSet restart
 )
@@ -59,19 +73,31 @@ async def train_ddp_with_restart(steps: int = 50, lr: float = 0.05) -> float:
     import torch.nn as nn
     from torch.nn.parallel import DistributedDataParallel as DDP
 
-    dist.init_process_group(backend="gloo")
+    ctx = flyte.ctx()
+
+    # Bind this rank to its local GPU BEFORE init_process_group so NCCL binds the right device.
+    if _BACKEND == "nccl" and torch.cuda.is_available():
+        torch.cuda.set_device(ctx.local_rank or 0)
+        device = torch.device(f"cuda:{ctx.local_rank or 0}")
+    else:
+        device = torch.device("cpu")
+
+    dist.init_process_group(backend=_BACKEND)
     rank_i = dist.get_rank()
     world_size = dist.get_world_size()
-    print(f"[rank {rank_i}/{world_size}] restart attempt {restart_attempt} — training", flush=True)
+    print(
+        f"[rank {rank_i}/{world_size}] device={device} restart attempt {restart_attempt} — training",
+        flush=True,
+    )
 
     torch.manual_seed(0)
-    model = nn.Linear(4, 1)
-    ddp = DDP(model)
+    model = nn.Linear(4, 1).to(device)
+    ddp = DDP(model, device_ids=[device.index] if device.type == "cuda" else None)
     opt = torch.optim.SGD(ddp.parameters(), lr=lr)
     loss_fn = nn.MSELoss()
 
     g = torch.Generator().manual_seed(rank_i)
-    x = torch.randn(64, 4, generator=g)
+    x = torch.randn(64, 4, generator=g).to(device)
     y = x.sum(dim=1, keepdim=True)
 
     last_loss = 0.0

--- a/examples/clustered/eviction_restart.py
+++ b/examples/clustered/eviction_restart.py
@@ -1,0 +1,82 @@
+"""
+Free restart on host maintenance / eviction.
+
+When a node is reclaimed by the cloud provider (spot reclaim, host maintenance, drain) the pod is
+evicted through no fault of the user's code. With ``restart_on_host_maintenance=True`` the JobSet
+treats that as a FREE restart: the whole set restarts (``restart_attempt`` increments) but the
+``max_restarts`` budget is left UNCHANGED, so a flaky cluster can't burn the user's real
+failure budget.
+
+Mechanism : the inner Job's ``podFailurePolicy`` matches the
+``DisruptionTarget`` pod condition and ``FailJob``s; the JobSet's failure policy then matches that
+``PodFailurePolicy`` job-failure reason and restarts with ``RestartJobSetAndIgnoreMaxRestarts``.
+
+This is hard to trigger purely from task code — you induce the eviction from the cluster side. The
+task just runs long enough for you to drain its node and watch the counters.
+
+Runbook:
+  1. Start the run; wait for the worker pods `<jobset>-workers-0-*` to be Running.
+  2. Find a worker's node:  kubectl get pod <jobset>-workers-0-1 -n <ns> -o wide
+  3. Drain it:             kubectl drain <node> --ignore-daemonsets --delete-emptydir-data
+  4. Observe: the JobSet restarts, `ctx.restart_attempt` climbs, but `failurePolicy.maxRestarts`
+     budget is not decremented (compare against a non-maintenance failure, which would consume it).
+
+    uv run python examples/clustered/eviction_restart.py
+"""
+
+from __future__ import annotations
+
+import flyte
+from flyte._image import DIST_FOLDER, PythonWheels
+from flyte.clustered import ClusteredTaskEnvironment, ClusterFailurePolicy, TorchRun
+
+image = (
+    flyte.Image.from_debian_base(name="eviction_restart")
+    .clone(addl_layer=PythonWheels(wheel_dir=DIST_FOLDER, package_name="flyte"))
+    .with_pip_packages("torch")
+)
+
+env = ClusteredTaskEnvironment(
+    name="eviction_env",
+    image=image,
+    resources=flyte.Resources(cpu=(1, 2), memory=("1Gi", "2Gi")),
+    replicas=2,
+    nproc_per_node=1,
+    runtime=TorchRun(rdzv_backend="static", max_restarts=0),
+    # The flag under test: evictions become free restarts, not budget-consuming failures.
+    failure_policy=ClusterFailurePolicy(max_restarts=1, restart_on_host_maintenance=True),
+)
+
+
+@env.task
+async def long_running(minutes: int = 10) -> int:
+    """Idle long enough (printing heartbeats) for you to drain a worker's node mid-run."""
+    import asyncio
+
+    import torch.distributed as dist
+
+    ctx = flyte.ctx()
+    attempt = ctx.restart_attempt or 0
+    rank = ctx.rank or 0
+
+    dist.init_process_group(backend="gloo")
+    print(f"[rank {rank}] restart_attempt={attempt} world_size={ctx.world_size} — draining now is safe", flush=True)
+
+    heartbeats = minutes * 6  # one every 10s
+    for hb in range(heartbeats):
+        if rank == 0 and hb % 6 == 0:
+            print(f"[rank 0] heartbeat {hb // 6} min, restart_attempt={attempt}", flush=True)
+        await asyncio.sleep(10)
+
+    dist.barrier()
+    dist.destroy_process_group()
+    print(f"[rank {rank}] finished after {minutes} min on attempt {attempt}", flush=True)
+    return attempt
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(long_running, minutes=10)
+    print("Run URL:", run.url)
+    run.wait()
+    print("Final phase:", run.phase)

--- a/examples/clustered/failure_cascade.py
+++ b/examples/clustered/failure_cascade.py
@@ -1,0 +1,116 @@
+"""
+Failure cascade + whole-set restart + checkpoint resume.
+
+The core fact of distributed training: if ONE rank dies, every other rank hangs forever in the next
+collective. So the clustered runtime sets ``backoffLimit=0`` and the JobSet's failure policy
+restarts the WHOLE set with a fresh rendezvous id, and the user code resumes from its last
+checkpoint. This example deliberately breaks the system to prove that loop works:
+
+  * ``ClusterFailurePolicy(max_restarts=2)`` — the JobSet may restart twice before giving up.
+  * On the FIRST attempt only, rank-1 hard-exits (``os._exit(1)``) partway through.
+  * Every attempt checkpoints its step counter to S3 and resumes from it, so progress is not lost.
+  * ``ctx.restart_attempt`` is printed each attempt — you should see it climb 0 -> 1 (-> 2).
+
+Expected outcomes:
+  * With the crash firing once, the set restarts, resumes, and SUCCEEDS on attempt 1.
+  * If you set ``ALWAYS_CRASH=True``, every attempt crashes, restarts are exhausted, and Flyte
+    surfaces a RetryableFailure (DownstreamSystemError) after attempt 2.
+
+CPU/gloo is sufficient — this is about the control plane, not the math.
+    uv run python examples/clustered/failure_cascade.py
+"""
+
+from __future__ import annotations
+
+import flyte
+from flyte._image import DIST_FOLDER, PythonWheels
+from flyte.clustered import ClusteredTaskEnvironment, ClusterFailurePolicy, TorchRun
+
+# --- Knobs ---------------------------------------------------------------------------------------
+ALWAYS_CRASH = False  # True => exhaust restarts and force a RetryableFailure
+CRASH_RANK = 2
+CRASH_AT_STEP = 15  # ~mid-run; with the 1s/step sleep below this is well into training
+
+image = (
+    flyte.Image.from_debian_base(name="failure_cascade")
+    .clone(addl_layer=PythonWheels(wheel_dir=DIST_FOLDER, package_name="flyte"))
+    .with_pip_packages("torch")
+)
+
+env = ClusteredTaskEnvironment(
+    name="failure_cascade_env",
+    image=image,
+    resources=flyte.Resources(cpu=(1, 2), memory=("1Gi", "2Gi")),
+    replicas=2,
+    nproc_per_node=2,  # world_size = 4 (ranks 0-3); CRASH_RANK=2 lives on pod 1
+    runtime=TorchRun(rdzv_backend="static", max_restarts=0),  # no in-pod retries; restart the set
+    failure_policy=ClusterFailurePolicy(max_restarts=2),
+)
+
+
+@env.task
+async def train_with_crash(steps: int = 40) -> int:
+    """Train; crash rank-1 once (or always); checkpoint + resume across JobSet restarts."""
+    import asyncio
+    import os
+
+    import torch
+    import torch.distributed as dist
+    import torch.nn as nn
+
+    ctx = flyte.ctx()
+    attempt = ctx.restart_attempt or 0
+    rank = ctx.rank or 0
+
+    dist.init_process_group(backend="gloo")
+    print(f"[rank {rank}] restart_attempt={attempt} world_size={ctx.world_size}", flush=True)
+
+    # Resume the step counter from the checkpoint written by a previous attempt (best-effort).
+    cp = ctx.checkpoint
+    start_step = 0
+    if cp is not None:
+        prev = await cp.load()
+        if prev is not None:
+            try:
+                payload = prev / "payload" if prev.is_dir() else prev
+                start_step = int(payload.read_text().strip())
+                print(f"[rank {rank}] resumed from checkpoint at step {start_step}", flush=True)
+            except (ValueError, OSError):
+                start_step = 0
+
+    model = nn.Linear(4, 1)
+    opt = torch.optim.SGD(model.parameters(), lr=0.01)
+    loss_fn = nn.MSELoss()
+    x = torch.randn(32, 4)
+    y = x.sum(dim=1, keepdim=True)
+
+    for step in range(start_step, steps):
+        opt.zero_grad()
+        loss = loss_fn(model(x), y)
+        loss.backward()
+        opt.step()
+        await asyncio.sleep(1)  # stretch the run so the crash lands mid-training and restarts are visible
+
+        # Checkpoint progress (rank-0 owns the upload) so the next attempt can resume.
+        if rank == 0 and cp is not None and step % 5 == 0:
+            await cp.save(str(step).encode())
+
+        # Inject the failure. On the first attempt (or always), rank-1 dies hard -> all ranks hang
+        # -> Job fails (backoffLimit=0) -> JobSet restarts the whole set with a fresh rendezvous id.
+        should_crash = ALWAYS_CRASH or attempt == 0
+        if should_crash and rank == CRASH_RANK and step == CRASH_AT_STEP:
+            print(f"[rank {rank}] INJECTED CRASH at step {step} (attempt {attempt})", flush=True)
+            os._exit(1)
+
+    dist.barrier()
+    dist.destroy_process_group()
+    print(f"[rank {rank}] completed all {steps} steps on attempt {attempt}", flush=True)
+    return steps
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(train_with_crash, steps=40)
+    print("Run URL:", run.url)
+    run.wait()
+    print("Final phase:", run.phase)

--- a/examples/clustered/fsdp_train.py
+++ b/examples/clustered/fsdp_train.py
@@ -1,0 +1,135 @@
+"""
+Fully Sharded Data Parallel (FSDP) training on a ClusteredTaskEnvironment.
+
+FSDP shards a model's parameters across ranks, so each GPU holds only a slice — the way you train
+models too big to fit one device. The cluster shape is identical to DDP (one JobSet, N rank-uniform
+pods); only the in-task wrapping differs (``FullyShardedDataParallel`` instead of ``DistributedDataParallel``),
+which is exactly the design's "one backend serves all" point.
+
+This example also demonstrates the **checkpoint-to-S3** pattern that FSDP requires (JobSets.md §7):
+pod-local disk is wiped on restart, so the model state must be persisted to durable storage. Because
+each rank only holds a shard, you either (a) gather a FULL state dict onto rank-0 and save it (fine
+for small models — shown here), or (b) have every rank write its own shard (scales to huge models —
+sketched in comments).
+
+Run on a GPU cluster (set USE_GPU=True) or smoke it on CPU/gloo:
+    uv run python examples/clustered/fsdp_train.py
+"""
+
+from __future__ import annotations
+
+import flyte
+from flyte._image import DIST_FOLDER, PythonWheels
+from flyte.clustered import ClusteredTaskEnvironment, ClusterFailurePolicy, TorchRun
+
+# --- Knobs ---------------------------------------------------------------------------------------
+USE_GPU = True  # FSDP is meant for GPU; CPU/gloo here is only a wiring smoke
+GPU_DEVICE = "L4"
+REPLICAS = 2
+NPROC_PER_NODE = 1
+
+_BACKEND = "nccl" if USE_GPU else "gloo"
+
+image = (
+    flyte.Image.from_debian_base(name="fsdp_train")
+    .clone(addl_layer=PythonWheels(wheel_dir=DIST_FOLDER, package_name="flyte"))
+    .with_pip_packages("torch")
+)
+
+resources = (
+    flyte.Resources(cpu=(2, 4), memory=("4Gi", "8Gi"), gpu=f"{GPU_DEVICE}:{NPROC_PER_NODE}")
+    if USE_GPU
+    else flyte.Resources(cpu=(1, 2), memory=("2Gi", "4Gi"))
+)
+
+env = ClusteredTaskEnvironment(
+    name="fsdp_env",
+    image=image,
+    resources=resources,
+    replicas=REPLICAS,
+    nproc_per_node=NPROC_PER_NODE,
+    runtime=TorchRun(rdzv_backend="static", max_restarts=0),
+    failure_policy=ClusterFailurePolicy(max_restarts=1),
+)
+
+
+@env.task
+async def train_fsdp(steps: int = 30, lr: float = 0.01) -> float:
+    """Train a small transformer under FSDP and checkpoint the gathered state to S3."""
+    import io
+
+    import torch
+    import torch.distributed as dist
+    import torch.nn as nn
+    from torch.distributed.fsdp import FullStateDictConfig, StateDictType
+    from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+    ctx = flyte.ctx()
+
+    if _BACKEND == "nccl" and torch.cuda.is_available():
+        torch.cuda.set_device(ctx.local_rank or 0)
+        device = torch.device(f"cuda:{ctx.local_rank or 0}")
+    else:
+        device = torch.device("cpu")
+    dist.init_process_group(backend=_BACKEND)
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    print(
+        f"[rank {rank}/{world_size}] device={device} ctx.rank={ctx.rank} "
+        f"ctx.world_size={ctx.world_size} ctx.nnodes={ctx.nnodes}",
+        flush=True,
+    )
+
+    # A small transformer encoder — each FSDP unit's parameters are sharded across ranks.
+    torch.manual_seed(0)
+    model = nn.Sequential(
+        nn.Linear(32, 64),
+        nn.TransformerEncoderLayer(d_model=64, nhead=4, dim_feedforward=128, batch_first=True),
+        nn.Linear(64, 1),
+    ).to(device)
+    fsdp_model = FSDP(model, device_id=device.index if device.type == "cuda" else None)
+    opt = torch.optim.AdamW(fsdp_model.parameters(), lr=lr)
+    loss_fn = nn.MSELoss()
+
+    # Synthetic per-rank data: learn to sum a sequence's features.
+    g = torch.Generator().manual_seed(rank)
+    x = torch.randn(16, 8, 32, generator=g).to(device)  # (batch, seq, features)
+    y = x.mean(dim=(1, 2), keepdim=True).squeeze(-1)[:, :1]
+
+    last_loss = 0.0
+    for step in range(steps):
+        opt.zero_grad()
+        out = fsdp_model(x).mean(dim=1)  # pool over sequence -> (batch, 1)
+        loss = loss_fn(out, y)
+        loss.backward()
+        opt.step()
+        last_loss = float(loss.detach())
+        if rank == 0 and step % 10 == 0:
+            print(f"[rank 0] step {step:3d}  loss {last_loss:.5f}", flush=True)
+
+    # --- Checkpoint-to-S3: gather a FULL state dict onto rank-0 and persist it. -------------------
+    # For models too large to gather, switch to StateDictType.SHARDED_STATE_DICT and have EVERY rank
+    # save its shard under a rank-suffixed key (e.g. f"shard-{rank}") instead of the rank-0-only path.
+    save_cfg = FullStateDictConfig(offload_to_cpu=True, rank0_only=True)
+    with FSDP.state_dict_type(fsdp_model, StateDictType.FULL_STATE_DICT, save_cfg):
+        full_state = fsdp_model.state_dict()  # populated only on rank-0
+
+    cp = ctx.checkpoint
+    if rank == 0 and cp is not None:
+        buf = io.BytesIO()
+        torch.save(full_state, buf)
+        await cp.save(buf.getvalue())
+        print(f"[rank 0] saved FSDP checkpoint ({buf.tell()} bytes) to {cp.path}", flush=True)
+
+    dist.barrier()
+    dist.destroy_process_group()
+    print(f"[rank {rank}] done — final loss {last_loss:.5f}", flush=True)
+    return last_loss
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(train_fsdp, steps=30)
+    print("Run URL:", run.url)
+    run.wait()
+    print("Final phase:", run.phase)

--- a/examples/clustered/lightning_mnist.py
+++ b/examples/clustered/lightning_mnist.py
@@ -1,0 +1,118 @@
+"""
+PyTorch Lightning MNIST training on a ClusteredTaskEnvironment.
+
+This is the clustered-backend port of the classic Kubeflow `Elastic` Lightning example (the v1
+`flytekitplugins-kfpytorch` MNIST autoencoder). It shows that Lightning — which has its own
+multi-process launching machinery — also rides the torchrun contract: we let the ``clustered`` ->
+``torchrun`` -> ``clustered`` chain start one process per rank, and configure Lightning's
+``Trainer`` to use the EXISTING process group rather than spawning its own.
+
+The key is ``strategy="ddp"`` with ``devices=<local ranks>`` / ``num_nodes=<nodes>``: Lightning
+attaches to the torchrun-provided env (RANK / LOCAL_RANK / WORLD_SIZE / MASTER_ADDR / MASTER_PORT)
+instead of re-launching. Do NOT use the spawn strategies here — they would fork a second launcher
+inside each rank.
+
+Run on a GPU cluster (USE_GPU=True) or smoke on CPU:
+    uv run python examples/clustered/lightning_mnist.py
+"""
+
+from __future__ import annotations
+
+import flyte
+from flyte._image import DIST_FOLDER, PythonWheels
+from flyte.clustered import ClusteredTaskEnvironment, ClusterFailurePolicy, TorchRun
+
+# --- Knobs ---------------------------------------------------------------------------------------
+USE_GPU = True
+GPU_DEVICE = "L4"
+REPLICAS = 2  # nodes
+NPROC_PER_NODE = 1  # processes (GPUs) per node
+
+image = (
+    flyte.Image.from_debian_base(name="lightning_mnist")
+    .clone(addl_layer=PythonWheels(wheel_dir=DIST_FOLDER, package_name="flyte"))
+    .with_pip_packages("torch", "torchvision", "lightning")
+)
+
+resources = (
+    flyte.Resources(cpu=(2, 4), memory=("4Gi", "8Gi"), gpu=f"{GPU_DEVICE}:{NPROC_PER_NODE}")
+    if USE_GPU
+    else flyte.Resources(cpu=(2, 4), memory=("2Gi", "4Gi"))
+)
+
+env = ClusteredTaskEnvironment(
+    name="lightning_env",
+    image=image,
+    resources=resources,
+    replicas=REPLICAS,
+    nproc_per_node=NPROC_PER_NODE,
+    runtime=TorchRun(rdzv_backend="static", max_restarts=0),
+    failure_policy=ClusterFailurePolicy(max_restarts=1),
+)
+
+
+@env.task
+async def train_lightning(max_steps: int = 50) -> float:
+    """Train a tiny MNIST autoencoder with Lightning DDP over the JobSet's torchrun ranks."""
+    import lightning as L
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+    from torch.utils.data import DataLoader, TensorDataset
+
+    ctx = flyte.ctx()
+    print(
+        f"[rank {ctx.rank}/{ctx.world_size}] node_rank={ctx.node_rank} nnodes={ctx.nnodes} "
+        f"local_rank={ctx.local_rank} master_addr={ctx.master_addr}",
+        flush=True,
+    )
+
+    class AutoEncoder(L.LightningModule):
+        def __init__(self):
+            super().__init__()
+            self.encoder = nn.Sequential(nn.Linear(28 * 28, 64), nn.ReLU(), nn.Linear(64, 3))
+            self.decoder = nn.Sequential(nn.Linear(3, 64), nn.ReLU(), nn.Linear(64, 28 * 28))
+
+        def training_step(self, batch, _):
+            x, _y = batch
+            x = x.view(x.size(0), -1)
+            z = self.encoder(x)
+            loss = F.mse_loss(self.decoder(z), x)
+            self.log("train_loss", loss, prog_bar=True)
+            return loss
+
+        def configure_optimizers(self):
+            return torch.optim.Adam(self.parameters(), lr=1e-3)
+
+    # Synthetic MNIST-shaped data so the example needs no dataset download; swap in torchvision MNIST
+    # for the real thing. Lightning's DistributedSampler shards this across ranks automatically.
+    torch.manual_seed(0)
+    images = torch.rand(512, 1, 28, 28)
+    labels = torch.zeros(512, dtype=torch.long)
+    loader = DataLoader(TensorDataset(images, labels), batch_size=32, shuffle=True)
+
+    # Attach to the torchrun-provided process group: ddp (not ddp_spawn), devices per node and
+    # num_nodes from the clustered context. Lightning reads RANK/WORLD_SIZE/MASTER_ADDR from env.
+    trainer = L.Trainer(
+        accelerator="gpu" if USE_GPU else "cpu",
+        devices=NPROC_PER_NODE,
+        num_nodes=ctx.nnodes or REPLICAS,
+        strategy="ddp",
+        max_steps=max_steps,
+        enable_checkpointing=False,
+        logger=False,
+    )
+    model = AutoEncoder()
+    trainer.fit(model, loader)
+
+    final_loss = float(trainer.callback_metrics.get("train_loss", torch.tensor(0.0)))
+    print(f"[rank {ctx.rank}] done — final loss {final_loss:.5f}", flush=True)
+    return final_loss
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(train_lightning, max_steps=50)
+    print("Run URL:", run.url)
+    run.wait()
+    print("Final phase:", run.phase)

--- a/examples/clustered/load_16pod.py
+++ b/examples/clustered/load_16pod.py
@@ -1,5 +1,5 @@
 """
-Scale / load test: 16-pod rendezvous on plain TCP (§9 exit-criterion #11).
+Scale / load test: 16-pod rendezvous on plain TCP.
 
 Most correctness bugs in distributed bootstrapping only show up at non-trivial scale: headless DNS
 for 16 pod names, the static rendezvous all 16 ranks must agree on, and the gang landing together.

--- a/examples/clustered/load_16pod.py
+++ b/examples/clustered/load_16pod.py
@@ -1,0 +1,71 @@
+"""
+Scale / load test: 16-pod rendezvous on plain TCP (§9 exit-criterion #11).
+
+Most correctness bugs in distributed bootstrapping only show up at non-trivial scale: headless DNS
+for 16 pod names, the static rendezvous all 16 ranks must agree on, and the gang landing together.
+This example does no real training — it just stands up a 16-pod JobSet, runs one collective
+(all-reduce) plus a barrier, and confirms every rank sees ``world_size == 16``. CPU/gloo keeps it
+cheap; the point is the control plane, not GPUs.
+
+If your cluster lacks 16 free slots and gang admission is not yet wired (StudyNotes §2.5), this will
+sit Queued until capacity frees up — that itself is a useful signal.
+
+    uv run python examples/clustered/load_16pod.py
+"""
+
+from __future__ import annotations
+
+import flyte
+from flyte._image import DIST_FOLDER, PythonWheels
+from flyte.clustered import ClusteredTaskEnvironment, ClusterFailurePolicy, TorchRun
+
+REPLICAS = 16  # 16 pods, one process each => world_size = 16
+
+image = (
+    flyte.Image.from_debian_base(name="load_16pod")
+    .clone(addl_layer=PythonWheels(wheel_dir=DIST_FOLDER, package_name="flyte"))
+    .with_pip_packages("torch")
+)
+
+env = ClusteredTaskEnvironment(
+    name="load_16pod_env",
+    image=image,
+    resources=flyte.Resources(cpu=(1, 2), memory=("512Mi", "1Gi")),
+    replicas=REPLICAS,
+    nproc_per_node=1,
+    runtime=TorchRun(rdzv_backend="static", max_restarts=0),
+    failure_policy=ClusterFailurePolicy(max_restarts=0),
+)
+
+
+@env.task
+async def all_reduce_smoke() -> int:
+    """Rendezvous 16 ranks, run one all-reduce + barrier, assert world_size == 16."""
+    import torch
+    import torch.distributed as dist
+
+    ctx = flyte.ctx()
+    dist.init_process_group(backend="gloo")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    print(f"[rank {rank}/{world_size}] node_rank={ctx.node_rank} master_addr={ctx.master_addr}", flush=True)
+
+    # Every rank contributes its rank number; the sum proves all 16 joined the collective.
+    t = torch.tensor([float(rank)])
+    dist.all_reduce(t, op=dist.ReduceOp.SUM)
+    expected = world_size * (world_size - 1) // 2  # 0 + 1 + ... + 15 = 120
+    assert int(t.item()) == expected, f"all_reduce sum {int(t.item())} != expected {expected}"
+
+    dist.barrier()
+    if rank == 0:
+        print(f"[rank 0] all {world_size} ranks rendezvoused; all_reduce sum = {int(t.item())}", flush=True)
+    dist.destroy_process_group()
+    return world_size
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(all_reduce_smoke)
+    print("Run URL:", run.url)
+    run.wait()
+    print("Final phase:", run.phase)

--- a/examples/clustered/manual_kill_pod.py
+++ b/examples/clustered/manual_kill_pod.py
@@ -74,8 +74,7 @@ async def idle_for_chaos(minutes: int = RUN_MINUTES) -> int:
     dist.init_process_group(backend="gloo")
     world_size = dist.get_world_size()
     print(
-        f"[rank {rank}/{world_size}] restart_attempt={attempt} — ready. Kill a worker pod now; "
-        f"watch the set restart.",
+        f"[rank {rank}/{world_size}] restart_attempt={attempt} — ready. Kill a worker pod now; watch the set restart.",
         flush=True,
     )
 

--- a/examples/clustered/manual_kill_pod.py
+++ b/examples/clustered/manual_kill_pod.py
@@ -1,0 +1,118 @@
+"""
+Long-running CPU job for MANUAL chaos testing — kill a pod yourself and watch (CPU / gloo).
+
+This task does light DDP work and then idles with heartbeats for a long time (default ~20 min) so
+YOU can delete one of its worker pods by hand and observe how the clustered runtime reacts. It
+checkpoints a step counter periodically, so after the set restarts you can see it resume rather than
+start over.
+
+What to expect when you kill a worker pod:
+    kubectl delete pod <jobset>-workers-0-1-xxxxx
+      ->  that pod's Job fails immediately (backoffLimit=0)
+      ->  the JobSet restarts ALL pods together with a fresh rendezvous id
+      ->  new pods come up; ctx.restart_attempt increments (printed in the heartbeats)
+      ->  training resumes from the last checkpoint
+    Repeat up to max_restarts; beyond that the run becomes a RetryableFailure.
+
+RUNBOOK (read-only setup + the one mutating kill):
+    export CLOUD_REPO=/Users/adil/Documents/Git/cloud
+    export AWS_CONFIG_FILE=$CLOUD_REPO/gen/cli-config/aws
+    export KUBECONFIG=$HOME/.kube/config:$CLOUD_REPO/gen/cli-config/kubeconfig
+    C=<your-context>           # e.g. org-dogfood-dogfood-1
+    NS=<project>-<domain>      # e.g. flytesnacks-development
+
+    # 1. Watch the JobSet + its pods (leave this running in one terminal):
+    kubectl get pods -n $NS --context=$C -w | grep workers
+    # 2. Pick a NON-rank-0 worker (rank-0 is <jobset>-workers-0-0) and delete it:
+    kubectl delete pod <jobset>-workers-0-1-xxxxx -n $NS --context=$C
+    # 3. Watch: the whole set is recreated; heartbeats show restart_attempt climb.
+
+Tip: killing rank-0 (<jobset>-workers-0-0) is also interesting — it's the rendezvous master, so the
+whole set must re-form around the new pod-0.
+
+    uv run python examples/clustered/manual_kill_pod.py
+"""
+
+from __future__ import annotations
+
+import flyte
+from flyte._image import DIST_FOLDER, PythonWheels
+from flyte.clustered import ClusteredTaskEnvironment, ClusterFailurePolicy, TorchRun
+
+# --- Knobs ---------------------------------------------------------------------------------------
+RUN_MINUTES = 20  # how long to idle (with heartbeats) so you have time to kill a pod
+MAX_RESTARTS = 3  # how many manual kills the set will recover from before giving up
+
+image = (
+    flyte.Image.from_debian_base(name="manual_kill_pod")
+    .clone(addl_layer=PythonWheels(wheel_dir=DIST_FOLDER, package_name="flyte"))
+    .with_pip_packages("torch")
+)
+
+env = ClusteredTaskEnvironment(
+    name="manual_kill_env",
+    image=image,
+    resources=flyte.Resources(cpu=(1, 2), memory=("1Gi", "2Gi")),
+    replicas=2,  # 2 worker pods so there's a non-rank-0 pod to kill
+    nproc_per_node=1,
+    runtime=TorchRun(rdzv_backend="static", max_restarts=0),
+    failure_policy=ClusterFailurePolicy(max_restarts=MAX_RESTARTS),
+)
+
+
+@env.task
+async def idle_for_chaos(minutes: int = RUN_MINUTES) -> int:
+    """Idle with heartbeats so a pod can be killed by hand; checkpoint + resume across restarts."""
+    import asyncio
+
+    import torch.distributed as dist
+
+    ctx = flyte.ctx()
+    attempt = ctx.restart_attempt or 0
+    rank = ctx.rank or 0
+
+    dist.init_process_group(backend="gloo")
+    world_size = dist.get_world_size()
+    print(
+        f"[rank {rank}/{world_size}] restart_attempt={attempt} — ready. Kill a worker pod now; "
+        f"watch the set restart.",
+        flush=True,
+    )
+
+    # Resume the heartbeat counter from a previous attempt's checkpoint (best-effort).
+    cp = ctx.checkpoint
+    start = 0
+    if cp is not None:
+        prev = await cp.load()
+        if prev is not None:
+            try:
+                payload = prev / "payload" if prev.is_dir() else prev
+                start = int(payload.read_text().strip())
+                print(f"[rank {rank}] resumed at heartbeat {start}", flush=True)
+            except (ValueError, OSError):
+                start = 0
+
+    total = minutes * 4  # one heartbeat every 15s
+    for hb in range(start, total):
+        # Every rank participates in a collective each heartbeat, so a killed pod is noticed promptly
+        # (the survivors block here until the JobSet restarts the set).
+        dist.barrier()
+        if rank == 0:
+            mins = hb / 4
+            print(f"[rank 0] heartbeat {hb}/{total} (~{mins:.2f} min)  restart_attempt={attempt}", flush=True)
+            if cp is not None and hb % 4 == 0:
+                await cp.save(str(hb).encode())  # checkpoint progress so the next attempt resumes
+        await asyncio.sleep(15)
+
+    dist.barrier()
+    dist.destroy_process_group()
+    print(f"[rank {rank}] finished {minutes} min on attempt {attempt}", flush=True)
+    return attempt
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(idle_for_chaos, minutes=RUN_MINUTES)
+    print("Run URL:", run.url)
+    run.wait()
+    print("Final phase:", run.phase)


### PR DESCRIPTION
## Summary
Adds 12 runnable `examples/clustered/` examples (DDP, FSDP, Lightning, compose, 16-pod scale, and the failure paths: rank kill, pod kill, eviction, bad spec).

  **Concrete, not illustrative** — every example was run against the demo cluster (GPU ones on real L4 nodes) and checked against its stated contract.

  ## Passing 
  `ddp_train(_gpu/_restart)`, `fsdp_train` (saves 148 KB ckpt), `lightning_mnist` (attaches to torchrun, no double-launch), `cpu_kill_rank` + `manual_kill_pod` whole-set restart), `load_16pod` (gang of 16, all-reduce sum=120), `bad_spec` (fast-fail, budget not consumed).

  ## Still broken / TODO  (product/SDK gaps, not the examples)
  1. **Composed clustered tasks can't run** — nested subtask gets a long action name → JobSet pod names >63 chars → webhook rejects → plugin retry-loops forever (run hangs RUNNING). Fix: bound/hash the JobSet name + treat the rejection as non-retryable.
  2. **Checkpoint-resume across restart doesn't work** — save works, but a restart  never loads the prior attempt's checkpoint (confirmed in `failure_cascade` and `manual_kill_pod`; masked because toy models retrain instantly). Likely per-attempt path scoping. TODO: confirm + fix path.
  3. **`restart_on_host_maintenance=True` is a no-op** — not wired into the JobSet (no `DisruptionTarget` podFailurePolicy / `RestartJobSetAndIgnoreMaxRestarts` rule). Proven: 2 evictions exhausted `maxRestarts=1`. Fix: emit those specs.