### PR TITLE
Route call_handler through Agent code mode

### DIFF
--- a/src/flyte/ai/agents/_code.py
+++ b/src/flyte/ai/agents/_code.py
@@ -3,9 +3,12 @@
 In *code mode* the agent does not emit JSON tool calls. Instead, on each turn the
 LLM writes a short Python program that is executed in the Monty sandbox
 (``flyte.sandbox.orchestrate_local``). The agent's tools are exposed to that
-sandbox as plain functions, so ``@env.task`` tools dispatch durably on the
-cluster, ``@flyte.trace`` helpers are traced, and ``flyte_map(...)`` fans out in
-parallel — all the usual Flyte features, driven by generated code.
+sandbox as plain functions. Tools with a ``call_handler`` are wrapped so the
+handler runs on each sandbox invocation (same as the tool-calling path).
+``@env.task`` tools without a handler are passed through as their underlying
+template so they dispatch durably on the cluster; ``@flyte.trace`` helpers are
+traced, and ``flyte_map(...)`` fans out in parallel — all the usual Flyte
+features, driven by generated code.
 
 This module is internal: the public surface is the ``code_mode`` flag on
 :class:`~flyte.ai.agents.Agent`.
@@ -18,7 +21,8 @@ import re
 import textwrap
 from typing import Any
 
-from ._tools import AgentTool, _summarize_signature
+from ._llm import LLMCallable
+from ._tools import AgentTool, _summarize_signature, invoke_agent_tool_from_call
 
 # A python code fence (```python / ```py / bare ```). Captures the body.
 _CODE_FENCE_RE = re.compile(r"```(?:python|py)?\s*\n?(.*?)```", re.DOTALL)
@@ -86,11 +90,30 @@ def _make_execute_wrapper(tool: AgentTool) -> Any:
     return _wrapper
 
 
