### PR TITLE
fix: tolerate permission-denied files when copying image build context (FLYTE-SDK-6F)

### DIFF
--- a/src/flyte/_internal/imagebuild/utils.py
+++ b/src/flyte/_internal/imagebuild/utils.py
@@ -71,6 +71,21 @@ def copy_files_to_context(src: Path, context_path: Path, ignore_patterns: list[s
                         f"Skipping '{src_file}' while building image context: file disappeared "
                         "between enumeration and copy."
                     )
+                except PermissionError:
+                    # ``shutil.copy2`` also copies file metadata (mode, timestamps, flags and
+                    # xattrs via ``copystat``), which can raise ``PermissionError`` ([Errno 1]
+                    # Operation not permitted) on macOS for files carrying special flags or SIP
+                    # protection — e.g. entries under a user's ``.git`` directory that get pulled
+                    # into the build context. Fall back to copying just the file contents; only if
+                    # even the data cannot be read do we skip it with a warning, rather than
+                    # aborting the whole image build with a raw traceback (see FLYTE-SDK-6F).
+                    try:
+                        shutil.copyfile(src_file, dst_file)
+                    except OSError:
+                        logger.warning(
+                            f"Skipping '{src_file}' while building image context: permission "
+                            "denied. Check the file's permissions or exclude it via .dockerignore."
+                        )
 
     else:
         # Single file

--- a/tests/flyte/imagebuild/test_utils.py
+++ b/tests/flyte/imagebuild/test_utils.py
@@ -255,6 +255,72 @@ def test_copy_files_to_context_skips_files_that_vanish_mid_walk():
         assert (dst / "keep.txt").exists()
 
 
+def test_copy_files_to_context_falls_back_when_copy2_permission_denied():
+    """``shutil.copy2`` also copies file metadata, which raises ``PermissionError`` ([Errno 1]
+    Operation not permitted) on macOS for flag/SIP-protected files (e.g. ``.git`` internals). The
+    build should fall back to copying just the file contents rather than crashing (FLYTE-SDK-6F).
+    """
+    with tempfile.TemporaryDirectory() as src_root, tempfile.TemporaryDirectory() as ctx_root:
+        src = Path(src_root)
+        keep = src / "keep.txt"
+        keep.write_text("kept\n")
+        protected = src / "protected.txt"
+        protected.write_text("payload\n")
+
+        real_copyfile = shutil.copyfile
+
+        def fragile_copy2(s, d, *args, **kwargs):
+            # Simulate copystat failing on a metadata-protected file while data is readable.
+            if Path(s).name == "protected.txt":
+                raise PermissionError(1, "Operation not permitted", str(s))
+            return real_copyfile(s, d)
+
+        import shutil as _shutil_mod
+
+        with patch.object(_shutil_mod, "copy2", side_effect=fragile_copy2):
+            # Should not raise — protected file falls back to copyfile, keep file copies normally.
+            dst = copy_files_to_context(src, Path(ctx_root))
+
+        assert (dst / "keep.txt").exists()
+        assert (dst / "protected.txt").read_text() == "payload\n"
+
+
+def test_copy_files_to_context_skips_when_data_unreadable():
+    """If even the file contents cannot be read (permission denied on the data itself), the entry
+    is skipped with a warning and the rest of the build continues (FLYTE-SDK-6F).
+    """
+    with tempfile.TemporaryDirectory() as src_root, tempfile.TemporaryDirectory() as ctx_root:
+        src = Path(src_root)
+        keep = src / "keep.txt"
+        keep.write_text("kept\n")
+        unreadable = src / "unreadable.txt"
+        unreadable.write_text("secret\n")
+
+        real_copyfile = shutil.copyfile
+
+        def fragile_copy2(s, d, *args, **kwargs):
+            if Path(s).name == "unreadable.txt":
+                raise PermissionError(1, "Operation not permitted", str(s))
+            return real_copyfile(s, d)
+
+        def fragile_copyfile(s, d, *args, **kwargs):
+            if Path(s).name == "unreadable.txt":
+                raise PermissionError(1, "Operation not permitted", str(s))
+            return real_copyfile(s, d, *args, **kwargs)
+
+        import shutil as _shutil_mod
+
+        with (
+            patch.object(_shutil_mod, "copy2", side_effect=fragile_copy2),
+            patch.object(_shutil_mod, "copyfile", side_effect=fragile_copyfile),
+        ):
+            # Should not raise — unreadable file is skipped, kept file is copied.
+            dst = copy_files_to_context(src, Path(ctx_root))
+
+        assert (dst / "keep.txt").exists()
+        assert not (dst / "unreadable.txt").exists()
+
+
 import shutil  # noqa: E402  (kept at bottom so the new tests own the import)
 
 


### PR DESCRIPTION
## Problem

`copy_files_to_context` (`src/flyte/_internal/imagebuild/utils.py`) walks a user's source tree and copies each file into the remote image build context with `shutil.copy2`. `copy2` copies file **metadata** as well as data (mode, timestamps, flags, xattrs via `copystat`), and on macOS that raises:

```
PermissionError: [Errno 1] Operation not permitted: '.../build.uc-image-builder/_flyte_abs_context/.../.git/config'
```

for flag- or SIP-protected files that get pulled into the context (e.g. entries under a user's `.git` directory). The raw traceback aborted the entire image build and surfaced in Sentry as an unhandled SDK crash (**FLYTE-SDK-6F**). The loop already tolerates `FileNotFoundError` (files that vanish mid-walk) but not `PermissionError`.

## Fix

On `PermissionError`, fall back to `shutil.copyfile` (copies data only, no metadata) — which succeeds when only the metadata copy was blocked. Only if the data itself cannot be read do we skip the entry with a warning and keep the build going, mirroring the existing `FileNotFoundError` handling.

## Tests

- `test_copy_files_to_context_falls_back_when_copy2_permission_denied` — copy2 raises PermissionError, contents still land via copyfile fallback.
- `test_copy_files_to_context_skips_when_data_unreadable` — data itself unreadable, entry skipped with warning, build continues.

14/14 tests in `tests/flyte/imagebuild/test_utils.py` pass.

fixes FLYTE-SDK-6F

🤖 Generated with [Claude Code](https://claude.com/claude-code)