### PR TITLE
Add related_to field as a run parameter

### DIFF
--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -94,6 +94,7 @@ class _Runner:
         domain: str | None = None,
         env_vars: Dict[str, str] | None = None,
         labels: Dict[str, str] | None = None,
+        related_to: str | None = None,
         annotations: Dict[str, str] | None = None,
         interruptible: bool | None = None,
         log_level: int | None = None,
@@ -140,6 +141,7 @@ class _Runner:
         self._domain = domain
         self._env_vars = env_vars
         self._labels = labels
+        self._related_to = related_to
         self._annotations = annotations
         self._interruptible = interruptible
         self._log_level = log_level
@@ -380,6 +382,11 @@ class _Runner:
             env_kv = run_pb2.Envs(values=kv_pairs)
             annotations = run_pb2.Annotations(values=self._annotations)
             labels = run_pb2.Labels(values=self._labels)
+            related_to = (
+                identifier_pb2.RunIdentifier(project=project, domain=domain, org=cfg.org, name=self._related_to)
+                if self._related_to
+                else None
+            )
             raw_data_storage = (
                 run_pb2.RawDataStorage(raw_data_prefix=self._raw_data_path) if self._raw_data_path else None
             )
@@ -433,6 +440,7 @@ class _Runner:
                         else None,
                         annotations=annotations,
                         labels=labels,
+                        related_to=related_to,
                         envs=env_kv,
                         cluster=self._queue or task.queue,
                         max_action_concurrency=self._max_action_concurrency or 0,
