### PR TITLE
add CLI JSON parsing for File, Dir, and DataFrame in collections

### DIFF
--- a/src/flyte/cli/_params.py
+++ b/src/flyte/cli/_params.py
@@ -22,7 +22,7 @@ from google.protobuf.json_format import MessageToDict
 from mashumaro.codecs.json import JSONEncoder
 
 from flyte._logging import logger
-from flyte.io import Dir, File
+from flyte.io import DataFrame, Dir, File
 from flyte.types._pickle import FlytePickleTransformer
 
 # ---------------------------------------------------
@@ -432,11 +432,22 @@ class JsonParamType(click.ParamType):
             except json.JSONDecodeError as e:
                 raise click.BadParameter(f"parameter {param} should be a valid json object, {value}, error: {e}")
 
+    def _unwrap_field_type(self, tp: typing.Type) -> typing.Type:
+        from flyte.types._type_engine import get_underlying_type
+
+        tp = get_underlying_type(tp)
+        origin = typing.get_origin(tp)
+        args = get_args(tp)
+        if origin is typing.Union:
+            non_none = [a for a in args if a is not type(None)]
+            if len(non_none) == 1:
+                return self._unwrap_field_type(non_none[0])
+        return tp
+
     def _blob_param_converter_for_type(self, field_type: typing.Type) -> typing.Optional[click.ParamType]:
-        from flyte.types._json_coercion import unwrap_optional_type
         from flyte.types._type_engine import TypeEngine
 
-        field_type = unwrap_optional_type(field_type)
+        field_type = self._unwrap_field_type(field_type)
         try:
             lt = TypeEngine.to_literal_type(field_type)
             converter = literal_type_to_click_type(lt, field_type)
@@ -446,32 +457,123 @@ class JsonParamType(click.ParamType):
             pass
         return None
 
