### PR TITLE
feat(image): allow base registry override via config or FLYTE_IMAGE_R…

### DIFF
--- a/examples/stress/sleep_fanout.py
+++ b/examples/stress/sleep_fanout.py
@@ -6,31 +6,12 @@ import flyte
 import flyte.report
 from flyte.extras import Sleep
 
-_STRESS_IMAGE_REGISTRY = os.getenv("FLYTE_STRESS_IMAGE_REGISTRY")
-_STRESS_IMAGE_NAME = os.getenv("FLYTE_STRESS_IMAGE_NAME")
-_STRESS_IMAGE_PLATFORMS = tuple(
-    p.strip() for p in os.getenv("FLYTE_STRESS_IMAGE_PLATFORMS", "linux/amd64").split(",") if p.strip()
-)
-_STRESS_RUNTIME_ENV = {
-    k: v
-    for k, v in {
-        "FLYTE_STRESS_IMAGE_REGISTRY": _STRESS_IMAGE_REGISTRY,
-        "FLYTE_STRESS_IMAGE_NAME": _STRESS_IMAGE_NAME,
-        "FLYTE_STRESS_IMAGE_PLATFORMS": ",".join(_STRESS_IMAGE_PLATFORMS),
-    }.items()
-    if v
-}
-
-# Let remote runs redirect image builds to a writable registry without
-# touching the task definitions. For dogfood, this can point at the shared ECR
-# repo used for ad hoc SDK test images. Default to amd64-only so the first
-# build is faster and matches the dogfood cluster architecture.
-stress_image = flyte.Image.from_debian_base(
-    python_version=(3, 12),
-    registry=_STRESS_IMAGE_REGISTRY,
-    name=_STRESS_IMAGE_NAME,
-    platform=_STRESS_IMAGE_PLATFORMS,
-)
+# One shared image for all three environments. The driver builds + pushes it exactly once
+# (with whichever builder is configured, local or remote) before the run starts. The nested
+# `flyte.run(...)` submissions in submit_runs reuse the built URI automatically: the resolved
+# image cache is transported into every task pod, and nested runs seed image resolution from
+# it instead of re-resolving in-cluster.
+stress_image = flyte.Image.from_debian_base(python_version=(3, 12))
 
 
 def _fanout_resources() -> flyte.Resources:
@@ -61,7 +42,6 @@ def _controller_tuning_env() -> dict[str, str]:
 
 def _nested_run_env() -> dict[str, str]:
     return {
-        **_STRESS_RUNTIME_ENV,
         **_controller_tuning_env(),
     }
 
@@ -84,14 +64,12 @@ def _controller_tuning_summary() -> str:
 sleep_env = flyte.TaskEnvironment(
     name="sleep_fanout_leaf",
     image=stress_image,
-    env_vars=_STRESS_RUNTIME_ENV,
     plugin_config=Sleep(),
 )
 
 fanout_env = flyte.TaskEnvironment(
     name="sleep_fanout",
     image=stress_image,
-    env_vars=_STRESS_RUNTIME_ENV,
     resources=_fanout_resources(),
     depends_on=[sleep_env],
 )
