### PR TITLE
Lower ceiling for connectrpc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,9 @@ dependencies = [
     "cloudpickle>=3.1.1",
     "docstring_parser>=0.16",
     "fsspec>=2025.3.0",
-    "connectrpc>=0.9.0,<1.0.0",
+    # Cap below 0.11: connectrpc 0.11.0 made RequestContext.request_headers a property
+    # (was a method), breaking the auth interceptor with "'Headers' object is not callable".
+    "connectrpc>=0.9.0,<0.11",
     "obstore>=0.7.3",
     "protobuf>=6.30.1",
     "pydantic>=2.10.6",

--- a/uv.lock
+++ b/uv.lock
@@ -21,12 +21,12 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-19T19:18:17.688884Z"
+exclude-newer = "2026-06-20T16:35:45.250259Z"
 exclude-newer-span = "P5D"
 
 [options.exclude-newer-package]
-flyteidl2 = { timestamp = "2026-06-24T19:18:17.688937Z", span = "PT0S" }
-flyte-controller-base = { timestamp = "2026-06-24T19:18:17.688941Z", span = "PT0S" }
+flyteidl2 = { timestamp = "2026-06-25T16:35:45.250265Z", span = "PT0S" }
+flyte-controller-base = { timestamp = "2026-06-25T16:35:45.250268Z", span = "PT0S" }
 
 [[package]]
 name = "aiofiles"
@@ -1183,7 +1183,7 @@ requires-dist = [
     { name = "async-lru", specifier = ">=2.0.5" },
     { name = "click", specifier = ">=8.2.1" },
     { name = "cloudpickle", specifier = ">=3.1.1" },
-    { name = "connectrpc", specifier = ">=0.9.0,<1.0.0" },
+    { name = "connectrpc", specifier = ">=0.9.0,<0.11" },
     { name = "deltalake", marker = "extra == 'examples-test'" },
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },


### PR DESCRIPTION
 connectrpc 0.11.0 made RequestContext.request_headers a property # (was a method), breaking the auth interceptor with "'Headers' object is not callable".