### PR TITLE
fix(controllers): bound informer watch establishment to recover from half-open reconnects

### DIFF
--- a/src/flyte/_internal/controllers/remote/_informer.py
+++ b/src/flyte/_internal/controllers/remote/_informer.py
@@ -260,9 +260,7 @@ class Informer:
                         if established:
                             resp = await watch_iter.__anext__()
                         else:
-                            resp = await asyncio.wait_for(
-                                watch_iter.__anext__(), timeout=self._watch_conn_timeout_sec
-                            )
+                            resp = await asyncio.wait_for(watch_iter.__anext__(), timeout=self._watch_conn_timeout_sec)
                     except StopAsyncIteration:
                         break
                     retries = 0

--- a/src/flyte/_internal/controllers/remote/_informer.py
+++ b/src/flyte/_internal/controllers/remote/_informer.py
@@ -253,29 +253,8 @@ class Informer:
                             parent_action_id=parent_action_id,
                         ),
                     )
-                # Bound the time to receive each message of the initial snapshot
-                # up to the sentinel. After a server restart the transport can
-                # hand back a pooled keep-alive connection that is half-open
-                # (peer gone, no RST); the request is written but the chunked
-                # response read never returns, and with read_timeout unset on the
-                # transport this would wedge the watch -- and the parent action --
-                # forever. The deadline turns that hang into a TimeoutError so the
-                # retry/backoff path can re-issue the watch on a fresh connection,
-                # whose snapshot re-syncs the children's current states.
-                #
-                # `established` is per-attempt (NOT self._ready): the incident
-                # hung on a *reconnect* after the informer was already ready, so
-                # the deadline must guard every fresh stream. Once the sentinel
-                # arrives the stream may legitimately idle between updates, so the
-                # deadline is dropped.
-                # ponytail: this only guards establishment; a stream that dies
-                # silently *after* the sentinel still needs server-side heartbeats
-                # (none today) to detect -- tracked separately.
                 established = False
                 watch_iter = watcher.__aiter__()
-                # Equivalent to `async for resp in watcher`; the outer loop gates
-                # on self._running and stop() cancels the await, so no per-message
-                # running check is needed here.
                 while True:
                     try:
                         if established:

--- a/src/flyte/_internal/controllers/remote/_informer.py
+++ b/src/flyte/_internal/controllers/remote/_informer.py
@@ -273,7 +273,10 @@ class Informer:
                 # (none today) to detect -- tracked separately.
                 established = False
                 watch_iter = watcher.__aiter__()
-                while self._running:
+                # Equivalent to `async for resp in watcher`; the outer loop gates
+                # on self._running and stop() cancels the await, so no per-message
+                # running check is needed here.
+                while True:
                     try:
                         if established:
                             resp = await watch_iter.__anext__()

--- a/src/flyte/_internal/controllers/remote/_informer.py
+++ b/src/flyte/_internal/controllers/remote/_informer.py
@@ -253,7 +253,36 @@ class Informer:
                             parent_action_id=parent_action_id,
                         ),
                     )
-                async for resp in watcher:
+                # Bound the time to receive each message of the initial snapshot
+                # up to the sentinel. After a server restart the transport can
+                # hand back a pooled keep-alive connection that is half-open
+                # (peer gone, no RST); the request is written but the chunked
+                # response read never returns, and with read_timeout unset on the
+                # transport this would wedge the watch -- and the parent action --
+                # forever. The deadline turns that hang into a TimeoutError so the
+                # retry/backoff path can re-issue the watch on a fresh connection,
+                # whose snapshot re-syncs the children's current states.
+                #
+                # `established` is per-attempt (NOT self._ready): the incident
+                # hung on a *reconnect* after the informer was already ready, so
+                # the deadline must guard every fresh stream. Once the sentinel
+                # arrives the stream may legitimately idle between updates, so the
+                # deadline is dropped.
+                # ponytail: this only guards establishment; a stream that dies
+                # silently *after* the sentinel still needs server-side heartbeats
+                # (none today) to detect -- tracked separately.
+                established = False
+                watch_iter = watcher.__aiter__()
+                while self._running:
+                    try:
+                        if established:
+                            resp = await watch_iter.__anext__()
+                        else:
+                            resp = await asyncio.wait_for(
+                                watch_iter.__anext__(), timeout=self._watch_conn_timeout_sec
+                            )
+                    except StopAsyncIteration:
+                        break
                     retries = 0
                     if resp is None:
                         # gRPC deserialization failure: _transform() caught an
@@ -266,6 +295,7 @@ class Informer:
                     if resp.control_message is not None and resp.control_message.sentinel:
                         logger.info(f"Received Sentinel, for run {self.name}")
                         await self._set_ready()
