### PR TITLE
Exclude union plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,6 +203,7 @@ exclude-newer = "5 days"
 [tool.uv.exclude-newer-package]
 flyteidl2 = "0 days"
 flyte_controller_base = "0 days"
+flyteplugins-union = "0 days"
 
 [tool.uv.sources]
 flyte_controller_base = { path = "rs_controller" }


### PR DESCRIPTION
Allows freshly published `flyteplugins-union` versions through the repo-wide uv `exclude-newer` cutoff, matching the existing Flyte package exceptions.

Checked with `uv -n pip install flyteplugins-union==0.5.0 --dry-run`.