### PR TITLE
fix(reuse): key actor pool version on the code-bundle path, not just its hash

### DIFF
--- a/src/flyte/_internal/runtime/reuse.py
+++ b/src/flyte/_internal/runtime/reuse.py
@@ -58,6 +58,19 @@ def extract_unique_id_and_image(
         components += f":{reuse_policy.get_scaledown_ttl()}"
     if code_bundle is not None:
         components += f":{code_bundle.computed_version}"
+        # The actor bridge pins each warm pod to the first code bundle it loads
+        # and rejects any task whose bundle path differs ("Task TGZ does not
+        # match the configured TGZ tasks", fasttask actor_environment.rs). The
+        # warm-pool routing key is this version, so it must include the exact
+        # path the bridge pins on — otherwise two bundles whose content hashes
+        # (computed_version) happen to match, but whose uploaded paths differ,
+        # collide on one pool and the pod rejects the second. Keying on the path
+        # makes "same pool ⇒ same bundle" an invariant. Paths are content-
+        # addressed, so identical code still shares a warm pod (reuse preserved).
+        if code_bundle.tgz is not None:
+            components += f":{code_bundle.tgz}"
+        if code_bundle.pkl is not None:
+            components += f":{code_bundle.pkl}"
     if task.security_context is not None:
         security_ctx_str = task.security_context.SerializeToString(deterministic=True)
         components += f":{security_ctx_str}"

--- a/tests/flyte/internal/runtime/test_reuse.py
+++ b/tests/flyte/internal/runtime/test_reuse.py
@@ -150,6 +150,63 @@ def test_extract_unique_id_with_security_context(container_task, code_bundle, re
     assert baseline_id != new_id
 
 
+def test_extract_unique_id_distinguishes_bundle_path(container_task, reuse_policy):
+    """Two bundles with the SAME computed_version but DIFFERENT upload path must
+    produce different ids, so they route to different warm pools.
+
+    The actor bridge pins each warm pod to the first bundle path it loads and
+    rejects any task whose path differs ("Task TGZ does not match the configured
+    TGZ tasks"). Keying the pool id on the path (not just the content hash)
+    guarantees a pool only ever holds one bundle, so the pin always matches.
+    """
+    id_tgz_a, _ = extract_unique_id_and_image(
+        env_name="test-env",
+        code_bundle=CodeBundle(computed_version="samehash", tgz="bundle-a.tgz"),
+        task=container_task,
+        reuse_policy=reuse_policy,
+    )
+    id_tgz_b, _ = extract_unique_id_and_image(
+        env_name="test-env",
+        code_bundle=CodeBundle(computed_version="samehash", tgz="bundle-b.tgz"),
+        task=container_task,
+        reuse_policy=reuse_policy,
+    )
+    assert id_tgz_a != id_tgz_b
+
+    # Same for pkl bundles.
+    id_pkl_a, _ = extract_unique_id_and_image(
+        env_name="test-env",
+        code_bundle=CodeBundle(computed_version="samehash", pkl="a.pkl.gz"),
+        task=container_task,
+        reuse_policy=reuse_policy,
+    )
+    id_pkl_b, _ = extract_unique_id_and_image(
+        env_name="test-env",
+        code_bundle=CodeBundle(computed_version="samehash", pkl="b.pkl.gz"),
+        task=container_task,
+        reuse_policy=reuse_policy,
+    )
+    assert id_pkl_a != id_pkl_b
+
+
+def test_extract_unique_id_stable_for_identical_bundle(container_task, reuse_policy):
+    """An identical bundle (same computed_version AND same path) yields the same
+    id, so identical code still shares a warm pod — reuse is preserved."""
+    id1, _ = extract_unique_id_and_image(
+        env_name="test-env",
+        code_bundle=CodeBundle(computed_version="samehash", tgz="bundle-a.tgz"),
+        task=container_task,
+        reuse_policy=reuse_policy,
+    )
+    id2, _ = extract_unique_id_and_image(
+        env_name="test-env",
+        code_bundle=CodeBundle(computed_version="samehash", tgz="bundle-a.tgz"),
+        task=container_task,
+        reuse_policy=reuse_policy,
+    )
+    assert id1 == id2
+
+
 def test_extract_unique_id_with_interruptible(container_task, code_bundle, reuse_policy):
     """Test that interruptible flag affects the unique ID."""
     # First get a baseline ID


### PR DESCRIPTION
## Problem

Reusable/actor tasks can fail on relaunch or concurrent runs with:

```
ValueError: Task TGZ does not match the configured TGZ tasks
  (fasttask worker-v2 executor/src/actor_environment.rs)
```

An actor pod pins to the **first code bundle (tgz/pkl path) it loads** and rejects any later task whose path differs. But the warm-pool routing key — the env "version" computed in `extract_unique_id_and_image` — included only `code_bundle.computed_version` (a content hash), **not** the uploaded bundle path. So whenever two bundles share a `computed_version` but resolve to different upload paths (e.g. a non-deterministic tarball, or a cached remote path paired with a freshly computed version), they collide on one pool and the pod rejects the second task — a hard failure.

## Fix

Fold the bundle's `tgz`/`pkl` **path** into the version components, so the pool routing key matches the exact identifier the actor bridge pins on. This makes *"same pool ⇒ same bundle path"* an invariant, so a pod's pin always matches what's routed to it.

- The env **name** is unchanged — no new task names in the UI; only the computed version differs across bundles.
- Upload paths are content-addressed, so identical code still maps to one version and **shares a warm pod (reuse preserved)**. Only genuinely different bundles split into separate pools — which the bridge requires anyway.

## Tests

- `test_extract_unique_id_distinguishes_bundle_path` — same `computed_version`, different `tgz` (and `pkl`) ⇒ different id.
- `test_extract_unique_id_stable_for_identical_bundle` — identical bundle ⇒ identical id (reuse preserved).

`pytest tests/flyte/internal/runtime/test_reuse.py` → 11 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)