### PR TITLE
fix: support connectrpc 0.11 property-form request_headers (FLYTE-SDK-5T)

### DIFF
--- a/src/flyte/remote/_client/auth/_interceptors/_compat.py
+++ b/src/flyte/remote/_client/auth/_interceptors/_compat.py
@@ -1,0 +1,26 @@
+"""Compatibility helpers for the connectrpc ``RequestContext`` API.
+
+The dependency pin is ``connectrpc>=0.9.0,<1.0.0``. In connectrpc < 0.11 the
+``RequestContext`` accessors (``request_headers`` and friends) are plain
+methods, so callers write ``ctx.request_headers()``. In connectrpc >= 0.11 the
+same accessors became ``@property`` attributes, so ``ctx.request_headers`` is
+already a ``Headers`` object and calling it raises
+``TypeError: 'Headers' object is not callable``.
+
+Because the pin spans both APIs, resolve the accessor defensively instead of
+assuming either form.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def request_headers(ctx: Any) -> Any:
+    """Return the request headers for a connectrpc ``RequestContext``.
+
+    Works across connectrpc < 0.11 (``request_headers`` is a method) and
+    connectrpc >= 0.11 (``request_headers`` is a property).
+    """
+    headers = ctx.request_headers
+    return headers() if callable(headers) else headers

--- a/src/flyte/remote/_client/auth/_interceptors/auth.py
+++ b/src/flyte/remote/_client/auth/_interceptors/auth.py
@@ -6,6 +6,7 @@ from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 
 from flyte._logging import logger
+from flyte.remote._client.auth._interceptors._compat import request_headers
 
 if typing.TYPE_CHECKING:
     from flyte.remote._client.auth._authenticators.base import Authenticator, AuthHeaders
@@ -32,13 +33,13 @@ class _BaseAuthInterceptor:
         # before injecting fresh ones — otherwise a header key change (e.g. "authorization" →
         # "flyte-authorization") leaves the stale key behind.
         if previous is not None:
-            headers = ctx.request_headers()
+            headers = request_headers(ctx)
             for key in previous.headers:
                 headers.pop(key, None)
 
         auth_headers = await self.authenticator.get_auth_headers()
         if auth_headers:
-            ctx.request_headers().update(auth_headers.headers)
+            request_headers(ctx).update(auth_headers.headers)
         return auth_headers
 
     async def _refresh_and_reinject(self, previous: AuthHeaders | None, ctx) -> None:

--- a/src/flyte/remote/_client/auth/_interceptors/default_metadata.py
+++ b/src/flyte/remote/_client/auth/_interceptors/default_metadata.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 import flyte
 from flyte._logging import logger
+from flyte.remote._client.auth._interceptors._compat import request_headers
 
 ALPHABET = string.ascii_lowercase + string.digits
 
@@ -33,13 +34,14 @@ class DefaultMetadataInterceptor:
     """
 
     async def on_start(self, ctx) -> None:
-        existing_rid = ctx.request_headers().get("x-request-id")
+        headers = request_headers(ctx)
+        existing_rid = headers.get("x-request-id")
         if existing_rid is not None:
             return None
 
         rid = _generate_request_id()
         logger.debug(f"request-id: {rid}")
-        ctx.request_headers()["x-request-id"] = rid
+        headers["x-request-id"] = rid
         return None
 
     async def on_end(self, token, ctx, error) -> None:

--- a/tests/flyte/remote/test_connectrpc_interceptors.py
+++ b/tests/flyte/remote/test_connectrpc_interceptors.py
@@ -10,6 +10,7 @@ from connectrpc.errors import ConnectError
 from flyte._context import internal_ctx
 from flyte.models import ActionID, RawDataPath, TaskContext
 from flyte.remote._client.auth._authenticators.base import AuthHeaders
