### PR TITLE
feat(connector): serve Connect (HTTP/1.1) alongside gRPC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ connector = [
     "grpcio-health-checking",
     "httpx",
     "prometheus-client",
+    "uvicorn",
 ]
 examples-test = [
     # Dependencies for running integration tests on examples

--- a/src/flyte/_bin/connect.py
+++ b/src/flyte/_bin/connect.py
@@ -14,7 +14,14 @@ def _connect():
     default="8000",
     is_flag=False,
     type=int,
-    help="Grpc port for the connector service. Defaults to 8000",
+    help="gRPC port for the connector service. Defaults to 8000",
+)
+@click.option(
+    "--connect_port",
+    default="8090",
+    is_flag=False,
+    type=int,
+    help="Connect (HTTP/1.1) port for the connector service. Defaults to 8090",
 )
 @click.option(
     "--prometheus_port",
@@ -35,8 +42,8 @@ def _connect():
     default=None,
     is_flag=False,
     type=int,
-    help="It will wait for the specified number of seconds before shutting down grpc server. It should only be used "
-    "for testing.",
+    help="It will wait for the specified number of seconds before shutting down the connector servers. It should only "
+    "be used for testing.",
 )
 @click.option(
     "--modules",
@@ -47,14 +54,20 @@ def _connect():
 )
 @click.pass_context
 def main(
-    _: click.Context, port: int, prometheus_port: int, worker: int, timeout: int | None, modules: List[str] | None
+    _: click.Context,
+    port: int,
+    connect_port: int,
+    prometheus_port: int,
+    worker: int,
+    timeout: int | None,
+    modules: List[str] | None,
 ):
     """
-    Start a grpc server for the connector service.
+    Start the connector service, serving both gRPC (``--port``) and Connect/HTTP1.1 (``--connect_port``).
     """
     from flyte.connectors import ConnectorService
 
-    ConnectorService.run(port, prometheus_port, worker, timeout, modules)
+    ConnectorService.run(port, connect_port, prometheus_port, worker, timeout, modules)
 
 
 if __name__ == "__main__":

--- a/src/flyte/app/_connector_environment.py
+++ b/src/flyte/app/_connector_environment.py
@@ -55,7 +55,19 @@ class ConnectorEnvironment(AppEnvironment):
                 port = self.port.port
             else:
                 port = self.port
-            base_args = ["c0", "--port", str(port), "--prometheus_port", "9092"]
+            # The Connect (HTTP/1.1) server runs alongside the gRPC server on a
+            # separate internal container port during the migration away from
+            # gRPC. ``port`` (the gRPC port) remains the externally exposed port.
+            connect_port = 8090 if port != 8090 else 8091
+            base_args = [
+                "c0",
+                "--port",
+                str(port),
+                "--connect_port",
+                str(connect_port),
+                "--prometheus_port",
+                "9092",
+            ]
             if self.include:
                 # Convert file paths to module names
                 modules = []