-def build_sandbox_tools(registry: dict[str, AgentTool]) -> list[Any]:
+def _make_call_handler_wrapper(tool: AgentTool, *, call_llm: LLMCallable, model: str) -> Any:
+    """Expose an ``AgentTool`` with ``call_handler`` as a sandbox async function."""
+
+    async def _wrapper(*args: Any, **kwargs: Any) -> Any:
+        return await invoke_agent_tool_from_call(tool, *args, call_llm=call_llm, model=model, **kwargs)
+
+    _wrapper.__name__ = _sandbox_name(tool)
+    underlying = _underlying_callable(tool)
+    _wrapper.__doc__ = (inspect.getdoc(underlying) if underlying is not None else None) or tool.description
+    return _wrapper
+
+
+def build_sandbox_tools(
+    registry: dict[str, AgentTool],
+    *,
+    call_llm: LLMCallable,
+    model: str,
+) -> list[Any]:
     """Map the agent's tool registry to objects ``orchestrate_local`` understands.
 
-    ``@env.task`` / ``LazyEntity`` / plain-callable tools are passed through as
-    their underlying object so they keep their native dispatch (durable tasks
+    Tools with a ``call_handler`` are wrapped so sandbox calls route through the
+    handler (using the agent's ``call_llm`` and ``model``). ``@env.task`` /
+    ``LazyEntity`` / plain-callable tools without a handler are passed through as
+    their underlying object so they keep native dispatch (durable tasks
     run on-cluster). Tools without such a target (e.g. MCP or hand-built
     :class:`AgentTool`) are wrapped in a named async shim over ``execute``.
 
@@ -113,6 +136,10 @@ def build_sandbox_tools(registry: dict[str, AgentTool]) -> list[Any]:
                 "tool(..., name=...) or by renaming the underlying function)."
             )
         seen[name] = tool.name
+
+        if tool.call_handler is not None:
+            out.append(_make_call_handler_wrapper(tool, call_llm=call_llm, model=model))
+            continue
 
         target = tool.target
         if isinstance(target, TaskTemplate) or (callable(target) and getattr(target, "__name__", None)):

--- a/src/flyte/ai/agents/_tools.py
+++ b/src/flyte/ai/agents/_tools.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable, Literal, Mapping, Se
 from flyte._internal.resolvers.default import DefaultTaskResolver
 from flyte.types._json_coercion import coerce_json_args
 
-from ._llm import LLMCallable
+from ._llm import LLMCallable, _default_call_llm
 
 if TYPE_CHECKING:
     from flyte._task import TaskTemplate
@@ -37,6 +37,8 @@ _ToolExecutor = Callable[[dict[str, Any]], Awaitable[Any]]
 # the arguments the model produced for the call. Whatever the handler returns is
 # used as the tool result.
 ToolCallHandler = Callable[..., Awaitable[Any]]
+
+_DEFAULT_TOOL_MODEL = "claude-haiku-4-5"
 
 
 @dataclass
@@ -68,6 +70,44 @@ class AgentTool:
     # Optional interceptor that customizes how the tool is invoked. See
     # :data:`ToolCallHandler`.
     call_handler: ToolCallHandler | None = None
+    # When set (typically by :class:`Agent` during construction), used as the
+    # default ``call_llm`` / ``model`` for :meth:`aio` and direct calls that
+    # route through ``call_handler``.
+    call_llm: LLMCallable | None = None
+    model: str | None = None
+
+    async def aio(self, *args: Any, **kwargs: Any) -> Any:
+        """Invoke the tool, routing through ``call_handler`` when one is registered.
+
+        Mirrors :meth:`~flyte._task.TaskTemplate.aio` enough for ``flyte.map`` and
+        in-task calls on ``@tool``-wrapped tasks. When a ``call_handler`` is set,
+        it runs with :attr:`call_llm` and :attr:`model` (or their defaults).
+        Otherwise, durable ``@env.task`` / remote-task targets delegate to their
+        underlying ``.aio``; everything else goes through :meth:`execute`.
+        """
+        if self.call_handler is not None:
+            return await invoke_agent_tool_from_call(
+                self,
+                *args,
+                call_llm=_effective_call_llm(self, None),
+                model=_effective_model(self, None),
+                **kwargs,
+            )
+
+        from flyte._task import TaskTemplate
+
+        if isinstance(self.target, TaskTemplate):
+            return await self.target.aio(*args, **kwargs)
+        if _is_lazy_entity(self.target):
+            call_args = _kwargs_from_call(self.target, args, kwargs)
+            return await self.target.aio(**call_args)  # type: ignore[attr-defined]
+
+        call_args = _kwargs_from_call(self.target, args, kwargs)
+        return await self.execute(call_args)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """Invoke the tool (async tools return an awaitable coroutine)."""
+        return self.aio(*args, **kwargs)
 
     def to_openai_format(self) -> dict[str, Any]:
         """Convert to the OpenAI / litellm tools schema."""
@@ -206,34 +246,51 @@ def _kwargs_from_call(target: Any, args: tuple[Any, ...], kwargs: dict[str, Any]
     return dict(bound.arguments)
 
 
+def _effective_call_llm(tool: AgentTool, call_llm: LLMCallable | None) -> LLMCallable:
+    return call_llm or tool.call_llm or _default_call_llm
+
+
+def _effective_model(tool: AgentTool, model: str | None) -> str:
+    return model or tool.model or _DEFAULT_TOOL_MODEL
+
+
+def _bind_tool_invocation_context(tool: AgentTool, *, call_llm: LLMCallable, model: str) -> AgentTool:
+    """Attach the owning agent's LLM callback to tools that define ``call_handler``."""
+    if tool.call_handler is None:
+        return tool
+    return replace(tool, call_llm=call_llm, model=model)
+
+
 async def invoke_agent_tool(
     tool: AgentTool,
     args: dict[str, Any],
     *,
-    call_llm: LLMCallable,
-    model: str,
+    call_llm: LLMCallable | None = None,
+    model: str | None = None,
 ) -> Any:
     """Run *tool*, routing through ``call_handler`` when one is registered."""
