### PR TITLE
fix: return App wrapper from dryrun app deploy (FLYTE-SDK-5W)

### DIFF
--- a/src/flyte/app/_deploy.py
+++ b/src/flyte/app/_deploy.py
@@ -108,8 +108,10 @@ async def _deploy_app(
             app_idl.spec.container.image = serialization_context.image_cache.image_lookup[app.name]
 
         if dryrun:
-            # Dryrun intentionally short-circuits with the translated IDL proto.
-            return typing.cast("App", app_idl)
+            # Wrap the raw IDL proto in an App so callers (e.g. table_repr) can use the same
+            # attribute accessors (.name, .revision, ...) as the non-dryrun path, which returns
+            # an App. Returning the bare proto here caused `AttributeError: name` in table_repr.
+            return App(app_idl)
         ensure_client()
         resolved_image = app_idl.spec.container.image if app_idl.spec.HasField("container") else image_uri_for_log
         msg = f"Deploying app {app.name}, with image {resolved_image} version {serialization_context.version}"

--- a/tests/flyte/app/test_app_deploy.py
+++ b/tests/flyte/app/test_app_deploy.py
@@ -1,9 +1,11 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from flyteidl2.app import app_definition_pb2
 
 from flyte.app import AppEnvironment
-from flyte.app._deploy import DeployedAppEnvironment
+from flyte.app._deploy import DeployedAppEnvironment, _deploy_app
+from flyte.models import SerializationContext
 from flyte.remote import App
 
 
@@ -39,3 +41,43 @@ def test_deployed_app_environment_table_repr_uses_public_and_console_urls():
     assert row["console_url"] == (
         "[link=https://console.example.com/apps/test-app]https://console.example.com/apps/test-app[/link]"
     )
+
+
+@pytest.mark.asyncio
+async def test_deploy_app_dryrun_returns_app_wrapper():
+    """Regression for FLYTE-SDK-5W: dryrun must return an App, not the raw IDL proto.
+
+    Returning the bare proto made DeployedAppEnvironment.table_repr() raise
+    `AttributeError: name` because the proto has no top-level `.name` attribute.
+    """
+    app_pb2 = app_definition_pb2.App(
+        metadata=app_definition_pb2.Meta(
+            id=app_definition_pb2.Identifier(
+                org="o",
+                project="p",
+                domain="d",
+                name="dryrun-app",
+            ),
+        ),
+        spec=app_definition_pb2.Spec(desired_state=app_definition_pb2.Spec.DESIRED_STATE_ACTIVE),
+    )
+    app_env = AppEnvironment(name="dryrun-app", image="auto")
+    sc = MagicMock(spec=SerializationContext)
+    sc.code_bundle = None
+    sc.image_cache = None
+
+    translate = MagicMock()
+    translate.aio = AsyncMock(return_value=app_pb2)
+    with patch("flyte.app._runtime.translate_app_env_to_idl", translate):
+        result = await _deploy_app(app_env, sc, dryrun=True)
+
+    assert isinstance(result, App)
+    assert result.name == "dryrun-app"
+
+    # table_repr must not raise AttributeError on the dryrun result.
+    mock_client = MagicMock()
+    mock_client.console.app_url.return_value = "https://console.example.com/apps/dryrun-app"
+    with patch("flyte.remote._app.get_client", return_value=mock_client):
+        row = dict(DeployedAppEnvironment(env=app_env, deployed_app=result).table_repr()[0])
+
+    assert row["name"] == "dryrun-app"


### PR DESCRIPTION
## Summary

`--dryrun` deploy of an `AppEnvironment` crashed the CLI with `AttributeError: name`.

`_deploy_app` returns a `remote.App` in the normal path but returned the raw
`app_definition_pb2.App` IDL proto in the dryrun branch. The proto has no
top-level `.name` attribute (its name is at `metadata.id.name`), so
`DeployedAppEnvironment.table_repr()` raised `AttributeError: name` at
`("name", self.deployed_app.name)` while the CLI rendered the deploy table.

## Fix

Wrap the dryrun proto in `App(app_idl)` so both branches return an `App` and
the `.name`/`.revision`/`.desired_state`/... accessors work uniformly (matches
the declared `-> App` return type). Adds a regression test that exercises the
dryrun path and asserts `table_repr()` no longer raises.

## Sentry

fixes FLYTE-SDK-5W

🤖 Generated with [Claude Code](https://claude.com/claude-code)