### PR TITLE
Classify task load EIO as system error

### DIFF
--- a/src/flyte/_internal/runtime/entrypoints.py
+++ b/src/flyte/_internal/runtime/entrypoints.py
@@ -1,3 +1,4 @@
+import errno
 import importlib
 import os
 import traceback
@@ -137,6 +138,15 @@ def load_task(resolver: str, *resolver_args: str) -> TaskTemplate:
         raise ModuleNotFoundError(msg) from e
 
 
+def _classify_load_error(err: Exception) -> Exception:
+    if isinstance(err, OSError) and err.errno == errno.EIO:
+        return flyte.errors.RuntimeSystemError(
+            "FilesystemIOError",
+            f"Filesystem I/O error while loading task: {err}",
+        )
+    return err
+
+
 def load_pkl_task(code_bundle: CodeBundle) -> TaskTemplate:
     """
     Loads a task from a pickled code bundle.
@@ -246,14 +256,17 @@ async def load_and_run_task(
     try:
         task = await _download_and_load_task(code_bundle, resolver, resolver_args)
     except Exception as e:
+        classified_error = _classify_load_error(e)
         # Import/load failures happen before the contextual_run wrapper below, so they must
         # also be uploaded to the error file -- otherwise the UI shows an empty message.
         logger.exception(f"Failed to load task before execution: {e}")
         if output_path:
             from .io import upload_error
 
-            error = convert_from_native_to_error(e)
+            error = convert_from_native_to_error(classified_error)
             await upload_error(error.err, output_path, recoverable=error.recoverable)
+        if classified_error is not e:
+            raise classified_error from e
         raise
 
     await contextual_run(

--- a/tests/flyte/internal/runtime/test_entrypoints.py
+++ b/tests/flyte/internal/runtime/test_entrypoints.py
@@ -1,9 +1,12 @@
+import errno
 import os
 import tempfile
 from unittest import mock
 
 import pytest
+from flyteidl2.core import execution_pb2
 
+import flyte.errors
 from flyte._internal.runtime.entrypoints import _list_user_files, load_and_run_task
 from flyte.models import ActionID, RawDataPath
 
@@ -150,6 +153,78 @@ async def test_load_failure_uploads_error_document():
     uploaded_err = mock_upload_error.call_args.args[0]
     assert "emoji" in uploaded_err.message
     assert uploaded_err.code == "ModuleNotFoundError"
+
+
+@pytest.mark.asyncio
+async def test_load_eio_failure_uploads_system_error_document():
+    """EIO while importing/loading the task indicates the filesystem failed to read bytes,
+    so surface it as a system error instead of a user/import error.
+    """
+    boom = OSError(errno.EIO, "Input/output error")
+
+    with (
+        mock.patch(
+            "flyte._internal.runtime.entrypoints._download_and_load_task",
+            side_effect=boom,
+        ),
+        mock.patch(
+            "flyte._internal.runtime.io.upload_error",
+            new_callable=mock.AsyncMock,
+        ) as mock_upload_error,
+    ):
+        with pytest.raises(flyte.errors.RuntimeSystemError):
+            await load_and_run_task(
+                action=ActionID(name="a0", run_name="r0"),
+                raw_data_path=RawDataPath(path="/tmp/raw"),
+                output_path="s3://bucket/outputs",
+                run_base_dir="s3://bucket/run",
+                version="v1",
+                controller=None,
+                resolver="some.resolver",
+                resolver_args=["mod", "task"],
+            )
+
+    mock_upload_error.assert_awaited_once()
+    uploaded_err = mock_upload_error.call_args.args[0]
+    assert uploaded_err.kind == execution_pb2.ExecutionError.SYSTEM
+    assert uploaded_err.code == "FilesystemIOError"
+    assert "Input/output error" in uploaded_err.message
+    assert mock_upload_error.call_args.kwargs["recoverable"] is True
+
+
+@pytest.mark.asyncio
+async def test_load_non_eio_os_error_is_not_promoted_to_system():
+    """Only errno.EIO is infrastructure-classified; ordinary OSErrors keep
+    the generic load-failure behavior.
+    """
+    boom = FileNotFoundError(errno.ENOENT, "No such file or directory")
+
+    with (
+        mock.patch(
+            "flyte._internal.runtime.entrypoints._download_and_load_task",
+            side_effect=boom,
+        ),
+        mock.patch(
+            "flyte._internal.runtime.io.upload_error",
+            new_callable=mock.AsyncMock,
+        ) as mock_upload_error,
+    ):
+        with pytest.raises(FileNotFoundError):
+            await load_and_run_task(
+                action=ActionID(name="a0", run_name="r0"),
+                raw_data_path=RawDataPath(path="/tmp/raw"),
+                output_path="s3://bucket/outputs",
+                run_base_dir="s3://bucket/run",
+                version="v1",
+                controller=None,
+                resolver="some.resolver",
+                resolver_args=["mod", "task"],
+            )
+
+    mock_upload_error.assert_awaited_once()
+    uploaded_err = mock_upload_error.call_args.args[0]
+    assert uploaded_err.kind == execution_pb2.ExecutionError.UNKNOWN
+    assert uploaded_err.code == "FileNotFoundError"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Task import/load failures happen before the normal task execution wrapper. The runtime already uploads an `error.pb` for these failures, but a raw `OSError` with `errno.EIO` was converted through the generic fallback instead of being attributed as a system failure.

That means filesystem/image read failures like `[Errno 5] Input/output error` during module import can be surfaced with the wrong attribution, even though `EIO` indicates the runtime failed to read bytes from the underlying filesystem/storage layer rather than a deterministic user-code error.

## Solution

Classify only task-load `OSError` values with `errno.EIO` as `RuntimeSystemError` before converting and uploading the load failure error document.

All other load-time exceptions, including non-EIO `OSError` values such as `FileNotFoundError`, continue through the existing generic path.

## Testing

- `uv run python -m pytest tests/flyte/internal/bin/test_runtime.py tests/flyte/internal/runtime/test_entrypoints.py`
- `uv run python -m ruff check src/flyte/_internal/runtime/entrypoints.py tests/flyte/internal/runtime/test_entrypoints.py`