+    resolved_llm = _effective_call_llm(tool, call_llm)
+    resolved_model = _effective_model(tool, model)
     if tool.call_handler is not None:
         coerced_args = await _coerce_tool_args(tool.target, args)
         bound = ToolFn(
             name=tool.name,
             description=tool.description,
             parameters=tool.parameters,
-            model=model,
+            model=resolved_model,
             target=tool.target,
             source=tool.source,
             _execute=tool.execute,
         )
-        return await tool.call_handler(call_llm, bound, **coerced_args)
+        return await tool.call_handler(resolved_llm, bound, **coerced_args)
     return await tool.execute(args)
 
 
 async def invoke_agent_tool_from_call(
     tool: AgentTool,
     *args: Any,
-    call_llm: LLMCallable,
-    model: str,
+    call_llm: LLMCallable | None = None,
+    model: str | None = None,
     **kwargs: Any,
 ) -> Any:
     """Like :func:`invoke_agent_tool` but accepts a Monty-style ``*args, **kwargs`` call."""

--- a/src/flyte/ai/agents/_tools.py
+++ b/src/flyte/ai/agents/_tools.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable, Literal, Mapping, Se
 from flyte._internal.resolvers.default import DefaultTaskResolver
 from flyte.types._json_coercion import coerce_json_args
 
+from ._llm import LLMCallable
+
 if TYPE_CHECKING:
     from flyte._task import TaskTemplate
     from flyte.remote._task import LazyEntity
@@ -181,6 +183,62 @@ async def _coerce_tool_args(target: Any, args: dict[str, Any]) -> dict[str, Any]
     if iface is None:
         return args
     return await coerce_json_args(args, iface.inputs)
