### PR TITLE
add support for flyte io in agents

### DIFF
--- a/examples/agents/flyte_agent/README.md
+++ b/examples/agents/flyte_agent/README.md
@@ -72,6 +72,7 @@ requests are routed to the agent directly (without a parent task entrypoint).
 | `agent_chat_ui.py` | Wrap an `Agent` in the built-in `AgentChatAppEnvironment` UI. |
 | `mcp_powered_agent.py` | Mix local Flyte task tools with remote MCP servers. |
 | `webhook_agent.py` | Trigger an agent run from an HTTP webhook (e.g. GitHub events). |
+| `io_types_agent.py` | Tools with `flyte.io.File`, `Dir`, and `DataFrame` inputs/outputs. |
 
 ## Quick start
 

--- a/examples/agents/flyte_agent/io_types_agent.py
+++ b/examples/agents/flyte_agent/io_types_agent.py
@@ -1,0 +1,142 @@
+"""Agent tools with flyte.io File, Dir, and DataFrame inputs/outputs.
+
+Demonstrates passing Flyte blob and structured-dataset types through the
+:class:`flyte.ai.agents.Agent` tool loop: the LLM receives JSON schemas for
+``File``, ``Dir``, and ``DataFrame``, tool arguments are coerced from those
+schemas, and tool results are serialized back for the model.
+
+Run locally (requires ``ANTHROPIC_API_KEY``)::
+
+    uv run python examples/agents/flyte_agent/io_types_agent.py
+
+Run on the demo cluster::
+
+    flyte run examples/agents/flyte_agent/io_types_agent.py run_io_agent \\
+        --prompt "Create a CSV with columns name,score for Ada:98 and Bob:87, save it, and summarize the file path."
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import flyte
+from flyte.ai.agents import Agent
+from flyte.io import DataFrame, File
+
+img = flyte.Image.from_debian_base().with_pip_packages("litellm", "pandas", "pyarrow")
+
+env = flyte.TaskEnvironment(
+    name="io-types-agent",
+    image=img,
+    resources=flyte.Resources(cpu=1, memory="1Gi"),
+    secrets=[flyte.Secret(key="internal-anthropic-api-key", as_env_var="ANTHROPIC_API_KEY")],
+)
+
+
+@env.task
+async def write_scores_csv(rows: list[dict[str, str | int]]) -> File:
+    """Write *rows* to a CSV file and return a flyte.io.File reference."""
+    import pandas as pd
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "scores.csv"
+        pd.DataFrame(rows).to_csv(path, index=False)
+        return await File.from_local(str(path))
+
+
+@env.task
+async def describe_file(file: File) -> dict[str, str]:
+    """Return metadata about a flyte.io.File (path and format)."""
+    return {"path": file.path, "format": file.format or "unknown"}
+
+
+@env.task
+async def dataframe_from_csv(csv_file: File) -> DataFrame:
+    """Wrap a CSV flyte.io.File as a flyte.io.DataFrame reference."""
+    return DataFrame.from_existing_remote(remote_path=csv_file.path, format="csv")
+
+
+@env.task
+async def summarize_dataframe(df: DataFrame) -> dict[str, str | int]:
+    """Load a flyte.io.DataFrame and return basic column/shape metadata."""
+    import pandas as pd
+
+    table = await df.open(pd.DataFrame).all()
+    return {
+        "columns": ",".join(table.columns),
+        "rows": len(table),
+        "uri": df.uri or "",
+    }
+
+
+agent = Agent(
+    name="io-types-helper",
+    instructions=(
+        "You demonstrate flyte.io File and DataFrame tools. For CSV requests you MUST "
+        "call tools in this exact order before answering:\n"
+        "1. write_scores_csv — create the CSV from the requested rows\n"
+        "2. describe_file — pass the File returned from step 1 as `file`\n"
+        "3. dataframe_from_csv — pass the same File as `csv_file`\n"
+        "4. summarize_dataframe — pass the DataFrame from step 3 as `df`\n"
+        "Only after all four succeed, reply with a one-sentence summary of the table metadata."
+    ),
+    model="claude-sonnet-4-20250514",
+    tools=[write_scores_csv, describe_file, dataframe_from_csv, summarize_dataframe],
+    max_turns=10,
+)
+
+# Code mode is more reliable for multi-step IO pipelines: the LLM writes a short
+# Python program that passes File/DataFrame handles between tools explicitly.
+code_mode_agent = Agent(
+    name="io-types-helper",
+    instructions=(
+        "Write Python that calls the available tools in order: write_scores_csv, "
+        "describe_file, dataframe_from_csv, summarize_dataframe. Pass return values "
+        "directly between calls. End with a string summary of the summarize_dataframe result."
+    ),
+    model="claude-sonnet-4-20250514",
+    tools=[write_scores_csv, describe_file, dataframe_from_csv, summarize_dataframe],
+    max_turns=8,
+    code_mode=True,
+)
+
+
+@env.task
+async def run_io_pipeline(rows: list[dict[str, str | int]]) -> dict[str, str | int]:
+    """Deterministic IO-type pipeline (no LLM): CSV → File → DataFrame → summary."""
+    csv_file = await write_scores_csv.aio(rows=rows)
+    meta = await describe_file.aio(file=csv_file)
+    df = await dataframe_from_csv.aio(csv_file=csv_file)
+    summary = await summarize_dataframe.aio(df=df)
+    return {
+        "file_path": meta["path"],
+        "columns": summary["columns"],
+        "rows": summary["rows"],
+        "dataframe_uri": summary["uri"],
+    }
+
+
+@env.task
+async def run_io_agent(prompt: str) -> str:
+    """Run the IO-types agent (code mode) with *prompt* and return the final summary."""
+    result = await code_mode_agent.run.aio(prompt)
+    return result.summary or result.error
+
+
+def main() -> None:
+    prompt = (
+        " ".join(sys.argv[1:])
+        or "Create a CSV with name,score for Ada:98 and Bob:87, describe the file, "
+        "wrap it as a DataFrame, and summarize the table."
+    )
+    result = agent.run(prompt)
+    if result.error:
+        print(f"[error] {result.error}")
+        sys.exit(1)
+    print(result.summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/flyte/ai/agents/_tools.py
+++ b/src/flyte/ai/agents/_tools.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Literal, Mapping, Sequence, cast, overload
 
 from flyte._internal.resolvers.default import DefaultTaskResolver
+from flyte.types._json_coercion import coerce_json_args
 
 if TYPE_CHECKING:
     from flyte._task import TaskTemplate
@@ -156,6 +157,32 @@ def _callable_short_doc(fn: Callable[..., Any]) -> str:
     return doc.split("\n\n")[0].replace("\n", " ").strip()
 
 
+def _native_interface_for_target(target: Any) -> Any | None:
+    """Return a :class:`~flyte.models.NativeInterface` for *target*, if derivable."""
+    if target is None:
+        return None
+    from flyte._task import TaskTemplate
+    from flyte.models import NativeInterface
+
+    if isinstance(target, TaskTemplate):
+        return target.native_interface
+    if callable(target):
+        fn = getattr(target, "__wrapped__", target)
+        try:
+            return NativeInterface.from_callable(fn)
+        except Exception:
+            return None
+    return None
+
+
+async def _coerce_tool_args(target: Any, args: dict[str, Any]) -> dict[str, Any]:
+    """Coerce LLM JSON tool arguments using the wrapped callable's type hints."""
+    iface = _native_interface_for_target(target)
+    if iface is None:
+        return args
+    return await coerce_json_args(args, iface.inputs)
+
+
 def _json_schema_for_callable(fn: Callable[..., Any]) -> dict[str, Any]:
     """Best-effort JSON schema for a plain Python callable.
 
@@ -182,9 +209,10 @@ def _make_callable_tool(fn: Callable[..., Any], *, name: str | None = None) -> A
     is_async = inspect.iscoroutinefunction(fn) or inspect.iscoroutinefunction(getattr(fn, "__wrapped__", fn))
 
     async def execute(args: dict[str, Any]) -> Any:
+        coerced = await _coerce_tool_args(fn, args)
         if is_async:
-            return await fn(**args)
-        return await asyncio.to_thread(fn, **args)
+            return await fn(**coerced)
+        return await asyncio.to_thread(fn, **coerced)
 
     return AgentTool(
         name=actual_name,
@@ -208,7 +236,8 @@ def _make_task_tool(task: "TaskTemplate", *, name: str | None = None) -> AgentTo
         parameters = _json_schema_for_callable(underlying)
 
     async def execute(args: dict[str, Any]) -> Any:
-        return await task.aio(**args)
+        coerced = await _coerce_tool_args(task, args)
+        return await task.aio(**coerced)
 
     return AgentTool(
         name=actual_name,
@@ -456,19 +485,45 @@ def _summarize_signature(tool: AgentTool) -> str:
     return f"{tool.name}({', '.join(parts)})"
 
 
-def _stringify_tool_result(result: Any) -> str:
+async def _stringify_tool_result(result: Any) -> str:
     if result is None:
         return ""
     if isinstance(result, str):
         return result
+    from flyte.types._json_coercion import serialize_json_value
+
+    serialized = await serialize_json_value(result)
     try:
-        return json.dumps(result, default=str)
+        return json.dumps(serialized, default=str)
     except (TypeError, ValueError):
         return str(result)
 
 
+def _registry_uses_flyte_io(registry: Mapping[str, AgentTool]) -> bool:
+    """Return True when any registered tool accepts or exposes flyte.io blob types."""
+
+    def _schema_has_io(schema: Any) -> bool:
+        if not isinstance(schema, dict):
+            return False
+        if schema.get("format") in ("blob", "structured-dataset"):
+            return True
+        for prop in schema.get("properties", {}).values():
+            if _schema_has_io(prop):
+                return True
+        if _schema_has_io(schema.get("items")):
+            return True
+        for variant in schema.get("oneOf", []):
+            if _schema_has_io(variant):
+                return True
+        return False
+
+    return any(_schema_has_io(tool.parameters) for tool in registry.values())
+
+
 def _abbreviate(value: Any, *, max_chars: int = 500) -> str:
-    text = _stringify_tool_result(value)
+    from flyte._utils.asyn import run_sync
+
+    text = run_sync(_stringify_tool_result, value) if not isinstance(value, str) else value
     if len(text) <= max_chars:
         return text
     return text[:max_chars] + f"... [+{len(text) - max_chars} chars]"

--- a/src/flyte/ai/agents/agent.py
+++ b/src/flyte/ai/agents/agent.py
@@ -64,6 +64,8 @@ from ._tools import (
     AgentTool,
     ToolFn,
     _abbreviate,
+    _coerce_tool_args,
+    _registry_uses_flyte_io,
     _resolve_tools,
     _stringify_tool_result,
     _summarize_signature,
@@ -366,6 +368,15 @@ class Agent:
             tool_lines.append(f"- {_tool.name}: {_tool.description}")
         tools_block = "\n".join(tool_lines) if tool_lines else "(no tools registered)"
 
+        io_hint = ""
+        if _registry_uses_flyte_io(self._registry):
+            io_hint = (
+                "\n\nWhen a tool returns a flyte.io File, Dir, or DataFrame (a JSON object "
+                "with a `uri` field), pass the **complete** tool-result JSON as the argument "
+                "to downstream tools that accept that type. Continue calling tools until the "
+                "user's request is fully satisfied before giving a final text answer."
+            )
+
         return (
             f"{self.instructions}\n\n"
             f"You have access to the following tools (full JSON schemas are provided "
@@ -373,6 +384,7 @@ class Agent:
             f"{tools_block}\n"
             f"Use tools deliberately. Reply with plain text when you have a final "
             f"answer or do not need a tool."
+            f"{io_hint}"
             f"{skills_block}"
         )
 
@@ -407,6 +419,7 @@ class Agent:
             if not approved:
                 return (f"Human reviewer declined tool `{tool.name}`. Try a different approach.", True)
         await _emit(AgentEvent("tool_start", {"tool": tool.name, "args": args}))
+        coerced_args = await _coerce_tool_args(tool.target, args)
         try:
             if tool.call_handler is not None:
                 bound = ToolFn(
@@ -418,14 +431,15 @@ class Agent:
                     source=tool.source,
                     _execute=tool.execute,
                 )
-                result = await tool.call_handler(self.call_llm, bound, **args)
+                result = await tool.call_handler(self.call_llm, bound, **coerced_args)
             else:
                 result = await tool.execute(args)
         except Exception as exc:
             await _emit(AgentEvent("tool_error", {"tool": tool.name, "error": str(exc)}))
             return (f"Error executing tool `{tool.name}`: {exc}", True)
         await _emit(AgentEvent("tool_end", {"tool": tool.name, "result": _abbreviate(result)}))
-        return (_stringify_tool_result(result), False)
+        result_text = await _stringify_tool_result(result)
+        return (result_text, False)
 
     @syncify
     async def run(
@@ -562,7 +576,7 @@ class Agent:
                 await _emit(AgentEvent("turn_end", {"turn": attempts, "had_code": True, "error": True}))
                 return _TurnResult(done=False)
 
-            observation = _stringify_tool_result(result)
+            observation = await _stringify_tool_result(result)
             await _emit(AgentEvent("tool_end", {"tool": "<sandbox>", "result": _abbreviate(result)}))
             messages.append(
                 {

--- a/src/flyte/cli/_params.py
+++ b/src/flyte/cli/_params.py
@@ -22,7 +22,7 @@ from google.protobuf.json_format import MessageToDict
 from mashumaro.codecs.json import JSONEncoder
 
 from flyte._logging import logger
-from flyte.io import DataFrame, Dir, File
+from flyte.io import Dir, File
 from flyte.types._pickle import FlytePickleTransformer
 
 # ---------------------------------------------------
@@ -432,22 +432,11 @@ class JsonParamType(click.ParamType):
             except json.JSONDecodeError as e:
                 raise click.BadParameter(f"parameter {param} should be a valid json object, {value}, error: {e}")
 
-    def _unwrap_field_type(self, tp: typing.Type) -> typing.Type:
-        from flyte.types._type_engine import get_underlying_type
-
-        tp = get_underlying_type(tp)
-        origin = typing.get_origin(tp)
-        args = get_args(tp)
-        if origin is typing.Union:
-            non_none = [a for a in args if a is not type(None)]
-            if len(non_none) == 1:
-                return self._unwrap_field_type(non_none[0])
-        return tp
-
     def _blob_param_converter_for_type(self, field_type: typing.Type) -> typing.Optional[click.ParamType]:
+        from flyte.types._json_coercion import unwrap_optional_type
         from flyte.types._type_engine import TypeEngine
 
-        field_type = self._unwrap_field_type(field_type)
+        field_type = unwrap_optional_type(field_type)
         try:
             lt = TypeEngine.to_literal_type(field_type)
             converter = literal_type_to_click_type(lt, field_type)
@@ -457,122 +446,32 @@ class JsonParamType(click.ParamType):
             pass
         return None
 
-    def _convert_blob_value(
+    def _make_string_blob_converter(
         self,
-        value: typing.Any,
-        field_type: typing.Type,
+        param: typing.Optional[click.Parameter],
+        ctx: typing.Optional[click.Context],
+    ) -> typing.Callable[[str, typing.Type], typing.Any]:
+        def convert_string_path(s: str, py_type: typing.Type) -> typing.Any:
+            converter = self._blob_param_converter_for_type(py_type)
+            if converter is None:
+                return s
+            return converter.convert(s, param, ctx)
+
+        return convert_string_path
+
+    def _coerce_parsed_json(
+        self,
+        parsed_value: typing.Any,
         param: typing.Optional[click.Parameter],
         ctx: typing.Optional[click.Context],
     ) -> typing.Any:
-        field_type = self._unwrap_field_type(field_type)
-        converter = self._blob_param_converter_for_type(field_type)
-        if converter is None:
-            return value
+        from flyte.types._json_coercion import coerce_json_value_sync
 
-        if isinstance(value, (File, Dir, DataFrame)):
-            return value
-
-        if isinstance(value, str):
-            return converter.convert(value, param, ctx)
-
-        if isinstance(value, dict) and isinstance(field_type, type):
-            from flyte.types._json_coercion import coerce_json_value_sync
-
-            return coerce_json_value_sync(value, field_type)
-
-        return value
-
-    def _convert_blob_collection_elements(
-        self,
-        parsed_value: typing.Union[typing.List[typing.Any], typing.Dict[str, typing.Any]],
-        element_type: typing.Type,
-        param: typing.Optional[click.Parameter],
-        ctx: typing.Optional[click.Context],
-    ) -> typing.Optional[typing.Any]:
-        """Convert string paths in list/dict CLI JSON to File, Dir, or DataFrame objects."""
-        if self._blob_param_converter_for_type(element_type) is None:
-            return None
-
-        if isinstance(parsed_value, list):
-            return [self._convert_blob_value(v, element_type, param, ctx) for v in parsed_value]
-        return {k: self._convert_blob_value(v, element_type, param, ctx) for k, v in parsed_value.items()}
-
-    def _convert_blob_fields_in_value(
-        self,
-        value: typing.Any,
-        python_type: typing.Type,
-        param: typing.Optional[click.Parameter],
-        ctx: typing.Optional[click.Context],
-    ) -> typing.Any:
-        if value is None:
-            return None
-
-        python_type = self._unwrap_field_type(python_type)
-        origin = typing.get_origin(python_type)
-        args = get_args(python_type)
-
-        if dataclasses.is_dataclass(python_type) and isinstance(value, dict):
-            field_types = typing.get_type_hints(python_type, include_extras=True)
-            return {
-                k: self._convert_blob_fields_in_value(v, field_types.get(k, type(v)), param, ctx)
-                for k, v in value.items()
-            }
-
-        if origin is list and isinstance(value, list):
-            elem_type = args[0] if args else typing.Any
-            return [self._convert_blob_fields_in_value(v, elem_type, param, ctx) for v in value]
-
-        if origin is dict and isinstance(value, dict):
-            val_type = args[1] if len(args) >= 2 else typing.Any
-            return {k: self._convert_blob_fields_in_value(v, val_type, param, ctx) for k, v in value.items()}
-
-        return self._convert_blob_value(value, python_type, param, ctx)
-
-    def _instantiate_dataclass(self, python_type: typing.Type, value: typing.Any) -> typing.Any:
-        if not isinstance(value, dict):
-            return value
-
-        field_types = typing.get_type_hints(python_type, include_extras=True)
-        kwargs: dict[str, typing.Any] = {}
-        for field in dataclasses.fields(python_type):
-            if field.name not in value:
-                continue
-            v = value[field.name]
-            if v is None:
-                kwargs[field.name] = None
-                continue
-
-            field_type = self._unwrap_field_type(field_types.get(field.name, field.type))
-            if dataclasses.is_dataclass(field_type) and isinstance(v, dict):
-                kwargs[field.name] = self._instantiate_dataclass(field_type, v)
-                continue
-
-            origin = typing.get_origin(field_type)
-            inner_args = get_args(field_type)
-            if origin is list and isinstance(v, list):
-                elem_type = self._unwrap_field_type(inner_args[0] if inner_args else typing.Any)
-                if dataclasses.is_dataclass(elem_type):
-                    kwargs[field.name] = [
-                        self._instantiate_dataclass(elem_type, item) if isinstance(item, dict) else item for item in v
-                    ]
-                else:
-                    kwargs[field.name] = v
-                continue
-
-            if origin is dict and isinstance(v, dict):
-                val_type = self._unwrap_field_type(inner_args[1] if len(inner_args) >= 2 else typing.Any)
-                if dataclasses.is_dataclass(val_type):
-                    kwargs[field.name] = {
-                        k: self._instantiate_dataclass(val_type, item) if isinstance(item, dict) else item
-                        for k, item in v.items()
-                    }
-                else:
-                    kwargs[field.name] = v
-                continue
-
-            kwargs[field.name] = v
-
-        return python_type(**kwargs)
+        return coerce_json_value_sync(
+            parsed_value,
+            self._python_type,
+            string_blob_converter=self._make_string_blob_converter(param, ctx),
+        )
 
     def convert(
         self, value: typing.Any, param: typing.Optional[click.Parameter], ctx: typing.Optional[click.Context]
@@ -594,34 +493,8 @@ class JsonParamType(click.ParamType):
             # We don't support native list/dict types with nested dataclasses.
             if get_args(self._python_type) == ():
                 return parsed_value
-            elif isinstance(parsed_value, list):
-                element_type = get_args(self._python_type)[0]
-                converted = self._convert_blob_collection_elements(parsed_value, element_type, param, ctx)
-                if converted is not None:
-                    return converted
-                if dataclasses.is_dataclass(element_type):
-                    dc_type = typing.cast(type[typing.Any], element_type)
-                    return [
-                        self._instantiate_dataclass(
-                            dc_type,
-                            self._convert_blob_fields_in_value(v, dc_type, param, ctx),
-                        )
-                        for v in parsed_value
-                    ]
-            elif isinstance(parsed_value, dict):
-                value_type = get_args(self._python_type)[1]
-                converted = self._convert_blob_collection_elements(parsed_value, value_type, param, ctx)
-                if converted is not None:
-                    return converted
-                if dataclasses.is_dataclass(value_type):
-                    dc_type = typing.cast(type[typing.Any], value_type)
-                    return {
-                        k: self._instantiate_dataclass(
-                            dc_type,
-                            self._convert_blob_fields_in_value(v, dc_type, param, ctx),
-                        )
-                        for k, v in parsed_value.items()
-                    }
+            elif isinstance(parsed_value, (list, dict)):
+                return self._coerce_parsed_json(parsed_value, param, ctx)
 
             return parsed_value
 
@@ -648,8 +521,7 @@ class JsonParamType(click.ParamType):
             )
         elif dataclasses.is_dataclass(self._python_type):
             if isinstance(parsed_value, dict):
-                converted = self._convert_blob_fields_in_value(parsed_value, self._python_type, param, ctx)
-                return self._instantiate_dataclass(self._python_type, converted)
+                return self._coerce_parsed_json(parsed_value, param, ctx)
 
             from mashumaro.codecs.json import JSONDecoder
 

--- a/src/flyte/cli/_params.py
+++ b/src/flyte/cli/_params.py
@@ -476,10 +476,9 @@ class JsonParamType(click.ParamType):
             return converter.convert(value, param, ctx)
 
         if isinstance(value, dict) and isinstance(field_type, type):
-            from pydantic import BaseModel
+            from flyte.types._json_coercion import coerce_json_value_sync
 
-            if issubclass(field_type, BaseModel):
-                return field_type.model_validate(value)
+            return coerce_json_value_sync(value, field_type)
 
         return value
 

--- a/src/flyte/types/_json_coercion.py
+++ b/src/flyte/types/_json_coercion.py
@@ -12,11 +12,15 @@ from __future__ import annotations
 import dataclasses
 import inspect
 import typing
+from collections.abc import Callable
 from typing import Any, Union, get_args, get_origin
 
 from flyteidl2.core import literals_pb2, types_pb2
 
 from flyte.io import DataFrame, Dir, File
+
+# Optional hook for CLI/local path strings → File/Dir/DataFrame (upload, validation).
+StringBlobConverter = Callable[[str, Any], Any]
 
 
 def unwrap_optional_type(tp: Any) -> Any:
@@ -109,7 +113,27 @@ def _supplement_io_metadata(out: dict[str, Any], value: Any) -> dict[str, Any]:
     return out
 
 
-async def coerce_json_value(value: Any, py_type: Any) -> Any:
+def _literal_type_is_io(lt: types_pb2.LiteralType) -> bool:
+    return lt.HasField("blob") or lt.HasField("structured_dataset_type")
+
+
+def _is_io_python_type(py_type: Any) -> bool:
+    if not isinstance(py_type, type):
+        return False
+    from flyte.types._type_engine import TypeEngine
+
+    try:
+        return _literal_type_is_io(TypeEngine.to_literal_type(py_type))
+    except Exception:
+        return py_type in (File, Dir, DataFrame)
+
+
+async def coerce_json_value(
+    value: Any,
+    py_type: Any,
+    *,
+    string_blob_converter: StringBlobConverter | None = None,
+) -> Any:
     """Coerce a JSON-like value into *py_type* using the Flyte type engine."""
     if value is None:
         return None
@@ -120,18 +144,25 @@ async def coerce_json_value(value: Any, py_type: Any) -> Any:
 
     if origin is list and isinstance(value, list):
         elem_type = args[0] if args else Any
-        return [await coerce_json_value(v, elem_type) for v in value]
+        return [await coerce_json_value(v, elem_type, string_blob_converter=string_blob_converter) for v in value]
 
     if origin is dict and isinstance(value, dict):
         val_type = args[1] if len(args) >= 2 else Any
-        return {k: await coerce_json_value(v, val_type) for k, v in value.items()}
+        return {
+            k: await coerce_json_value(v, val_type, string_blob_converter=string_blob_converter)
+            for k, v in value.items()
+        }
 
     if isinstance(value, dict) and isinstance(py_type, type) and dataclasses.is_dataclass(py_type):
         field_types = typing.get_type_hints(py_type, include_extras=True)
         field_names = {f.name for f in dataclasses.fields(py_type)}
         return py_type(
             **{
-                name: await coerce_json_value(val, field_types.get(name, type(val)))
+                name: await coerce_json_value(
+                    val,
+                    field_types.get(name, type(val)),
+                    string_blob_converter=string_blob_converter,
+                )
                 for name, val in value.items()
                 if name in field_names
             }
@@ -141,6 +172,8 @@ async def coerce_json_value(value: Any, py_type: Any) -> Any:
         return value
 
     if isinstance(value, str):
+        if string_blob_converter is not None and _is_io_python_type(unwrap_optional_type(py_type)):
+            return string_blob_converter(value, py_type)
         if py_type is File:
             return File(path=value)
         if py_type is Dir:
@@ -164,11 +197,16 @@ async def coerce_json_value(value: Any, py_type: Any) -> Any:
     return value
 
 
-def coerce_json_value_sync(value: Any, py_type: Any) -> Any:
+def coerce_json_value_sync(
+    value: Any,
+    py_type: Any,
+    *,
+    string_blob_converter: StringBlobConverter | None = None,
+) -> Any:
     """Synchronous wrapper around :func:`coerce_json_value` for CLI use."""
     from flyte._utils.asyn import run_sync
 
-    return run_sync(coerce_json_value, value, py_type)
+    return run_sync(coerce_json_value, value, py_type, string_blob_converter=string_blob_converter)
 
 
 def serialize_json_value_sync(value: Any, py_type: Any | None = None) -> Any:

--- a/src/flyte/types/_json_coercion.py
+++ b/src/flyte/types/_json_coercion.py
@@ -1,0 +1,247 @@
+"""Convert JSON-like values to/from native Python types via the Flyte type engine.
+
+Shared by the CLI (``flyte run`` JSON params) and agent tool I/O. LLM tool
+schemas and CLI JSON both use the Flyte JSON-schema shape (``uri`` for blobs,
+etc.), which differs from Python model fields (``path`` on ``File``/``Dir``).
+The type engine already knows how to bridge Literal ↔ native; this module
+constructs Literals from JSON dicts and projects Literals back to tool/CLI JSON.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import typing
+from typing import Any, Union, get_args, get_origin
+
+from flyteidl2.core import literals_pb2, types_pb2
+
+from flyte.io import DataFrame, Dir, File
+
+
+def unwrap_optional_type(tp: Any) -> Any:
+    """Strip ``Optional[T]`` / ``Annotated`` wrappers."""
+    from flyte.types._type_engine import get_underlying_type
+
+    tp = get_underlying_type(tp)
+    origin = get_origin(tp)
+    if origin is Union:
+        args = typing.get_args(tp)
+        non_none = [a for a in args if a is not type(None)]
+        if len(non_none) == 1:
+            return unwrap_optional_type(non_none[0])
+    return tp
+
+
+def json_dict_to_literal(value: dict[str, Any], lt: types_pb2.LiteralType) -> literals_pb2.Literal:
+    """Build a Flyte ``Literal`` from a JSON-schema-shaped dict."""
+    hash_val = value.get("hash") or ""
+
+    if lt.HasField("blob"):
+        uri = value.get("uri") or value.get("path") or ""
+        fmt = value.get("format")
+        if fmt is None:
+            fmt = lt.blob.format or ""
+        return literals_pb2.Literal(
+            scalar=literals_pb2.Scalar(
+                blob=literals_pb2.Blob(
+                    metadata=literals_pb2.BlobMetadata(
+                        type=types_pb2.BlobType(format=fmt, dimensionality=lt.blob.dimensionality)
+                    ),
+                    uri=uri,
+                )
+            ),
+            hash=hash_val or None,
+        )
+
+    if lt.HasField("structured_dataset_type"):
+        uri = value.get("uri") or ""
+        fmt = value.get("format")
+        if fmt is None:
+            fmt = ""
+        return literals_pb2.Literal(
+            scalar=literals_pb2.Scalar(
+                structured_dataset=literals_pb2.StructuredDataset(
+                    metadata=literals_pb2.StructuredDatasetMetadata(
+                        structured_dataset_type=types_pb2.StructuredDatasetType(format=fmt)
+                    ),
+                    uri=uri,
+                )
+            ),
+            hash=hash_val or None,
+        )
+
+    raise TypeError(f"Cannot construct Literal from JSON dict for literal type {lt}")
+
+
+def literal_to_json_dict(lit: literals_pb2.Literal, lt: types_pb2.LiteralType) -> dict[str, Any]:
+    """Project a Flyte ``Literal`` to the JSON-schema shape tools/CLI expose."""
+    if lt.HasField("blob"):
+        dim = lit.scalar.blob.metadata.type.dimensionality
+        dim_str = "MULTIPART" if dim == types_pb2.BlobType.BlobDimensionality.MULTIPART else "SINGLE"
+        out: dict[str, Any] = {
+            "uri": lit.scalar.blob.uri,
+            "format": lit.scalar.blob.metadata.type.format or "",
+            "dimensionality": dim_str,
+        }
+        if lit.hash:
+            out["hash"] = lit.hash
+        return out
+
+    if lt.HasField("structured_dataset_type"):
+        sd = lit.scalar.structured_dataset
+        out = {
+            "uri": sd.uri,
+            "format": sd.metadata.structured_dataset_type.format or "",
+        }
+        if lit.hash:
+            out["hash"] = lit.hash
+        return out
+
+    raise TypeError(f"Cannot project Literal to JSON dict for literal type {lt}")
+
+
+def _supplement_io_metadata(out: dict[str, Any], value: Any) -> dict[str, Any]:
+    """Add Python-only metadata (e.g. ``name``) not stored on the Literal."""
+    if isinstance(value, (File, Dir)) and value.name:
+        out = dict(out)
+        out["name"] = value.name
+    return out
+
+
+async def coerce_json_value(value: Any, py_type: Any) -> Any:
+    """Coerce a JSON-like value into *py_type* using the Flyte type engine."""
+    if value is None:
+        return None
+
+    py_type = unwrap_optional_type(py_type)
+    origin = get_origin(py_type)
+    args = get_args(py_type)
+
+    if origin is list and isinstance(value, list):
+        elem_type = args[0] if args else Any
+        return [await coerce_json_value(v, elem_type) for v in value]
+
+    if origin is dict and isinstance(value, dict):
+        val_type = args[1] if len(args) >= 2 else Any
+        return {k: await coerce_json_value(v, val_type) for k, v in value.items()}
+
+    if isinstance(value, dict) and isinstance(py_type, type) and dataclasses.is_dataclass(py_type):
+        field_types = typing.get_type_hints(py_type, include_extras=True)
+        field_names = {f.name for f in dataclasses.fields(py_type)}
+        return py_type(
+            **{
+                name: await coerce_json_value(val, field_types.get(name, type(val)))
+                for name, val in value.items()
+                if name in field_names
+            }
+        )
+
+    if isinstance(py_type, type) and isinstance(value, py_type):
+        return value
+
+    if isinstance(value, str):
+        if py_type is File:
+            return File(path=value)
+        if py_type is Dir:
+            return Dir(path=value)
+        if py_type is DataFrame:
+            return DataFrame.from_existing_remote(remote_path=value)
+
+    if isinstance(value, dict) and isinstance(py_type, type):
+        from flyte.types._type_engine import TypeEngine
+
+        lt = TypeEngine.to_literal_type(py_type)
+        if lt.HasField("blob") or lt.HasField("structured_dataset_type"):
+            lit = json_dict_to_literal(value, lt)
+            return await TypeEngine.to_python_value(lit, py_type)
+
+        # Pydantic models, dataclass-backed structs, etc.: let the transformer coerce.
+        lm = await TypeEngine.dict_to_literal_map({"_": value}, {"_": py_type})
+        kwargs = await TypeEngine.literal_map_to_kwargs(lm, {"_": py_type})
+        return kwargs["_"]
+
+    return value
+
+
+def coerce_json_value_sync(value: Any, py_type: Any) -> Any:
+    """Synchronous wrapper around :func:`coerce_json_value` for CLI use."""
+    from flyte._utils.asyn import run_sync
+
+    return run_sync(coerce_json_value, value, py_type)
+
+
+def serialize_json_value_sync(value: Any, py_type: Any | None = None) -> Any:
+    """Synchronous wrapper around :func:`serialize_json_value`."""
+    from flyte._utils.asyn import run_sync
+
+    return run_sync(serialize_json_value, value, py_type)
+
+
+async def coerce_json_args(
+    args: dict[str, Any],
+    inputs: dict[str, tuple[Any, Any]],
+) -> dict[str, Any]:
+    """Coerce a kwargs dict using a :class:`~flyte.models.NativeInterface` inputs map."""
+    coerced: dict[str, Any] = {}
+    for name, value in args.items():
+        input_info = inputs.get(name)
+        if input_info is None:
+            coerced[name] = value
+            continue
+        py_type, _default = input_info
+        if py_type is inspect.Parameter.empty:
+            coerced[name] = value
+            continue
+        coerced[name] = await coerce_json_value(value, py_type)
+    return coerced
+
+
+async def serialize_json_value(value: Any, py_type: Any | None = None) -> Any:
+    """Serialize a native value to a JSON-schema-compatible structure."""
+    if value is None:
+        return None
+
+    if py_type is None:
+        py_type = type(value)
+
+    py_type = unwrap_optional_type(py_type)
+
+    if isinstance(py_type, type):
+        from flyte.types._type_engine import TypeEngine
+
+        try:
+            lt = TypeEngine.to_literal_type(py_type)
+            if lt.HasField("blob") or lt.HasField("structured_dataset_type"):
+                lit = await TypeEngine.to_literal(value, py_type, lt)
+                return _supplement_io_metadata(literal_to_json_dict(lit, lt), value)
+        except Exception:
+            pass
+
+    origin = get_origin(py_type)
+
+    if origin is list and isinstance(value, list):
+        elem_type = get_args(py_type)[0] if get_args(py_type) else Any
+        return [await serialize_json_value(v, elem_type) for v in value]
+
+    if origin is dict and isinstance(value, dict):
+        args = get_args(py_type)
+        val_type = args[1] if len(args) >= 2 else Any
+        return {k: await serialize_json_value(v, val_type) for k, v in value.items()}
+
+    if dataclasses.is_dataclass(py_type) and dataclasses.is_dataclass(value) and not isinstance(value, type):
+        field_types = typing.get_type_hints(py_type, include_extras=True)
+        return {
+            f.name: await serialize_json_value(
+                getattr(value, f.name), field_types.get(f.name, type(getattr(value, f.name)))
+            )
+            for f in dataclasses.fields(value)
+        }
+
+    from pydantic import BaseModel
+
+    if isinstance(value, BaseModel):
+        model_type = py_type if isinstance(py_type, type) else type(value)
+        return await serialize_json_value(value.model_dump(), model_type)
+
+    return value