+                        established = True
                         continue
                     node = await self._action_cache.observe_state(resp.action_update)
                     await self._shared_queue.put(node)

--- a/tests/internal/controllers/test_informer_watch.py
+++ b/tests/internal/controllers/test_informer_watch.py
@@ -22,16 +22,12 @@ from flyte._internal.controllers.remote._informer import Informer
 
 def _update(child_id, phase, output_uri="s3://out"):
     return actions_service_pb2.WatchForUpdatesResponse(
-        action_update=state_service_pb2.ActionUpdate(
-            action_id=child_id, phase=phase, output_uri=output_uri
-        )
+        action_update=state_service_pb2.ActionUpdate(action_id=child_id, phase=phase, output_uri=output_uri)
     )
 
 
 def _sentinel():
-    return actions_service_pb2.WatchForUpdatesResponse(
-        control_message=state_service_pb2.ControlMessage(sentinel=True)
-    )
+    return actions_service_pb2.WatchForUpdatesResponse(control_message=state_service_pb2.ControlMessage(sentinel=True))
 
 
 class _FlakyActions:
@@ -80,6 +76,7 @@ async def test_informer_recovers_from_hung_reconnect():
     )
     await informer.start(timeout=5)
     try:
+
         async def _await_terminal():
             while True:
                 a = await informer.get("a1")

--- a/tests/internal/controllers/test_informer_watch.py
+++ b/tests/internal/controllers/test_informer_watch.py
@@ -1,0 +1,132 @@
+"""
+Regression tests for Informer.watch() stream recovery.
+
+Incident: a flyte2 server restart left the parent action's watch stream wedged
+forever. The runtime reconnected onto a pooled keep-alive connection that was
+half-open (peer gone, no RST), wrote the WatchForUpdates request, and then
+blocked indefinitely reading the chunked response because the transport's
+read_timeout is unset and the intended `watch_conn_timeout_sec` guard was never
+wired in. The parent never re-synced its children's terminal states and stayed
+"Running" for hours.
+"""
+
+import asyncio
+
+import pytest
+from flyteidl2.actions import actions_service_pb2
+from flyteidl2.common import identifier_pb2, phase_pb2
+from flyteidl2.workflow import state_service_pb2
+
+from flyte._internal.controllers.remote._informer import Informer
+
+
+def _update(child_id, phase, output_uri="s3://out"):
+    return actions_service_pb2.WatchForUpdatesResponse(
+        action_update=state_service_pb2.ActionUpdate(
+            action_id=child_id, phase=phase, output_uri=output_uri
+        )
+    )
+
+
+def _sentinel():
+    return actions_service_pb2.WatchForUpdatesResponse(
+        control_message=state_service_pb2.ControlMessage(sentinel=True)
+    )
+
+
+class _FlakyActions:
+    """watch_for_updates that establishes once, then hangs on reconnect, then heals."""
+
+    def __init__(self, child_id):
+        self._child_id = child_id
+        self.calls = 0
+
+    async def watch_for_updates(self, req, **kwargs):
+        self.calls += 1
+        n = self.calls
+        if n == 1:
+            # Initial establishment succeeds (snapshot + sentinel), then the
+            # stream dies -> informer is now "ready" and observed the child RUNNING.
+            yield _update(self._child_id, phase_pb2.ACTION_PHASE_RUNNING)
+            yield _sentinel()
+            return
+        if n == 2:
+            # Reconnect onto a half-open pooled connection: the request is sent
+            # but the snapshot read never returns. Without an establishment
+            # deadline this wedges the watch (and the parent) forever.
+            await asyncio.sleep(3600)
+            yield  # pragma: no cover
+            return
+        # Healthy reconnect: server replays the snapshot, child now terminal.
+        yield _update(self._child_id, phase_pb2.ACTION_PHASE_SUCCEEDED)
+        yield _sentinel()
+        await asyncio.sleep(3600)  # keep the stream open, idle
+
+
+@pytest.mark.asyncio
+async def test_informer_recovers_from_hung_reconnect():
+    run_id = identifier_pb2.RunIdentifier(name="r1", project="p", domain="d")
+    child_id = identifier_pb2.ActionIdentifier(name="a1", run=run_id)
+    flaky = _FlakyActions(child_id)
+
+    informer = Informer(
+        run_id=run_id,
+        parent_action_name="a0",
+        shared_queue=asyncio.Queue(),
+        actions_client=flaky,
+        min_watch_backoff=0.01,
+        max_watch_backoff=0.02,
+        watch_conn_timeout_sec=0.2,
+    )
+    await informer.start(timeout=5)
+    try:
+        async def _await_terminal():
+            while True:
+                a = await informer.get("a1")
+                if a is not None and a.is_terminal():
+                    return
+                await asyncio.sleep(0.01)
+
+        # Without the fix, call #2 blocks forever, the SUCCEEDED snapshot (call #3)
+        # never arrives, and the child stays RUNNING -> this times out.
+        await asyncio.wait_for(_await_terminal(), timeout=5)
+        assert flaky.calls >= 3
+    finally:
+        await informer.stop()
+
+
+@pytest.mark.asyncio
+async def test_informer_does_not_recycle_idle_established_stream():
+    """A healthy stream that idles (no updates) after the sentinel must NOT be
+    torn down by the establishment deadline."""
+    run_id = identifier_pb2.RunIdentifier(name="r2", project="p", domain="d")
+    child_id = identifier_pb2.ActionIdentifier(name="a1", run=run_id)
+
+    class _IdleActions:
+        def __init__(self):
+            self.calls = 0
+
+        async def watch_for_updates(self, req, **kwargs):
+            self.calls += 1
+            yield _sentinel()
+            await asyncio.sleep(3600)  # established, then idle far longer than the deadline
+            yield  # pragma: no cover
+
+    idle = _IdleActions()
+    informer = Informer(
+        run_id=run_id,
+        parent_action_name="a0",
+        shared_queue=asyncio.Queue(),
+        actions_client=idle,
+        min_watch_backoff=0.01,
+        max_watch_backoff=0.02,
+        watch_conn_timeout_sec=0.05,
+    )
+    await informer.start(timeout=5)
+    try:
+        # Far longer than the establishment deadline; a correct impl stays on the
+        # single established stream and does not reconnect.
+        await asyncio.sleep(0.5)
+        assert idle.calls == 1
+    finally:
+        await informer.stop()