+
+
+def _kwargs_from_call(target: Any, args: tuple[Any, ...], kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Merge positional and keyword sandbox arguments into a kwargs dict."""
+    fn: Any = target
+    from flyte._task import TaskTemplate
+
+    if isinstance(target, TaskTemplate):
+        fn = getattr(target, "func", None)
+    elif callable(target):
+        fn = getattr(target, "__wrapped__", target)
+    if fn is None:
+        if args:
+            raise TypeError(f"Tool target does not accept positional arguments; got {args!r}")
+        return dict(kwargs)
+    try:
+        bound = inspect.signature(fn).bind_partial(*args, **kwargs)
+    except TypeError as exc:
+        raise TypeError(f"Invalid arguments for tool call: {exc}") from exc
+    bound.apply_defaults()
+    return dict(bound.arguments)
+
+
+async def invoke_agent_tool(
+    tool: AgentTool,
+    args: dict[str, Any],
+    *,
+    call_llm: LLMCallable,
+    model: str,
+) -> Any:
+    """Run *tool*, routing through ``call_handler`` when one is registered."""
+    if tool.call_handler is not None:
+        coerced_args = await _coerce_tool_args(tool.target, args)
+        bound = ToolFn(
+            name=tool.name,
+            description=tool.description,
+            parameters=tool.parameters,
+            model=model,
+            target=tool.target,
+            source=tool.source,
+            _execute=tool.execute,
+        )
+        return await tool.call_handler(call_llm, bound, **coerced_args)
+    return await tool.execute(args)
+
+
+async def invoke_agent_tool_from_call(
+    tool: AgentTool,
+    *args: Any,
+    call_llm: LLMCallable,
+    model: str,
+    **kwargs: Any,
+) -> Any:
+    """Like :func:`invoke_agent_tool` but accepts a Monty-style ``*args, **kwargs`` call."""
+    call_args = _kwargs_from_call(tool.target, args, kwargs)
+    return await invoke_agent_tool(tool, call_args, call_llm=call_llm, model=model)
 
 
 def _json_schema_for_callable(fn: Callable[..., Any]) -> dict[str, Any]:

--- a/src/flyte/ai/agents/agent.py
+++ b/src/flyte/ai/agents/agent.py
@@ -62,13 +62,12 @@ from ._llm import LLMCallable, LLMMessage, _default_call_llm
 from ._mcp import MCPServerSpec, _MCPToolLoader
 from ._tools import (
     AgentTool,
-    ToolFn,
     _abbreviate,
-    _coerce_tool_args,
     _registry_uses_flyte_io,
     _resolve_tools,
     _stringify_tool_result,
     _summarize_signature,
+    invoke_agent_tool,
 )
 from .memory import (
     MemoryStore,
@@ -272,10 +271,11 @@ class Agent:
         expression becomes the observation for the next turn; the loop ends when
         the LLM replies with plain text (no code block). This unlocks generated
         control flow (loops, ``flyte_map`` fan-out, intermediate aggregation)
-        while still dispatching ``@env.task`` tools durably on-cluster. Requires
-        ``pydantic-monty`` in the runtime image. Note: per-tool HITL approval is
-        not enforced in code mode, since tools are invoked from inside the
-        sandbox rather than as discrete approved calls.
+        while still dispatching ``@env.task`` tools durably on-cluster. Tools
+        with a ``call_handler`` run through that handler in code mode as well.
+        Requires ``pydantic-monty`` in the runtime image. Note: per-tool HITL
+        approval is not enforced in code mode, since tools are invoked from inside
+        the sandbox rather than as discrete approved calls.
     """
 
     name: str = "flyte-agent"
@@ -419,21 +419,8 @@ class Agent:
             if not approved:
                 return (f"Human reviewer declined tool `{tool.name}`. Try a different approach.", True)
         await _emit(AgentEvent("tool_start", {"tool": tool.name, "args": args}))
-        coerced_args = await _coerce_tool_args(tool.target, args)
         try:
-            if tool.call_handler is not None:
-                bound = ToolFn(
-                    name=tool.name,
-                    description=tool.description,
-                    parameters=tool.parameters,
-                    model=self.model,
-                    target=tool.target,
-                    source=tool.source,
-                    _execute=tool.execute,
-                )
-                result = await tool.call_handler(self.call_llm, bound, **coerced_args)
-            else:
-                result = await tool.execute(args)
+            result = await invoke_agent_tool(tool, args, call_llm=self.call_llm, model=self.model)
         except Exception as exc:
             await _emit(AgentEvent("tool_error", {"tool": tool.name, "error": str(exc)}))
             return (f"Error executing tool `{tool.name}`: {exc}", True)
@@ -538,7 +525,7 @@ class Agent:
 
         from ._code import build_sandbox_tools, extract_python_code
 
-        sandbox_tools = build_sandbox_tools(self._registry)
+        sandbox_tools = build_sandbox_tools(self._registry, call_llm=self.call_llm, model=self.model)
         last_code = ""
 
         async def step(llm_msg: LLMMessage, messages: list[dict[str, Any]], attempts: int) -> _TurnResult:

--- a/src/flyte/ai/agents/agent.py
+++ b/src/flyte/ai/agents/agent.py
@@ -63,6 +63,7 @@ from ._mcp import MCPServerSpec, _MCPToolLoader
 from ._tools import (
     AgentTool,
     _abbreviate,
+    _bind_tool_invocation_context,
     _registry_uses_flyte_io,
     _resolve_tools,
     _stringify_tool_result,
@@ -300,7 +301,10 @@ class Agent:
     # ------------------------------------------------------------------
 
     def __post_init__(self) -> None:
-        self._registry = _resolve_tools(self.tools)
+        self._registry = {
+            name: _bind_tool_invocation_context(tool, call_llm=self.call_llm, model=self.model)
+            for name, tool in _resolve_tools(self.tools).items()
+        }
         self._mcp_loader = _MCPToolLoader(self.mcp_servers)
         if self.code_mode and any(t.requires_approval for t in self._registry.values()):
             logger.warning(
@@ -345,9 +349,9 @@ class Agent:
         for _tool in new.values():
             if _tool.name in self._registry:
                 raise ValueError(f"Duplicate tool name '{_tool.name}'")
-            self._registry[_tool.name] = _tool
+            self._registry[_tool.name] = _bind_tool_invocation_context(_tool, call_llm=self.call_llm, model=self.model)
         self._system_prompt = self._build_system_prompt()
-        return next(iter(new.values()))
+        return _bind_tool_invocation_context(next(iter(new.values())), call_llm=self.call_llm, model=self.model)
 
     # ------------------------------------------------------------------
     # Prompt construction

--- a/src/flyte/sandbox/_bridge.py
+++ b/src/flyte/sandbox/_bridge.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 from typing import Any, Callable, Dict, List
 
@@ -114,9 +115,52 @@ class ExternalFunctionBridge:
             if key in kwargs:
                 map_kwargs[key] = kwargs[key]
 
-        results: List[Any] = []
-        async for r in flyte_map.aio(task, *iterables, **map_kwargs):
-            results.append(r)
+        from flyte._task import TaskTemplate
+
+        if isinstance(task, TaskTemplate):
+            results: List[Any] = []
+            async for r in flyte_map.aio(task, *iterables, **map_kwargs):  # type: ignore[arg-type]
+                results.append(r)
+            return results
+
+        return await self._map_callable(task, iterables, **map_kwargs)
+
+    async def _map_callable(
+        self,
+        fn: Callable[..., Any],
+        iterables: list[Any],
+        *,
+        concurrency: int | None = None,
+        return_exceptions: bool = False,
+        group_name: str | None = None,
+    ) -> list[Any]:
+        """Map *fn* over zipped *iterables* (for sandbox tools that are not TaskTemplates)."""
+        del group_name  # only supported for durable flyte.map over TaskTemplate
+        rows = list(zip(*iterables)) if iterables else []
+
+        async def run_row(row: tuple[Any, ...]) -> Any:
+            try:
+                result = fn(*row)
+                while inspect.iscoroutine(result):
+                    result = await result
+                return result
+            except Exception as exc:
+                if return_exceptions:
+                    return exc
+                raise
+
+        if concurrency and concurrency > 0:
+            sem = asyncio.Semaphore(concurrency)
+
+            async def limited(row: tuple[Any, ...]) -> Any:
+                async with sem:
+                    return await run_row(row)
+
+            return list(await asyncio.gather(*[limited(row) for row in rows]))
+
+        results: list[Any] = []
+        for row in rows:
+            results.append(await run_row(row))
         return results
 
     async def execute_monty(self, monty_cls: Any, code: str, input_names: list[str], inputs: Dict[str, Any]) -> Any:

--- a/tests/flyte/ai/agents/test_agent.py
+++ b/tests/flyte/ai/agents/test_agent.py
@@ -602,6 +602,11 @@ def _make_llm(responses: list[LLMMessage]) -> AsyncMock:
     return mock
 
 
+def _sandbox_tool_build_kwargs() -> dict[str, object]:
+    """Keyword args required by :func:`build_sandbox_tools` since call_handler support."""
+    return {"call_llm": AsyncMock(return_value=LLMMessage(content="")), "model": "test-model"}
+
+
 @pytest.mark.asyncio
 class TestRunLoop:
     async def test_no_tool_calls_returns_text(self):
@@ -1882,9 +1887,41 @@ class TestCodeModeHelpers:
             """Fetch."""
             return x
 
-        tools = build_sandbox_tools({"fetch": fetch})
+        tools = build_sandbox_tools({"fetch": fetch}, **_sandbox_tool_build_kwargs())
         # The underlying TaskTemplate is passed through (durable dispatch).
         assert tools[0] is fetch.target
+
+    def test_build_sandbox_tools_wraps_tool_with_call_handler(self):
+        from flyte.ai.agents._code import build_sandbox_tools
+
+        def base(x: int) -> int:
+            """Base."""
+            return x
+
+        async def handler(call_llm, tool_fn, **kwargs):
+            return (await tool_fn(**kwargs)) * 10
+
+        decorated = tool_decorator(base, call_handler=handler)
+        llm = AsyncMock()
+        tools = build_sandbox_tools({"base": decorated}, call_llm=llm, model="m")
+        fn = tools[0]
+        assert fn is not decorated.target
+        assert fn.__name__ == "base"
+
+    @pytest.mark.asyncio
+    async def test_sandbox_call_handler_wrapper_invokes_handler(self):
+        from flyte.ai.agents._code import build_sandbox_tools
+
+        async def base(x: int) -> int:
+            return x
+
+        async def handler(call_llm, tool_fn, **kwargs):
+            return (await tool_fn(**kwargs)) * 10
+
+        decorated = tool_decorator(base, call_handler=handler)
+        llm = AsyncMock()
+        fn = build_sandbox_tools({"base": decorated}, call_llm=llm, model="m")[0]
+        assert await fn(x=4) == 40
 
     def test_build_sandbox_tools_wraps_targetless_tool(self):
         from flyte.ai.agents._code import build_sandbox_tools
@@ -1898,7 +1935,7 @@ class TestCodeModeHelpers:
             parameters={"type": "object", "properties": {}},
             execute=execute,
         )
-        tools = build_sandbox_tools({"custom": custom})
+        tools = build_sandbox_tools({"custom": custom}, **_sandbox_tool_build_kwargs())
         fn = tools[0]
         assert fn.__name__ == "custom"
         assert callable(fn)
@@ -1913,7 +1950,7 @@ class TestCodeModeHelpers:
         a = AgentTool(name="dup", description="a", parameters={"type": "object", "properties": {}}, execute=execute)
         b = AgentTool(name="dup", description="b", parameters={"type": "object", "properties": {}}, execute=execute)
         with pytest.raises(ValueError, match="distinct sandbox function names"):
-            build_sandbox_tools({"first": a, "second": b})
+            build_sandbox_tools({"first": a, "second": b}, **_sandbox_tool_build_kwargs())
 
     def test_tool_prompt_block_pseudo_signature_for_targetless_tool(self):
         from flyte.ai.agents._code import _tool_prompt_block
@@ -2127,7 +2164,7 @@ class TestCodeModeRun:
             parameters={"type": "object", "properties": {}},
             execute=execute,
         )
-        fn = build_sandbox_tools({"bump": custom})[0]
+        fn = build_sandbox_tools({"bump": custom}, **_sandbox_tool_build_kwargs())[0]
         assert await fn(x=41) == 42
 
     async def test_code_mode_warns_when_tool_requires_approval(self):

--- a/tests/flyte/ai/agents/test_agent.py
+++ b/tests/flyte/ai/agents/test_agent.py
@@ -450,6 +450,64 @@ class TestCallHandler:
         # Denied approval short-circuits before the handler runs.
         assert ran["handler"] is False
 
+    async def test_agent_tool_aio_runs_call_handler(self):
+        seen: dict[str, object] = {}
+
+        def base(x: int) -> int:
+            """Base tool."""
+            return x
+
+        async def handler(call_llm, tool_fn, **kwargs):
+            seen["call_llm"] = call_llm
+            seen["model"] = tool_fn.model
+            return (await tool_fn(**kwargs)) * 10
+
+        decorated = tool_decorator(base, call_handler=handler)
+        llm = AsyncMock()
+        from dataclasses import replace
+
+        bound = replace(decorated, call_llm=llm, model="bound-model")
+        assert await bound.aio(x=4) == 40
+        assert seen["call_llm"] is llm
+        assert seen["model"] == "bound-model"
+
+    async def test_agent_tool_call_runs_call_handler(self):
+        async def base(x: int) -> int:
+            return x
+
+        async def handler(call_llm, tool_fn, **kwargs):
+            return (await tool_fn(**kwargs)) + 1
+
+        decorated = tool_decorator(base, call_handler=handler)
+        assert await decorated(x=6) == 7
+
+    async def test_agent_binds_call_llm_for_handler_tools(self):
+        def base(x: int) -> int:
+            return x
+
+        async def handler(call_llm, tool_fn, **kwargs):
+            return await tool_fn(**kwargs)
+
+        decorated = tool_decorator(base, call_handler=handler)
+        llm = AsyncMock()
+        agent = Agent(name="t", instructions="I", model="agent-model", tools=[decorated], call_llm=llm)
+        tool = agent._registry["base"]
+        assert tool.call_llm is llm
+        assert tool.model == "agent-model"
+
+    async def test_agent_tool_aio_delegates_to_wrapped_task_without_handler(self):
+        env = TaskEnvironment(name="tool_aio_task_env", image="auto")
+
+        @tool_decorator
+        @env.task
+        async def fetch(x: int) -> int:
+            """Fetch."""
+            return x
+
+        with patch.object(fetch.target, "aio", new_callable=AsyncMock, return_value=99) as mock_aio:
+            assert await fetch.aio(x=41) == 99
+            mock_aio.assert_awaited_once_with(x=41)
+
 
 # ----------------------------------------------------------------------------
 # Signature + helpers

--- a/tests/flyte/sandbox/test_map_in_sandbox.py
+++ b/tests/flyte/sandbox/test_map_in_sandbox.py
@@ -186,6 +186,36 @@ class TestFlyteMapBuiltinInSandbox:
         assert result == [2, 4, 6]
 
     @pytest.mark.asyncio
+    async def test_flyte_map_call_handler_wrapper(self, env):
+        """flyte_map works when the registered tool is a call_handler sandbox wrapper."""
+        from unittest.mock import AsyncMock
+
+        from flyte.ai.agents import LLMMessage
+        from flyte.ai.agents import tool as tool_decorator
+        from flyte.ai.agents._code import build_sandbox_tools
+        from flyte.sandbox import orchestrate_local
+
+        @env.sandbox.orchestrator
+        def double(x: int) -> int:
+            return x * 2
+
+        async def handler(call_llm, tool_fn, **kwargs):
+            return (await tool_fn(**kwargs)) * 10
+
+        decorated = tool_decorator(double, call_handler=handler)
+        llm = AsyncMock(return_value=LLMMessage(content=""))
+        wrapped = build_sandbox_tools({"double": decorated}, call_llm=llm, model="m")[0]
+
+        result = await orchestrate_local(
+            """
+            list(flyte_map("double", items))
+            """,
+            inputs={"items": [1, 2, 3]},
+            tasks=[wrapped],
+        )
+        assert result == [20, 40, 60]
+
+    @pytest.mark.asyncio
     async def test_flyte_map_with_aggregation(self, env):
         """flyte_map results can be further processed."""
         from flyte.sandbox import orchestrate_local


### PR DESCRIPTION
## Summary
- Wrap tools that define `call_handler` when building the Monty sandbox registry so code mode invokes handlers with the agent's `call_llm` and `model`, matching tool-calling mode behavior.
- Extract shared `invoke_agent_tool` / `invoke_agent_tool_from_call` helpers used by both execution paths.
- Extend `flyte_map` in the sandbox bridge to fan out over call-handler wrappers (non-`TaskTemplate` refs).
- Add `AgentTool.aio` / `AgentTool.__call__` so direct invocations and `flyte.map` also route through `call_handler`; the agent binds `call_llm` and `model` onto handler tools at registration.

## Test plan
- [x] `uv run pytest tests/flyte/ai/agents/test_agent.py::TestCodeModeHelpers -q`
- [x] `uv run pytest tests/flyte/ai/agents/test_agent.py::TestCallHandler -q`
- [x] `uv run pytest tests/flyte/ai/agents/test_agent.py::TestCodeModeRun -q`
- [x] `uv run pytest tests/flyte/sandbox/test_map_in_sandbox.py -q`