### PR TITLE
feat: populate RunSpec.related_to on rerun and in-container flyte.run

### DIFF
--- a/plugins/anthropic/uv.lock
+++ b/plugins/anthropic/uv.lock
@@ -393,7 +393,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -460,7 +460,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -469,7 +469,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]

--- a/plugins/bigquery/uv.lock
+++ b/plugins/bigquery/uv.lock
@@ -463,7 +463,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -530,7 +530,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -539,7 +539,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]

--- a/plugins/codegen/uv.lock
+++ b/plugins/codegen/uv.lock
@@ -765,7 +765,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -832,7 +832,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -841,7 +841,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]

--- a/plugins/dask/uv.lock
+++ b/plugins/dask/uv.lock
@@ -619,7 +619,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -686,7 +686,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -695,7 +695,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]

--- a/plugins/databricks/uv.lock
+++ b/plugins/databricks/uv.lock
@@ -648,7 +648,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -715,7 +715,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -724,7 +724,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]

--- a/plugins/echo/uv.lock
+++ b/plugins/echo/uv.lock
@@ -359,7 +359,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -426,7 +426,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -435,7 +435,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]

--- a/plugins/gemini/uv.lock
+++ b/plugins/gemini/uv.lock
@@ -479,7 +479,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -546,7 +546,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -555,7 +555,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]

--- a/plugins/hitl/uv.lock
+++ b/plugins/hitl/uv.lock
@@ -389,7 +389,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -456,7 +456,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -465,7 +465,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]

--- a/plugins/huggingface/uv.lock
+++ b/plugins/huggingface/uv.lock
@@ -712,7 +712,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -779,7 +779,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -788,7 +788,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]

--- a/plugins/hydra/uv.lock
+++ b/plugins/hydra/uv.lock
@@ -485,7 +485,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -552,7 +552,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -561,7 +561,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]

--- a/plugins/jsonl/uv.lock
+++ b/plugins/jsonl/uv.lock
@@ -365,7 +365,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -432,7 +432,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -441,7 +441,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]

--- a/plugins/mlflow/uv.lock
+++ b/plugins/mlflow/uv.lock
@@ -15,6 +15,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P5D"
 
 [options.exclude-newer-package]
+flyteplugins-union = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 flyteidl2 = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 flyte-controller-base = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 

--- a/plugins/omegaconf/uv.lock
+++ b/plugins/omegaconf/uv.lock
@@ -371,7 +371,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -438,7 +438,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -447,7 +447,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]

--- a/plugins/openai/uv.lock
+++ b/plugins/openai/uv.lock
@@ -472,7 +472,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -539,7 +539,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -548,7 +548,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]

--- a/plugins/pandera/uv.lock
+++ b/plugins/pandera/uv.lock
@@ -585,7 +585,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -652,7 +652,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -661,7 +661,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]

--- a/plugins/papermill/uv.lock
+++ b/plugins/papermill/uv.lock
@@ -15,6 +15,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P5D"
 
 [options.exclude-newer-package]
+flyteplugins-union = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 flyteidl2 = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 flyte-controller-base = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 

--- a/plugins/polars/uv.lock
+++ b/plugins/polars/uv.lock
@@ -366,7 +366,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -433,7 +433,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -442,7 +442,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]

--- a/plugins/pytorch/uv.lock
+++ b/plugins/pytorch/uv.lock
@@ -445,7 +445,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -512,7 +512,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -521,7 +521,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]

--- a/plugins/ray/pyproject.toml
+++ b/plugins/ray/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.10,<3.13"
 dependencies = [
     "ray[default]",
     "flyte",
-    "flyteidl2==2.0.26",
+    "flyteidl2==2.0.27",
 ]
 
 [dependency-groups]

--- a/plugins/ray/uv.lock
+++ b/plugins/ray/uv.lock
@@ -536,7 +536,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -603,7 +603,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -612,7 +612,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]
@@ -634,7 +634,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "flyte", editable = "../../" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "ray", extras = ["default"] },
 ]
 

--- a/plugins/redis/uv.lock
+++ b/plugins/redis/uv.lock
@@ -391,7 +391,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -458,7 +458,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -467,7 +467,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]

--- a/plugins/sglang/uv.lock
+++ b/plugins/sglang/uv.lock
@@ -365,7 +365,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -432,7 +432,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -441,7 +441,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]

--- a/plugins/snowflake/uv.lock
+++ b/plugins/snowflake/uv.lock
@@ -512,7 +512,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -579,7 +579,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -588,7 +588,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]

--- a/plugins/spark/uv.lock
+++ b/plugins/spark/uv.lock
@@ -463,7 +463,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -530,7 +530,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -539,7 +539,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]

--- a/plugins/vllm/uv.lock
+++ b/plugins/vllm/uv.lock
@@ -365,7 +365,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -432,7 +432,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -441,7 +441,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]

--- a/plugins/wandb/uv.lock
+++ b/plugins/wandb/uv.lock
@@ -459,7 +459,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -526,7 +526,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -535,7 +535,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "async-lru>=2.0.5",
     "mashumaro",
     "aiolimiter>=1.2.1",
