### PR TITLE
typed output/input API on ActionDetails/Run

### DIFF
--- a/src/flyte/remote/_action.py
+++ b/src/flyte/remote/_action.py
@@ -9,6 +9,7 @@ from typing import (
     Any,
     AsyncGenerator,
     AsyncIterator,
+    Callable,
     Dict,
     Iterator,
     List,
@@ -23,6 +24,7 @@ import rich.repr
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from flyteidl2.common import identifier_pb2, list_pb2, phase_pb2
+from flyteidl2.core import literals_pb2
 from flyteidl2.dataproxy import dataproxy_service_pb2
 from flyteidl2.task import common_pb2
 from flyteidl2.workflow import run_definition_pb2, run_service_pb2
@@ -640,6 +642,7 @@ class ActionDetails(ToJSONMixin):
     _inputs: ActionInputs | None = None
     _outputs: ActionOutputs | None = None
     _preserve_original_types: bool = False
+    _action_data: dataproxy_service_pb2.GetActionDataResponse | None = None
 
     @syncify
     @classmethod
@@ -951,6 +954,21 @@ class ActionDetails(ToJSONMixin):
             return attempts[attempt - 1].logs_available
         return False
 
+    async def _fetch_action_data(self) -> dataproxy_service_pb2.GetActionDataResponse:
+        """
+        Fetch the action's raw inputs/outputs from the data proxy, caching the response on the
+        instance. This deliberately does not reconstruct any types, so it never fails (or pays the
+        cost) when an input/output type can't be reconstructed on the client -- see
+        :meth:`output_literals` / :meth:`typed_outputs`.
+        """
+        if self._action_data is None:
+            self._action_data = await get_client().dataproxy_service.get_action_data(
+                request=dataproxy_service_pb2.GetActionDataRequest(
+                    action_id=self.pb2.id
+                )
+            )
+        return self._action_data
+
     @syncify
     async def _cache_data(self) -> bool:
         """
@@ -964,11 +982,7 @@ class ActionDetails(ToJSONMixin):
             return True
         if self._inputs and not self.done():
             return False
-        resp = await get_client().dataproxy_service.get_action_data(
-            request=dataproxy_service_pb2.GetActionDataRequest(
-                action_id=self.pb2.id,
-            )
-        )
+        resp = await self._fetch_action_data()
 
         with internal_ctx().new_preserve_original_types(self._preserve_original_types):
             native_iface = None
@@ -1022,6 +1036,115 @@ class ActionDetails(ToJSONMixin):
                     "Please wait for the action to complete."
                 )
         return cast(ActionOutputs, self._outputs)
+
+    async def output_literals(self) -> Dict[str, literals_pb2.Literal]:
+        """
+        Return the action's raw output literals keyed by output name (``o0``, ``o1``, ...) without
+        reconstructing the producer's types from the stored schema.
+
+        Unlike :meth:`outputs`, this never calls ``guess_python_type``, so it can't fail (or pay the
+        cost) when an output's type isn't reconstructable on the client, and it returns every output
+        even if a sibling's type is un-guessable. Pair it with :meth:`typed_outputs` (or
+        ``TypeEngine.literal_map_to_kwargs``) to decode the specific outputs you care about.
+        """
+        resp = await self._fetch_action_data()
+        if not resp.outputs:
+            return {}
+        return {nl.name: nl.value for nl in resp.outputs.literals}
+
+    async def input_literals(self) -> Dict[str, literals_pb2.Literal]:
+        """
+        Return the action's raw input literals keyed by input name, without reconstructing types.
+        The input-side equivalent of :meth:`output_literals`.
+        """
+        resp = await self._fetch_action_data()
+        if not resp.inputs:
+            return {}
+        return {nl.name: nl.value for nl in resp.inputs.literals}
+
+    async def typed_outputs(
+        self,
+        types: Dict[str, type],
+        deserializers: Dict[type, Callable[[Any], Any]] | None = None,
+    ) -> Dict[str, Any]:
+        """
+        Fetch the action's outputs and re-hydrate the requested ones into caller-supplied types.
+
+        This is the supported "give me this action's ``o0`` as ``MyModel``" path:
+
+        * Only the outputs named in ``types`` are converted -- sibling outputs are never
+          reconstructed, so an un-reconstructable sibling type can't fail the whole fetch.
+        * Because you supply the type, the result is your real class (with its validators, methods
+          and custom (de)serializers), not a permissive schema-derived look-alike.
+
+        :param types: Mapping of output name (``o0``, ``o1``, ...) to the Python type to decode into.
+        :param deserializers: Optional mapping of Python type -> a callable that builds an instance
+            from the raw (pre-validation) payload, e.g. ``{MyModel: MyModel.load}``. When a requested
+            output's type appears here, the raw payload is handed to the callable instead of the
+            default decode/``model_validate`` -- the hook for versioned-schema models that must
+            migrate historical payloads before validation. Types not listed use the normal decode.
+        :return: Mapping of output name to decoded value, restricted to the requested names that are
+            present in the action's outputs.
+        """
+        return await self._typed_literals(
+            await self.output_literals(), types, deserializers
+        )
+
+    async def typed_inputs(
+        self,
+        types: Dict[str, type],
+        deserializers: Dict[type, Callable[[Any], Any]] | None = None,
+    ) -> Dict[str, Any]:
+        """
+        Fetch the action's inputs and re-hydrate the requested ones into caller-supplied types.
+        The input-side equivalent of :meth:`typed_outputs`; ``deserializers`` works the same way.
+        """
+        return await self._typed_literals(
+            await self.input_literals(), types, deserializers
+        )
+
+    @staticmethod
+    async def _typed_literals(
+        literals: Dict[str, literals_pb2.Literal],
+        py_types: Dict[str, type],
+        deserializers: Dict[type, Callable[[Any], Any]] | None = None,
+    ) -> Dict[str, Any]:
+        """Decode only the ``py_types`` slots of ``literals`` using the caller-supplied types.
+
+        Passing ``python_types`` (not ``literal_types``) keeps ``literal_map_to_kwargs`` from calling
+        ``guess_python_type`` -- the conversion uses the caller's real type and touches no siblings.
+        Slots whose type has a ``deserializers`` entry skip the default decode: their raw payload is
+        handed to the caller's callable so versioned-schema models can migrate before validating.
+        """
+        from flyte.types import TypeEngine
+
+        selected = {name: lit for name, lit in literals.items() if name in py_types}
+        if not selected:
+            return {}
+        deserializers = deserializers or {}
+
+        custom = {
+            name: lit
+            for name, lit in selected.items()
+            if py_types[name] in deserializers
+        }
+        standard = {name: lit for name, lit in selected.items() if name not in custom}
+
+        result: Dict[str, Any] = {}
+        if standard:
+            result.update(
+                await TypeEngine.literal_map_to_kwargs(
+                    literals_pb2.LiteralMap(literals=standard),
+                    python_types={name: py_types[name] for name in standard},
+                )
+            )
+
+        for name, lit in custom.items():
+            # ``dict`` is the raw, un-validated payload form for STRUCT and msgpack-binary scalars.
+            raw_payload = await TypeEngine.to_python_value(lit, dict)
+            result[name] = deserializers[py_types[name]](raw_payload)
+
+        return result
 
     def done(self) -> bool:
         """