@@ -99,7 +77,6 @@ fanout_env = flyte.TaskEnvironment(
 swarm_env = flyte.TaskEnvironment(
     name="sleep_fanout_swarm",
     image=stress_image,
-    env_vars=_STRESS_RUNTIME_ENV,
     resources=flyte.Resources(cpu=1, memory="500Mi"),
     depends_on=[fanout_env],
 )

--- a/src/flyte/_deploy.py
+++ b/src/flyte/_deploy.py
@@ -388,12 +388,20 @@ async def _build_images(
     deployment: DeploymentPlan,
     image_refs: Dict[str, str] | None = None,
     copy_style: "CopyFiles" = "loaded_modules",
+    seed_cache: ImageCache | None = None,
 ) -> ImageCache:
     """
     Build the images for the given deployment plan and update the environment with the built image.
 
     Resolves any ``CodeBundleLayer`` layers first so callers (apply, build_images, serve,
     connectors, run) don't each need to duplicate that step.
+
+    :param seed_cache: Optional ImageCache of environments already built by a prior deploy
+        (e.g. the parent run that launched the current task pod, transported in via the task
+        context). Environments found in the seed reuse the recorded URI directly — skipping
+        hashing, existence checks, and builds. This matters in-cluster, where the resolved
+        URI can differ from the locally-predicted one (the remote builder may push to a
+        backend-assigned system registry) and where there may be no builder available at all.
     """
     from flyte._image import _DEFAULT_IMAGE_REF_NAME, resolve_code_bundle_layer
     from flyte.errors import InvalidImageNameError
@@ -412,6 +420,10 @@ async def _build_images(
     image_identifier_map: Dict[str, str] = {}
     build_run_ids: Dict[str, Any] = {}
     for env_name, env in deployment.envs.items():
+        if seed_cache and env_name in seed_cache.image_lookup:
+            # Already built by a prior deploy — reuse the resolved URI (see docstring).
+            image_identifier_map[env_name] = seed_cache.image_lookup[env_name]
+            continue
         if env.image and not isinstance(env.image, str):
             if env.image._ref_name is not None:
                 if env.image._ref_name in image_refs:
@@ -664,7 +676,11 @@ async def deploy(
 
 
 @syncify
-async def build_images(*envs: Environment, copy_style: "CopyFiles" = "loaded_modules") -> ImageCache:
+async def build_images(
+    *envs: Environment,
+    copy_style: "CopyFiles" = "loaded_modules",
+    seed_cache: ImageCache | None = None,
+) -> ImageCache:
     """
     Build the images for the given environment(s).
     :param envs: One or more environments to build images for. When multiple environments are
@@ -673,6 +689,9 @@ async def build_images(*envs: Environment, copy_style: "CopyFiles" = "loaded_mod
     :param copy_style: Copy style that the eventual deploy will use. Must match the deploy's
         ``--copy-style`` so the image content hashes — and therefore the registry tags — line
         up, letting deploy reuse the pre-built image.
+    :param seed_cache: Optional ImageCache of environments already built by a prior deploy.
+        Seeded environments reuse the recorded URI and skip the build pipeline entirely; see
+        ``_build_images`` for details.
     :return: ImageCache containing the built images.
     """
     from ._internal.imagebuild.image_builder import ImageCache
@@ -680,7 +699,7 @@ async def build_images(*envs: Environment, copy_style: "CopyFiles" = "loaded_mod
     cfg = get_init_config()
     images = cfg.images if cfg else {}
     deployment_plans = plan_deploy(*envs)
-    caches = [await _build_images(plan, images, copy_style) for plan in deployment_plans]
+    caches = [await _build_images(plan, images, copy_style, seed_cache=seed_cache) for plan in deployment_plans]
     if len(caches) == 1:
         return caches[0]
 

--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -481,9 +481,21 @@ _CREATE_FLYTE_USER_CMD = (
 
 def _get_base_registry() -> str:
     """
-    Returns the base registry based on the Flyte config endpoint.
-    If the endpoint contains 'localhost', use the localhost registry.
+    Returns the base registry to use when building images.
+
+    Resolution order:
+
+    1. The ``image.registry`` config entry or the ``FLYTE_IMAGE_REGISTRY`` environment variable,
+       if either is set. This takes precedence over everything else.
+    2. The localhost registry, if the Flyte config endpoint contains 'localhost'.
+    3. The built-in default base registry.
     """
+    from flyte.config._config import ImageConfig
+
+    registry = ImageConfig.auto().registry
+    if registry:
+        return registry
+
     from flyte._initialize import _get_init_config
 
     init_config = _get_init_config()

--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -485,20 +485,22 @@ def _get_base_registry() -> str:
 
     Resolution order:
 
-    1. The ``image.registry`` config entry or the ``FLYTE_IMAGE_REGISTRY`` environment variable,
-       if either is set. This takes precedence over everything else.
-    2. The localhost registry, if the Flyte config endpoint contains 'localhost'.
-    3. The built-in default base registry.
+    1. The registry recorded at init time (``image.registry`` from the config file passed to
+       ``flyte.init_from_config``, or ``flyte.init(image_registry=...)``). This honors an
+       explicit ``--config`` path, which ambient discovery below would miss.
+    2. The ambient ``image.registry`` config entry or the ``FLYTE_IMAGE_REGISTRY`` environment
+       variable — covers images defined before init, or init calls that didn't set a registry.
+    3. The localhost registry, if the Flyte config endpoint contains 'localhost'.
+    4. The built-in default base registry.
     """
+    from flyte._initialize import _get_init_config
     from flyte.config._config import ImageConfig
 
-    registry = ImageConfig.auto().registry
+    init_config = _get_init_config()
+    registry = (init_config.image_registry if init_config else None) or ImageConfig.auto().registry
     if registry:
         return registry
 
-    from flyte._initialize import _get_init_config
-
-    init_config = _get_init_config()
     if init_config and init_config.client:
         endpoint = init_config.client.endpoint
         if endpoint and "localhost" in endpoint:

--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -47,6 +47,7 @@ class _InitConfig(CommonInit):
     storage: Optional[Storage] = None
     image_builder: "ImageBuildEngine.ImageBuilderType" = "local"
     images: typing.Dict[str, str] = field(default_factory=dict)
+    image_registry: str | None = None
 
     def replace(self, **kwargs) -> _InitConfig:
         return replace(self, **kwargs)
@@ -215,6 +216,7 @@ async def init(
     batch_size: int = 1000,
     image_builder: ImageBuildEngine.ImageBuilderType = "local",
     images: typing.Dict[str, str] | None = None,
+    image_registry: str | None = None,
     source_config_path: Optional[Path] = None,
     sync_local_sys_paths: bool = True,
     load_plugin_type_transformers: bool = True,
@@ -256,6 +258,8 @@ async def init(
       batch_size will be split into multiple requests.
     :param image_builder: Optional image builder configuration, if not provided, the default image builder will be used.
     :param images: Optional dict of images that can be used by referencing the image name.
+    :param image_registry: Optional container registry to push built images to, overriding the
+      built-in default base registry. Equivalent to the ``image.registry`` config entry.
     :param source_config_path: Optional path to the source configuration file (This is only used for documentation)
     :param sync_local_sys_paths: Whether to include and synchronize local sys.path entries under the root directory
       into the remote container (default: True).
@@ -317,6 +321,7 @@ async def init(
             batch_size=batch_size,
             image_builder=image_builder,
             images=images or {},
+            image_registry=image_registry,
             source_config_path=source_config_path,
             sync_local_sys_paths=sync_local_sys_paths,
             local_persistence=local_persistence,
@@ -406,6 +411,7 @@ async def init_from_config(
         image_builder=image_builder or cfg.image.builder or "local",
         batch_size=batch_size,
         images=cfg.image.image_refs,
+        image_registry=cfg.image.registry,
         storage=storage,
         source_config_path=cfg_path,
         sync_local_sys_paths=sync_local_sys_paths,

--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     from flyte.remote._task import LazyEntity
 
     from ._code_bundle import CopyFiles
+    from ._internal.imagebuild.image_builder import ImageCache
 
 Mode = Literal["local", "remote", "hybrid"]
 CacheLookupScope = Literal["global", "project-domain"]
@@ -72,6 +73,22 @@ async def _get_code_bundle_for_run(name: str) -> CodeBundle | None:
 def _get_main_run_mode() -> Mode | None:
     """Get the current run mode from the context variable."""
     return _run_mode_var.get()
+
+
+def _ambient_image_cache() -> ImageCache | None:
+    """Image cache transported into this process by the run that launched it, if any.
+
+    Inside a task pod, the parent run's deploy already built every environment in its plan
+    and shipped the resolved URIs here (``TaskContext.compiled_image_cache``). A nested
+    ``flyte.run(...)`` submitted from task code seeds image resolution with it so
+    already-built environments are never re-resolved in-cluster — where the predicted URI
+    can differ from where the builder actually pushed (e.g. the remote builder's system
+    registry), and where no builder may be available at all. Same-run child calls already
+    reuse this cache via the controller; this extends that behavior to nested runs.
+    Returns None on the driver (no task context), leaving behavior unchanged there.
+    """
+    tctx = internal_ctx().data.task_context
+    return tctx.compiled_image_cache if tctx else None
 
 
 def _to_cache_lookup_scope(scope: CacheLookupScope | None = None):
@@ -229,7 +246,10 @@ class _Runner:
                 _env.image = resolve_code_bundle_layer(_env.image, self._copy_files, pathlib.Path(cfg.root_dir))
 
         if not self._dry_run:
-            image_cache = await build_images.aio(parent_env)
+            # Seed with the cache transported from the launching run (if we're inside a task
+            # pod) so already-built environments reuse their pushed URIs instead of being
+            # re-resolved in-cluster. No-op on the driver.
+            image_cache = await build_images.aio(parent_env, seed_cache=_ambient_image_cache())
         else:
             image_cache = None
 
@@ -664,7 +684,7 @@ class _Runner:
             if isinstance(_env.image, Image):
                 _env.image = resolve_code_bundle_layer(_env.image, self._copy_files, pathlib.Path(cfg.root_dir))
 
-        image_cache = await build_images.aio(cast(Environment, obj.parent_env()))
+        image_cache = await build_images.aio(cast(Environment, obj.parent_env()), seed_cache=_ambient_image_cache())
 
         code_bundle = None
         if self._name is not None:

--- a/src/flyte/cli/_create.py
+++ b/src/flyte/cli/_create.py
@@ -268,6 +268,17 @@ def secret(
     show_default=True,
 )
 @click.option(
+    "--registry",
+    type=str,
+    default=None,
+    required=False,
+    help=(
+        "Container registry to use as the base registry when building images (e.g. 'ghcr.io/my-org'). "
+        "When set, this overrides the built-in default base registry. Equivalent to the 'image.registry' "
+        "config entry or the FLYTE_IMAGE_REGISTRY environment variable."
+    ),
+)
+@click.option(
     "--auth-type",
     type=click.Choice(common.ALL_AUTH_OPTIONS, case_sensitive=False),
     default=None,
@@ -291,6 +302,7 @@ def config(
     domain: str | None = None,
     force: bool = False,
     image_builder: str | None = None,
+    registry: str | None = None,
     auth_type: str | None = None,
     local_persistence: bool = False,
 ):
@@ -337,6 +349,8 @@ def config(
     image: Dict[str, str] = {}
     if image_builder:
         image["builder"] = image_builder
+    if registry:
+        image["registry"] = registry
 
     local: Dict[str, Any] = {}
     if local_persistence:

--- a/src/flyte/config/_config.py
+++ b/src/flyte/config/_config.py
@@ -152,6 +152,7 @@ class ImageConfig(object):
 
     builder: str | None = None
     image_refs: typing.Dict[str, str] = field(default_factory=dict)
+    registry: str | None = None
 
     @classmethod
     def auto(cls, config_file: typing.Optional[typing.Union[str, ConfigFile]] = None) -> "ImageConfig":
@@ -164,6 +165,7 @@ class ImageConfig(object):
         kwargs: typing.Dict[str, typing.Any] = {}
         kwargs = set_if_exists(kwargs, "builder", _internal.Image.BUILDER.read(config_file))
         kwargs = set_if_exists(kwargs, "image_refs", _internal.Image.IMAGE_REFS.read(config_file))
+        kwargs = set_if_exists(kwargs, "registry", _internal.Image.REGISTRY.read(config_file))
         return ImageConfig(**kwargs)
 
 

--- a/src/flyte/config/_internal.py
+++ b/src/flyte/config/_internal.py
@@ -76,3 +76,9 @@ class Image(object):
 
     BUILDER = ConfigEntry(YamlConfigEntry("image.builder"))
     IMAGE_REFS = ConfigEntry(YamlConfigEntry("image.image_refs"))
+    REGISTRY = ConfigEntry(YamlConfigEntry("image.registry"))
+    """
+    The container registry to use as the base registry when building images (e.g. ``ghcr.io/my-org``).
+    Read from the ``image.registry`` config entry or the ``FLYTE_IMAGE_REGISTRY`` environment variable.
+    When set, this overrides the built-in default base registry.
+    """

--- a/tests/flyte/test_deploy_image_cache.py
+++ b/tests/flyte/test_deploy_image_cache.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+import flyte
 from flyte._deploy import DeploymentPlan, _build_images
 from flyte._image import Image
 from flyte._task_environment import TaskEnvironment
@@ -40,3 +41,88 @@ async def test_create_image_cache_lookup(python_version, expected_py_version):
 
         # Check the image_lookup dict contains the expected image URI
         assert image_cache.image_lookup[env_name] == fake_image_uri
+
+
+# ---------------------------------------------------------------------------
+# seed_cache: nested runs reuse URIs already resolved by the launching run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_images_seed_cache_reuses_uri_and_skips_build():
+    """An env present in seed_cache reuses the recorded URI; the builder is never invoked."""
+    flyte.init()
+    from flyte._internal.imagebuild.image_builder import ImageCache
+
+    env_name = "seeded_env"
+    seeded_uri = "356633062068.dkr.ecr.us-east-2.amazonaws.com/union/demo:flyte-abc123"
+    env = TaskEnvironment(name=env_name, image=Image.from_debian_base(python_version=(3, 12)))
+    plan = DeploymentPlan(envs={env_name: env})
+    seed = ImageCache(image_lookup={env_name: seeded_uri})
+
+    with patch("flyte._deploy._build_image_bg", new_callable=AsyncMock) as mock_build:
+        image_cache = await _build_images(plan, seed_cache=seed)
+
+    mock_build.assert_not_called()
+    assert image_cache.image_lookup[env_name] == seeded_uri
+
+
+@pytest.mark.asyncio
+async def test_build_images_seed_cache_partial_hit():
+    """Envs missing from seed_cache still build; seeded envs are reused."""
+    flyte.init()
+    from flyte._internal.imagebuild.image_builder import ImageCache
+
+    seeded_uri = "registry.example.com/prebuilt:tag1"
+    built_uri = "registry.example.com/fresh:tag2"
+    seeded_env = TaskEnvironment(name="seeded_env", image=Image.from_debian_base(python_version=(3, 12)))
+    fresh_env = TaskEnvironment(name="fresh_env", image=Image.from_debian_base(python_version=(3, 12)))
+    plan = DeploymentPlan(envs={"seeded_env": seeded_env, "fresh_env": fresh_env})
+    seed = ImageCache(image_lookup={"seeded_env": seeded_uri})
+
+    with patch("flyte._deploy._build_image_bg", new_callable=AsyncMock) as mock_build:
+        mock_build.return_value = ("fresh_env", built_uri, None)
+        image_cache = await _build_images(plan, seed_cache=seed)
+
+    assert mock_build.call_count == 1
+    assert mock_build.call_args[0][0] == "fresh_env"
+    assert image_cache.image_lookup == {"seeded_env": seeded_uri, "fresh_env": built_uri}
+
+
+@pytest.mark.asyncio
+async def test_build_images_no_seed_builds_everything():
+    """seed_cache=None preserves existing behavior."""
+    flyte.init()
+    env_name = "plain_env"
+    built_uri = "registry.example.com/fresh:tag3"
+    env = TaskEnvironment(name=env_name, image=Image.from_debian_base(python_version=(3, 12)))
+    plan = DeploymentPlan(envs={env_name: env})
+
+    with patch("flyte._deploy._build_image_bg", new_callable=AsyncMock) as mock_build:
+        mock_build.return_value = (env_name, built_uri, None)
+        image_cache = await _build_images(plan, seed_cache=None)
+
+    assert mock_build.call_count == 1
+    assert image_cache.image_lookup[env_name] == built_uri
+
+
+def test_ambient_image_cache_none_on_driver():
+    """Outside a task pod there is no task context, so no seed is used."""
+    from flyte._run import _ambient_image_cache
+
+    assert _ambient_image_cache() is None
+
+
+def test_ambient_image_cache_returns_transported_cache_in_pod():
+    """Inside a task pod the transported compiled_image_cache is returned as the seed."""
+    from unittest.mock import Mock
+
+    from flyte._internal.imagebuild.image_builder import ImageCache
+    from flyte._run import _ambient_image_cache
+
+    cache = ImageCache(image_lookup={"env_a": "registry.example.com/img:tag"})
+    fake_ctx = Mock()
+    fake_ctx.data.task_context.compiled_image_cache = cache
+
+    with patch("flyte._run.internal_ctx", return_value=fake_ctx):
+        assert _ambient_image_cache() is cache

--- a/tests/flyte/test_image.py
+++ b/tests/flyte/test_image.py
@@ -818,13 +818,26 @@ def test_resolve_code_bundle_loaded_modules_copy_style_none(tmp_path):
     assert bundle_layers[0].dst == "."
 
 
-def test_get_base_registry_returns_default_when_not_initialized():
+@pytest.fixture
+def no_ambient_registry(monkeypatch):
+    """Isolate _get_base_registry from any ambient registry (local .flyte config or env var).
+
+    The endpoint-based resolution only runs when no registry is configured, so tests that
+    exercise it must not pick up a registry from the environment they happen to run in.
+    """
+    monkeypatch.delenv("FLYTE_IMAGE_REGISTRY", raising=False)
+    with patch("flyte.config._config.ImageConfig.auto") as mock_auto:
+        mock_auto.return_value = MagicMock(registry=None)
+        yield
+
+
+def test_get_base_registry_returns_default_when_not_initialized(no_ambient_registry):
     """When flyte is not initialized, _get_base_registry returns the default registry."""
     with patch("flyte._initialize._get_init_config", return_value=None):
         assert _get_base_registry() == _BASE_REGISTRY
 
 
-def test_get_base_registry_returns_default_when_no_client():
+def test_get_base_registry_returns_default_when_no_client(no_ambient_registry):
     """When init config has no client, _get_base_registry returns the default registry."""
     mock_config = MagicMock()
     mock_config.client = None
@@ -832,7 +845,7 @@ def test_get_base_registry_returns_default_when_no_client():
         assert _get_base_registry() == _BASE_REGISTRY
 
 
-def test_get_base_registry_returns_default_for_remote_endpoint():
+def test_get_base_registry_returns_default_for_remote_endpoint(no_ambient_registry):
     """When endpoint is a remote URL, _get_base_registry returns the default registry."""
     mock_config = MagicMock()
     mock_config.client.endpoint = "dns:///my-cluster.example.com"
@@ -840,7 +853,7 @@ def test_get_base_registry_returns_default_for_remote_endpoint():
         assert _get_base_registry() == _BASE_REGISTRY
 
 
-def test_get_base_registry_returns_localhost_for_localhost_endpoint():
+def test_get_base_registry_returns_localhost_for_localhost_endpoint(no_ambient_registry):
     """When endpoint contains 'localhost', _get_base_registry returns the localhost registry."""
     mock_config = MagicMock()
     mock_config.client.endpoint = "localhost:8090"
@@ -848,7 +861,7 @@ def test_get_base_registry_returns_localhost_for_localhost_endpoint():
         assert _get_base_registry() == _LOCALHOST_REGISTRY
 
 
-def test_get_base_registry_returns_localhost_for_localhost_in_url():
+def test_get_base_registry_returns_localhost_for_localhost_in_url(no_ambient_registry):
     """When endpoint contains 'localhost' as part of a URL, _get_base_registry returns the localhost registry."""
     mock_config = MagicMock()
     mock_config.client.endpoint = "dns:///localhost:30080"
@@ -856,7 +869,7 @@ def test_get_base_registry_returns_localhost_for_localhost_in_url():
         assert _get_base_registry() == _LOCALHOST_REGISTRY
 
 
-def test_get_base_registry_returns_default_for_empty_endpoint():
+def test_get_base_registry_returns_default_for_empty_endpoint(no_ambient_registry):
     """When endpoint is empty string, _get_base_registry returns the default registry."""
     mock_config = MagicMock()
     mock_config.client.endpoint = ""

--- a/tests/flyte/test_image.py
+++ b/tests/flyte/test_image.py
@@ -831,6 +831,17 @@ def no_ambient_registry(monkeypatch):
         yield
 
 
+def _mock_init_config(endpoint=None, image_registry=None):
+    """Init-config mock with image_registry defaulted to None (a bare MagicMock attr is truthy)."""
+    mock_config = MagicMock()
+    mock_config.image_registry = image_registry
+    if endpoint is None:
+        mock_config.client = None
+    else:
+        mock_config.client.endpoint = endpoint
+    return mock_config
+
+
 def test_get_base_registry_returns_default_when_not_initialized(no_ambient_registry):
     """When flyte is not initialized, _get_base_registry returns the default registry."""
     with patch("flyte._initialize._get_init_config", return_value=None):
@@ -839,52 +850,42 @@ def test_get_base_registry_returns_default_when_not_initialized(no_ambient_regis
 
 def test_get_base_registry_returns_default_when_no_client(no_ambient_registry):
     """When init config has no client, _get_base_registry returns the default registry."""
-    mock_config = MagicMock()
-    mock_config.client = None
-    with patch("flyte._initialize._get_init_config", return_value=mock_config):
+    with patch("flyte._initialize._get_init_config", return_value=_mock_init_config()):
         assert _get_base_registry() == _BASE_REGISTRY
 
 
 def test_get_base_registry_returns_default_for_remote_endpoint(no_ambient_registry):
     """When endpoint is a remote URL, _get_base_registry returns the default registry."""
-    mock_config = MagicMock()
-    mock_config.client.endpoint = "dns:///my-cluster.example.com"
+    mock_config = _mock_init_config(endpoint="dns:///my-cluster.example.com")
     with patch("flyte._initialize._get_init_config", return_value=mock_config):
         assert _get_base_registry() == _BASE_REGISTRY
 
 
 def test_get_base_registry_returns_localhost_for_localhost_endpoint(no_ambient_registry):
     """When endpoint contains 'localhost', _get_base_registry returns the localhost registry."""
-    mock_config = MagicMock()
-    mock_config.client.endpoint = "localhost:8090"
+    mock_config = _mock_init_config(endpoint="localhost:8090")
     with patch("flyte._initialize._get_init_config", return_value=mock_config):
         assert _get_base_registry() == _LOCALHOST_REGISTRY
 
 
 def test_get_base_registry_returns_localhost_for_localhost_in_url(no_ambient_registry):
     """When endpoint contains 'localhost' as part of a URL, _get_base_registry returns the localhost registry."""
-    mock_config = MagicMock()
-    mock_config.client.endpoint = "dns:///localhost:30080"
+    mock_config = _mock_init_config(endpoint="dns:///localhost:30080")
     with patch("flyte._initialize._get_init_config", return_value=mock_config):
         assert _get_base_registry() == _LOCALHOST_REGISTRY
 
 
 def test_get_base_registry_returns_default_for_empty_endpoint(no_ambient_registry):
     """When endpoint is empty string, _get_base_registry returns the default registry."""
-    mock_config = MagicMock()
-    mock_config.client.endpoint = ""
+    mock_config = _mock_init_config(endpoint="")
     with patch("flyte._initialize._get_init_config", return_value=mock_config):
         assert _get_base_registry() == _BASE_REGISTRY
 
 
 def test_get_base_registry_uses_env_var(monkeypatch):
     """When FLYTE_IMAGE_REGISTRY is set, _get_base_registry returns it, overriding endpoint logic."""
-    from flyte.config._reader import get_config_file
-
-    get_config_file.cache_clear()
     monkeypatch.setenv("FLYTE_IMAGE_REGISTRY", "my.registry.io/team")
-    mock_config = MagicMock()
-    mock_config.client.endpoint = "localhost:8090"
+    mock_config = _mock_init_config(endpoint="localhost:8090")
     with patch("flyte._initialize._get_init_config", return_value=mock_config):
         assert _get_base_registry() == "my.registry.io/team"
 
@@ -892,9 +893,18 @@ def test_get_base_registry_uses_env_var(monkeypatch):
 def test_get_base_registry_uses_config(monkeypatch):
     """When image.registry is set in config, _get_base_registry returns it."""
     monkeypatch.delenv("FLYTE_IMAGE_REGISTRY", raising=False)
-    with patch("flyte.config._config.ImageConfig.auto") as mock_auto:
-        mock_auto.return_value = MagicMock(registry="cfg.registry.io/team")
-        assert _get_base_registry() == "cfg.registry.io/team"
+    with patch("flyte._initialize._get_init_config", return_value=_mock_init_config()):
+        with patch("flyte.config._config.ImageConfig.auto") as mock_auto:
+            mock_auto.return_value = MagicMock(registry="cfg.registry.io/team")
+            assert _get_base_registry() == "cfg.registry.io/team"
+
+
+def test_get_base_registry_uses_init_config_registry(no_ambient_registry):
+    """The registry recorded at init time (e.g. from an explicit --config file) wins, even
+    when ambient config discovery finds nothing."""
+    mock_config = _mock_init_config(endpoint="localhost:8090", image_registry="init.registry.io/team")
+    with patch("flyte._initialize._get_init_config", return_value=mock_config):
+        assert _get_base_registry() == "init.registry.io/team"
 
 
 def test_get_base_registry_falls_back_when_registry_unset(monkeypatch):
@@ -902,8 +912,7 @@ def test_get_base_registry_falls_back_when_registry_unset(monkeypatch):
     monkeypatch.delenv("FLYTE_IMAGE_REGISTRY", raising=False)
     with patch("flyte.config._config.ImageConfig.auto") as mock_auto:
         mock_auto.return_value = MagicMock(registry=None)
-        mock_config = MagicMock()
-        mock_config.client.endpoint = "localhost:8090"
+        mock_config = _mock_init_config(endpoint="localhost:8090")
         with patch("flyte._initialize._get_init_config", return_value=mock_config):
             assert _get_base_registry() == _LOCALHOST_REGISTRY
 

--- a/tests/flyte/test_image.py
+++ b/tests/flyte/test_image.py
@@ -864,6 +864,37 @@ def test_get_base_registry_returns_default_for_empty_endpoint():
         assert _get_base_registry() == _BASE_REGISTRY
 
 
+def test_get_base_registry_uses_env_var(monkeypatch):
+    """When FLYTE_IMAGE_REGISTRY is set, _get_base_registry returns it, overriding endpoint logic."""
+    from flyte.config._reader import get_config_file
+
+    get_config_file.cache_clear()
+    monkeypatch.setenv("FLYTE_IMAGE_REGISTRY", "my.registry.io/team")
+    mock_config = MagicMock()
+    mock_config.client.endpoint = "localhost:8090"
+    with patch("flyte._initialize._get_init_config", return_value=mock_config):
+        assert _get_base_registry() == "my.registry.io/team"
+
+
+def test_get_base_registry_uses_config(monkeypatch):
+    """When image.registry is set in config, _get_base_registry returns it."""
+    monkeypatch.delenv("FLYTE_IMAGE_REGISTRY", raising=False)
+    with patch("flyte.config._config.ImageConfig.auto") as mock_auto:
+        mock_auto.return_value = MagicMock(registry="cfg.registry.io/team")
+        assert _get_base_registry() == "cfg.registry.io/team"
+
+
+def test_get_base_registry_falls_back_when_registry_unset(monkeypatch):
+    """When no registry is configured, _get_base_registry falls back to endpoint-based logic."""
+    monkeypatch.delenv("FLYTE_IMAGE_REGISTRY", raising=False)
+    with patch("flyte.config._config.ImageConfig.auto") as mock_auto:
+        mock_auto.return_value = MagicMock(registry=None)
+        mock_config = MagicMock()
+        mock_config.client.endpoint = "localhost:8090"
+        with patch("flyte._initialize._get_init_config", return_value=mock_config):
+            assert _get_base_registry() == _LOCALHOST_REGISTRY
+
+
 def test_released_default_image_is_not_cloned():
     """A released, unmodified default image should have _is_cloned=False so the SDK skips building it."""
     with patch("flyte._version.__version__", "1.2.3"):


### PR DESCRIPTION
…EGISTRY

Add an `image.registry` config entry (read from the config file or the `FLYTE_IMAGE_REGISTRY` environment variable). When set, `_get_base_registry` uses it instead of the built-in default/localhost base registry, letting users point image builds at their own registry without code changes.

Resolution order in `_get_base_registry`:
1. `image.registry` config / `FLYTE_IMAGE_REGISTRY` env var
2. localhost registry when the endpoint is localhost
3. built-in default base registry