-    "flyteidl2==2.0.26",
+    "flyteidl2==2.0.27",
     "packaging",
     "sentry-sdk>=2.0",
     "pyOpenSSL>=24.0.0",

--- a/rs_controller/Cargo.lock
+++ b/rs_controller/Cargo.lock
@@ -269,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a684621f6b0ed4cb921f05fd4baa84e83451d737406c0ed8aa720f0f6042c155"
+checksum = "bd9802dcb1dc809ee9182bed3168142bd595dc9fa8bc4f062e5e106075dfaecb"
 dependencies = [
  "async-trait",
  "futures",

--- a/rs_controller/Cargo.toml
+++ b/rs_controller/Cargo.toml
@@ -34,7 +34,7 @@ async-trait = "0.1"
 thiserror = "1.0"
 # Uncomment this if you need to use local flyteidl2
 #flyteidl2 = { path = "/Users/ytong/go/src/github.com/flyteorg/flyte/gen/rust" }
-flyteidl2 = "=2.0.26"
+flyteidl2 = "=2.0.27"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/rs_controller/pyproject.toml
+++ b/rs_controller/pyproject.toml
@@ -9,7 +9,7 @@ description = "Rust controller for Union"
 requires-python = ">=3.10"
 classifiers = ["Programming Language :: Python", "Programming Language :: Rust"]
 dependencies = [
-    "flyteidl2==2.0.26",
+    "flyteidl2==2.0.27",
 ]
 [tool.maturin]
 module-name = "flyte_controller_base"

--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -858,6 +858,7 @@ async def _init_for_testing(
     root_dir: Path | None = None,
     log_level: int | None = None,
     client: ClientSet | None = None,
+    org: str | None = None,
 ):
     global _init_config  # noqa: PLW0603
 
@@ -871,6 +872,7 @@ async def _init_for_testing(
             project=project,
             domain=domain,
             client=client,
+            org=org,
         )
 
 

--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -196,6 +196,43 @@ class _Runner:
             return rerun_run_name
         return r  # explicit run-name string
 
+    def _resolve_related_to(self, source_run: Any = None) -> Any | None:
+        """Resolve the provenance pointer (``RunSpec.related_to``) for the run being created.
+
+        An explicit ``source_run`` (the rerun path) wins; otherwise, when invoked from inside a
+        running remote task container (``TaskContext.is_in_cluster()``), the current run is the
+        parent. The effective source scope is the source's ids with empty fields inherited from
+        the init config; the pointer is stamped only when that scope equals the new run's target
+        scope exactly and all four id fields are non-empty (the server requires min_len=1 on
+        each, and related_to is same-org/project/domain as the new run by contract). Returns
+        None otherwise — a provenance pointer must never fail run creation. Pure resolution,
+        no I/O.
+        """
+        from flyteidl2.common import identifier_pb2
+
+        if source_run is not None:
+            org, project, domain, name = source_run.org, source_run.project, source_run.domain, source_run.name
+        else:
+            tctx = internal_ctx().data.task_context
+            if tctx is None or not tctx.is_in_cluster():
+                return None
+            action = tctx.action
+            org, project, domain, name = action.org or "", action.project or "", action.domain or "", action.run_name
+
+        cfg = get_init_config()
+        org = org or cfg.org or ""
+        project = project or cfg.project or ""
+        domain = domain or cfg.domain or ""
+
+        target = (cfg.org or "", self._project or cfg.project or "", self._domain or cfg.domain or "")
+        if (org, project, domain) != target:
+            logger.debug(f"Skipping RunSpec.related_to: source scope {(org, project, domain)} != target {target}")
+            return None
+        if not (org and project and domain and name):
+            logger.debug("Skipping RunSpec.related_to: incomplete source run identifier")
+            return None
+        return identifier_pb2.RunIdentifier(org=org, project=project, domain=domain, name=name)
+
     async def _build_task_spec_from_template(self, obj: TaskTemplate[P, R, F]) -> Tuple[Any, Any, str]:
         """Build ``(task_spec, code_bundle, version)`` from a local ``TaskTemplate``.
 
@@ -353,14 +390,18 @@ class _Runner:
             )
         return None, identifier_pb2.ProjectIdentifier(name=project, domain=domain, organization=org)
 
-    def _apply_overrides(self, base: Any, *, task: Any = None, recover_ref: str | None = None) -> Any:
+    def _apply_overrides(
+        self, base: Any, *, task: Any = None, recover_ref: str | None = None, related_to: Any = None
+    ) -> Any:
         """Build the ``RunSpec`` for ``create_run``.
 
         ``base is None`` -> a fresh spec from runner config (the run / recover path).
         ``base`` set     -> deep-copy a prior run's ``RunSpec`` and merge runner overrides by key
         (the rerun path: env merge + explicitly-set field overrides). Pure proto assembly, no I/O.
         This is the single place runner config maps onto a ``RunSpec``. ``recover_ref`` is the already-
-        resolved reference run to recover from (see ``_resolve_recover_ref``), or None.
+        resolved reference run to recover from (see ``_resolve_recover_ref``), or None. ``related_to``
+        is the already-resolved provenance pointer (see ``_resolve_related_to``), or None; stamped
+        only when this flyteidl2 build has the field.
         """
         from flyteidl2.core import literals_pb2, security_pb2
         from flyteidl2.task import run_pb2
@@ -462,6 +503,16 @@ class _Runner:
             from flyteidl2.common import identifier_pb2
 
             run_spec.recover.CopyFrom(run_pb2.Recover(run_id=identifier_pb2.RunIdentifier(name=recover_ref)))
+
+        # related_to: implicit provenance (rerun source, or the invoking in-cluster run). Unlike
+        # recover — explicitly user-requested, so absence raises — silently skip when this
+        # flyteidl2 build predates RunSpec.related_to so reruns keep working on older builds.
+        if "related_to" in run_pb2.RunSpec.DESCRIPTOR.fields_by_name:
+            run_spec.ClearField("related_to")  # never inherit a rerun base's stale (grandparent) pointer
+            if related_to is not None:
+                run_spec.related_to.CopyFrom(related_to)
+        elif related_to is not None:
+            logger.debug("RunSpec.related_to unavailable in this flyteidl2 build; skipping provenance pointer.")
 
         return run_spec
 
@@ -603,7 +654,12 @@ class _Runner:
                 if task_spec.task_template.id.version == "":
                     task_spec.task_template.id.version = version
 
-            run_spec = self._apply_overrides(None, task=task, recover_ref=self._resolve_recover_ref(None))
+            run_spec = self._apply_overrides(
+                None,
+                task=task,
+                recover_ref=self._resolve_recover_ref(None),
+                related_to=self._resolve_related_to(),
+            )
             return await self._submit_remote(
                 task_spec=task_spec,
                 task_id=task_id,
@@ -1058,7 +1114,18 @@ class _Runner:
             if tt_id.version == "":
                 tt_id.version = version
 
-        run_spec = self._apply_overrides(base_run_spec, recover_ref=self._resolve_recover_ref(run_name))
+        # Provenance: the run being rerun. Explicit source wins entirely over any ambient task
+        # context (a rerun triggered from inside a task points at the rerun source, not the
+        # invoking run). The fetched id can be empty in degenerate cases; fall back to run_name.
+        from flyteidl2.common import identifier_pb2
+
+        src = action_details.pb2.id.run
+        related_to = self._resolve_related_to(
+            identifier_pb2.RunIdentifier(org=src.org, project=src.project, domain=src.domain, name=src.name or run_name)
+        )
+        run_spec = self._apply_overrides(
+            base_run_spec, recover_ref=self._resolve_recover_ref(run_name), related_to=related_to
+        )
         return await self._submit_remote(
             task_spec=task_spec,
             task_id=None,

--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -400,8 +400,7 @@ class _Runner:
         (the rerun path: env merge + explicitly-set field overrides). Pure proto assembly, no I/O.
         This is the single place runner config maps onto a ``RunSpec``. ``recover_ref`` is the already-
         resolved reference run to recover from (see ``_resolve_recover_ref``), or None. ``related_to``
-        is the already-resolved provenance pointer (see ``_resolve_related_to``), or None; stamped
-        only when this flyteidl2 build has the field.
+        is the already-resolved provenance pointer (see ``_resolve_related_to``), or None.
         """
         from flyteidl2.core import literals_pb2, security_pb2
         from flyteidl2.task import run_pb2
@@ -504,15 +503,10 @@ class _Runner:
 
             run_spec.recover.CopyFrom(run_pb2.Recover(run_id=identifier_pb2.RunIdentifier(name=recover_ref)))
 
-        # related_to: implicit provenance (rerun source, or the invoking in-cluster run). Unlike
-        # recover — explicitly user-requested, so absence raises — silently skip when this
-        # flyteidl2 build predates RunSpec.related_to so reruns keep working on older builds.
-        if "related_to" in run_pb2.RunSpec.DESCRIPTOR.fields_by_name:
-            run_spec.ClearField("related_to")  # never inherit a rerun base's stale (grandparent) pointer
-            if related_to is not None:
-                run_spec.related_to.CopyFrom(related_to)
-        elif related_to is not None:
-            logger.debug("RunSpec.related_to unavailable in this flyteidl2 build; skipping provenance pointer.")
+        # related_to: implicit provenance (rerun source, or the invoking in-cluster run).
+        run_spec.ClearField("related_to")  # never inherit a rerun base's stale (grandparent) pointer
+        if related_to is not None:
+            run_spec.related_to.CopyFrom(related_to)
 
         return run_spec
 

--- a/tests/flyte/test_related_to.py
+++ b/tests/flyte/test_related_to.py
@@ -1,0 +1,93 @@
+"""Unit tests for _Runner._resolve_related_to: the provenance pointer (RunSpec.related_to)
+resolution rules. These run on any flyteidl2 build — the resolver only constructs a
+RunIdentifier; the descriptor-gated stamping is covered in test_run_runspec_chars.py."""
+
+import pytest
+from flyteidl2.common import identifier_pb2
+
+from flyte._context import Context, ContextData
+from flyte._initialize import _init_for_testing
+from flyte._run import _Runner
+from flyte.models import ActionID, RawDataPath, TaskContext
+from flyte.report import Report
+
+
+def _fake_task_ctx(mode="remote", org="o", project="p", domain="d", run_name="parent-run"):
+    """A Context carrying a TaskContext, as the in-container runtime would set up."""
+    action = ActionID(name="a0", run_name=run_name, project=project, domain=domain, org=org)
+    task_context = TaskContext(
+        action=action,
+        version="v1",
+        raw_data_path=RawDataPath(path="/tmp/raw"),
+        output_path="/tmp/out",
+        run_base_dir="/tmp/base",
+        report=Report(name="a0"),
+        mode=mode,
+    )
+    return Context(data=ContextData(task_context=task_context))
+
+
+@pytest.mark.asyncio
+async def test_no_ctx_no_source_returns_none():
+    await _init_for_testing(project="p", domain="d", org="o")
+    assert _Runner(force_mode="remote")._resolve_related_to() is None
+
+
+@pytest.mark.asyncio
+async def test_remote_ctx_stamps_current_run():
+    await _init_for_testing(project="p", domain="d", org="o")
+    with _fake_task_ctx(mode="remote"):
+        related_to = _Runner(force_mode="remote")._resolve_related_to()
+    assert related_to == identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="parent-run")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["local", "hybrid"])
+async def test_non_remote_ctx_not_stamped(mode):
+    """Only a true in-container (remote) execution links its child runs."""
+    await _init_for_testing(project="p", domain="d", org="o")
+    with _fake_task_ctx(mode=mode):
+        assert _Runner(force_mode="remote")._resolve_related_to() is None
+
+
+@pytest.mark.asyncio
+async def test_explicit_source_wins_over_ctx():
+    """The rerun path passes the source run explicitly; ambient ctx must not leak in."""
+    await _init_for_testing(project="p", domain="d", org="o")
+    source = identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="src-run")
+    with _fake_task_ctx(mode="remote", run_name="ctx-run"):
+        related_to = _Runner(force_mode="remote")._resolve_related_to(source)
+    assert related_to is not None
+    assert related_to.name == "src-run"
+
+
+@pytest.mark.asyncio
+async def test_scope_mismatch_runner_project_override():
+    """related_to is same-scope by contract: a run targeting another project is not linked."""
+    await _init_for_testing(project="p", domain="d", org="o")
+    source = identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="src-run")
+    assert _Runner(force_mode="remote", project="other")._resolve_related_to(source) is None
+
+
+@pytest.mark.asyncio
+async def test_scope_mismatch_source_org():
+    await _init_for_testing(project="p", domain="d", org="o")
+    source = identifier_pb2.RunIdentifier(org="different", project="p", domain="d", name="src-run")
+    assert _Runner(force_mode="remote")._resolve_related_to(source) is None
+
+
+@pytest.mark.asyncio
+async def test_empty_org_returns_none():
+    """All four id fields are server-required (min_len=1); no org configured -> no pointer."""
+    await _init_for_testing(project="p", domain="d")
+    with _fake_task_ctx(mode="remote", org=None):
+        assert _Runner(force_mode="remote")._resolve_related_to() is None
+
+
+@pytest.mark.asyncio
+async def test_source_scope_filled_from_cfg():
+    """A name-only source (degenerate fetched id) inherits the init config's scope."""
+    await _init_for_testing(project="p", domain="d", org="o")
+    source = identifier_pb2.RunIdentifier(name="src-run")
+    related_to = _Runner(force_mode="remote")._resolve_related_to(source)
+    assert related_to == identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="src-run")