--- a/src/flyte/remote/_action.py
+++ b/src/flyte/remote/_action.py
@@ -963,9 +963,7 @@ class ActionDetails(ToJSONMixin):
         """
         if self._action_data is None:
             self._action_data = await get_client().dataproxy_service.get_action_data(
-                request=dataproxy_service_pb2.GetActionDataRequest(
-                    action_id=self.pb2.id
-                )
+                request=dataproxy_service_pb2.GetActionDataRequest(action_id=self.pb2.id)
             )
         return self._action_data
 
@@ -1086,9 +1084,7 @@ class ActionDetails(ToJSONMixin):
         :return: Mapping of output name to decoded value, restricted to the requested names that are
             present in the action's outputs.
         """
-        return await self._typed_literals(
-            await self.output_literals(), types, deserializers
-        )
+        return await self._typed_literals(await self.output_literals(), types, deserializers)
 
     async def typed_inputs(
         self,
@@ -1099,9 +1095,7 @@ class ActionDetails(ToJSONMixin):
         Fetch the action's inputs and re-hydrate the requested ones into caller-supplied types.
         The input-side equivalent of :meth:`typed_outputs`; ``deserializers`` works the same way.
         """
-        return await self._typed_literals(
-            await self.input_literals(), types, deserializers
-        )
+        return await self._typed_literals(await self.input_literals(), types, deserializers)
 
     @staticmethod
     async def _typed_literals(
@@ -1123,11 +1117,7 @@ class ActionDetails(ToJSONMixin):
             return {}
         deserializers = deserializers or {}
 
-        custom = {
-            name: lit
-            for name, lit in selected.items()
-            if py_types[name] in deserializers
-        }
+        custom = {name: lit for name, lit in selected.items() if py_types[name] in deserializers}
         standard = {name: lit for name, lit in selected.items() if name not in custom}
 
         result: Dict[str, Any] = {}

--- a/src/flyte/remote/_run.py
+++ b/src/flyte/remote/_run.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import AsyncGenerator, AsyncIterator, Literal, Tuple
+from typing import Any, AsyncGenerator, AsyncIterator, Callable, Dict, Literal, Tuple
 
 import rich.repr
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from flyteidl2.common import identifier_pb2, list_pb2, phase_pb2
+from flyteidl2.core import literals_pb2
 from flyteidl2.workflow import run_definition_pb2, run_service_pb2
 
 from flyte._initialize import ensure_client, get_client, get_init_config
@@ -301,6 +302,50 @@ class Run(ToJSONMixin):
         details = await self.details.aio()
         return await details.outputs()
 
+    @syncify
+    async def output_literals(self) -> Dict[str, literals_pb2.Literal]:
+        """Raw output literals of the run's action, without reconstructing types.
+
+        See :meth:`ActionDetails.output_literals`.
+        """
+        details = await self.details.aio()
+        return await details.output_literals()
+
+    @syncify
+    async def input_literals(self) -> Dict[str, literals_pb2.Literal]:
+        """Raw input literals of the run's action, without reconstructing types.
+
+        See :meth:`ActionDetails.input_literals`.
+        """
+        details = await self.details.aio()
+        return await details.input_literals()
+
+    @syncify
+    async def typed_outputs(
+        self,
+        types: Dict[str, type],
+        deserializers: Dict[type, Callable[[Any], Any]] | None = None,
+    ) -> Dict[str, Any]:
+        """Re-hydrate the run's requested outputs into caller-supplied types.
+
+        See :meth:`ActionDetails.typed_outputs`.
+        """
+        details = await self.details.aio()
+        return await details.typed_outputs(types, deserializers)
+
+    @syncify
+    async def typed_inputs(
+        self,
+        types: Dict[str, type],
+        deserializers: Dict[type, Callable[[Any], Any]] | None = None,
+    ) -> Dict[str, Any]:
+        """Re-hydrate the run's requested inputs into caller-supplied types.
+
+        See :meth:`ActionDetails.typed_inputs`.
+        """
+        details = await self.details.aio()
+        return await details.typed_inputs(types, deserializers)
+
     @property
     def url(self) -> str:
         """
@@ -464,6 +509,30 @@ class RunDetails(ToJSONMixin):
         Placeholder for outputs. This can be extended to handle outputs from the run context.
         """
         return await self.action_details.outputs()
+
+    async def output_literals(self) -> Dict[str, literals_pb2.Literal]:
+        """Raw output literals without reconstructing types. See :meth:`ActionDetails.output_literals`."""
+        return await self.action_details.output_literals()
+
+    async def input_literals(self) -> Dict[str, literals_pb2.Literal]:
+        """Raw input literals without reconstructing types. See :meth:`ActionDetails.input_literals`."""
+        return await self.action_details.input_literals()
+
+    async def typed_outputs(
+        self,
+        types: Dict[str, type],
+        deserializers: Dict[type, Callable[[Any], Any]] | None = None,
+    ) -> Dict[str, Any]:
+        """Re-hydrate requested outputs into caller-supplied types. See :meth:`ActionDetails.typed_outputs`."""
+        return await self.action_details.typed_outputs(types, deserializers)
+
+    async def typed_inputs(
+        self,
+        types: Dict[str, type],
+        deserializers: Dict[type, Callable[[Any], Any]] | None = None,
+    ) -> Dict[str, Any]:
+        """Re-hydrate requested inputs into caller-supplied types. See :meth:`ActionDetails.typed_inputs`."""
+        return await self.action_details.typed_inputs(types, deserializers)
 
     def __rich_repr__(self) -> rich.repr.Result:
         """

--- a/tests/flyte/remote/test_action_io.py
+++ b/tests/flyte/remote/test_action_io.py
@@ -795,9 +795,7 @@ class TestActionDetailsTypedAccess:
     @pytest.mark.asyncio
     async def test_typed_outputs_only_converts_requested_leaving_siblings_untouched(self):
         # B1 non-fatal: only o0 is requested, so o1 is never reconstructed and can't fail the call.
-        outs = common_pb2.Outputs(
-            literals=[await _named("o0", _Report(name="x"), _Report), await _named("o1", 7, int)]
-        )
+        outs = common_pb2.Outputs(literals=[await _named("o0", _Report(name="x"), _Report), await _named("o1", 7, int)])
         typed = await _action_details(outputs=outs).typed_outputs({"o0": _Report})
         assert set(typed) == {"o0"}
 
@@ -819,9 +817,7 @@ class TestActionDetailsTypedAccess:
     async def test_typed_outputs_uses_caller_deserializer_to_migrate(self):
         # B4: a versioned model whose loader migrates a legacy payload (tags stored as a delimited
         # string) that the current model's default validation would reject.
-        outs = common_pb2.Outputs(
-            literals=[await _named("o0", {"name": "x", "tags": "a,b,c"}, dict)]
-        )
+        outs = common_pb2.Outputs(literals=[await _named("o0", {"name": "x", "tags": "a,b,c"}, dict)])
         typed = await _action_details(outputs=outs).typed_outputs(
             {"o0": _VersionedReport}, deserializers={_VersionedReport: _VersionedReport.load}
         )

--- a/tests/flyte/remote/test_action_io.py
+++ b/tests/flyte/remote/test_action_io.py
@@ -1,15 +1,23 @@
+import asyncio
 import base64
 import datetime
 
 import msgpack
+import pytest
+from flyteidl2.common import phase_pb2
 from flyteidl2.core import literals_pb2
+from flyteidl2.dataproxy import dataproxy_service_pb2
 from flyteidl2.task import common_pb2
+from flyteidl2.workflow import run_definition_pb2
 from google.protobuf.duration_pb2 import Duration
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.struct_pb2 import Struct
 from google.protobuf.timestamp_pb2 import Timestamp
+from pydantic import BaseModel, Field
 
-from flyte.remote._action import ActionOutputs
+from flyte.remote._action import ActionDetails, ActionOutputs
+from flyte.remote._run import Run, RunDetails
+from flyte.types import TypeEngine
 
 
 class TestActionOutputsTupleBehavior:
@@ -718,3 +726,155 @@ class TestActionOutputsWithVariousTypes:
         result_dict = outputs.to_dict()
         assert isinstance(result_dict, dict)
         assert "literals" in result_dict
+
+
+class _Report(BaseModel):
+    name: str
+    tags: list[str] = Field(default_factory=list)
+
+
+class _VersionedReport(BaseModel):
+    """A model whose ``load`` migrates legacy payloads (tags stored as a delimited string)."""
+
+    name: str
+    tags: list[str] = Field(default_factory=list)
+
+    @classmethod
+    def load(cls, payload: dict) -> "_VersionedReport":
+        data = dict(payload)
+        if isinstance(data.get("tags"), str):
+            data["tags"] = [t for t in data["tags"].split(",") if t]
+        return cls(**data)
+
+
+async def _named(name: str, value, py_type) -> common_pb2.NamedLiteral:
+    lit = await TypeEngine.to_literal(value, py_type, TypeEngine.to_literal_type(py_type))
+    return common_pb2.NamedLiteral(name=name, value=lit)
+
+
+def _named_sync(name: str, value, py_type) -> common_pb2.NamedLiteral:
+    """Build a NamedLiteral from a synchronous (non-async) test."""
+    return asyncio.run(_named(name, value, py_type))
+
+
+def _action_details(outputs=None, inputs=None) -> ActionDetails:
+    """An ActionDetails with the data-proxy response pre-seeded, so the raw-literal/typed-output
+    accessors never hit the network and never reconstruct the stored interface."""
+    resp = dataproxy_service_pb2.GetActionDataResponse(
+        outputs=outputs or common_pb2.Outputs(),
+        inputs=inputs or common_pb2.Inputs(),
+    )
+    return ActionDetails(pb2=run_definition_pb2.ActionDetails(), _action_data=resp)
+
+
+class TestActionDetailsTypedAccess:
+    """B1/B2/B3: raw-literal access and re-hydration into caller-supplied types."""
+
+    @pytest.mark.asyncio
+    async def test_output_literals_returns_raw_literals(self):
+        # B1: raw literals, keyed by output name, with no interface reconstruction.
+        outs = common_pb2.Outputs(
+            literals=[await _named("o0", _Report(name="x", tags=["a"]), _Report), await _named("o1", 42, int)]
+        )
+        raw = await _action_details(outputs=outs).output_literals()
+        assert set(raw) == {"o0", "o1"}
+        assert all(isinstance(v, literals_pb2.Literal) for v in raw.values())
+
+    @pytest.mark.asyncio
+    async def test_output_literals_empty_when_no_outputs(self):
+        assert await _action_details().output_literals() == {}
+
+    @pytest.mark.asyncio
+    async def test_typed_outputs_rehydrates_the_real_class(self):
+        # B2: the result is the caller's actual class (validators/methods), not a schema look-alike.
+        outs = common_pb2.Outputs(literals=[await _named("o0", _Report(name="x", tags=["a"]), _Report)])
+        typed = await _action_details(outputs=outs).typed_outputs({"o0": _Report})
+        assert isinstance(typed["o0"], _Report)
+        assert typed["o0"].name == "x" and typed["o0"].tags == ["a"]
+
+    @pytest.mark.asyncio
+    async def test_typed_outputs_only_converts_requested_leaving_siblings_untouched(self):
+        # B1 non-fatal: only o0 is requested, so o1 is never reconstructed and can't fail the call.
+        outs = common_pb2.Outputs(
+            literals=[await _named("o0", _Report(name="x"), _Report), await _named("o1", 7, int)]
+        )
+        typed = await _action_details(outputs=outs).typed_outputs({"o0": _Report})
+        assert set(typed) == {"o0"}
+
+    @pytest.mark.asyncio
+    async def test_typed_outputs_omits_missing_requested_names(self):
+        outs = common_pb2.Outputs(literals=[await _named("o0", _Report(name="x"), _Report)])
+        # Asking for an output that isn't present is lenient: it's simply omitted, not an error.
+        assert await _action_details(outputs=outs).typed_outputs({"o5": _Report}) == {}
+
+    @pytest.mark.asyncio
+    async def test_typed_inputs_rehydrates_the_real_class(self):
+        ins = common_pb2.Inputs(literals=[await _named("a", _Report(name="in", tags=["t"]), _Report)])
+        ad = _action_details(inputs=ins)
+        assert set(await ad.input_literals()) == {"a"}
+        typed = await ad.typed_inputs({"a": _Report})
+        assert isinstance(typed["a"], _Report) and typed["a"].name == "in"
+
+    @pytest.mark.asyncio
+    async def test_typed_outputs_uses_caller_deserializer_to_migrate(self):
+        # B4: a versioned model whose loader migrates a legacy payload (tags stored as a delimited
+        # string) that the current model's default validation would reject.
+        outs = common_pb2.Outputs(
+            literals=[await _named("o0", {"name": "x", "tags": "a,b,c"}, dict)]
+        )
+        typed = await _action_details(outputs=outs).typed_outputs(
+            {"o0": _VersionedReport}, deserializers={_VersionedReport: _VersionedReport.load}
+        )
+        assert isinstance(typed["o0"], _VersionedReport)
+        assert typed["o0"].tags == ["a", "b", "c"]
+
+    @pytest.mark.asyncio
+    async def test_typed_outputs_mixes_deserialized_and_standard_slots(self):
+        # B4: o0 goes through the caller's loader; o1 uses the normal decode -- both come back.
+        outs = common_pb2.Outputs(
+            literals=[
+                await _named("o0", {"name": "x", "tags": "a,b"}, dict),
+                await _named("o1", _Report(name="r", tags=["z"]), _Report),
+            ]
+        )
+        typed = await _action_details(outputs=outs).typed_outputs(
+            {"o0": _VersionedReport, "o1": _Report}, deserializers={_VersionedReport: _VersionedReport.load}
+        )
+        assert isinstance(typed["o0"], _VersionedReport) and typed["o0"].tags == ["a", "b"]
+        assert isinstance(typed["o1"], _Report) and typed["o1"].tags == ["z"]
+
+
+def _run_with_outputs(outs: common_pb2.Outputs) -> Run:
+    """A Run whose terminal action's data proxy response is pre-seeded (no network, no fetch)."""
+    rd_pb2 = run_definition_pb2.RunDetails()
+    rd_pb2.action.status.phase = phase_pb2.ACTION_PHASE_SUCCEEDED
+    rd = RunDetails(rd_pb2)
+    rd.action_details._action_data = dataproxy_service_pb2.GetActionDataResponse(outputs=outs)
+    run_pb2 = run_definition_pb2.Run()
+    run_pb2.action.SetInParent()  # Run.__post_init__ requires an action to be present
+    run = Run(pb2=run_pb2)
+    run._details = rd  # bypass the remote fetch; rd.done() is True so details() won't refetch
+    return run
+
+
+class TestRunTypedAccess:
+    """The Run/RunDetails wrappers surface the same API; Run's are syncified like ``outputs()``."""
+
+    @pytest.mark.asyncio
+    async def test_run_details_typed_outputs_delegates(self):
+        outs = common_pb2.Outputs(literals=[await _named("o0", _Report(name="x", tags=["a"]), _Report)])
+        rd = await _run_with_outputs(outs).details.aio()
+        typed = await rd.typed_outputs({"o0": _Report})
+        assert isinstance(typed["o0"], _Report) and typed["o0"].name == "x"
+
+    def test_run_typed_outputs_is_callable_synchronously(self):
+        # The "sync" ask: run.typed_outputs(...) works without await, like run.outputs().
+        outs = common_pb2.Outputs(literals=[_named_sync("o0", _Report(name="x", tags=["a"]), _Report)])
+        run = _run_with_outputs(outs)
+        typed = run.typed_outputs({"o0": _Report})
+        assert isinstance(typed["o0"], _Report) and typed["o0"].tags == ["a"]
+
+    def test_run_output_literals_is_callable_synchronously(self):
+        run = _run_with_outputs(common_pb2.Outputs(literals=[_named_sync("o0", 7, int)]))
+        raw = run.output_literals()
+        assert set(raw) == {"o0"} and isinstance(raw["o0"], literals_pb2.Literal)


### PR DESCRIPTION
Fetching another action's output via ActionDetails.outputs() eagerly reconstructs the whole interface and fails fast if any one type can't be guessed; the result is also a synthetic schema-derived look-alike, and there's no first-class way to ask
for an output as a known type. This adds an API addressing those gaps:

- output_literals() / input_literals(): raw {name: Literal} straight from the data proxy, with no interface reconstruction.
- typed_outputs(types) / typed_inputs(types): re-hydrate only the requested slots into caller-supplied types via literal_map_to_kwargs(python_types=...), which skips guess_python_type. Sibling types are never touched and the result is the caller's real class with its validators/methods.
- deserializers={Type: loader}: optional hook handing the raw pre-validation payload to a caller loader instead of the default decode, for versioned-schema models that migrate historical payloads before validating.

The data-proxy fetch is factored into a cached _fetch_action_data() shared by _cache_data and the new methods. Wrappers are surfaced on RunDetails (async) and Run (syncified).

Fixes https://linear.app/unionai/issue/ENG26-759/first-class-typed-output-fetch-without-eager-interface-reconstruction, https://linear.app/unionai/issue/ENG26-760/caller-supplied-deserializer-hook-for-pydantic-schema-migration