--- a/tests/flyte/ai/agents/test_agent.py
+++ b/tests/flyte/ai/agents/test_agent.py
@@ -476,14 +476,20 @@ class TestSignatureFormatter:
 
 
 class TestStringify:
+    @staticmethod
+    def _s(result):
+        from flyte._utils.asyn import run_sync
+
+        return run_sync(_stringify_tool_result, result)
+
     def test_none_becomes_empty(self):
-        assert _stringify_tool_result(None) == ""
+        assert self._s(None) == ""
 
     def test_string_passes_through(self):
-        assert _stringify_tool_result("hello") == "hello"
+        assert self._s("hello") == "hello"
 
     def test_dict_jsonified(self):
-        out = _stringify_tool_result({"k": 1})
+        out = self._s({"k": 1})
         assert json.loads(out) == {"k": 1}
 
     def test_non_json_fallback(self):
@@ -491,8 +497,7 @@ class TestStringify:
             def __repr__(self):
                 return "<weird>"
 
-        # json.dumps falls through default=str, so we still serialize
-        assert "weird" in _stringify_tool_result(Weird())
+        assert "weird" in self._s(Weird())
 
 
 class TestAbbreviate:
@@ -1812,9 +1817,11 @@ class TestAsyncToolExecution:
 
 class TestStringifyEdgeCases:
     def test_circular_reference_falls_back_to_str(self):