--- a/tests/flyte/test_rerun.py
+++ b/tests/flyte/test_rerun.py
@@ -141,12 +141,7 @@ def test_replay_is_removed():
     assert not hasattr(flyte, "replay")
 
 
-# --- related_to provenance pointer (descriptor-gated; see _apply_overrides) -------------
-
-_RELATED_TO_AVAILABLE = "related_to" in run_pb2.RunSpec.DESCRIPTOR.fields_by_name
-requires_related_to = pytest.mark.skipif(
-    not _RELATED_TO_AVAILABLE, reason="RunSpec.related_to not in this flyteidl2 build"
-)
+# --- related_to provenance pointer (see _apply_overrides) -------------------------------
 
 
 def _full_action_id(org="testorg", project="test", domain="test", run_name="r1"):
@@ -173,15 +168,6 @@ async def _rerun_and_capture(prior_run, org="testorg", run_name="r1", **runconte
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(_RELATED_TO_AVAILABLE, reason="field available; the silent-skip gate no longer applies")
-async def test_rerun_silent_noop_when_related_to_field_absent():
-    """Provenance is implicit: rerun must succeed unchanged on a flyteidl2 build without the field."""
-    req = await _rerun_and_capture(_fake_prior_run(action_id=_full_action_id()))
-    assert req.run_spec.cluster == "orig"  # normal inherited spec, no raise
-
-
-@pytest.mark.asyncio
-@requires_related_to
 async def test_rerun_stamps_source_run():
     from flyteidl2.common import identifier_pb2
 
@@ -192,7 +178,6 @@ async def test_rerun_stamps_source_run():
 
 
 @pytest.mark.asyncio
-@requires_related_to
 async def test_rerun_of_rerun_overwrites_grandparent():
     """A rerun of a rerun points at its immediate source, not the inherited grandparent."""
     from flyteidl2.common import identifier_pb2
@@ -206,7 +191,6 @@ async def test_rerun_of_rerun_overwrites_grandparent():
 
 
 @pytest.mark.asyncio
-@requires_related_to
 async def test_rerun_scope_mismatch_clears_related_to():
     """Cross-scope rerun: no pointer stamped, and the inherited one is cleared, not propagated."""
     from flyteidl2.common import identifier_pb2
@@ -220,7 +204,6 @@ async def test_rerun_scope_mismatch_clears_related_to():
 
 
 @pytest.mark.asyncio
-@requires_related_to
 async def test_rerun_empty_fetched_id_falls_back_to_run_name():
     """A degenerate fetch (empty action id) still yields provenance: name from the rerun
     argument, scope from the init config."""

--- a/tests/flyte/test_rerun.py
+++ b/tests/flyte/test_rerun.py
@@ -43,14 +43,19 @@ def _mock_client_with_run():
     return mock_client, mock_run_service, mock_dataproxy, prior_inputs
 
 
-def _fake_prior_run(base_envs=None):
-    """A stand-in RunDetails: prior RunSpec + a root action carrying a task spec."""
-    base_run_spec = run_pb2.RunSpec(
-        envs=run_pb2.Envs(values=[literals_pb2.KeyValuePair(key="KEEP", value="1")] + (base_envs or [])),
-        cluster="orig",
-    )
+def _fake_prior_run(base_envs=None, action_id=None, base_run_spec=None):
+    """A stand-in RunDetails: prior RunSpec + a root action carrying a task spec.
+
+    ``action_id`` optionally carries the prior run's full ActionIdentifier (as the real
+    fetch would); ``base_run_spec`` optionally substitutes the prior RunSpec wholesale.
+    """
+    if base_run_spec is None:
+        base_run_spec = run_pb2.RunSpec(
+            envs=run_pb2.Envs(values=[literals_pb2.KeyValuePair(key="KEEP", value="1")] + (base_envs or [])),
+            cluster="orig",
+        )
     task_spec = run_definition_pb2.ActionDetails(
-        id=run_definition_pb2.ActionDetails().id,
+        id=action_id,
         task=_task_spec_with_string_input(),
     )
     action_details = SimpleNamespace(pb2=task_spec)
@@ -134,3 +139,94 @@ async def test_rerun_rejects_non_remote_mode():
 def test_replay_is_removed():
     """flyte.replay was deleted in favor of flyte.rerun."""
     assert not hasattr(flyte, "replay")
+
+
+# --- related_to provenance pointer (descriptor-gated; see _apply_overrides) -------------
+
+_RELATED_TO_AVAILABLE = "related_to" in run_pb2.RunSpec.DESCRIPTOR.fields_by_name
+requires_related_to = pytest.mark.skipif(
+    not _RELATED_TO_AVAILABLE, reason="RunSpec.related_to not in this flyteidl2 build"
+)
+
+
+def _full_action_id(org="testorg", project="test", domain="test", run_name="r1"):
+    from flyteidl2.common import identifier_pb2
+
+    return identifier_pb2.ActionIdentifier(
+        run=identifier_pb2.RunIdentifier(org=org, project=project, domain=domain, name=run_name),
+        name="a0",
+    )
+
+
+async def _rerun_and_capture(prior_run, org="testorg", run_name="r1", **runcontext_kwargs):
+    """Rerun `run_name` against a mocked fetch of `prior_run`; return the CreateRunRequest."""
+    mock_client, mock_run_service, _, _ = _mock_client_with_run()
+    await _init_for_testing(client=mock_client, project="test", domain="test", org=org)
+
+    with mock.patch("flyte.remote._run.RunDetails") as RD:
+        RD.get.aio = AsyncMock(return_value=prior_run)
+        run = await flyte.with_runcontext(mode="remote", **runcontext_kwargs).rerun.aio(run_name)
+
+    assert run
+    req: run_service_pb2.CreateRunRequest = mock_run_service.create_run.call_args[0][0]
+    return req
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(_RELATED_TO_AVAILABLE, reason="field available; the silent-skip gate no longer applies")
+async def test_rerun_silent_noop_when_related_to_field_absent():
+    """Provenance is implicit: rerun must succeed unchanged on a flyteidl2 build without the field."""
+    req = await _rerun_and_capture(_fake_prior_run(action_id=_full_action_id()))
+    assert req.run_spec.cluster == "orig"  # normal inherited spec, no raise
+
+
+@pytest.mark.asyncio
+@requires_related_to
+async def test_rerun_stamps_source_run():
+    from flyteidl2.common import identifier_pb2
+
+    req = await _rerun_and_capture(_fake_prior_run(action_id=_full_action_id()))
+    assert req.run_spec.related_to == identifier_pb2.RunIdentifier(
+        org="testorg", project="test", domain="test", name="r1"
+    )
+
+
+@pytest.mark.asyncio
+@requires_related_to
+async def test_rerun_of_rerun_overwrites_grandparent():
+    """A rerun of a rerun points at its immediate source, not the inherited grandparent."""
+    from flyteidl2.common import identifier_pb2
+
+    base = run_pb2.RunSpec(cluster="orig")
+    base.related_to.CopyFrom(
+        identifier_pb2.RunIdentifier(org="testorg", project="test", domain="test", name="grandparent")
+    )
+    req = await _rerun_and_capture(_fake_prior_run(action_id=_full_action_id(), base_run_spec=base))
+    assert req.run_spec.related_to.name == "r1"
+
+
+@pytest.mark.asyncio
+@requires_related_to
+async def test_rerun_scope_mismatch_clears_related_to():
+    """Cross-scope rerun: no pointer stamped, and the inherited one is cleared, not propagated."""
+    from flyteidl2.common import identifier_pb2
+
+    base = run_pb2.RunSpec(cluster="orig")
+    base.related_to.CopyFrom(
+        identifier_pb2.RunIdentifier(org="testorg", project="test", domain="test", name="grandparent")
+    )
+    req = await _rerun_and_capture(_fake_prior_run(action_id=_full_action_id(), base_run_spec=base), project="other")
+    assert not req.run_spec.HasField("related_to")
+
+
+@pytest.mark.asyncio
+@requires_related_to
+async def test_rerun_empty_fetched_id_falls_back_to_run_name():
+    """A degenerate fetch (empty action id) still yields provenance: name from the rerun
+    argument, scope from the init config."""
+    from flyteidl2.common import identifier_pb2
+
+    req = await _rerun_and_capture(_fake_prior_run())
+    assert req.run_spec.related_to == identifier_pb2.RunIdentifier(
+        org="testorg", project="test", domain="test", name="r1"
+    )

--- a/tests/flyte/test_run_runspec_chars.py
+++ b/tests/flyte/test_run_runspec_chars.py
@@ -55,13 +55,13 @@ def _patch_build(fn):
     return fn
 
 
-async def _run_and_capture(mock_build_image_bg, mock_code_bundler, **runcontext_kwargs):
+async def _run_and_capture(mock_build_image_bg, mock_code_bundler, _org=None, **runcontext_kwargs):
     """Run task1 in remote mode with the given runcontext kwargs; return the CreateRunRequest."""
     mock_client, mock_run_service = _make_mock_client()
     mock_code_bundler.return_value = CodeBundle(computed_version="v1", tgz="test.tgz")
     mock_build_image_bg.return_value = (env.name, "image_name", None)
 
-    await _init_for_testing(client=mock_client, project="test", domain="test")
+    await _init_for_testing(client=mock_client, project="test", domain="test", org=_org)
     run = await flyte.with_runcontext(mode="remote", **runcontext_kwargs).run.aio(task1, "hello")
     assert run
     req: run_service_pb2.CreateRunRequest = mock_run_service.create_run.call_args[0][0]
@@ -376,3 +376,96 @@ async def test_recover_rejected_in_local_mode():
     await flyte.init.aio()
     with pytest.raises(ValueError, match="recover is only supported in remote mode"):
         await flyte.with_runcontext(mode="local", recover="r1").run.aio(task1, "hello")
+
+
+# --- related_to provenance pointer (implicit; descriptor-gated like recover) ------------
+
+_RELATED_TO_AVAILABLE = "related_to" in run_pb2.RunSpec.DESCRIPTOR.fields_by_name
+requires_related_to = pytest.mark.skipif(
+    not _RELATED_TO_AVAILABLE, reason="RunSpec.related_to not in this flyteidl2 build"
+)
+
+
+def _fake_remote_task_ctx(org="testorg", project="test", domain="test", run_name="parent-run"):
+    """A Context carrying an in-cluster TaskContext, as the container runtime would set up."""
+    from flyte._context import Context, ContextData
+    from flyte.models import ActionID, RawDataPath, TaskContext
+    from flyte.report import Report
+
+    action = ActionID(name="a0", run_name=run_name, project=project, domain=domain, org=org)
+    task_context = TaskContext(
+        action=action,
+        version="v1",
+        raw_data_path=RawDataPath(path="/tmp/raw"),
+        output_path="/tmp/out",
+        run_base_dir="/tmp/base",
+        report=Report(name="a0"),
+        mode="remote",
+    )
+    return Context(data=ContextData(task_context=task_context))
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(_RELATED_TO_AVAILABLE, reason="field available; the silent-skip gate no longer applies")
+async def test_apply_overrides_related_to_silent_noop_when_field_absent():
+    """Unlike recover (explicitly user-requested, raises), implicit provenance silently
+    skips on a flyteidl2 build without RunSpec.related_to — reruns must keep working."""
+    from flyteidl2.common import identifier_pb2
+
+    from flyte._run import _Runner
+
+    mock_client, _ = _make_mock_client()
+    await _init_for_testing(client=mock_client, project="test", domain="test")
+
+    related = identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="r1")
+    out = _Runner(force_mode="remote")._apply_overrides(None, related_to=related)
+    assert out is not None  # no raise, spec built normally
+
+
+@pytest.mark.asyncio
+@requires_related_to
+async def test_apply_overrides_related_to_stamped_overwritten_cleared():
+    """Fresh path stamps; base-copy overwrites a stale (grandparent) pointer; None clears it."""
+    from flyteidl2.common import identifier_pb2
+    from flyteidl2.task import run_pb2
+
+    from flyte._run import _Runner
+
+    mock_client, _ = _make_mock_client()
+    await _init_for_testing(client=mock_client, project="test", domain="test")
+    runner = _Runner(force_mode="remote")
+
+    related = identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="r1")
+    fresh = runner._apply_overrides(None, related_to=related)
+    assert fresh.related_to == related
+
+    base = run_pb2.RunSpec()
+    base.related_to.CopyFrom(identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="grandparent"))
+    overwritten = runner._apply_overrides(base, related_to=related)
+    assert overwritten.related_to.name == "r1"
+
+    cleared = runner._apply_overrides(base, related_to=None)
+    assert not cleared.HasField("related_to")
+
+
+@pytest.mark.asyncio
+@requires_related_to
+@_patch_build
+async def test_runspec_related_to_from_task_ctx(mock_code_bundler, mock_build_image_bg):
+    """flyte.run from inside a remote task container stamps the invoking run as related_to."""
+    with _fake_remote_task_ctx():
+        req = await _run_and_capture(mock_build_image_bg, mock_code_bundler, _org="testorg")
+    from flyteidl2.common import identifier_pb2
+
+    assert req.run_spec.related_to == identifier_pb2.RunIdentifier(
+        org="testorg", project="test", domain="test", name="parent-run"
+    )
+
+
+@pytest.mark.asyncio
+@requires_related_to
+@_patch_build
+async def test_runspec_related_to_unset_without_ctx(mock_code_bundler, mock_build_image_bg):
+    """A plain remote run (no task context) carries no provenance pointer."""
+    req = await _run_and_capture(mock_build_image_bg, mock_code_bundler, _org="testorg")
+    assert not req.run_spec.HasField("related_to")

