### PR TITLE
fix(logging): forward USER_LOG_LEVEL to task pods

### DIFF
--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -19,7 +19,7 @@ from flyte._initialize import (
     requires_initialization,
     requires_storage,
 )
-from flyte._logging import LogFormat, logger
+from flyte._logging import LogFormat, logger, user_logger
 from flyte._task import F, P, R, TaskTemplate
 from flyte.models import (
     ActionID,
@@ -317,8 +317,8 @@ class _Runner:
         if env.get("LOG_LEVEL") is None:
             env["LOG_LEVEL"] = str(self._log_level) if self._log_level else str(logger.getEffectiveLevel())
         env["LOG_FORMAT"] = self._log_format
-        if self._user_log_level is not None:
-            env["USER_LOG_LEVEL"] = str(self._user_log_level)
+        if env.get("USER_LOG_LEVEL") is None:
+            env["USER_LOG_LEVEL"] = str(self._user_log_level or user_logger.getEffectiveLevel())
         if self._reset_root_logger:
             env["FLYTE_RESET_ROOT_LOGGER"] = "1"
         if self._debug:

--- a/tests/flyte/test_run_log_env.py
+++ b/tests/flyte/test_run_log_env.py
@@ -1,0 +1,45 @@
+"""Tests for LOG_LEVEL / USER_LOG_LEVEL forwarding in _Runner._build_env_dict.
+
+Regression: a shell-set USER_LOG_LEVEL was dropped on remote runs because, unlike
+LOG_LEVEL, it had no fallback to the logger's effective level when not explicitly
+passed through with_runcontext.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from flyte._run import _Runner
+
+_NO_SYNC_CFG = SimpleNamespace(sync_local_sys_paths=False, root_dir=".")
+
+
+def _env(**runner_kwargs):
+    with patch("flyte._run.get_init_config", return_value=_NO_SYNC_CFG):
+        return _Runner(**runner_kwargs)._build_env_dict()
+
+
+def test_user_log_level_falls_back_to_logger_level():
+    # Not passed explicitly -> should still be present (mirrors LOG_LEVEL behavior).
+    with patch("flyte._run.user_logger.getEffectiveLevel", return_value=logging.DEBUG):
+        env = _env()
+    assert env["USER_LOG_LEVEL"] == str(logging.DEBUG)
+
+
+def test_explicit_user_log_level_wins_over_logger_level():
+    with patch("flyte._run.user_logger.getEffectiveLevel", return_value=logging.INFO):
+        env = _env(user_log_level=logging.ERROR)
+    assert env["USER_LOG_LEVEL"] == str(logging.ERROR)
+
+
+def test_user_log_level_from_env_vars_is_preserved():
+    env = _env(env_vars={"USER_LOG_LEVEL": "10"})
+    assert env["USER_LOG_LEVEL"] == "10"
+
+
+def test_both_log_levels_always_present():
+    env = _env()
+    assert "LOG_LEVEL" in env
+    assert "USER_LOG_LEVEL" in env


### PR DESCRIPTION
## Why

Reported in Slack: on a remote `flyte run`, setting both `LOG_LEVEL` and `USER_LOG_LEVEL` in the shell only forwards `LOG_LEVEL` to the task pod — `USER_LOG_LEVEL` is dropped.

```
LOG_LEVEL=DEBUG USER_LOG_LEVEL=DEBUG flyte run ...   # only LOG_LEVEL reaches the pod
flyte run -e LOG_LEVEL=DEBUG -e USER_LOG_LEVEL=DEBUG  # both reach the pod
```

Root cause: in `_Runner._build_env_dict`, `LOG_LEVEL` always gets injected (it falls back to `logger.getEffectiveLevel()`), but `USER_LOG_LEVEL` was only set when explicitly threaded through `with_runcontext` — which the CLI doesn't do.

## What

`_build_env_dict` now mirrors `LOG_LEVEL` for `USER_LOG_LEVEL`: falls back to `user_logger.getEffectiveLevel()`, so a shell-set value reaches the pod on both the CLI and direct-script paths.

## Tests

- `tests/flyte/test_run_log_env.py` — `USER_LOG_LEVEL` fallback / precedence in `_build_env_dict`.