+from flyte.remote._client.auth._interceptors._compat import request_headers
 from flyte.remote._client.auth._interceptors.auth import (
     AuthBidiStreamInterceptor,
     AuthClientStreamInterceptor,
@@ -78,11 +79,42 @@ class TestRequestIdGeneration:
 
 
 def _make_ctx_mock():
-    """Create a mock RequestContext where request_headers() returns a mutable dict."""
+    """Create a mock RequestContext where request_headers() returns a mutable dict.
+
+    Mimics connectrpc < 0.11, where ``request_headers`` is a method.
+    """
     headers = {}
     ctx = Mock()
     ctx.request_headers.return_value = headers
     return ctx, headers
+
+
+def _make_ctx_mock_property():
+    """Create a mock RequestContext where request_headers is a property.
+
+    Mimics connectrpc >= 0.11, where ``request_headers`` is a ``@property`` that
+    returns the (non-callable) ``Headers`` object directly. Calling it as a
+    method raises ``TypeError: 'Headers' object is not callable`` — the crash
+    behind FLYTE-SDK-5T.
+    """
+    headers = {}
+    ctx = Mock()
+    ctx.request_headers = headers
+    return ctx, headers
+
+
+class TestRequestHeadersCompat:
+    """request_headers() must resolve both connectrpc API shapes (FLYTE-SDK-5T)."""
+
+    def test_method_form(self):
+        """connectrpc < 0.11: request_headers is a callable method."""
+        ctx, headers = _make_ctx_mock()
+        assert request_headers(ctx) is headers
+
+    def test_property_form(self):
+        """connectrpc >= 0.11: request_headers is a non-callable property."""
+        ctx, headers = _make_ctx_mock_property()
+        assert request_headers(ctx) is headers
 
 
 class TestDefaultMetadataInterceptor:
@@ -266,6 +298,36 @@ class TestAuthUnaryInterceptor:
         assert headers["flyte-authorization"] == "Bearer fresh"
         assert headers["x-request-id"] == "req-123", "non-auth headers must be preserved"
         assert headers["content-type"] == "application/proto", "non-auth headers must be preserved"
+
+
+class TestConnectrpc011PropertyForm:
+    """connectrpc >= 0.11 exposes request_headers as a property, not a method.
+
+    These guard against the FLYTE-SDK-5T regression where ``ctx.request_headers()``
+    raised ``TypeError: 'Headers' object is not callable`` on the property form,
+    breaking every control-plane RPC (SelectCluster, uploads, runs).
+    """
+
+    @pytest.mark.asyncio
+    async def test_default_metadata_injects_request_id(self):
+        interceptor = DefaultMetadataInterceptor()
+        ctx, headers = _make_ctx_mock_property()
+        await interceptor.on_start(ctx)
+        assert "x-request-id" in headers
+        assert len(headers["x-request-id"]) > 0
+
+    @pytest.mark.asyncio
+    async def test_auth_injects_headers(self):
+        auth = _make_mock_authenticator({"authorization": "Bearer token123"})
+        interceptor = AuthUnaryInterceptor(lambda: auth)
+
+        call_next = AsyncMock(return_value="response")
+        ctx, headers = _make_ctx_mock_property()
+
+        result = await interceptor.intercept_unary(call_next, "request", ctx)
+
+        assert result == "response"
+        assert headers["authorization"] == "Bearer token123"
 
 
 class TestIsAuthRetriable:


### PR DESCRIPTION
## Problem (FLYTE-SDK-5T)

connectrpc **0.11** changed `RequestContext.request_headers` (and the other accessors) from **methods** into **`@property`** attributes. Our auth interceptors call `ctx.request_headers()` as a method, so any user who resolved `connectrpc>=0.11` — which is permitted by our `connectrpc>=0.9.0,<1.0.0` pin — crashes with:

```
TypeError: 'Headers' object is not callable
  at flyte/remote/_client/auth/_interceptors/default_metadata.py:36 on_start
```

Because the failure is in the metadata/auth interceptor that runs on **every** outgoing control-plane RPC, the user can't `SelectCluster`, upload, or run anything — it surfaces in Sentry as `RuntimeSystemError: Upload failed ... SelectCluster failed`. Seen on the latest release **2.5.4**.

## Fix

Add a tiny `_compat.request_headers(ctx)` accessor that resolves both API shapes:

```python
headers = ctx.request_headers
return headers() if callable(headers) else headers
```

- connectrpc `<0.11`: `request_headers` is a bound method → callable → invoked.
- connectrpc `>=0.11`: `request_headers` is a `Headers` property → not callable → used directly.

All four interceptor call sites (`default_metadata.py` ×2, `auth.py` ×2) now route through it. This keeps the SDK working across the entire pinned connectrpc range rather than betting on one API shape.

## Tests

`tests/flyte/remote/test_connectrpc_interceptors.py`:
- `TestRequestHeadersCompat` — unit tests for both method-form and property-form contexts.
- `TestConnectrpc011PropertyForm` — DefaultMetadata + Auth interceptors against a property-form context (regression guard for 5T).

47/47 pass locally.

fixes FLYTE-SDK-5T