--- a/tests/flyte/test_run_runspec_chars.py
+++ b/tests/flyte/test_run_runspec_chars.py
@@ -378,12 +378,7 @@ async def test_recover_rejected_in_local_mode():
         await flyte.with_runcontext(mode="local", recover="r1").run.aio(task1, "hello")
 
 
-# --- related_to provenance pointer (implicit; descriptor-gated like recover) ------------
-
-_RELATED_TO_AVAILABLE = "related_to" in run_pb2.RunSpec.DESCRIPTOR.fields_by_name
-requires_related_to = pytest.mark.skipif(
-    not _RELATED_TO_AVAILABLE, reason="RunSpec.related_to not in this flyteidl2 build"
-)
+# --- related_to provenance pointer (implicit) ------------
 
 
 def _fake_remote_task_ctx(org="testorg", project="test", domain="test", run_name="parent-run"):
@@ -406,24 +401,6 @@ def _fake_remote_task_ctx(org="testorg", project="test", domain="test", run_name
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(_RELATED_TO_AVAILABLE, reason="field available; the silent-skip gate no longer applies")
-async def test_apply_overrides_related_to_silent_noop_when_field_absent():
-    """Unlike recover (explicitly user-requested, raises), implicit provenance silently
-    skips on a flyteidl2 build without RunSpec.related_to — reruns must keep working."""
-    from flyteidl2.common import identifier_pb2
-
-    from flyte._run import _Runner
-
-    mock_client, _ = _make_mock_client()
-    await _init_for_testing(client=mock_client, project="test", domain="test")
-
-    related = identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="r1")
-    out = _Runner(force_mode="remote")._apply_overrides(None, related_to=related)
-    assert out is not None  # no raise, spec built normally
-
-
-@pytest.mark.asyncio
-@requires_related_to
 async def test_apply_overrides_related_to_stamped_overwritten_cleared():
     """Fresh path stamps; base-copy overwrites a stale (grandparent) pointer; None clears it."""
     from flyteidl2.common import identifier_pb2