+        from flyte._utils.asyn import run_sync
+
         circular: dict[str, object] = {}
         circular["self"] = circular
-        out = _stringify_tool_result(circular)
+        out = run_sync(_stringify_tool_result, circular)
         # json.dumps raises ValueError on circular refs even with default=str,
         # so we fall back to the plain ``str()`` representation.
         assert "self" in out

--- a/tests/flyte/ai/agents/test_tools_io.py
+++ b/tests/flyte/ai/agents/test_tools_io.py
@@ -1,0 +1,183 @@
+"""Tests for flyte.io File / Dir / DataFrame support in agent tools."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from flyte import TaskEnvironment
+from flyte.ai.agents._tools import (
+    _coerce_tool_args,
+    _json_schema_for_callable,
+    _make_callable_tool,
+    _stringify_tool_result,
+)
+from flyte.io import DataFrame, Dir, File
+from flyte.models import NativeInterface
+from flyte.types._json_coercion import coerce_json_value_sync, serialize_json_value_sync
+
+
+def test_json_schema_includes_file_dir_dataframe():
+    def process(input_file: File, output_dir: Dir, table: DataFrame, label: str) -> str:
+        """Process IO types."""
+        return label
+
+    schema = _json_schema_for_callable(process)
+    assert schema["properties"]["input_file"]["format"] == "blob"
+    assert schema["properties"]["input_file"]["properties"]["dimensionality"]["default"] == "SINGLE"
+    assert schema["properties"]["output_dir"]["format"] == "blob"
+    assert schema["properties"]["output_dir"]["properties"]["dimensionality"]["default"] == "MULTIPART"
+    assert schema["properties"]["table"]["format"] == "structured-dataset"
+    assert schema["properties"]["label"] == {"type": "string"}
+
+
+def test_coerce_uri_dict_to_file():
+    value = {"uri": "s3://bucket/data.csv", "format": "csv", "dimensionality": "SINGLE"}
+    out = coerce_json_value_sync(value, File)
+    assert isinstance(out, File)
+    assert out.path == "s3://bucket/data.csv"
+    assert out.format == "csv"
+
+
+def test_coerce_uri_dict_to_dir():
+    value = {"uri": "s3://bucket/output/", "format": "", "dimensionality": "MULTIPART"}
+    out = coerce_json_value_sync(value, Dir)
+    assert isinstance(out, Dir)
+    assert out.path == "s3://bucket/output/"
+
+
+def test_coerce_uri_dict_to_dataframe():
+    value = {"uri": "s3://bucket/table.parquet", "format": "parquet"}
+    out = coerce_json_value_sync(value, DataFrame)
+    assert isinstance(out, DataFrame)
+    assert out.uri == "s3://bucket/table.parquet"
+    assert out.format == "parquet"
+
+
+def test_coerce_string_path_to_file():
+    out = coerce_json_value_sync("/tmp/example.csv", File)
+    assert isinstance(out, File)
+    assert out.path == "/tmp/example.csv"
+
+
+def test_serialize_file_for_llm():
+    f = File(path="s3://bucket/a.txt", format="txt", hash="abc")
+    payload = serialize_json_value_sync(f, File)
+    assert payload == {
+        "uri": "s3://bucket/a.txt",
+        "format": "txt",
+        "dimensionality": "SINGLE",
+        "name": "a.txt",
+        "hash": "abc",
+    }
+
+
+def test_serialize_dir_for_llm():
+    d = Dir(path="s3://bucket/out/", format="")
+    payload = serialize_json_value_sync(d, Dir)
+    assert payload["uri"] == "s3://bucket/out/"
+    assert payload["dimensionality"] == "MULTIPART"
+
+
+def test_stringify_file_result():
+    from flyte._utils.asyn import run_sync
+
+    f = File(path="s3://bucket/report.txt", format="txt")
+    out = run_sync(_stringify_tool_result, f)
+    parsed = json.loads(out)
+    assert parsed["uri"] == "s3://bucket/report.txt"
+    assert parsed["dimensionality"] == "SINGLE"
+
+
+@pytest.mark.asyncio
+async def test_callable_tool_coerces_file_input():
+    seen: dict[str, object] = {}
+
+    def inspect_file(f: File) -> str:
+        """Return the file path."""
+        seen["path"] = f.path
+        return f.path
+
+    tool = _make_callable_tool(inspect_file)
+    result = await tool.execute({"f": {"uri": "s3://bucket/x.csv", "format": "csv"}})
+    assert result == "s3://bucket/x.csv"
+    assert seen["path"] == "s3://bucket/x.csv"
+
+
+@pytest.mark.asyncio
+async def test_task_tool_coerces_dataframe_input():
+    env = TaskEnvironment(name="io_tool_env", image="auto")
+
+    @env.task
+    async def row_count(df: DataFrame) -> int:
+        """Count rows in a dataframe reference."""
+        return len(df.uri or "")
+
+    assert NativeInterface.from_callable(row_count.func)
+
+    coerced = await _coerce_tool_args(
+        row_count,
+        {"df": {"uri": "s3://bucket/table.parquet", "format": "parquet"}},
+    )
+    assert isinstance(coerced["df"], DataFrame)
+    assert coerced["df"].uri == "s3://bucket/table.parquet"
+
+
+@pytest.mark.asyncio
+async def test_agent_chains_file_through_mock_llm():
+    """Regression: agent loop must run multiple task tools when the LLM requests them."""
+    from flyte.ai.agents import Agent, LLMMessage
+
+    executed: list[str] = []
+
+    async def write_scores_csv(rows: list[dict[str, str | int]]) -> File:
+        executed.append("write_scores_csv")
+        return File(path="s3://bucket/scores.csv", format="csv")
+
+    async def describe_file(file: File) -> dict[str, str]:
+        executed.append("describe_file")
+        return {"path": file.path, "format": file.format}
+
+    file_json = {"uri": "s3://bucket/scores.csv", "format": "csv", "dimensionality": "SINGLE"}
+
+    llm = AsyncMock(
+        side_effect=[
+            LLMMessage(
+                content=None,
+                tool_calls=[
+                    {"id": "c1", "name": "write_scores_csv", "arguments": {"rows": [{"name": "Ada", "score": 98}]}}
+                ],
+            ),
+            LLMMessage(
+                content=None,
+                tool_calls=[{"id": "c2", "name": "describe_file", "arguments": {"file": file_json}}],
+            ),
+            LLMMessage(content="CSV has 1 row at s3://bucket/scores.csv", tool_calls=[]),
+        ]
+    )
+
+    agent = Agent(
+        name="chain-test",
+        instructions="Chain tools.",
+        tools=[write_scores_csv, describe_file],
+        call_llm=llm,
+        max_turns=5,
+    )
+    result = await agent.run.aio("create and describe csv", [])
+    assert result.error == ""
+    assert executed == ["write_scores_csv", "describe_file"]
+    assert result.attempts == 3
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_includes_io_handoff_hint():
+    from flyte.ai.agents import Agent
+
+    async def describe_file(file: File) -> dict[str, str]:
+        return {"path": file.path}
+
+    agent = Agent(name="t", instructions="Do work.", tools=[describe_file])
+    assert "complete" in agent.system_prompt.lower()
+    assert "`uri`" in agent.system_prompt

--- a/tests/flyte/types/test_json_coercion.py
+++ b/tests/flyte/types/test_json_coercion.py
@@ -1,0 +1,84 @@
+"""Tests for flyte.types._json_coercion."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from flyte.io import DataFrame, Dir, File
+from flyte.types._json_coercion import (
+    coerce_json_value_sync,
+    json_dict_to_literal,
+    literal_to_json_dict,
+    serialize_json_value_sync,
+)
+from flyte.types._type_engine import TypeEngine
+
+
+def test_json_dict_to_literal_file():
+    lt = TypeEngine.to_literal_type(File)
+    lit = json_dict_to_literal({"uri": "s3://bucket/x.csv", "format": "csv", "hash": "abc"}, lt)
+    assert lit.scalar.blob.uri == "s3://bucket/x.csv"
+    assert lit.scalar.blob.metadata.type.format == "csv"
+    assert lit.hash == "abc"
+
+
+def test_literal_to_json_dict_file_roundtrip():
+    lt = TypeEngine.to_literal_type(File)
+    lit = json_dict_to_literal({"uri": "s3://bucket/x.csv", "format": "csv"}, lt)
+    out = literal_to_json_dict(lit, lt)
+    assert out["uri"] == "s3://bucket/x.csv"
+    assert out["format"] == "csv"
+    assert out["dimensionality"] == "SINGLE"
+
+
+def test_coerce_json_value_file_from_uri_dict():
+    out = coerce_json_value_sync({"uri": "s3://bucket/data.csv", "format": "csv"}, File)
+    assert isinstance(out, File)
+    assert out.path == "s3://bucket/data.csv"
+    assert out.format == "csv"
+
+
+def test_coerce_json_value_dir_from_uri_dict():
+    out = coerce_json_value_sync({"uri": "s3://bucket/output/", "format": ""}, Dir)
+    assert isinstance(out, Dir)
+    assert out.path == "s3://bucket/output/"
+
+
+def test_coerce_json_value_dataframe_from_uri_dict():
+    out = coerce_json_value_sync({"uri": "s3://bucket/table.parquet", "format": "parquet"}, DataFrame)
+    assert isinstance(out, DataFrame)
+    assert out.uri == "s3://bucket/table.parquet"
+
+
+def test_serialize_json_value_file():
+    f = File(path="s3://bucket/a.txt", format="txt", hash="abc")
+    payload = serialize_json_value_sync(f, File)
+    assert payload == {
+        "uri": "s3://bucket/a.txt",
+        "format": "txt",
+        "dimensionality": "SINGLE",
+        "name": "a.txt",
+        "hash": "abc",
+    }
+
+
+@pytest.mark.asyncio
+async def test_type_engine_roundtrip_file():
+    original = File(path="s3://bucket/a.txt", format="txt")
+    lt = TypeEngine.to_literal_type(File)
+    lit = await TypeEngine.to_literal(original, File, lt)
+    restored = await TypeEngine.to_python_value(lit, File)
+    assert restored.path == original.path
+    assert restored.format == original.format
+
+
+def test_stringify_via_agents_helper():
+    from flyte._utils.asyn import run_sync
+    from flyte.ai.agents._tools import _stringify_tool_result
+
+    f = File(path="s3://bucket/report.txt", format="txt")
+    parsed = json.loads(run_sync(_stringify_tool_result, f))
+    assert parsed["uri"] == "s3://bucket/report.txt"
+    assert parsed["dimensionality"] == "SINGLE"


