### PR TITLE
docs: fix _Condition docstring example to use .aio() in async task

### DIFF
--- a/src/flyte/_condition.py
+++ b/src/flyte/_condition.py
@@ -49,8 +49,8 @@ class _Condition(Generic[ConditionType]):
 
     @env.task
     async def my_task() -> Optional[int]:
-        condition = await flyte.new_condition(name="my_condition", prompt="Is it ok to continue?", data_type=bool)
-        result = await condition.wait()
+        condition = await flyte.new_condition.aio(name="my_condition", prompt="Is it ok to continue?", data_type=bool)
+        result = await condition.wait.aio()
         if result:
             return 42
         else:


### PR DESCRIPTION
The `_Condition` class docstring (which surfaces in the API reference) shows:

```python
condition = await flyte.new_condition(name="my_condition", ...)
result = await condition.wait()
```

But `new_condition` and `_Condition.wait` are `@syncify` — the bare call is sync (returns the value, not an awaitable), so `await flyte.new_condition(...)` / `await condition.wait()` raise `TypeError` inside an `async def` task. The correct async form is `.aio()`:

```python
condition = await flyte.new_condition.aio(name="my_condition", ...)
result = await condition.wait.aio()
```

This matches `examples/advanced/conditions.py` and the auto-generated "use `.aio()` to call asynchronously" note. Docs-only (docstring); no behavior change.

Surfaced while writing the External conditions user-guide page (unionai-docs#1087); the page had copied this same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)