### PR TITLE
Fix: SSH/VS Code debug entrypoint re-binds debug port (Errno 98)

### DIFF
--- a/src/flyte/_debug/constants.py
+++ b/src/flyte/_debug/constants.py
@@ -55,6 +55,8 @@ EXIT_CODE_SUCCESS = 0
 # sshd key-auth gates *the shell*.
 # ---------------------------------------------------------------------------
 
+# Env var that flips the a0 entrypoint into code-server (VS Code) debug mode.
+FLYTE_ENABLE_VSCODE_KEY = "_F_E_VS"
 # Env var (parallel to _F_E_VS) that flips the a0 entrypoint into ssh-debug mode.
 FLYTE_ENABLE_SSH_KEY = "_F_E_SSH"
 # Env var carrying the user's SSH *public* key contents to authorize for login.

--- a/src/flyte/_debug/ssh.py
+++ b/src/flyte/_debug/ssh.py
@@ -49,6 +49,8 @@ if TYPE_CHECKING:
 from flyte._debug.constants import (
     DEFAULT_SSH_USER,
     DEFAULT_UP_SECONDS,
+    FLYTE_ENABLE_SSH_KEY,
+    FLYTE_ENABLE_VSCODE_KEY,
     FLYTE_SSH_PUBKEY_KEY,
     FLYTE_SSH_USER_KEY,
     SSH_DEBUG_DIR,
@@ -404,6 +406,11 @@ def _write_debug_helpers(ctx) -> Optional[str]:
             "#!/usr/bin/env bash\n"
             "# Run the task entrypoint under pdb. Set a breakpoint() in your task,\n"
             "# or step from the top. Same args VS Code's 'Interactive Debugging' uses.\n"
+            "#\n"
+            "# Unset the debug-mode env vars: they are still set in the pod env, and\n"
+            "# without this the entrypoint would re-enter ssh/vscode debug mode and try\n"
+            "# to bind a second server on the already-in-use debug port.\n"
+            f"unset {FLYTE_ENABLE_SSH_KEY} {FLYTE_ENABLE_VSCODE_KEY}\n"
             f"exec {_sys.executable} -m pdb {program} {quoted}\n"
         )
         script.chmod(0o755)

--- a/src/flyte/_debug/vscode.py
+++ b/src/flyte/_debug/vscode.py
@@ -22,6 +22,8 @@ from flyte._debug.constants import (
     DOWNLOAD_DIR,
     EXECUTABLE_NAME,
     EXIT_CODE_SUCCESS,
+    FLYTE_ENABLE_SSH_KEY,
+    FLYTE_ENABLE_VSCODE_KEY,
     HEARTBEAT_PATH,
     MAX_IDLE_SECONDS,
 )
@@ -199,6 +201,13 @@ def prepare_launch_json(ctx: click.Context, pid: int):
                 "program": f"{virtual_venv}/bin/runtime.py",
                 "console": "integratedTerminal",
                 "justMyCode": True,
+                # The debug-mode env vars are still set in the pod env. Without
+                # clearing them the entrypoint would re-enter ssh/vscode debug
+                # mode and try to bind a second server on the in-use debug port.
+                "env": {
+                    FLYTE_ENABLE_VSCODE_KEY: "",
+                    FLYTE_ENABLE_SSH_KEY: "",
+                },
                 "args": [
                     "a0",
                     "--inputs",


### PR DESCRIPTION
## Problem

When you open the SSH debugger and run the remote debugger, it fails:

```
OSError: [Errno 98] error while attempting to bind on address ('127.0.0.1', 2222): [errno 98] address already in use
```

The generated `.flyte-ssh-debug/flyte-debug-task.sh` re-executes the task entrypoint (`runtime.py main`) under pdb. But the pod still has `_F_E_SSH` (and `_F_SSH_PK`) set in its environment, so `runtime.py` thinks it should start a **second** SSH server:

```python
ssh_debug = os.getenv(FLYTE_ENABLE_SSH_KEY, "").lower() in ("1", "true", "yes")
if ssh_debug and name == "a0":
    asyncio.run(_start_ssh_server(ctx))   # <-- tries to bind :2222 again
```

`:2222` is already held by the SSH server you connected through, so it crashes. The same flaw exists on the VS Code "Interactive Debugging" (F5) path, which re-runs the entrypoint with `_F_E_VS`/`_F_E_SSH` still set.

## Fix

Clear the debug-mode env vars on both debug-launch paths so the entrypoint runs the task body instead of re-starting a server:

- **`flyte-debug-task.sh` (pdb path)** now `unset`s `_F_E_SSH _F_E_VS` before `exec`'ing pdb.
- **`launch.json` "Interactive Debugging" (F5 path)** now sets an `env` override clearing both vars.
- Added `FLYTE_ENABLE_VSCODE_KEY` to `constants.py` (it only had the SSH key) and imported both keys in `ssh.py` / `vscode.py` instead of hardcoding the strings.

With the vars cleared, `ssh_debug`/`debug` evaluate to `False`, the entrypoint skips the server-start branch, and the debugger drops straight into the task body.

> Note: the script/launch.json are generated at pod startup, so this takes effect for debug pods launched after a rebuild including these changes — an already-running debug pod still has the old script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)