--- a/tests/internal/controllers/test_informer_watch.py
+++ b/tests/internal/controllers/test_informer_watch.py
@@ -100,7 +100,6 @@ async def test_informer_does_not_recycle_idle_established_stream():
     """A healthy stream that idles (no updates) after the sentinel must NOT be
     torn down by the establishment deadline."""
     run_id = identifier_pb2.RunIdentifier(name="r2", project="p", domain="d")
-    child_id = identifier_pb2.ActionIdentifier(name="a1", run=run_id)
 
     class _IdleActions:
         def __init__(self):


### PR DESCRIPTION
## What

Wire `watch_conn_timeout_sec` into `Informer.watch()` as a **per-stream establishment deadline** so a watch stream that connects but never delivers its initial snapshot can no longer wedge a parent action forever.

## Why (the incident)

A flyte2 server restart left ~13 in-flight parent actions stuck `Running` for hours. Root cause, traced end to end:

- The runtime's watch informer reconnected onto a **pooled keep-alive connection** (pyqwest/reqwest pools by default) that was **half-open** — the old server pod was SIGKILLed, peer gone, no RST.
- It wrote the `WatchForUpdates` request onto that dead connection and then **blocked forever reading the HTTP/1.1 chunked response** (the original failure was `unexpected EOF during chunk size line`).
- The transport has `read_timeout=None`, and the intended `watch_conn_timeout_sec` guard was **never wired in**, so a hung read raised no exception. The retry/backoff loop only fires on exceptions, so it never fired — the client logged `attempt 5/10` and went silent for ~3h.
- The server confirmed it never received the request (no `WatchForUpdates stream started` log), so the snapshot that would have re-synced the children's terminal states was never delivered. The 30s sleep children were long done; the parent just never observed it.

## The fix

Replace the unbounded `async for resp in watcher` with manual iteration that applies `watch_conn_timeout_sec` to each read **up to the sentinel**. A stalled reconnect now raises `TimeoutError`, the existing backoff/retry re-issues `watch_for_updates` on a fresh connection, and the server's snapshot (`ListChildActions` + sentinel) re-syncs child state.

Key correctness points:
- The deadline is **per-attempt** (a local `established` flag), **not** `self._ready` — the incident hung on a *reconnect* after the informer was already ready, so gating on the global ready flag would not have fixed it.
- The deadline is **dropped once the sentinel arrives**, so a healthy stream that idles between updates is never recycled.

### Known gap
This guards stream *establishment*. A stream that dies *silently after* the sentinel still needs server-side heartbeats on `WatchForUpdates` (none today) to detect — a separate flyte2 change. Marked with a `ponytail:`-style comment in the code.

## Tests

`tests/internal/controllers/test_informer_watch.py`:
- `test_informer_recovers_from_hung_reconnect` — reproduces the exact incident path (establish → stream dies → reconnect hangs half-open → recover). Times out against the old code; passes with the fix.
- `test_informer_does_not_recycle_idle_established_stream` — a healthy stream that idles far longer than the deadline must not reconnect.

Full controllers suite: 98 passed.