### PR TITLE
fix: raise InitializationError when auth-config endpoint returns HTML

### DIFF
--- a/src/flyte/remote/_client/auth/_client_config.py
+++ b/src/flyte/remote/_client/auth/_client_config.py
@@ -68,9 +68,32 @@ class RemoteClientConfigStore(ClientConfigStore):
         """
         Retrieves the ClientConfig from the AuthMetadataService via ConnectRPC.
         """
+        from connectrpc.errors import ConnectError
+
         oauth2_metadata_task = self._client.get_o_auth2_metadata(GetOAuth2MetadataRequest())
         public_client_config_task = self._client.get_public_client_config(GetPublicClientConfigRequest())
-        oauth2_metadata, public_client_config = await asyncio.gather(oauth2_metadata_task, public_client_config_task)
+        try:
+            oauth2_metadata, public_client_config = await asyncio.gather(
+                oauth2_metadata_task, public_client_config_task
+            )
+        except ConnectError as e:
+            # The endpoint answered with a non-protobuf (e.g. HTML) body, so connectrpc could not
+            # decode the response. This is virtually always a misconfigured endpoint -- the address
+            # points at a web console/login page or sits behind a proxy that doesn't forward
+            # gRPC/Connect traffic -- not an SDK bug. Re-raise as a user-facing InitializationError
+            # so it reaches the user with an actionable message instead of leaking as a system error.
+            if "invalid content-type" in str(e):
+                from flyte.errors import InitializationError
+
+                raise InitializationError(
+                    "InvalidEndpoint",
+                    "user",
+                    "The configured endpoint returned a non-protobuf (HTML) response while fetching the "
+                    "auth client configuration. Verify that the endpoint points to your Flyte/Union API "
+                    "endpoint (not a web console or login URL) and that any proxy/ingress in front of it "
+                    "forwards gRPC/Connect traffic.",
+                ) from e
+            raise
         return ClientConfig(
             token_endpoint=oauth2_metadata.token_endpoint,
             authorization_endpoint=oauth2_metadata.authorization_endpoint,

--- a/tests/flyte/remote/test_connectrpc_error_handling.py
+++ b/tests/flyte/remote/test_connectrpc_error_handling.py
@@ -266,3 +266,43 @@ class TestDeployErrors:
             )
             assert isinstance(result, DeployedTask)
             mock_status.info.assert_called_once()
+
+
+# --- RemoteClientConfigStore.get_client_config (FLYTE-SDK-5N) ---
+
+
+class TestGetClientConfigHtmlResponse:
+    """The auth-config endpoint answering with HTML (non-protobuf) means the endpoint is
+    misconfigured, not an SDK bug. connectrpc raises ConnectError(UNKNOWN, 'invalid content-type
+    ...') which we re-raise as a user-facing InitializationError."""
+
+    def _make_store(self):
+        from flyte.remote._client.auth._client_config import RemoteClientConfigStore
+
+        store = RemoteClientConfigStore.__new__(RemoteClientConfigStore)
+        store._client = MagicMock()
+        return store
+
+    @pytest.mark.asyncio
+    async def test_html_content_type_raises_initialization_error(self):
+        store = self._make_store()
+        store._client.get_o_auth2_metadata = AsyncMock(
+            side_effect=ConnectError(Code.UNKNOWN, "invalid content-type: 'text/html'; expecting 'application/proto'")
+        )
+        store._client.get_public_client_config = AsyncMock(
+            side_effect=ConnectError(Code.UNKNOWN, "invalid content-type: 'text/html'; expecting 'application/proto'")
+        )
+        with pytest.raises(flyte.errors.InitializationError) as exc_info:
+            await store.get_client_config()
+        assert exc_info.value.code == "InvalidEndpoint"
+        assert isinstance(exc_info.value.__cause__, ConnectError)
+
+    @pytest.mark.asyncio
+    async def test_other_connect_error_propagates(self):
+        store = self._make_store()
+        store._client.get_o_auth2_metadata = AsyncMock(side_effect=ConnectError(Code.UNAVAILABLE, "connection refused"))
+        store._client.get_public_client_config = AsyncMock(
+            side_effect=ConnectError(Code.UNAVAILABLE, "connection refused")
+        )
+        with pytest.raises(ConnectError):
+            await store.get_client_config()

