### PR TITLE
Fix: propagate sub-action error on parent recovery (USER error masked as SYSTEM)

### DIFF
--- a/src/flyte/_internal/controllers/remote/_controller.py
+++ b/src/flyte/_internal/controllers/remote/_controller.py
@@ -270,7 +270,10 @@ class RemoteController(Controller):
             )
 
         if n.has_error() or n.phase == phase_pb2.ACTION_PHASE_FAILED:
-            exc = await handle_action_failure(action, _task.name)
+            # Pass `n` (the observed/cached final state from the informer), not the local `action`
+            # stub. On a recovery the watch observes the pre-existing terminal sub-action before the
+            # parent submits, so the error lands on the cached object (`n`) while the stub stays empty.
+            exc = await handle_action_failure(n, _task.name)
             raise exc
 
         if _task.native_interface.outputs:
@@ -590,7 +593,8 @@ class RemoteController(Controller):
             raise
 
         if n.has_error() or n.phase == phase_pb2.ACTION_PHASE_FAILED:
-            exc = await handle_action_failure(action, task_name)
+            # See _submit: use `n`, the observed final state, not the local `action` stub.
+            exc = await handle_action_failure(n, task_name)
             raise exc
 
         if native_interface.outputs:

--- a/tests/internal/controllers/test_remote_controller.py
+++ b/tests/internal/controllers/test_remote_controller.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from flyteidl2.common import identifier_pb2, phase_pb2
+from flyteidl2.core import execution_pb2
 from flyteidl2.task import common_pb2
 
 import flyte
@@ -203,11 +204,82 @@ async def test_submit_task_with_error():
         )
         with ctx.replace_task_context(tctx):
             controller = RemoteController(client_coro=make_client(), workers=2, max_system_retries=2)
-            with pytest.raises(Exception, match="Error in task"):
+            # The returned action carries client_err — that real error must propagate, not be
+            # swallowed into a generic "Error in task ...: None" fallback.
+            with pytest.raises(Exception, match="Task failed"):
                 await controller.submit(t1)
 
         mock_upload_inputs.assert_called_once()
         mock_submit_and_wait.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_submit_task_error_from_observed_action_on_recovery():
+    """Regression: on recovery, the failed sub-action's error is observed on the action object
+    that submit_and_wait_for_action *returns* (the cache/`from_state` object), NOT on the local
+    stub that ``_submit`` builds via ``Action.from_task``.
+
+    The first run happens to work because the stub is also the cached object (submit-before-watch),
+    so ``merge_state`` lands the error on it. On a retry the watch observes the pre-existing FAILED
+    action first, so the returned ``n`` carries the error while the local stub stays empty. The
+    propagated exception must reflect the *real* user error, not a generic
+    ``UnableToConvertError: Error in task ...: None``.
+    """
+
+    async def make_client() -> ClientSet:
+        return AsyncMock()  # type: ignore
+
+    # `n` — the observed/cached action returned by submit_and_wait_for_action. Distinct object
+    # from the stub that _submit builds internally; it is the only one carrying the failure.
+    observed = Action(
+        parent_action_name="test_parent_action",
+        action_id=identifier_pb2.ActionIdentifier(name="test_action"),
+        phase=phase_pb2.ACTION_PHASE_FAILED,
+        err=execution_pb2.ExecutionError(
+            code="BadRequest",
+            message="400 Resources exceeded during query execution: Memory exceeded while reading Parquet",
+            kind=execution_pb2.ExecutionError.USER,
+        ),
+        run_output_base="/tmp/outputs/base",
+    )
+
+    with (
+        patch(
+            "flyte._internal.controllers.remote._controller.upload_inputs_with_retry",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "flyte._internal.controllers.remote._controller.RemoteController.submit_and_wait_for_action",
+            new_callable=AsyncMock,
+        ) as mock_submit_and_wait,
+        patch("flyte._initialize.get_init_config") as mock_get_common_config,
+    ):
+        mock_get_common_config.return_value.root_dir = pathlib.Path(__file__).parent
+        mock_submit_and_wait.return_value = observed
+
+        this_dir_str = str(pathlib.Path(__file__).parent.absolute())
+        ctx = internal_ctx()
+        tctx = TaskContext(
+            action=ActionID(name="test"),
+            raw_data_path=RawDataPath(path="test"),
+            output_path="/tmp",
+            version="v1",
+            run_base_dir="/tmp/outputs/base",
+            report=flyte.report.Report(name="test_report"),
+            code_bundle=CodeBundle(
+                computed_version="vcode-bundle",
+                destination=this_dir_str,
+                tgz="dummy.tgz",
+            ),
+        )
+        with ctx.replace_task_context(tctx):
+            controller = RemoteController(client_coro=make_client(), workers=2, max_system_retries=2)
+            with pytest.raises(flyte.errors.RuntimeUserError, match="Resources exceeded") as exc_info:
+                await controller.submit(t1)
+
+        # The propagated error must be the real USER error, not the generic dropped-error fallback.
+        assert "UnableToConvertError" not in str(exc_info.value)
+        assert "None" not in str(exc_info.value)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Severity: Critical**

When a parent action recovers/retries and re-watches a sub-action that is already in a terminal `FAILED` state, the controller passes the local `action` stub (not the observed final state `n`) to `handle_action_failure`. The stub has no phase/error, so a recoverable **USER** error gets masked as a **SYSTEM** `UnableToConvertError: ... None`. That synthesized error is itself recoverable, so the parent retries and re-hits the same failed child indefinitely.

First attempts are unaffected — only the recovery path is broken.

## Fix
Pass `n` (the observed/cached final state) to `handle_action_failure` in `_submit` and `_submit_task_ref`.

## Test
Adds a regression test for the recovery race (fails before, passes after) and updates `test_submit_task_with_error`, which had asserted the buggy fallback. `pytest tests/internal/controllers/` → 97 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
