### PR TITLE
fix: accept an ImageBuilder instance in _get_builder (FLYTE-SDK-61)

### DIFF
--- a/src/flyte/_internal/imagebuild/image_builder.py
+++ b/src/flyte/_internal/imagebuild/image_builder.py
@@ -344,9 +344,15 @@ class ImageBuildEngine:
         return result
 
     @classmethod
-    def _get_builder(cls, builder: ImageBuildEngine.ImageBuilderType | None = "local") -> ImageBuilder:
+    def _get_builder(cls, builder: ImageBuildEngine.ImageBuilderType | ImageBuilder | None = "local") -> ImageBuilder:
         if builder is None:
             builder = "local"
+        # A caller (e.g. ``flyte.init(image_builder=MyBuilder())``) may hand us an
+        # already-instantiated builder instead of its registered name. Use it as-is
+        # rather than trying to resolve it as an entry-point name, which would raise
+        # ``ValueError: Unknown image builder type: <MyBuilder object ...>`` (FLYTE-SDK-61).
+        if not isinstance(builder, str):
+            return builder
         if builder == "remote":
             from flyte._internal.imagebuild.remote_builder import RemoteImageBuilder
 

--- a/src/flyte/_internal/imagebuild/image_builder.py
+++ b/src/flyte/_internal/imagebuild/image_builder.py
@@ -347,10 +347,6 @@ class ImageBuildEngine:
     def _get_builder(cls, builder: ImageBuildEngine.ImageBuilderType | ImageBuilder | None = "local") -> ImageBuilder:
         if builder is None:
             builder = "local"
-        # A caller (e.g. ``flyte.init(image_builder=MyBuilder())``) may hand us an
-        # already-instantiated builder instead of its registered name. Use it as-is
-        # rather than trying to resolve it as an entry-point name, which would raise
-        # ``ValueError: Unknown image builder type: <MyBuilder object ...>`` (FLYTE-SDK-61).
         if not isinstance(builder, str):
             return builder
         if builder == "remote":

--- a/tests/flyte/imagebuild/test_image_build_engine.py
+++ b/tests/flyte/imagebuild/test_image_build_engine.py
@@ -14,6 +14,29 @@ from flyte._internal.imagebuild.image_builder import (
 )
 
 
+def test_get_builder_accepts_instance():
+    """A builder instance (e.g. from ``flyte.init(image_builder=MyBuilder())``) is used as-is.
+
+    Regression for FLYTE-SDK-61: passing an instance previously fell through to the
+    entry-point name lookup and raised ``ValueError: Unknown image builder type``.
+    """
+
+    class _CustomBuilder:
+        async def build_image(self, image, dry_run, wait=True, force=False):  # pragma: no cover
+            raise NotImplementedError
+
+        def get_checkers(self):
+            return None
+
+    instance = _CustomBuilder()
+    assert ImageBuildEngine._get_builder(instance) is instance
+
+
+def test_get_builder_unknown_name_still_raises():
+    with pytest.raises(ValueError, match="Unknown image builder type"):
+        ImageBuildEngine._get_builder("does-not-exist")
+
+
 @mock.patch("flyte._internal.imagebuild.image_builder.DockerAPIImageChecker.image_exists")
 @mock.patch("flyte._internal.imagebuild.image_builder.LocalDockerCommandImageChecker.image_exists")
 @mock.patch("flyte._internal.imagebuild.image_builder.PersistentCacheImageChecker.image_exists")


### PR DESCRIPTION
## Problem
`ImageBuildEngine._get_builder` only handled the string builder names (`local`/`remote`/registered entry-point names). When a caller supplies an **already-instantiated** builder — e.g. `flyte.init(image_builder=ArteraImageBuilder())` — the object was passed to `_load_custom_image_builders`, where `ep.name != <object>` never matches, so it fell through to:

```
ValueError: Unknown image builder type: <artera.flyte_env.image_builder.v2.ArteraImageBuilder object at 0x...>. Available builders: ['artera', 'local', 'remote']
```

This leaked to Sentry as an SDK crash (FLYTE-SDK-61, on 2.5.7).

## Fix
If `builder` is not a string (and not `None`), it is already an `ImageBuilder` instance — return it directly instead of trying to resolve it as an entry-point name. String names keep their existing behavior, and unknown names still raise the clear `ValueError`.

## Tests
- `test_get_builder_accepts_instance` — an instance is returned as-is.
- `test_get_builder_unknown_name_still_raises` — unknown string names still raise.

fixes FLYTE-SDK-61