### PR TITLE
Centralize EIO system error conversion

### DIFF
--- a/src/flyte/_internal/runtime/convert.py
+++ b/src/flyte/_internal/runtime/convert.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import contextvars
+import errno
 import hashlib
 import inspect
 from dataclasses import dataclass
@@ -369,6 +370,14 @@ def convert_from_native_to_error(err: BaseException) -> Error:
                 worker=err.worker,
             ),
             recoverable=False,
+        )
+    elif isinstance(err, OSError) and err.errno == errno.EIO:
+        return Error(
+            err=execution_pb2.ExecutionError(
+                kind=execution_pb2.ExecutionError.SYSTEM,
+                code="FilesystemIOError",
+                message=f"Filesystem I/O error: {err}",
+            )
         )
     elif isinstance(err, flyte.errors.RuntimeUnknownError):
         return Error(

--- a/src/flyte/_internal/runtime/entrypoints.py
+++ b/src/flyte/_internal/runtime/entrypoints.py
@@ -1,4 +1,3 @@
-import errno
 import importlib
 import os
 import traceback
@@ -138,15 +137,6 @@ def load_task(resolver: str, *resolver_args: str) -> TaskTemplate:
         raise ModuleNotFoundError(msg) from e
 
 
-def _classify_load_error(err: Exception) -> Exception:
-    if isinstance(err, OSError) and err.errno == errno.EIO:
-        return flyte.errors.RuntimeSystemError(
-            "FilesystemIOError",
-            f"Filesystem I/O error while loading task: {err}",
-        )
-    return err
-
-
 def load_pkl_task(code_bundle: CodeBundle) -> TaskTemplate:
     """
     Loads a task from a pickled code bundle.
@@ -256,17 +246,14 @@ async def load_and_run_task(
     try:
         task = await _download_and_load_task(code_bundle, resolver, resolver_args)
     except Exception as e:
-        classified_error = _classify_load_error(e)
         # Import/load failures happen before the contextual_run wrapper below, so they must
         # also be uploaded to the error file -- otherwise the UI shows an empty message.
         logger.exception(f"Failed to load task before execution: {e}")
         if output_path:
             from .io import upload_error
 
-            error = convert_from_native_to_error(classified_error)
+            error = convert_from_native_to_error(e)
             await upload_error(error.err, output_path, recoverable=error.recoverable)
-        if classified_error is not e:
-            raise classified_error from e
         raise
 
     await contextual_run(

--- a/tests/flyte/internal/runtime/test_convert.py
+++ b/tests/flyte/internal/runtime/test_convert.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import inspect
 import time
 from dataclasses import dataclass
@@ -7,6 +8,7 @@ from typing import Optional, Tuple, Union
 
 import pytest
 import pytest_asyncio
+from flyteidl2.core import execution_pb2
 from flyteidl2.core.interface_pb2 import TypedInterface, Variable, VariableEntry, VariableMap
 from flyteidl2.core.literals_pb2 import (
     Literal,
@@ -40,6 +42,23 @@ test_cases = [
     ((NativeInterface.from_types({"x": (int, inspect.Parameter.empty)}, {}), (3,)), "et7s2yhynbrhdtsawc2wny9o6"),
     ((NativeInterface.from_types({"x": (int, inspect.Parameter.empty)}, {}), (4,)), "5nf5f0zrm2jkqcijzjls1pgfh"),
 ]
+
+
+def test_convert_eio_os_error_to_recoverable_system_error():
+    err = convert.convert_from_native_to_error(OSError(errno.EIO, "Input/output error"))
+
+    assert err.recoverable is True
+    assert err.err.kind == execution_pb2.ExecutionError.SYSTEM
+    assert err.err.code == "FilesystemIOError"
+    assert "Input/output error" in err.err.message
+
+
+def test_convert_non_eio_os_error_uses_generic_unknown_error():
+    err = convert.convert_from_native_to_error(FileNotFoundError(errno.ENOENT, "No such file or directory"))
+
+    assert err.recoverable is True
+    assert err.err.kind == execution_pb2.ExecutionError.UNKNOWN
+    assert err.err.code == "FileNotFoundError"
 
 
 @pytest_asyncio.fixture(params=test_cases)

--- a/tests/flyte/internal/runtime/test_entrypoints.py
+++ b/tests/flyte/internal/runtime/test_entrypoints.py
@@ -6,7 +6,6 @@ from unittest import mock
 import pytest
 from flyteidl2.core import execution_pb2
 
-import flyte.errors
 from flyte._internal.runtime.entrypoints import _list_user_files, load_and_run_task
 from flyte.models import ActionID, RawDataPath
 
@@ -172,7 +171,7 @@ async def test_load_eio_failure_uploads_system_error_document():
             new_callable=mock.AsyncMock,
         ) as mock_upload_error,
     ):
-        with pytest.raises(flyte.errors.RuntimeSystemError):
+        with pytest.raises(OSError):
             await load_and_run_task(
                 action=ActionID(name="a0", run_name="r0"),
                 raw_data_path=RawDataPath(path="/tmp/raw"),


### PR DESCRIPTION
## Problem

PR #1264 fixed task-load `OSError(errno.EIO)` attribution in the normal `a0` entrypoint path, but the EIO classification lived in `entrypoints.py`. Review feedback pointed out that this is really exception-to-Flyte-error conversion behavior, and other runtime paths such as Rust/worker-v2 loading should not need their own copy of the same classification rule.

## Solution

Move the raw `OSError(errno.EIO)` mapping into `convert_from_native_to_error()` so any runtime path that serializes native exceptions through the shared converter gets the same result:

- `ExecutionError.kind = SYSTEM`
- `code = FilesystemIOError`
- `recoverable = True`

The entrypoint load-failure path now simply converts the original exception and re-raises it, removing the local classifier and special `raise classified_error from e` block.

## Testing

- `uv run python -m pytest tests/flyte/internal/runtime/test_convert.py tests/flyte/internal/runtime/test_entrypoints.py tests/flyte/internal/bin/test_runtime.py`
- `uv run python -m ruff check src/flyte/_internal/runtime/convert.py src/flyte/_internal/runtime/entrypoints.py tests/flyte/internal/runtime/test_convert.py tests/flyte/internal/runtime/test_entrypoints.py`