@@ -849,6 +857,7 @@ def with_runcontext(
     domain: str | None = None,
     env_vars: Dict[str, str] | None = None,
     labels: Dict[str, str] | None = None,
+    related_to: str | None = None,
     annotations: Dict[str, str] | None = None,
     interruptible: bool | None = None,
     log_level: int | None = None,
@@ -914,6 +923,9 @@ def with_runcontext(
     :param env_vars: Optional Environment variables to set for the run
     :param labels: Optional user-defined labels to attach to the run as KEY=VALUE pairs, used for
         filtering and organizing runs (e.g. ``flyte get run --with-label team=ml``)
+    :param related_to: Optional name of a parent run that this run is derived from. Recorded on the run
+        as provenance (scoped to this run's project/domain/org) so the parent and its derived runs can
+        be linked. Set once at creation and immutable thereafter.
     :param annotations: Optional Annotations to set for the run
     :param interruptible: Optional If true, the run can be scheduled on interruptible instances and false implies
         that all tasks in the run should only be scheduled on non-interruptible instances. If not specified the
@@ -976,6 +988,7 @@ def with_runcontext(
         overwrite_cache=overwrite_cache,
         env_vars=env_vars,
         labels=labels,
+        related_to=related_to,
         annotations=annotations,
         interruptible=interruptible,
         project=project,

--- a/src/flyte/cli/_get.py
+++ b/src/flyte/cli/_get.py
@@ -103,6 +103,13 @@ def project(cfg: common.CLIConfig, name: str | None = None, archived: bool = Fal
     default=(),
     help="Filter runs that have this label key present (existence check). Can be specified multiple times.",
 )
+@click.option(
+    "--related-to",
+    "related_to",
+    type=str,
+    default=None,
+    help="Filter runs derived from (whose parent is) the run with this name.",
+)
 @click.pass_obj
 def run(
     cfg: common.CLIConfig,
@@ -120,6 +127,7 @@ def run(
     updated_before: dt.datetime | None = None,
     with_label: Tuple[str, ...] = (),
     with_label_key: Tuple[str, ...] = (),
+    related_to: str | None = None,
 ):
     """
     Get a list of all runs, or details of a specific run by name.
@@ -140,6 +148,12 @@ def run(
     ```bash
     $ flyte get run --with-label team=ml --with-label env=prod
     $ flyte get run --with-label-key team
+    ```
+
+    You can filter runs by their parent run (provenance):
+
+    ```bash
+    $ flyte get run --related-to my_parent_run
     ```
     """
 
@@ -196,6 +210,7 @@ def run(
                     updated_at=updated_at,
                     with_labels=parsed_with_labels,
                     with_label_keys=list(with_label_key) or None,
+                    related_to=related_to,
                 ),
                 cfg.output_format,
             )

--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -289,6 +289,18 @@ class RunArguments:
             )
         },
     )
+    related_to: str | None = field(
+        default=None,
+        metadata={
+            "click.option": click.Option(
+                ["--related-to"],
+                type=str,
+                default=None,
+                help="Name of a parent run this run is derived from (provenance). "
+                "Scoped to this run's project/domain/org.",
+            )
+        },
+    )
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> RunArguments:
@@ -401,6 +413,7 @@ Missing required parameter(s): {", ".join(f"--{p[0]} (type: {p[1]})" for p in mi
                 env_vars=self.run_args.parsed_env_vars(),
                 max_action_concurrency=self.run_args.max_action_concurrency,
                 labels=self.run_args.parsed_labels(),
+                related_to=self.run_args.related_to,
             )
             result = await execution_context.run.aio(self.obj, **ctx.params)
         except Exception as e:
@@ -465,6 +478,7 @@ Missing required parameter(s): {", ".join(f"--{p[0]} (type: {p[1]})" for p in mi
                 debug=self.run_args.debug,
                 env_vars=self.run_args.parsed_env_vars(),
                 labels=self.run_args.parsed_labels(),
+                related_to=self.run_args.related_to,
                 _tracker=tracker,
             )
             return await execution_context.run.aio(self.obj, **ctx.params)
@@ -626,6 +640,7 @@ Missing required parameter(s): {", ".join(f"--{p[0]} (type: {p[1]})" for p in mi
                 env_vars=self.run_args.parsed_env_vars(),
                 max_action_concurrency=self.run_args.max_action_concurrency,
                 labels=self.run_args.parsed_labels(),
+                related_to=self.run_args.related_to,
             )
             result = await execution_context.run.aio(task, **ctx.params)
         except Exception as e:

--- a/src/flyte/remote/_run.py
+++ b/src/flyte/remote/_run.py
@@ -56,6 +56,7 @@ class Run(ToJSONMixin):
         updated_at: TimeFilter | None = None,
         with_labels: dict[str, str] | None = None,
         with_label_keys: list[str] | None = None,
+        related_to: str | None = None,
     ) -> AsyncIterator[Run]:
         """
         Get all runs for the current project and domain.
@@ -72,6 +73,7 @@ class Run(ToJSONMixin):
         :param updated_at: Filter runs by last-update time range.
         :param with_labels: Filter runs whose labels include all of these key=value pairs (AND semantics).
         :param with_label_keys: Filter runs that have all of these label keys present (existence check).
+        :param related_to: Filter runs derived from (whose parent is) the run with this name.
         :return: An iterator of runs.
         """
         ensure_client()
@@ -147,6 +149,16 @@ class Run(ToJSONMixin):
                         field=f"labels.{k}",
                     ),
                 )
+
+        # Filter by provenance: runs whose parent (``related_to``) is the given run name.
+        if related_to:
+            filters.append(
+                list_pb2.Filter(
+                    function=list_pb2.Filter.Function.EQUAL,
+                    field="related_to",
+                    values=[related_to],
+                ),
+            )
 
         cfg = get_init_config()
         i = 0
@@ -470,6 +482,7 @@ class RunDetails(ToJSONMixin):
         Rich representation of the Run object.
         """
         yield "labels", str(self.pb2.run_spec.labels)
+        yield "related-to", self.pb2.run_spec.related_to.name
         yield "annotations", str(self.pb2.run_spec.annotations)
         yield "env-vars", str(self.pb2.run_spec.envs)
         yield "is-interruptible", str(self.pb2.run_spec.interruptible)

--- a/tests/flyte/remote/test_listall_filters.py
+++ b/tests/flyte/remote/test_listall_filters.py
@@ -211,6 +211,18 @@ class TestRunListallFilters:
         assert "created_at" not in fields
         assert "updated_at" not in fields
 
+    def test_related_to_filter_is_sent(self, mock_client, mock_init_config):
+        call_args = self._call_listall(mock_client, mock_init_config, related_to="parent-run")
+        filters = list(call_args[0][0].request.filters)
+        related = next(f for f in filters if f.field == "related_to")
+        assert related.function == list_pb2.Filter.Function.EQUAL
+        assert list(related.values) == ["parent-run"]
+
+    def test_no_related_to_sends_no_related_to_field(self, mock_client, mock_init_config):
+        call_args = self._call_listall(mock_client, mock_init_config)
+        fields = [f.field for f in call_args[0][0].request.filters]
+        assert "related_to" not in fields
+
 
 # ---------------------------------------------------------------------------
 # Action.listall() — verify time filters sent to the gRPC stub
@@ -315,3 +327,42 @@ class TestTimeFilterExport:
         from flyte.remote import TimeFilter as TF
 
         assert TF is TimeFilter
+
+
+# ---------------------------------------------------------------------------
+# RunDetails — verify related_to surfaces on read (get run)
+# ---------------------------------------------------------------------------
+
+
+class TestRunDetailsRelatedTo:
+    def _make_run_details(self, related_to_name: str = ""):
+        from flyteidl2.common import identifier_pb2
+        from flyteidl2.task import run_pb2
+        from flyteidl2.workflow import run_definition_pb2
+
+        from flyte.remote._run import RunDetails
+
+        action = run_definition_pb2.ActionDetails(
+            id=identifier_pb2.ActionIdentifier(
+                run=identifier_pb2.RunIdentifier(name="child-run"),
+                name="a0",
+            ),
+        )
+        spec = run_pb2.RunSpec()
+        if related_to_name:
+            spec.related_to.CopyFrom(identifier_pb2.RunIdentifier(name=related_to_name))
+        return RunDetails(run_definition_pb2.RunDetails(action=action, run_spec=spec))
+
+    def test_related_to_in_rich_repr(self):
+        rd = self._make_run_details(related_to_name="parent-run")
+        assert dict(rd.__rich_repr__())["related-to"] == "parent-run"
+
+    def test_related_to_empty_when_unset(self):
+        rd = self._make_run_details()
+        assert dict(rd.__rich_repr__())["related-to"] == ""
+
+    def test_related_to_in_json(self):
+        import json
+
+        rd = self._make_run_details(related_to_name="parent-run")
+        assert json.loads(rd.to_json())["runSpec"]["relatedTo"] == {"name": "parent-run"}

--- a/tests/flyte/test_union_run_basic.py
+++ b/tests/flyte/test_union_run_basic.py
@@ -258,3 +258,39 @@ def test_with_runcontext_rejects_max_action_concurrency_of_one():
 def test_with_runcontext_allows_zero_max_action_concurrency():
     flyte.with_runcontext(max_action_concurrency=0)
     flyte.with_runcontext(max_action_concurrency=2)
+
+
+@pytest.mark.asyncio
+@mock.patch("flyte._deploy._build_image_bg", new_callable=AsyncMock)
+@mock.patch("flyte._code_bundle.build_code_bundle", new_callable=AsyncMock)
+async def test_run_spec_related_to(mock_code_bundler: AsyncMock, mock_build_image_bg: AsyncMock):
+    """related_to from with_runcontext should land on RunSpec as a RunIdentifier scoped to the run."""
+    mock_client, mock_run_service = _make_mock_client()
+    mock_code_bundler.return_value = CodeBundle(computed_version="v1", tgz="test.tgz")
+    mock_build_image_bg.return_value = (env.name, "image_name", None)
+
+    await _init_for_testing(client=mock_client, project="test", domain="test")
+    run = await flyte.with_runcontext(mode="remote", related_to="parent-run").run.aio(task1, "hello")
+
+    assert run
+    req: run_service_pb2.CreateRunRequest = mock_run_service.create_run.call_args[0][0]
+    assert req.run_spec.related_to.name == "parent-run"
+    assert req.run_spec.related_to.project == "test"
+    assert req.run_spec.related_to.domain == "test"
+
+
+@pytest.mark.asyncio
+@mock.patch("flyte._deploy._build_image_bg", new_callable=AsyncMock)
+@mock.patch("flyte._code_bundle.build_code_bundle", new_callable=AsyncMock)
+async def test_run_spec_related_to_default_unset(mock_code_bundler: AsyncMock, mock_build_image_bg: AsyncMock):
+    """When related_to is not provided, RunSpec carries an empty RunIdentifier (unset)."""
+    mock_client, mock_run_service = _make_mock_client()
+    mock_code_bundler.return_value = CodeBundle(computed_version="v1", tgz="test.tgz")
+    mock_build_image_bg.return_value = (env.name, "image_name", None)
+
+    await _init_for_testing(client=mock_client, project="test", domain="test")
+    run = await flyte.with_runcontext(mode="remote").run.aio(task1, "hello")
+
+    assert run
+    req: run_service_pb2.CreateRunRequest = mock_run_service.create_run.call_args[0][0]
+    assert req.run_spec.related_to.name == ""


### PR DESCRIPTION
This commit adds related_to to the runspec.
It is an immutable property of the run, entered at create run time via either a cli parameter or through the sdk withRunContext().