@@ -449,7 +426,6 @@ async def test_apply_overrides_related_to_stamped_overwritten_cleared():
 
 
 @pytest.mark.asyncio
-@requires_related_to
 @_patch_build
 async def test_runspec_related_to_from_task_ctx(mock_code_bundler, mock_build_image_bg):
     """flyte.run from inside a remote task container stamps the invoking run as related_to."""
@@ -463,7 +439,6 @@ async def test_runspec_related_to_from_task_ctx(mock_code_bundler, mock_build_im
 
 
 @pytest.mark.asyncio
-@requires_related_to
 @_patch_build
 async def test_runspec_related_to_unset_without_ctx(mock_code_bundler, mock_build_image_bg):
     """A plain remote run (no task context) carries no provenance pointer."""

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P5D"
 
 [options.exclude-newer-package]
+flyteplugins-union = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 flyteidl2 = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 flyte-controller-base = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 
@@ -1220,7 +1221,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.26" },
+    { name = "flyteidl2", specifier = "==2.0.27" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -1294,11 +1295,11 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "flyteidl2", specifier = "==2.0.26" }]
+requires-dist = [{ name = "flyteidl2", specifier = "==2.0.27" }]
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.26"
+version = "2.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -1307,7 +1308,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1a/b89902f358bc243eebcae549da9b11d3964d8f0f2e998f5756c2caccaa47/flyteidl2-2.0.26-py3-none-any.whl", hash = "sha256:7ac8c7e3fabaabb8dbf6db330c3895a97d960aba2edc48ea6b5efbcae56ed7b5", size = 350021, upload-time = "2026-06-24T18:35:01.794Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/6e8eb2173e544247cade0d4608f10a950e0f623c66574cfdf0792ee8af11/flyteidl2-2.0.27-py3-none-any.whl", hash = "sha256:eb5a8d9df3d190288b23f771d384d094105b0ece98449790329cb5faf1a10bd8", size = 350354, upload-time = "2026-07-03T00:00:44.163Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

