### PR TITLE
fix(ci): build flyte with pretend version in integration tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -17,12 +17,6 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
     env:
-      # Set at job level so every uv build of flyte (uv sync in setup-python-env,
-      # `make dist`, and `uv pip install "../[examples-test]"`) picks up this version.
-      # A per-step `export` only affects that step's shell, so the source builds in
-      # other steps fell back to setuptools_scm's default 0.1.devN (checkout is
-      # shallow with --no-tags, so no tag is available to derive a real version).
-      # Use the global var; vcs-versioning does not honor the _FOR_FLYTE variant.
       SETUPTOOLS_SCM_PRETEND_VERSION: "9.9.9.dev0"
     strategy:
       matrix:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -16,6 +16,14 @@ concurrency:
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
+    env:
+      # Set at job level so every uv build of flyte (uv sync in setup-python-env,
+      # `make dist`, and `uv pip install "../[examples-test]"`) picks up this version.
+      # A per-step `export` only affects that step's shell, so the source builds in
+      # other steps fell back to setuptools_scm's default 0.1.devN (checkout is
+      # shallow with --no-tags, so no tag is available to derive a real version).
+      # Use the global var; vcs-versioning does not honor the _FOR_FLYTE variant.
+      SETUPTOOLS_SCM_PRETEND_VERSION: "9.9.9.dev0"
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -37,7 +45,7 @@ jobs:
           key: uv-${{ runner.os }}-${{ matrix.python-version }}
       - name: Install flyte & Build wheel
         run: |
-          export SETUPTOOLS_SCM_PRETEND_VERSION="9.9.9.dev"
+          # Version comes from the job-level SETUPTOOLS_SCM_PRETEND_VERSION env.
           make dist
       - name: Install plugins and example dependencies
         working-directory: plugins

--- a/examples/plugins/spark_example.py
+++ b/examples/plugins/spark_example.py
@@ -16,7 +16,7 @@ image = (
         extendable=True,
         platform=("linux/amd64", "linux/arm64"),
     )
-    .with_pip_packages("flyteplugins-spark>=2.0.0")
+    .with_pip_packages("flyteplugins-spark>=2.5.0")
 )
 
 task_env = flyte.TaskEnvironment(


### PR DESCRIPTION
## Why

In the Integration Tests workflow, flyte was reported as `0.1.dev1+...` even though the workflow set `SETUPTOOLS_SCM_PRETEND_VERSION="9.9.9.dev"`. See [this run](https://github.com/flyteorg/flyte-sdk/actions/runs/28165174530/job/83415231927) — final `uv pip list` shows `flyte 0.1.dev1+gfc78c9342`.

Root cause: each `run:` block is its own shell, so the per-step `export` only applied inside the "Install flyte & Build wheel" step. But the flyte that the tests actually import is built from source by `uv` in **other** steps, where the var was unset:

| Step | Builds flyte as |
|------|-----------------|
| `uv sync` (in `setup-python-env`) | `0.1.dev1` |
| `make dist` (var was set here) | `9.9.9.dev0` wheel → written to `dist/`, **never installed** |
| `uv pip install "../[examples-test]"` | rebuilds → `0.1.dev1` ← final installed version |

The `0.1` fallback comes from `actions/checkout@v4` fetching shallow with `--no-tags`, so setuptools_scm/vcs-versioning finds no tag and uses its default `0.1.dev<distance>`.

## What

- Promote `SETUPTOOLS_SCM_PRETEND_VERSION` to a **job-level `env:`** so it applies to every `uv` build of flyte (sync, `make dist`, and the `examples-test` reinstall).
- Use the global var (not `..._FOR_FLYTE`) — the `vcs-versioning` fork in this repo does not honor the package-specific variant.
- Normalize the value to `9.9.9.dev0` to drop the `Normalizing '9.9.9.dev' to '9.9.9.dev0'` warning.
- Remove the now-redundant per-step `export`.

## Test

The Integration Tests workflow runs on changes to `.github/workflows/integration_tests.yml`, so this PR exercises the path. After the change, the source builds of flyte should report `9.9.9.dev0` in `uv pip list`.