-    def _make_string_blob_converter(
+    def _convert_blob_value(
         self,
-        param: typing.Optional[click.Parameter],
-        ctx: typing.Optional[click.Context],
-    ) -> typing.Callable[[str, typing.Type], typing.Any]:
-        def convert_string_path(s: str, py_type: typing.Type) -> typing.Any:
-            converter = self._blob_param_converter_for_type(py_type)
-            if converter is None:
-                return s
-            return converter.convert(s, param, ctx)
-
-        return convert_string_path
-
-    def _coerce_parsed_json(
-        self,
-        parsed_value: typing.Any,
+        value: typing.Any,
+        field_type: typing.Type,
         param: typing.Optional[click.Parameter],
         ctx: typing.Optional[click.Context],
     ) -> typing.Any:
-        from flyte.types._json_coercion import coerce_json_value_sync
+        field_type = self._unwrap_field_type(field_type)
+        converter = self._blob_param_converter_for_type(field_type)
+        if converter is None:
+            return value
 
-        return coerce_json_value_sync(
-            parsed_value,
-            self._python_type,
-            string_blob_converter=self._make_string_blob_converter(param, ctx),
-        )
+        if isinstance(value, (File, Dir, DataFrame)):
+            return value
+
+        if isinstance(value, str):
+            return converter.convert(value, param, ctx)
+
+        if isinstance(value, dict) and isinstance(field_type, type):
+            from pydantic import BaseModel
+
+            if issubclass(field_type, BaseModel):
+                return field_type.model_validate(value)
+
+        return value
+
+    def _convert_blob_collection_elements(
+        self,
+        parsed_value: typing.Union[typing.List[typing.Any], typing.Dict[str, typing.Any]],
+        element_type: typing.Type,
+        param: typing.Optional[click.Parameter],
+        ctx: typing.Optional[click.Context],
+    ) -> typing.Optional[typing.Any]:
+        """Convert string paths in list/dict CLI JSON to File, Dir, or DataFrame objects."""
+        if self._blob_param_converter_for_type(element_type) is None:
+            return None
+
+        if isinstance(parsed_value, list):
+            return [self._convert_blob_value(v, element_type, param, ctx) for v in parsed_value]
+        return {k: self._convert_blob_value(v, element_type, param, ctx) for k, v in parsed_value.items()}
+
+    def _convert_blob_fields_in_value(
+        self,
+        value: typing.Any,
+        python_type: typing.Type,
+        param: typing.Optional[click.Parameter],
+        ctx: typing.Optional[click.Context],
+    ) -> typing.Any:
+        if value is None:
+            return None
+
+        python_type = self._unwrap_field_type(python_type)
+        origin = typing.get_origin(python_type)
+        args = get_args(python_type)
+
+        if dataclasses.is_dataclass(python_type) and isinstance(value, dict):
+            field_types = typing.get_type_hints(python_type, include_extras=True)
+            return {
+                k: self._convert_blob_fields_in_value(v, field_types.get(k, type(v)), param, ctx)
+                for k, v in value.items()
+            }
+
+        if origin is list and isinstance(value, list):
+            elem_type = args[0] if args else typing.Any
+            return [self._convert_blob_fields_in_value(v, elem_type, param, ctx) for v in value]
+
+        if origin is dict and isinstance(value, dict):
+            val_type = args[1] if len(args) >= 2 else typing.Any
+            return {k: self._convert_blob_fields_in_value(v, val_type, param, ctx) for k, v in value.items()}
+
+        return self._convert_blob_value(value, python_type, param, ctx)
+
+    def _instantiate_dataclass(self, python_type: typing.Type, value: typing.Any) -> typing.Any:
+        if not isinstance(value, dict):
+            return value
+
+        field_types = typing.get_type_hints(python_type, include_extras=True)
+        kwargs: dict[str, typing.Any] = {}
+        for field in dataclasses.fields(python_type):
+            if field.name not in value:
+                continue
+            v = value[field.name]
+            if v is None:
+                kwargs[field.name] = None
+                continue
+
+            field_type = self._unwrap_field_type(field_types.get(field.name, field.type))
+            if dataclasses.is_dataclass(field_type) and isinstance(v, dict):
+                kwargs[field.name] = self._instantiate_dataclass(field_type, v)
+                continue
+
+            origin = typing.get_origin(field_type)
+            inner_args = get_args(field_type)
+            if origin is list and isinstance(v, list):
+                elem_type = self._unwrap_field_type(inner_args[0] if inner_args else typing.Any)
+                if dataclasses.is_dataclass(elem_type):
+                    kwargs[field.name] = [
+                        self._instantiate_dataclass(elem_type, item) if isinstance(item, dict) else item for item in v
+                    ]
+                else:
+                    kwargs[field.name] = v
+                continue
+
+            if origin is dict and isinstance(v, dict):
+                val_type = self._unwrap_field_type(inner_args[1] if len(inner_args) >= 2 else typing.Any)
+                if dataclasses.is_dataclass(val_type):
+                    kwargs[field.name] = {
+                        k: self._instantiate_dataclass(val_type, item) if isinstance(item, dict) else item
+                        for k, item in v.items()
+                    }
+                else:
+                    kwargs[field.name] = v
+                continue
+
+            kwargs[field.name] = v
+
+        return python_type(**kwargs)
 
     def convert(
         self, value: typing.Any, param: typing.Optional[click.Parameter], ctx: typing.Optional[click.Context]
@@ -493,8 +595,34 @@ class JsonParamType(click.ParamType):
             # We don't support native list/dict types with nested dataclasses.
             if get_args(self._python_type) == ():
                 return parsed_value
-            elif isinstance(parsed_value, (list, dict)):
-                return self._coerce_parsed_json(parsed_value, param, ctx)
+            elif isinstance(parsed_value, list):
+                element_type = get_args(self._python_type)[0]
+                converted = self._convert_blob_collection_elements(parsed_value, element_type, param, ctx)
+                if converted is not None:
+                    return converted
+                if dataclasses.is_dataclass(element_type):
+                    dc_type = typing.cast(type[typing.Any], element_type)
+                    return [
+                        self._instantiate_dataclass(
+                            dc_type,
+                            self._convert_blob_fields_in_value(v, dc_type, param, ctx),
+                        )
+                        for v in parsed_value
+                    ]
+            elif isinstance(parsed_value, dict):
+                value_type = get_args(self._python_type)[1]
+                converted = self._convert_blob_collection_elements(parsed_value, value_type, param, ctx)
+                if converted is not None:
+                    return converted
+                if dataclasses.is_dataclass(value_type):
+                    dc_type = typing.cast(type[typing.Any], value_type)
+                    return {
+                        k: self._instantiate_dataclass(
+                            dc_type,
+                            self._convert_blob_fields_in_value(v, dc_type, param, ctx),
+                        )
+                        for k, v in parsed_value.items()
+                    }
 
             return parsed_value
 
@@ -521,7 +649,8 @@ class JsonParamType(click.ParamType):
             )
         elif dataclasses.is_dataclass(self._python_type):
             if isinstance(parsed_value, dict):
-                return self._coerce_parsed_json(parsed_value, param, ctx)
+                converted = self._convert_blob_fields_in_value(parsed_value, self._python_type, param, ctx)
+                return self._instantiate_dataclass(self._python_type, converted)
 
             from mashumaro.codecs.json import JSONDecoder
 

--- a/tests/cli/test_params.py
+++ b/tests/cli/test_params.py
@@ -1,11 +1,19 @@
 import enum
+import json
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+from unittest.mock import MagicMock
 
 import click
 import pytest
 from flyteidl2.core.interface_pb2 import Variable
 from flyteidl2.core.types_pb2 import LiteralType, SimpleType
 
-from flyte.cli._params import EnumParamType, to_click_option
+from flyte.cli._params import EnumParamType, JsonParamType, to_click_option
+from flyte.cli._run import RunArguments
+from flyte.io import DataFrame, Dir, File
 
 
 class Color(str, enum.Enum):
@@ -87,3 +95,252 @@ def test_boolean_flag_no_default():
     assert option.is_flag is True
     assert option.default is False  # Should default to False for boolean flags
     assert option.required is False
+
+
+# ---------------------------------------------------------------------------
+# JsonParamType: File, Dir, and DataFrame CLI JSON parsing
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def local_mode_ctx():
+    run_args = RunArguments(local=True)
+    mock_cli_obj = MagicMock()
+    mock_cli_obj.run_args = run_args
+    ctx = MagicMock()
+    ctx.obj = mock_cli_obj
+    return ctx
+
+
+@pytest.fixture
+def temp_txt_file():
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt") as f:
+        f.write("test content")
+        path = f.name
+    yield path
+    Path(path).unlink(missing_ok=True)
+
+
+@pytest.fixture
+def temp_dir():
+    with tempfile.TemporaryDirectory() as path:
+        yield path
+
+
+pd = None
+try:
+    import pandas as pd
+except ImportError:
+    pass
+
+
+@pytest.fixture
+def temp_parquet_file():
+    if pd is None:
+        pytest.skip("pandas is not installed")
+    df = pd.DataFrame({"name": ["Alice"], "age": [25]})
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".parquet") as f:
+        df.to_parquet(f.name)
+        yield f.name
+    Path(f.name).unlink(missing_ok=True)
+
+
+def test_json_param_type_list_of_file_paths(local_mode_ctx):
+    result = JsonParamType(list[File]).convert(
+        json.dumps(["s3://bucket/a.txt", "s3://bucket/b.txt"]),
+        None,
+        local_mode_ctx,
+    )
+    assert len(result) == 2
+    assert all(isinstance(f, File) for f in result)
+    assert result[0].path == "s3://bucket/a.txt"
+    assert result[1].path == "s3://bucket/b.txt"
+
+
+def test_json_param_type_list_of_dir_paths(local_mode_ctx):
+    result = JsonParamType(list[Dir]).convert(
+        json.dumps(["s3://bucket/dir-a", "s3://bucket/dir-b"]),
+        None,
+        local_mode_ctx,
+    )
+    assert len(result) == 2
+    assert all(isinstance(d, Dir) for d in result)
+    assert result[0].path == "s3://bucket/dir-a"
+    assert result[1].path == "s3://bucket/dir-b"
+
+
+def test_json_param_type_dict_of_file_paths(local_mode_ctx, temp_txt_file):
+    result = JsonParamType(dict[str, File]).convert(
+        json.dumps({"remote": "s3://bucket/file.txt", "local": temp_txt_file}),
+        None,
+        local_mode_ctx,
+    )
+    assert isinstance(result["remote"], File)
+    assert isinstance(result["local"], File)
+    assert result["remote"].path == "s3://bucket/file.txt"
+    assert result["local"].path == temp_txt_file
+
+
+def test_json_param_type_dict_of_dir_paths(local_mode_ctx, temp_dir):
+    result = JsonParamType(dict[str, Dir]).convert(
+        json.dumps({"remote": "s3://bucket/data", "local": temp_dir}),
+        None,
+        local_mode_ctx,
+    )
+    assert isinstance(result["remote"], Dir)
+    assert isinstance(result["local"], Dir)
+    assert result["remote"].path == "s3://bucket/data"
+    assert result["local"].path == temp_dir
+
+
+def test_json_param_type_dataclass_with_file_and_dir(local_mode_ctx):
+    @dataclass
+    class FlyteTypes:
+        flytefile: Optional[File] = None
+        flytedir: Optional[Dir] = None
+
+    result = JsonParamType(FlyteTypes).convert(
+        json.dumps({"flytefile": "s3://bucket/file.txt", "flytedir": "s3://bucket/dir"}),
+        None,
+        local_mode_ctx,
+    )
+    assert isinstance(result, FlyteTypes)
+    assert isinstance(result.flytefile, File)
+    assert isinstance(result.flytedir, Dir)
+    assert result.flytefile.path == "s3://bucket/file.txt"
+    assert result.flytedir.path == "s3://bucket/dir"
+
+
+def test_json_param_type_list_of_dataclass_with_file(local_mode_ctx):
+    @dataclass
+    class Item:
+        flytefile: File
+
+    result = JsonParamType(list[Item]).convert(
+        json.dumps([{"flytefile": "s3://bucket/a.txt"}, {"flytefile": "s3://bucket/b.txt"}]),
+        None,
+        local_mode_ctx,
+    )
+    assert len(result) == 2
+    assert all(isinstance(item, Item) for item in result)
+    assert all(isinstance(item.flytefile, File) for item in result)
+    assert result[0].flytefile.path == "s3://bucket/a.txt"
+
+
+def test_json_param_type_nested_dataclass_with_file(local_mode_ctx):
+    @dataclass
+    class Inner:
+        flytefile: File
+
+    @dataclass
+    class Outer:
+        inner: Inner
+        list_inner: Optional[List[Inner]] = None
+
+    result = JsonParamType(Outer).convert(
+        json.dumps(
+            {
+                "inner": {"flytefile": "s3://inner-path"},
+                "list_inner": [{"flytefile": "s3://list-1"}, {"flytefile": "s3://list-2"}],
+            }
+        ),
+        None,
+        local_mode_ctx,
+    )
+    assert isinstance(result.inner.flytefile, File)
+    assert result.inner.flytefile.path == "s3://inner-path"
+    assert len(result.list_inner) == 2
+    assert result.list_inner[0].flytefile.path == "s3://list-1"
+
+
+def test_json_param_type_accepts_structured_dict_for_file_and_dir(local_mode_ctx):
+    @dataclass
+    class FlyteTypes:
+        flytefile: File
+        flytedir: Dir
+
+    result = JsonParamType(FlyteTypes).convert(
+        json.dumps({"flytefile": {"path": "s3://bucket/file.txt"}, "flytedir": {"path": "s3://bucket/dir"}}),
+        None,
+        local_mode_ctx,
+    )
+    assert isinstance(result.flytefile, File)
+    assert isinstance(result.flytedir, Dir)
+    assert result.flytefile.path == "s3://bucket/file.txt"
+    assert result.flytedir.path == "s3://bucket/dir"
+
+
+def test_json_param_type_passthrough_file_dir_objects(local_mode_ctx):
+    existing_file = File(path="s3://already/file.txt")
+    existing_dir = Dir(path="s3://already/dir")
+
+    @dataclass
+    class FlyteTypes:
+        flytefile: File
+        flytedir: Dir
+
+    result = JsonParamType(FlyteTypes).convert(
+        {"flytefile": existing_file, "flytedir": existing_dir},
+        None,
+        local_mode_ctx,
+    )
+    assert result.flytefile is existing_file
+    assert result.flytedir is existing_dir
+
+
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
+def test_json_param_type_list_of_dataframe_paths(local_mode_ctx, temp_parquet_file):
+    result = JsonParamType(list[DataFrame]).convert(
+        json.dumps(["s3://bucket/data.parquet", temp_parquet_file]),
+        None,
+        local_mode_ctx,
+    )
+    assert len(result) == 2
+    assert all(isinstance(df, DataFrame) for df in result)
+    assert result[0].uri == "s3://bucket/data.parquet"
+    assert result[1].uri == temp_parquet_file
+
+
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
+def test_json_param_type_dict_of_dataframe_paths(local_mode_ctx, temp_parquet_file):
+    result = JsonParamType(dict[str, DataFrame]).convert(
+        json.dumps({"remote": "s3://bucket/data.parquet", "local": temp_parquet_file}),
+        None,
+        local_mode_ctx,
+    )
+    assert isinstance(result["remote"], DataFrame)
+    assert isinstance(result["local"], DataFrame)
+    assert result["remote"].uri == "s3://bucket/data.parquet"
+    assert result["local"].uri == temp_parquet_file
+
+
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
+def test_json_param_type_dataclass_with_dataframe_path(local_mode_ctx, temp_parquet_file):
+    @dataclass
+    class DataFrameInput:
+        dataframe: Optional[DataFrame] = None
+
+    result = JsonParamType(DataFrameInput).convert(
+        json.dumps({"dataframe": temp_parquet_file}),
+        None,
+        local_mode_ctx,
+    )
+    assert isinstance(result, DataFrameInput)
+    assert isinstance(result.dataframe, DataFrame)
+    assert result.dataframe.uri == temp_parquet_file
+
+
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
+def test_json_param_type_accepts_structured_dict_for_dataframe(local_mode_ctx, temp_parquet_file):
+    @dataclass
+    class DataFrameInput:
+        dataframe: DataFrame
+
+    result = JsonParamType(DataFrameInput).convert(
+        json.dumps({"dataframe": {"uri": temp_parquet_file, "format": "parquet"}}),
+        None,
+        local_mode_ctx,
+    )
+    assert isinstance(result.dataframe, DataFrame)
+    assert result.dataframe.uri == temp_parquet_file
+    assert result.dataframe.format == "parquet"


