### PR TITLE
fix(cli/docs): emit markdown-safe CLI reference (fenced examples, inline aliases)

### DIFF
--- a/src/flyte/cli/_gen.py
+++ b/src/flyte/cli/_gen.py
@@ -1,3 +1,4 @@
+import inspect
 import sys
 import textwrap
 from os import getcwd
@@ -171,7 +172,7 @@ def _render_command(
 
     if cmd.help:
         output.append("")
-        output.append(f"{dedent(cmd.help)}")
+        output.append(_format_command_help(cmd.help))
 
     if not cmd.params:
         return output
@@ -187,13 +188,11 @@ def _render_command(
             if len(all_opts) == 1:
                 opts = f"`{all_opts[0]}`"
             else:
-                opts = "".join(
-                    [
-                        "{{< multiline >}}",
-                        "\n".join([f"`{opt}`" for opt in all_opts]),
-                        "{{< /multiline >}}",
-                    ]
-                )
+                # Render aliases inline. The multiline shortcode emits raw
+                # <div>/<br/> HTML, which fails Hugo's build inside a
+                # {{< markdown >}} block (plugin commands) under goldmark
+                # unsafe=false + --panicOnWarning.
+                opts = " ".join(f"`{opt}`" for opt in all_opts)
             default_value = ""
             if param.default is not None:
                 default_value = f"`{param.default}`"
@@ -450,3 +449,33 @@ def dedent(text: str) -> str:
     Remove leading whitespace from a string.
     """
     return textwrap.dedent(text).strip("\n")
+
+
+def _format_command_help(text: str) -> str:
+    """Render a command's help text as Markdown.
+
+    click help strings put the first line on the opening triple-quote (column 0)
+    and indent the rest, which ``textwrap.dedent`` cannot normalize;
+    ``inspect.cleandoc`` handles that. Any remaining indented blocks (e.g.
+    ``Examples:`` command listings) are wrapped in fenced code blocks rather than
+    left as indentation-based code blocks — indented code does not survive the
+    ``{{< markdown >}}`` shortcode's ``RenderString`` and renders inconsistently.
+    """
+    lines = inspect.cleandoc(text).split("\n")
+    out: list[str] = []
+    i = 0
+    while i < len(lines):
+        if lines[i].startswith("    "):
+            block: list[str] = []
+            while i < len(lines) and (lines[i].startswith("    ") or lines[i].strip() == ""):
+                block.append(lines[i])
+                i += 1
+            while block and block[-1].strip() == "":
+                block.pop()
+            out.append("```bash")
+            out.extend(textwrap.dedent("\n".join(block)).split("\n"))
+            out.append("```")
+        else:
+            out.append(lines[i])
+            i += 1
+    return "\n".join(out)


### PR DESCRIPTION
## Problem
`flyte gen docs --type markdown` produces the CLI reference page (`flyte-cli.md`) for the docs site. For **plugin** commands it wraps each command in a `{{< variant >}}{{< markdown >}}` block (variant-gating). Two constructs it emits then break the Hugo build inside that block:

1. **Multi-name/alias options** are rendered with the `{{< multiline >}}` shortcode (`_gen.py`), which outputs raw `<div>`/`<br/>` HTML. Inside `{{< markdown >}}`'s `.Page.RenderString` (goldmark `unsafe=false`, build run with `--panicOnWarning`) that is a fatal *"Raw HTML omitted"*.
2. **`Examples:` blocks** come through as indentation-based code, which doesn't survive `RenderString` and renders inconsistently.

Core commands sit in *plain* page markdown (shortcode HTML passes straight through, never re-rendered), so this only bites plugin commands — and only surfaced now because flyte 2.5.6's new `flyte connect` plugin command is the first with multi-alias options + an Examples block. It took down the entire `Build and deploy docs` job (see unionai-docs#1153).

## Fix (`src/flyte/cli/_gen.py`)
- **Aliases inline:** render multi-name options as `` `--a` `--b` `` instead of the `{{< multiline >}}` shortcode — works in both plain and `{{< markdown >}}` contexts, no raw HTML.
- **Fenced examples:** new `_format_command_help()` formats command help with `inspect.cleandoc` (handles the first-line-on-`"""` docstring case that `textwrap.dedent` can't) and wraps indented blocks in fenced ```bash code blocks instead of relying on indentation.

Docs-pipeline plumbing only; no runtime/behavior change. Verified the formatter output on the `connect ssh` help (prose dedented, examples fenced, `<…>` placeholders now safe inside the fence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)