--- a/src/flyte/connectors/_connect_server.py
+++ b/src/flyte/connectors/_connect_server.py
@@ -1,0 +1,210 @@
+"""Connect (HTTP/1.1) transport for the Flyte connector service.
+
+This serves the same connector RPCs as the gRPC server in ``_server.py`` but
+over the Connect protocol via ASGI, so it can run behind a plain HTTP server
+(uvicorn). The two servers run side by side during the migration away from gRPC
+(see ``utils._start_connector_servers``); both delegate to the shared ``_do_*``
+business-logic handlers in ``_server.py`` so they never drift.
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import Callable, Iterable, Tuple
+
+from connectrpc.code import Code
+from connectrpc.errors import ConnectError
+from connectrpc.request import RequestContext
+from flyteidl2.connector.connector_pb2 import (
+    CreateTaskRequest,
+    CreateTaskResponse,
+    DeleteTaskRequest,
+    DeleteTaskResponse,
+    GetConnectorRequest,
+    GetConnectorResponse,
+    GetTaskLogsRequest,
+    GetTaskMetricsRequest,
+    GetTaskMetricsResponse,
+    GetTaskRequest,
+    GetTaskResponse,
+    ListConnectorsRequest,
+    ListConnectorsResponse,
+)
+from flyteidl2.connector.service_connect import (
+    AsyncConnectorServiceASGIApplication,
+    ConnectorMetadataServiceASGIApplication,
+)
+
+from flyte._logging import logger
+from flyte.connectors._connector import FlyteConnectorNotFound
+from flyte.connectors._server import (
+    _do_create_task,
+    _do_delete_task,
+    _do_get_connector,
+    _do_get_task,
+    _do_get_task_logs,
+    _do_get_task_metrics,
+    _do_list_connectors,
+    _extract_metrics_meta,
+    input_literal_size,
+    request_failure_count,
+    request_latency,
+    request_success_count,
+)
+
+HEALTH_CHECK_PATHS = ("/healthz", "/health")
+
+
+def _to_connect_error(e: Exception, task_type: str, operation: str) -> ConnectError:
+    """Map a handler exception to a ``ConnectError`` and record the failure metric.
+
+    This is the Connect counterpart of ``_server._handle_exception`` (which
+    mutates a gRPC ``ServicerContext``); both increment the same Prometheus
+    failure counter with matching labels.
+    """
+    if isinstance(e, FlyteConnectorNotFound):
+        error_message = f"Cannot find connector for task type: {task_type}."
+        logger.error(error_message)
+        request_failure_count.labels(task_type=task_type, operation=operation, error_code=HTTPStatus.NOT_FOUND).inc()
+        return ConnectError(Code.NOT_FOUND, error_message)
+    error_message = f"failed to {operation} {task_type} task with error:\n {e}."
+    logger.error(error_message)
+    request_failure_count.labels(
+        task_type=task_type, operation=operation, error_code=HTTPStatus.INTERNAL_SERVER_ERROR
+    ).inc()
+    return ConnectError(Code.INTERNAL, error_message)
+
+
+def _record_connect_metrics(func: Callable):
+    """Connect counterpart of ``_server.record_connector_metrics``.
+
+    Records the same Prometheus metrics, but surfaces failures as
+    ``ConnectError`` instead of mutating a gRPC ``ServicerContext``.
+    """
+
+    async def wrapper(self, request, ctx: RequestContext, *args, **kwargs):
+        task_type, operation, input_size = _extract_metrics_meta(request)
+        if task_type is None:
+            raise ConnectError(Code.UNIMPLEMENTED, "Method not implemented!")
+        if input_size is not None:
+            input_literal_size.labels(task_type=task_type).observe(input_size)
+
+        try:
+            with request_latency.labels(task_type=task_type, operation=operation).time():
+                res = await func(self, request, ctx, *args, **kwargs)
+            request_success_count.labels(task_type=task_type, operation=operation).inc()
+            return res
+        except Exception as e:
+            raise _to_connect_error(e, task_type, operation) from e
+
+    return wrapper
+
+
+class ConnectAsyncConnectorService:
+    """Connect implementation of ``flyteidl2.connector.AsyncConnectorService``."""
+
+    @_record_connect_metrics
+    async def create_task(self, request: CreateTaskRequest, ctx: RequestContext) -> CreateTaskResponse:
+        return await _do_create_task(request)
+
+    @_record_connect_metrics
+    async def get_task(self, request: GetTaskRequest, ctx: RequestContext) -> GetTaskResponse:
+        return await _do_get_task(request)
+
+    @_record_connect_metrics
+    async def delete_task(self, request: DeleteTaskRequest, ctx: RequestContext) -> DeleteTaskResponse:
+        return await _do_delete_task(request)
+
+    async def get_task_metrics(self, request: GetTaskMetricsRequest, ctx: RequestContext) -> GetTaskMetricsResponse:
+        return await _do_get_task_metrics(request)
+
+    async def get_task_logs(self, request: GetTaskLogsRequest, ctx: RequestContext):
+        # Server-streaming: connectRPC calls this (without awaiting) and iterates
+        # the returned async iterator, so it must be an async generator.
+        async for msg in _do_get_task_logs(request):
+            yield msg
+
+
+class ConnectConnectorMetadataService:
+    """Connect implementation of ``flyteidl2.connector.ConnectorMetadataService``."""
+
+    async def get_connector(self, request: GetConnectorRequest, ctx: RequestContext) -> GetConnectorResponse:
+        try:
+            return _do_get_connector(request)
+        except FlyteConnectorNotFound as e:
+            raise ConnectError(Code.NOT_FOUND, str(e)) from e
+
+    async def list_connectors(self, request: ListConnectorsRequest, ctx: RequestContext) -> ListConnectorsResponse:
+        return _do_list_connectors(request)
+
+
+async def _respond(send, status: HTTPStatus, body: bytes) -> None:
+    await send(
+        {
+            "type": "http.response.start",
+            "status": int(status),
+            "headers": [(b"content-type", b"text/plain; charset=utf-8")],
+        }
+    )
+    await send({"type": "http.response.body", "body": body, "more_body": False})
+
+
+class _ConnectorASGIApp:
+    """Minimal ASGI router for the connector.
+
+    Dispatches Connect RPC paths to the generated service applications, answers
+    health-check probes with ``200``, and ``404``s everything else. Handles the
+    ``lifespan`` scope directly because both services are plain instances whose
+    endpoints resolve lazily on the first request.
+    """
+
+    def __init__(
+        self,
+        applications: Iterable[Tuple[str, object]],
+        health_paths: Iterable[str] = HEALTH_CHECK_PATHS,
+    ):
+        # applications: iterable of (path_prefix, asgi_app)
+        self._applications = tuple(applications)
+        self._health_paths = tuple(health_paths)
+
+    async def __call__(self, scope, receive, send):
+        scope_type = scope["type"]
+        if scope_type == "lifespan":
+            await self._handle_lifespan(receive, send)
+            return
+        if scope_type != "http":
+            return
+
+        path = scope.get("path", "")
+        if path in self._health_paths:
+            await _respond(send, HTTPStatus.OK, b"OK")
+            return
+
+        for prefix, app in self._applications:
+            if path == prefix or path.startswith(prefix + "/"):
+                await app(scope, receive, send)
+                return
+
+        await _respond(send, HTTPStatus.NOT_FOUND, b"Not Found")
+
+    @staticmethod
+    async def _handle_lifespan(receive, send) -> None:
+        while True:
+            message = await receive()
+            if message["type"] == "lifespan.startup":
+                await send({"type": "lifespan.startup.complete"})
+            elif message["type"] == "lifespan.shutdown":
+                await send({"type": "lifespan.shutdown.complete"})
+                return
+
+
+def build_asgi_app() -> _ConnectorASGIApp:
+    """Build the combined ASGI app serving both connector services plus health checks."""
+    async_app = AsyncConnectorServiceASGIApplication(ConnectAsyncConnectorService())
+    metadata_app = ConnectorMetadataServiceASGIApplication(ConnectConnectorMetadataService())
+    return _ConnectorASGIApp(
+        applications=(
+            (async_app.path, async_app),
+            (metadata_app.path, metadata_app),
+        )
+    )

--- a/src/flyte/connectors/_server.py
+++ b/src/flyte/connectors/_server.py
@@ -2,7 +2,7 @@ import inspect
 import os
 import sys
 from http import HTTPStatus
-from typing import Callable, Dict, List, Tuple, Type, Union
+from typing import Callable, Dict, List, Optional, Tuple, Type, Union
 
 from flyteidl2.connector.connector_pb2 import (
     CreateTaskRequest,
@@ -28,7 +28,7 @@ from flyte._internal.runtime.convert import Inputs, convert_from_inputs_to_nativ
 from flyte._logging import logger
 from flyte.connectors._connector import ConnectorRegistry, FlyteConnectorNotFound, get_resource_proto
 from flyte.connectors._grpc import grpc
-from flyte.connectors.utils import _start_grpc_server
+from flyte.connectors.utils import _start_connector_servers
 from flyte.models import NativeInterface, _has_default
 from flyte.syncify import syncify
 from flyte.types import TypeEngine
@@ -57,6 +57,119 @@ request_latency = Summary(
 input_literal_size = Summary(f"{metric_prefix}input_literal_bytes", "Size of input literal", ["task_type"])
 
 
+def _get_connection_kwargs(request: Connection) -> Dict[str, str]:
+    kwargs = {}
+
+    for k, v in request.secrets.items():
+        kwargs[k] = v
+    for k, v in request.configs.items():
+        kwargs[k] = v
+
+    return kwargs
+
+
+def _extract_metrics_meta(
+    request: Union[CreateTaskRequest, GetTaskRequest, DeleteTaskRequest],
+) -> Tuple[Optional[str], str, Optional[int]]:
+    """Resolve ``(task_type, operation, input_literal_bytes)`` for metric labels.
+
+    ``task_type`` is ``None`` for unrecognized request types so the caller can
+    surface an "unimplemented" error (in which case ``operation`` is unused).
+    This is shared by the gRPC and Connect metric wrappers so both transports
+    label metrics identically.
+    """
+    if isinstance(request, CreateTaskRequest):
+        input_size = request.inputs.ByteSize() if request.inputs else None
+        return request.template.type, create_operation, input_size
+    if isinstance(request, GetTaskRequest):
+        return request.task_category.name, get_operation, None
+    if isinstance(request, DeleteTaskRequest):
+        return request.task_category.name, delete_operation, None
+    return None, "", None
+
+
+# ---------------------------------------------------------------------------
+# Transport-agnostic business logic.
+#
+# These handlers contain the actual connector logic and raise plain exceptions
+# (e.g. ``FlyteConnectorNotFound``). The gRPC servicers below and the Connect
+# services in ``_connect_server`` are thin adapters that wrap these with their
+# transport-specific metrics and error mapping, so the two servers never drift.
+# ---------------------------------------------------------------------------
+async def _do_create_task(request: CreateTaskRequest) -> CreateTaskResponse:
+    template = request.template
+    connector = ConnectorRegistry.get_connector(template.type, template.task_type_version)
+    logger.info(f"{connector.name} start creating the job")
+    python_interface_inputs: Dict[str, Tuple[Type, Type[_has_default] | Type[inspect._empty]]] = {
+        entry.key: (TypeEngine.guess_python_type(entry.value.type), inspect.Parameter.empty)
+        for entry in template.interface.inputs.variables
+    }
+    native_interface = NativeInterface.from_types(inputs=python_interface_inputs, outputs={})
+    native_inputs = await convert_from_inputs_to_native(native_interface, Inputs(proto_inputs=request.inputs))
+    resource_meta = await connector.create(
+        task_template=request.template,
+        inputs=native_inputs,
+        output_prefix=request.output_prefix,
+        task_execution_metadata=request.task_execution_metadata,
+        **_get_connection_kwargs(request.connection),
+    )
+    return CreateTaskResponse(resource_meta=resource_meta.encode())
+
+
+async def _do_get_task(request: GetTaskRequest) -> GetTaskResponse:
+    connector = ConnectorRegistry.get_connector(request.task_category.name, request.task_category.version)
+    logger.info(f"{connector.name} start checking the status of the job")
+    res = await connector.get(
+        resource_meta=connector.metadata_type.decode(request.resource_meta),
+        **_get_connection_kwargs(request.connection),
+    )
+    return GetTaskResponse(resource=await get_resource_proto(res))
+
+
+async def _do_delete_task(request: DeleteTaskRequest) -> DeleteTaskResponse:
+    connector = ConnectorRegistry.get_connector(request.task_category.name, request.task_category.version)
+    logger.info(f"{connector.name} start deleting the job")
+    await connector.delete(
+        resource_meta=connector.metadata_type.decode(request.resource_meta),
+        **_get_connection_kwargs(request.connection),
+    )
+    return DeleteTaskResponse()
+
+
+async def _do_get_task_metrics(request: GetTaskMetricsRequest) -> GetTaskMetricsResponse:
+    connector = ConnectorRegistry.get_connector(request.task_category.name, request.task_category.version)
+    logger.info(f"{connector.name} start getting metrics of the job")
+    return await connector.get_metrics(resource_meta=connector.metadata_type.decode(request.resource_meta))
+
+
+async def _do_get_task_logs(request: GetTaskLogsRequest):
+    connector = ConnectorRegistry.get_connector(request.task_category.name, request.task_category.version)
+    logger.info(f"{connector.name} start getting logs of the job")
+    # `get_logs` may be either:
+    #   - an async generator yielding multiple GetTaskLogsResponse messages
+    #     (preferred — supports interleaved body/header/body pagination, since
+    #     proto3 oneof keeps only one of body/header per message),
+    #   - or an async function returning a single GetTaskLogsResponse.
+    result = connector.get_logs(
+        resource_meta=connector.metadata_type.decode(request.resource_meta),
+        token=request.token,
+    )
+    if inspect.isasyncgen(result):
+        async for msg in result:
+            yield msg
+        return
+    response = await result
+    yield response
+
+
+def _do_get_connector(request: GetConnectorRequest) -> GetConnectorResponse:
+    return GetConnectorResponse(connector=ConnectorRegistry._get_connector_metadata(request.name))
+
+
+def _do_list_connectors(request: ListConnectorsRequest) -> ListConnectorsResponse:
+    return ListConnectorsResponse(connectors=ConnectorRegistry._list_connectors())
+
+
 def _handle_exception(e: Exception, context: grpc.ServicerContext, task_type: str, operation: str):
     if isinstance(e, FlyteConnectorNotFound):
         error_message = f"Cannot find connector for task type: {task_type}."
@@ -77,11 +190,19 @@ def _handle_exception(e: Exception, context: grpc.ServicerContext, task_type: st
 class ConnectorService:
     @syncify
     @classmethod
-    async def run(cls, port: int, prometheus_port: int, worker: int, timeout: int | None, modules: List[str] | None):
+    async def run(
+        cls,
+        port: int,
+        connect_port: int,
+        prometheus_port: int,
+        worker: int,
+        timeout: int | None,
+        modules: List[str] | None,
+    ):
         working_dir = os.getcwd()
         if all(os.path.realpath(path) != working_dir for path in sys.path):
             sys.path.append(working_dir)
-        await _start_grpc_server(port, prometheus_port, worker, timeout, modules)
+        await _start_connector_servers(port, connect_port, prometheus_port, worker, timeout, modules)
 
 
 def record_connector_metrics(func: Callable):
@@ -92,21 +213,13 @@ def record_connector_metrics(func: Callable):
         *args,
         **kwargs,
     ):
-        if isinstance(request, CreateTaskRequest):
-            task_type = request.template.type
-            operation = create_operation
-            if request.inputs:
-                input_literal_size.labels(task_type=task_type).observe(request.inputs.ByteSize())
-        elif isinstance(request, GetTaskRequest):
-            task_type = request.task_category.name
-            operation = get_operation
-        elif isinstance(request, DeleteTaskRequest):
-            task_type = request.task_category.name
-            operation = delete_operation
-        else:
+        task_type, operation, input_size = _extract_metrics_meta(request)
+        if task_type is None:
             context.set_code(grpc.StatusCode.UNIMPLEMENTED)
             context.set_details("Method not implemented!")
             return None
+        if input_size is not None:
+            input_literal_size.labels(task_type=task_type).observe(input_size)
 
         try:
             with request_latency.labels(task_type=task_type, operation=operation).time():
@@ -119,90 +232,34 @@ def record_connector_metrics(func: Callable):
     return wrapper
 
 
-def _get_connection_kwargs(request: Connection) -> Dict[str, str]:
-    kwargs = {}
-
-    for k, v in request.secrets.items():
-        kwargs[k] = v
-    for k, v in request.configs.items():
-        kwargs[k] = v
-
-    return kwargs
-
-
 class AsyncConnectorService(AsyncConnectorServiceServicer):
     @record_connector_metrics
     async def CreateTask(self, request: CreateTaskRequest, context: grpc.ServicerContext) -> CreateTaskResponse:
-        template = request.template
-        connector = ConnectorRegistry.get_connector(template.type, template.task_type_version)
-        logger.info(f"{connector.name} start creating the job")
-        python_interface_inputs: Dict[str, Tuple[Type, Type[_has_default] | Type[inspect._empty]]] = {
-            entry.key: (TypeEngine.guess_python_type(entry.value.type), inspect.Parameter.empty)
-            for entry in template.interface.inputs.variables
-        }
-        native_interface = NativeInterface.from_types(inputs=python_interface_inputs, outputs={})
-        native_inputs = await convert_from_inputs_to_native(native_interface, Inputs(proto_inputs=request.inputs))
-        resource_meta = await connector.create(
-            task_template=request.template,
-            inputs=native_inputs,
-            output_prefix=request.output_prefix,
-            task_execution_metadata=request.task_execution_metadata,
-            **_get_connection_kwargs(request.connection),
-        )
-        return CreateTaskResponse(resource_meta=resource_meta.encode())
+        return await _do_create_task(request)
 
     @record_connector_metrics
     async def GetTask(self, request: GetTaskRequest, context: grpc.ServicerContext) -> GetTaskResponse:
-        connector = ConnectorRegistry.get_connector(request.task_category.name, request.task_category.version)
-        logger.info(f"{connector.name} start checking the status of the job")
-        res = await connector.get(
-            resource_meta=connector.metadata_type.decode(request.resource_meta),
-            **_get_connection_kwargs(request.connection),
-        )
-        return GetTaskResponse(resource=await get_resource_proto(res))
+        return await _do_get_task(request)
 
     @record_connector_metrics
     async def DeleteTask(self, request: DeleteTaskRequest, context: grpc.ServicerContext) -> DeleteTaskResponse:
-        connector = ConnectorRegistry.get_connector(request.task_category.name, request.task_category.version)
-        logger.info(f"{connector.name} start deleting the job")
-        await connector.delete(
-            resource_meta=connector.metadata_type.decode(request.resource_meta),
-            **_get_connection_kwargs(request.connection),
-        )
-        return DeleteTaskResponse()
+        return await _do_delete_task(request)
 
     async def GetTaskMetrics(
         self, request: GetTaskMetricsRequest, context: grpc.ServicerContext
     ) -> GetTaskMetricsResponse:
-        connector = ConnectorRegistry.get_connector(request.task_category.name, request.task_category.version)
-        logger.info(f"{connector.name} start getting metrics of the job")
-        return await connector.get_metrics(resource_meta=connector.metadata_type.decode(request.resource_meta))
+        return await _do_get_task_metrics(request)
 
     async def GetTaskLogs(self, request: GetTaskLogsRequest, context: grpc.ServicerContext) -> GetTaskLogsResponse:
-        connector = ConnectorRegistry.get_connector(request.task_category.name, request.task_category.version)
-        logger.info(f"{connector.name} start getting logs of the job")
-        # `get_logs` may be either:
-        #   - an async generator yielding multiple GetTaskLogsResponse messages
-        #     (preferred — supports interleaved body/header/body pagination, since
-        #     proto3 oneof keeps only one of body/header per message),
-        #   - or an async function returning a single GetTaskLogsResponse.
-        result = connector.get_logs(
-            resource_meta=connector.metadata_type.decode(request.resource_meta),
-            token=request.token,
-        )
-        if inspect.isasyncgen(result):
-            async for msg in result:
-                yield msg
-            return
-        response = await result
-        yield response
+        async for msg in _do_get_task_logs(request):
+            yield msg
 
 
 class ConnectorMetadataService(ConnectorMetadataServiceServicer):
     async def GetConnector(self, request: GetConnectorRequest, context: grpc.ServicerContext) -> GetConnectorResponse:
-        return GetConnectorResponse(connector=ConnectorRegistry._get_connector_metadata(request.name))
+        return _do_get_connector(request)
 
     async def ListConnectors(
         self, request: ListConnectorsRequest, context: grpc.ServicerContext
     ) -> ListConnectorsResponse:
-        return ListConnectorsResponse(connectors=ConnectorRegistry._list_connectors())
+        return _do_list_connectors(request)

--- a/src/flyte/connectors/utils.py
+++ b/src/flyte/connectors/utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 from concurrent import futures
 from importlib.metadata import entry_points
@@ -44,13 +45,25 @@ def convert_to_flyte_phase(state: str) -> TaskExecution.Phase:
     raise ValueError(f"Unrecognized state: {state}")
 
 
-async def _start_grpc_server(
-    port: int, prometheus_port: int, worker: int, timeout: int | None, modules: List[str] | None
+async def _start_connector_servers(
+    port: int,
+    connect_port: int,
+    prometheus_port: int,
+    worker: int,
+    timeout: int | None,
+    modules: List[str] | None,
 ):
+    """Run the gRPC and Connect connector servers side by side in one process.
+
+    During the migration away from gRPC the connector serves both transports:
+    the existing gRPC server on ``port`` (for the still-gRPC backend) and a
+    Connect/HTTP1.1 server on ``connect_port`` (for migrated clients). Connector
+    discovery and the Prometheus metrics server are set up once, shared by both.
+    """
     try:
         from flyte.connectors._server import (
-            AsyncConnectorService,
-            ConnectorMetadataService,
+            AsyncConnectorService,  # noqa: F401
+            ConnectorMetadataService,  # noqa: F401
         )
     except ImportError as e:
         raise ImportError(
@@ -64,6 +77,18 @@ async def _start_grpc_server(
 
     print_metadata()
 
+    await asyncio.gather(
+        _serve_grpc(port, worker, timeout),
+        _serve_connect(connect_port, timeout),
+    )
+
+
+async def _serve_grpc(port: int, worker: int, timeout: int | None):
+    from flyte.connectors._server import (
+        AsyncConnectorService,
+        ConnectorMetadataService,
+    )
+
     server = grpc.aio.server(futures.ThreadPoolExecutor(max_workers=worker))
 
     add_AsyncConnectorServiceServicer_to_server(AsyncConnectorService(), server)
@@ -71,8 +96,54 @@ async def _start_grpc_server(
     _start_health_check_server(server, worker)
 
     server.add_insecure_port(f"[::]:{port}")
+    click.secho(f"gRPC connector service listening on [::]:{port}")
     await server.start()
     await server.wait_for_termination(timeout)
+
+
+async def _serve_connect(port: int, timeout: int | None):
+    try:
+        import uvicorn
+    except ImportError as e:
+        raise ImportError(
+            "uvicorn is required to serve the Connect connector service."
+            " Please install it using `pip install flyteplugins-connector` or `pip install uvicorn`"
+        ) from e
+
+    from flyte.connectors._connect_server import build_asgi_app
+
+    class _NoSignalServer(uvicorn.Server):
+        # The connector process manages its own lifecycle and shares the event
+        # loop with the gRPC server, so don't let uvicorn install its own
+        # SIGINT/SIGTERM handlers (the default disposition terminates the
+        # process, tearing down both servers — matching the gRPC-only behavior).
+        def install_signal_handlers(self) -> None:
+            pass
+
+    config = uvicorn.Config(
+        build_asgi_app(),
+        host="0.0.0.0",
+        port=port,
+        log_level="warning",
+        access_log=False,
+        loop="asyncio",
+        lifespan="auto",
+    )
+    server = _NoSignalServer(config)
+    click.secho(f"Connect connector service listening on 0.0.0.0:{port}")
+
+    if timeout is None:
+        await server.serve()
+        return
+
+    # ``timeout`` is a testing aid mirroring grpc's wait_for_termination(timeout):
+    # serve for the requested window, then shut down gracefully.
+    serve_task = asyncio.ensure_future(server.serve())
+    try:
+        await asyncio.sleep(timeout)
+    finally:
+        server.should_exit = True
+        await serve_task
 
 
 def _start_http_server(prometheus_port: int):

--- a/tests/flyte/app/test_connector_environment.py
+++ b/tests/flyte/app/test_connector_environment.py
@@ -96,7 +96,7 @@ def test_connector_environment_container_args_default():
     )
 
     args = conn_env.container_args(ctx)
-    assert args == ["c0", "--port", "8080", "--prometheus_port", "9092"]
+    assert args == ["c0", "--port", "8080", "--connect_port", "8090", "--prometheus_port", "9092"]
 
 
 def test_connector_environment_container_args_custom_port():
@@ -122,7 +122,7 @@ def test_connector_environment_container_args_custom_port():
     )
 
     args = conn_env.container_args(ctx)
-    assert args == ["c0", "--port", "9999", "--prometheus_port", "9092"]
+    assert args == ["c0", "--port", "9999", "--connect_port", "8090", "--prometheus_port", "9092"]
 
 
 def test_connector_environment_container_args_with_custom_args():
@@ -302,7 +302,7 @@ def test_connector_environment_comprehensive_happy_path():
         root_dir=pathlib.Path.cwd(),
     )
     args = conn_env.container_args(ctx)
-    assert args == ["c0", "--port", "8181", "--prometheus_port", "9092"]
+    assert args == ["c0", "--port", "8181", "--connect_port", "8090", "--prometheus_port", "9092"]
 
     # Test container_cmd with code bundle
     ctx_with_bundle = SerializationContext(
@@ -533,7 +533,7 @@ def test_connector_environment_empty_args_vs_none_args():
         image=Image.from_base("python:3.11"),
         args=None,
     )
-    assert conn_none.container_args(ctx) == ["c0", "--port", "8080", "--prometheus_port", "9092"]
+    assert conn_none.container_args(ctx) == ["c0", "--port", "8080", "--connect_port", "8090", "--prometheus_port", "9092"]
 
     # Empty list should return empty list (not connector defaults)
     conn_empty = ConnectorEnvironment(

--- a/tests/flyte/connector/test_connect_connector_service.py
+++ b/tests/flyte/connector/test_connect_connector_service.py
@@ -1,0 +1,255 @@
+import pathlib
+import typing
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+import pytest
+from connectrpc.code import Code
+from connectrpc.errors import ConnectError
+from flyteidl2.connector.connector_pb2 import (
+    CreateTaskRequest,
+    DeleteTaskRequest,
+    DeleteTaskResponse,
+    GetConnectorRequest,
+    GetTaskLogsRequest,
+    GetTaskLogsResponse,
+    GetTaskLogsResponseBody,
+    GetTaskMetricsRequest,
+    GetTaskMetricsResponse,
+    GetTaskRequest,
+    ListConnectorsRequest,
+    TaskCategory,
+)
+from flyteidl2.core import literals_pb2
+from flyteidl2.core.execution_pb2 import TaskExecution, TaskLog
+from flyteidl2.core.metrics_pb2 import ExecutionMetricResult
+from flyteidl2.core.tasks_pb2 import TaskTemplate
+from flyteidl2.task import common_pb2
+
+import flyte
+from flyte._internal.runtime.task_serde import get_proto_task
+from flyte.connectors._connect_server import (
+    ConnectAsyncConnectorService,
+    ConnectConnectorMetadataService,
+    build_asgi_app,
+)
+from flyte.connectors._connector import AsyncConnector, ConnectorRegistry, Resource, ResourceMeta
+from flyte.models import SerializationContext
+
+
+@dataclass
+class DummyMetadata(ResourceMeta):
+    job_id: str
+    output_path: typing.Optional[str] = None
+    task_name: typing.Optional[str] = None
+
+
+class DummyConnector(AsyncConnector):
+    name: str = "Dummy Connector"
+    task_type_name: str = "async_dummy"
+    metadata_type: type = DummyMetadata
+
+    async def create(
+        self, task_template: TaskTemplate, inputs: typing.Optional[typing.Dict[str, typing.Any]], **kwargs
+    ) -> DummyMetadata:
+        return DummyMetadata(job_id="dummy_id", output_path="/tmp/dummy_id", task_name="async_dummy")
+
+    async def get(self, resource_meta: DummyMetadata, **kwargs) -> Resource:
+        return Resource(
+            phase=TaskExecution.SUCCEEDED,
+            log_links=[TaskLog(name="console", uri="localhost:3000")],
+            custom_info={"custom": "info", "num": 1},
+        )
+
+    async def delete(self, resource_meta: DummyMetadata, **kwargs): ...
+
+    async def get_metrics(self, resource_meta: DummyMetadata, **kwargs) -> GetTaskMetricsResponse:
+        return GetTaskMetricsResponse(
+            results=[ExecutionMetricResult(metric="EXECUTION_METRIC_LIMIT_MEMORY_BYTES", data=None)]
+        )
+
+    async def get_logs(self, resource_meta: DummyMetadata, **kwargs) -> GetTaskLogsResponse:
+        return GetTaskLogsResponse(body=GetTaskLogsResponseBody(results=["foo", "bar"]))
+
+
+def get_task_template() -> TaskTemplate:
+    env = flyte.TaskEnvironment(name="test_env_connect", image="python:3.10")
+
+    @env.task
+    async def test_function(a: int) -> int:
+        return a
+
+    test_function.task_type = "async_dummy"
+    context = SerializationContext(
+        project="test-project",
+        domain="test-domain",
+        version="test-version",
+        org="test-org",
+        image_cache=None,
+        code_bundle=None,
+        root_dir=pathlib.Path.cwd(),
+    )
+    return get_proto_task(test_function, context)
+
+
+async def _drive(app, scope, body: bytes = b""):
+    """Drive an ASGI app through a single request and collect the sent messages."""
+    sent: list[dict] = []
+    received = [{"type": "http.request", "body": body, "more_body": False}]
+
+    async def receive():
+        return received.pop(0) if received else {"type": "http.disconnect"}
+
+    async def send(message):
+        sent.append(message)
+
+    await app(scope, receive, send)
+    return sent
+
+
+@pytest.fixture
+def dummy_connector():
+    connector = DummyConnector()
+    ConnectorRegistry.register(connector, override=True)
+    return connector
+
+
+@pytest.mark.asyncio
+async def test_connect_async_connector_service(dummy_connector):
+    service = ConnectAsyncConnectorService()
+    ctx = MagicMock()
+
+    inputs_proto = common_pb2.Inputs(
+        literals=[
+            common_pb2.NamedLiteral(
+                name="a",
+                value=literals_pb2.Literal(scalar=literals_pb2.Scalar(primitive=literals_pb2.Primitive(integer=1))),
+            ),
+        ],
+    )
+
+    output_prefix = "/tmp"
+    dummy_id = "dummy_id"
+    metadata_bytes = DummyMetadata(
+        job_id=dummy_id,
+        output_path=f"{output_prefix}/{dummy_id}",
+        task_name=dummy_connector.task_type_name,
+    ).encode()
+
+    task_category = TaskCategory(name=dummy_connector.task_type_name, version=dummy_connector.task_type_version)
+
+    create_res = await service.create_task(
+        CreateTaskRequest(inputs=inputs_proto, template=get_task_template(), output_prefix=output_prefix), ctx
+    )
+    assert create_res.resource_meta == metadata_bytes
+
+    get_res = await service.get_task(GetTaskRequest(task_category=task_category, resource_meta=metadata_bytes), ctx)
+    assert get_res.resource.phase == TaskExecution.SUCCEEDED
+
+    delete_res = await service.delete_task(
+        DeleteTaskRequest(task_category=task_category, resource_meta=metadata_bytes), ctx
+    )
+    assert delete_res == DeleteTaskResponse()
+
+    metrics_res = await service.get_task_metrics(
+        GetTaskMetricsRequest(task_category=task_category, resource_meta=metadata_bytes), ctx
+    )
+    assert metrics_res.results[0].metric == "EXECUTION_METRIC_LIMIT_MEMORY_BYTES"
+
+    log_responses = [
+        msg
+        async for msg in service.get_task_logs(
+            GetTaskLogsRequest(task_category=task_category, resource_meta=metadata_bytes), ctx
+        )
+    ]
+    assert log_responses[0].body.results == ["foo", "bar"]
+
+
+@pytest.mark.asyncio
+async def test_connect_service_not_found_raises_connect_error(dummy_connector):
+    service = ConnectAsyncConnectorService()
+    ctx = MagicMock()
+
+    with pytest.raises(ConnectError) as exc_info:
+        await service.get_task(
+            GetTaskRequest(task_category=TaskCategory(name="does-not-exist", version=0), resource_meta=b"{}"), ctx
+        )
+    assert exc_info.value.code == Code.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_connect_metadata_service(dummy_connector):
+    service = ConnectConnectorMetadataService()
+    ctx = MagicMock()
+
+    get_res = await service.get_connector(GetConnectorRequest(name=dummy_connector.name), ctx)
+    assert get_res.connector.name == dummy_connector.name
+    assert get_res.connector.supported_task_categories[0].name == dummy_connector.task_type_name
+
+    list_res = await service.list_connectors(ListConnectorsRequest(), ctx)
+    assert any(c.name == dummy_connector.name for c in list_res.connectors)
+
+    with pytest.raises(ConnectError) as exc_info:
+        await service.get_connector(GetConnectorRequest(name="non-exist-name"), ctx)
+    assert exc_info.value.code == Code.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_asgi_app_health_check():
+    app = build_asgi_app()
+    for path in ("/healthz", "/health"):
+        scope = {"type": "http", "method": "GET", "path": path, "headers": [], "root_path": ""}
+        sent = await _drive(app, scope)
+        assert sent[0]["type"] == "http.response.start"
+        assert sent[0]["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_asgi_app_unknown_path_returns_404():
+    app = build_asgi_app()
+    scope = {"type": "http", "method": "GET", "path": "/unknown", "headers": [], "root_path": ""}
+    sent = await _drive(app, scope)
+    assert sent[0]["status"] == 404
+
+
+@pytest.mark.asyncio
+async def test_asgi_app_routes_to_connect_services():
+    app = build_asgi_app()
+    # A request under each service prefix should be routed to the generated
+    # application (which rejects this malformed GET), not handled as 404 by the router.
+    for prefix in (
+        "/flyteidl2.connector.AsyncConnectorService/CreateTask",
+        "/flyteidl2.connector.ConnectorMetadataService/ListConnectors",
+    ):
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": prefix,
+            "headers": [],
+            "root_path": "",
+            "query_string": b"",
+            "scheme": "http",
+            "extensions": {},
+        }
+        sent = await _drive(app, scope)
+        # The generated ConnectASGIApplication handled it (any status other than
+        # the router's own 404-for-unknown-prefix is fine).
+        assert sent, "expected the connect application to produce a response"
+        assert sent[0]["type"] == "http.response.start"
+
+
+@pytest.mark.asyncio
+async def test_asgi_app_lifespan():
+    app = build_asgi_app()
+    events = [{"type": "lifespan.startup"}, {"type": "lifespan.shutdown"}]
+    sent: list[dict] = []
+
+    async def receive():
+        return events.pop(0)
+
+    async def send(message):
+        sent.append(message)
+
+    await app({"type": "lifespan"}, receive, send)
+    assert {"type": "lifespan.startup.complete"} in sent
+    assert {"type": "lifespan.shutdown.complete"} in sent

--- a/tests/user_api_apps/test_connector_environment.py
+++ b/tests/user_api_apps/test_connector_environment.py
@@ -36,14 +36,14 @@ def test_connector_default_args():
     conn = ConnectorEnvironment(name="my-connector", image=Image.from_base("python:3.11"))
     ctx = SerializationContext(org="org", project="proj", domain="dev", version="v1", root_dir=pathlib.Path.cwd())
     args = conn.container_args(ctx)
-    assert args == ["c0", "--port", "8080", "--prometheus_port", "9092"]
+    assert args == ["c0", "--port", "8080", "--connect_port", "8090", "--prometheus_port", "9092"]
 
 
 def test_connector_default_args_custom_port():
     conn = ConnectorEnvironment(name="my-connector", image=Image.from_base("python:3.11"), port=9999)
     ctx = SerializationContext(org="org", project="proj", domain="dev", version="v1", root_dir=pathlib.Path.cwd())
     args = conn.container_args(ctx)
-    assert args == ["c0", "--port", "9999", "--prometheus_port", "9092"]
+    assert args == ["c0", "--port", "9999", "--connect_port", "8090", "--prometheus_port", "9092"]
 
 
 def test_connector_custom_args_list():


### PR DESCRIPTION
## What
Adds a **Connect (HTTP/1.1) transport** to the connector server, running **side by side with the existing gRPC server in a single process on two ports**:

- gRPC server on `--port` (default 8080, `h2c`) — unchanged, for the still-gRPC backend.
- Connect/HTTP1.1 server (uvicorn) on the new `--connect_port` (default 8090) — serves `AsyncConnectorService` + `ConnectorMetadataService` over the Connect protocol plus a plain HTTP `GET /healthz` probe.

The per-RPC logic was extracted into transport-agnostic `_do_*` handlers in `_server.py`; the gRPC servicers and the new connectRPC services in `_connect_server.py` are thin adapters over them (each with its own metrics + error mapping), so the two transports can't drift. Connector loading and the Prometheus metrics server are set up once and shared.

## Why
flyte core already moved from gRPC to buf/Connect, but the connector was still gRPC-only. This is the connector half of that migration. Because the Go backend plugin still speaks gRPC to the connector, both transports run simultaneously during the transition — zero-downtime: deploy the connector serving both, migrate the backend to the Connect port, then drop gRPC in a follow-up.

> **Note on the two-port design:** the gRPC *wire protocol* cannot be served reliably from connect-python on a single negotiated port — it requires HTTP/2 + response trailers, and connectRPC's docs flag the HTTP/2 ASGI servers (hypercorn/granian) as not passing conformance (only the very new `pyvoy` does). The Connect protocol (unary **and** the server-streaming used by `GetTaskLogs`) runs fine over HTTP/1.1 via uvicorn, so we serve Connect on its own HTTP/1.1 port and keep gRPC on grpcio.

## Changes
- `connectors/_server.py` — shared `_do_*` handlers + `_extract_metrics_meta`; gRPC servicers reduced to thin wrappers; `ConnectorService.run` gains `connect_port`.
- `connectors/_connect_server.py` *(new)* — connectRPC service impls, `ConnectError` mapping, and `build_asgi_app()` (router → both services + `/healthz`, handles the ASGI `lifespan` scope).
- `connectors/utils.py` — `_start_connector_servers` runs `_serve_grpc` + `_serve_connect` (uvicorn, signal handlers suppressed) via `asyncio.gather`; `timeout` honored for tests.
- `_bin/connect.py` — `--connect_port` option.
- `app/_connector_environment.py` — `container_args` passes `--connect_port` (internal container port; gRPC `port` stays the exposed one).
- `pyproject.toml` — add `uvicorn` to the `connector` extra (kept `grpcio*` for the transition).

## Test
- New `tests/flyte/connector/test_connect_connector_service.py` (7 tests): Connect create/get/delete/metrics/logs handlers, `FlyteConnectorNotFound` → `ConnectError(NOT_FOUND)`, `/healthz`→200, prefix routing, 404, and `lifespan`.
- Updated 6 `container_args` assertions for the new `--connect_port`.
- Local end-to-end (not in CI): started both servers, hit `/healthz`→200 and real Connect RPCs (`list_connectors`, `get_connector`, `get_task`→SUCCEEDED) over HTTP/1.1; not-found surfaced as `Code.NOT_FOUND` over the wire.
- `mypy`, `ruff check`/`format` clean; 44 connector/env + 216 app tests pass.

## Out of scope (Go-side / deploy, follow-up)
Exposing the Connect port at the k8s Service and repointing the backend plugin to it. This PR only makes the connector *serve* both. gRPC removal is a later step once the backend is migrated.