### PR DESCRIPTION
This pull request refactors and extends the logic for converting CLI parameter values to Python types in the Flyte CLI, with a focus on better handling of complex types such as dataclasses, lists, dicts, and special Flyte IO types (`File`, `Dir`, `DataFrame`). The main improvements include more robust type unwrapping, recursive conversion of nested structures, and support for Pydantic models.

Type handling and conversion improvements:
* Introduced `_unwrap_field_type` to recursively resolve underlying types, especially for handling `Optional`/`Union` types, ensuring correct type conversion throughout the code.
* Refactored blob parameter conversion: replaced `_make_string_blob_converter` with `_convert_blob_value`, which now supports direct conversion of `File`, `Dir`, and `DataFrame` objects, and integrates with Pydantic models.
* Added `_convert_blob_collection_elements` and `_convert_blob_fields_in_value` to recursively convert elements in lists, dicts, and dataclasses, ensuring nested structures are properly handled.

Dataclass and collection instantiation:
* Implemented `_instantiate_dataclass` to recursively construct dataclass instances from dictionaries, including handling of nested dataclasses in lists and dicts.
* Updated the main `convert` method to use the new recursive conversion and instantiation logic for lists, dicts, and dataclasses, improving correctness and flexibility for complex parameter types.

Other improvements:
* Added import of `DataFrame` from `flyte.io` to support new conversion logic.

These changes make parameter parsing more robust and extensible, especially for workflows using complex/nested types and Flyte-specific IO objects.