--- a/tests/flyte/test_sentry.py
+++ b/tests/flyte/test_sentry.py
@@ -462,3 +462,31 @@ def test_capture_exception_still_reports_connect_error_internal_in_upload_chain(
     ):
         _sentry.capture_exception(err)
     capture_mock.assert_called_once_with(err)
+
+
+def test_capture_exception_skips_wrapped_invalid_endpoint_error():
+    """FLYTE-SDK-5N: the auth-config endpoint returns HTML instead of protobuf, surfaced by
+    connectrpc as ConnectError(UNKNOWN, 'invalid content-type ...'). RemoteClientConfigStore
+    re-raises it as a user-facing InitializationError, which then gets wrapped as
+    RuntimeSystemError('Upload failed ...') during a run. The cause chain reveals the user
+    misconfiguration, so it must not be reported to Sentry."""
+    from flyte.errors import InitializationError, RuntimeSystemError
+
+    try:
+        try:
+            raise InitializationError(
+                "InvalidEndpoint",
+                "user",
+                "The configured endpoint returned a non-protobuf (HTML) response ...",
+            )
+        except InitializationError:
+            raise RuntimeSystemError("RuntimeError", "Upload failed for /tmp/spec.pb (org='x', ...).")
+    except RuntimeSystemError as e:
+        err = e
+
+    chain = list(_sentry._iter_cause_chain(err))
+    assert any(isinstance(c, InitializationError) for c in chain)
+
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()


### PR DESCRIPTION
## Problem

**Sentry: FLYTE-SDK-5N** (count 3, recurring on the latest SDK **2.5.1**)

The first call the SDK makes against a configured endpoint is the unauthenticated `AuthMetadataService` config fetch (`get_public_client_config` / `get_o_auth2_metadata`). When that endpoint returns an HTML body instead of protobuf — typically a **misconfigured endpoint** (a web console / login URL rather than the API endpoint), or a proxy/ingress that doesn't forward gRPC/Connect traffic — connectrpc raises:

```
ConnectError(UNKNOWN, "invalid content-type: 'text/html'; expecting 'application/proto'")
```

This propagated up through `RemoteClientConfigStore.get_client_config` and leaked into Sentry wrapped as `RuntimeSystemError("Upload failed for .../spec.pb")`, masking a clear user misconfiguration as an SDK/system bug.

## Fix

`RemoteClientConfigStore.get_client_config` now catches the content-type `ConnectError` and re-raises it as `InitializationError("InvalidEndpoint", "user", ...)` with an actionable message pointing the user at their endpoint configuration. `InitializationError` is in the `_is_user_error` allowlist, so the wrapped cause chain is filtered from Sentry. Other `ConnectError` codes (e.g. `UNAVAILABLE`) still propagate unchanged.

Note: `Code.UNKNOWN` is intentionally **not** added to the global `_USER_ACTIONABLE_CONNECT_CODES` filter set — UNKNOWN is too broad and can indicate real bugs; the fix is scoped to the content-type signal at the config-fetch site.

## Tests
- `TestGetClientConfigHtmlResponse` — HTML content-type → `InitializationError("InvalidEndpoint")`; other ConnectError codes propagate.
- `test_capture_exception_skips_wrapped_invalid_endpoint_error` — the full `RuntimeSystemError → InitializationError` chain is filtered from Sentry.

`make fmt` clean; full `test_sentry.py` + `test_connectrpc_error_handling.py` pass (44).

fixes FLYTE-SDK-5N