### PR DESCRIPTION
This pull request introduces support for using Flyte IO types (`File`, `Dir`, `DataFrame`) as inputs and outputs for agent tools, enabling seamless integration of blob and structured-dataset types in LLM-driven workflows. It adds a new example demonstrating these capabilities, improves type coercion and serialization for agent tool arguments and results, and enhances the agent's system prompt to guide correct handling of IO types. Several internal utilities are updated to support these features.

**New Example and Documentation:**

* Added `io_types_agent.py`, an example agent demonstrating tools with `flyte.io.File`, `Dir`, and `DataFrame` inputs/outputs, including multi-step tool chaining and code-mode agent execution.

**Agent Tool Argument Coercion and Serialization:**

* Introduced `_coerce_tool_args` and updated agent tool execution to coerce LLM-provided JSON arguments to the correct Flyte types using type hints, ensuring proper handling of `File`, `Dir`, and `DataFrame` arguments.
* Updated result serialization with `_stringify_tool_result` to handle Flyte IO types by serializing them to JSON before returning to the LLM.

**Agent Prompt and Tool Registry Enhancements:**

* Improved the agent's system prompt to provide explicit guidance for passing IO-type tool results as arguments to downstream tools, only when relevant tools are registered.
* Added `_registry_uses_flyte_io` to detect when IO types are present in the tool registry and trigger the above prompt enhancement.

**CLI Parameter Parsing:**

* Updated CLI parameter parsing to use Flyte's JSON coercion for blob types, improving robustness and consistency for command-line workflows.

These changes collectively make it easier to build LLM-powered agents that interact with Flyte's advanced IO types, enabling more complex and reliable toolchains.