The backend added `RunSpec.related_to` (field 15, `flyteidl2.common.RunIdentifier`): an optional, set-at-creation pointer to the single parent run this run was derived from (re-run, recover, clone, or explicit provenance). This PR makes the SDK populate it automatically at CreateRun time.

## What

Two implicit provenance sources, both resolved by a new `_Runner._resolve_related_to` helper and stamped in `_apply_overrides`:

1. **Rerun** — every rerun surface (`flyte rerun`, `flyte run --rerun-from`, `flyte.rerun`, `with_runcontext().rerun()`) converges on `_Runner.rerun`; the new run points at the run being rerun. The source id comes from the fetched `action_details.pb2.id.run`, with a fallback to the `run_name` argument when the fetched id is empty.
2. **In-container `flyte.run`** — when a run is created from inside a running remote task (`TaskContext.is_in_cluster()`), the new run points at the invoking run (`flyte.ctx().action`). Local and hybrid executions are excluded; in a rerun the explicit source wins over the ambient task context.

### Gating & scope rules

- **Descriptor-gated, silent skip**: the published flyteidl2 (2.0.26) doesn't ship the field yet. Unlike `recover` — explicitly user-requested, so its absence raises — implicit provenance silently skips with a debug log, so reruns keep working on older builds.
- **Same-scope, complete-id only**: per the proto contract `related_to` is scoped to the new run's org/project/domain, and all four `RunIdentifier` fields are server-required (buf.validate `min_len=1`). The resolver stamps only when the source scope (empty fields inherited from the init config) equals the new run's target scope and the id is complete — a provenance pointer must never fail run creation.
- **Rerun base-copy path**: the field is unconditionally cleared before stamping, so a rerun-of-rerun overwrites the inherited grandparent pointer, and a cross-scope rerun (e.g. `with_runcontext(project="other").rerun(...)`) clears it rather than propagating a wrong-scope pointer.

### Tests

- New `tests/flyte/test_related_to.py`: resolver rules (ctx detection, mode gating, explicit-source precedence, scope mismatch, empty-org, cfg-scope leniency) — runs on any flyteidl2 build.
- `test_run_runspec_chars.py` / `test_rerun.py`: wire-level tests gated on `RunSpec.DESCRIPTOR.fields_by_name` — they skip on 2.0.26 and were verified to pass against the generated protos that ship the field (stamping, overwrite, clear, name fallback). Two inverse-gated tests pin the silent no-op on old builds and flag when the gate becomes obsolete.
- `_init_for_testing` gains an `org=` parameter (stamping requires a non-empty org); existing tests init without org and are unaffected — the RunSpec snapshot oracle stays byte-for-byte identical.

### Notes for reviewers

- **Backend caveat**: if the server stamps `related_to` itself, a rerun performed with an *old* SDK fetches the base spec carrying field 15 as an unknown field, which `CopyFrom` preserves and `ClearField` cannot touch — the backend should treat client-sent `related_to` at create time as advisory.
- Follow-ups deliberately out of scope: explicit `with_runcontext(related_to=...)`, provenance for trigger-created runs.
