### PR TITLE
make the Agent callback event stream multi-agent compatible

### DIFF
--- a/src/flyte/ai/agents/agent.py
+++ b/src/flyte/ai/agents/agent.py
@@ -95,10 +95,37 @@ agent_progress_cb: contextvars.ContextVar[AgentProgressCallback | None] = contex
 )
 
 
+@dataclass(frozen=True)
+class _RunIdentity:
+    """Identifies the agent run that is emitting events in the current context.
+
+    Set by :meth:`Agent._run_loop` for the duration of a run so that
+    :func:`_emit` can stamp ``agent`` and ``run_id`` onto every event. Stored
+    in a :class:`~contextvars.ContextVar` so concurrent runs in the same
+    process (fan-out via ``asyncio.gather``, sub-agents invoked as tools) each
+    stamp their own identity instead of conflating.
+    """
+
+    agent: str
+    run_id: str
+
+
+_current_run: contextvars.ContextVar[_RunIdentity | None] = contextvars.ContextVar(
+    "agent_current_run",
+    default=None,
+)
+
+
 async def _emit(event: "AgentEvent") -> None:
     cb = agent_progress_cb.get()
     if cb is None:
         return
+    identity = _current_run.get()
+    if identity is not None:
+        if not event.agent:
+            event.agent = identity.agent
+        if not event.run_id:
+            event.run_id = identity.run_id
     try:
         await cb(event)
     except Exception:  # pragma: no cover - progress hooks must never break the loop
@@ -131,10 +158,17 @@ class AgentEvent:
     The agent stays decoupled from any specific UI: subscribe via
     :data:`agent_progress_cb` to forward these to logs, NDJSON streams, websockets,
     Flyte reports, etc.
+
+    ``agent`` and ``run_id`` are stamped automatically on every event so that
+    consumers receiving events from multiple runs in one process (concurrent
+    agents, sub-agents used as tools, parallel runs of the same agent) can
+    attribute each event to the run that produced it.
     """
 
     type: EventType
     data: dict[str, Any] = field(default_factory=dict)
+    agent: str = ""
+    run_id: str = ""
 
 
 # ----------------------------------------------------------------------------
@@ -634,13 +668,15 @@ class Agent:
         to a passed :class:`MemoryStore`) but never saved; persistence is the
         caller's responsibility.
         """
-        await self._ensure_mcp_loaded()
+        run_id = uuid.uuid4().hex[:8]
+        identity_token = _current_run.set(_RunIdentity(agent=self.name, run_id=run_id))
 
         # Render the loop's progress into the task report (best-effort; a no-op when
         # there is no active report), chaining onto any callback the caller installed.
         prev_cb = agent_progress_cb.get()
         cb_token = agent_progress_cb.set(build_report_callback(_REPORT_TAB, prev_cb))
         try:
+            await self._ensure_mcp_loaded()
             start_data: dict[str, Any] = {"name": self.name, "model": self.model}
             if mode is not None:
                 start_data["mode"] = mode
@@ -694,6 +730,7 @@ class Agent:
             except Exception:  # pragma: no cover - no active report / local run
                 pass
             agent_progress_cb.reset(cb_token)
+            _current_run.reset(identity_token)
 
     async def _execute_calls(
         self,

--- a/src/flyte/ai/chat/app.py
+++ b/src/flyte/ai/chat/app.py
@@ -517,7 +517,22 @@ class AgentChatAppEnvironment(flyte.app.AppEnvironment):
 
             # Map :class:`AgentEvent` types onto the UI's three progress steps
             # (plan → execute → format) so the existing chat JS works unchanged.
+            #
+            # Only the top-level run drives the UI: the first ``run_id`` seen is
+            # latched, and events stamped with a different ``run_id`` (sub-agents
+            # invoked as tools) are dropped so their ``turn_start`` doesn't clobber
+            # the attempt counter and their ``agent_end`` doesn't flip the phase
+            # early. Unstamped events (custom :class:`AgentProtocol`
+            # implementations emitting hand-built events) pass through unchanged.
+            top_run_id: str | None = None
+
             async def on_event(event: AgentEvent) -> None:
+                nonlocal top_run_id
+                if event.run_id:
+                    if top_run_id is None:
+                        top_run_id = event.run_id
+                    elif event.run_id != top_run_id:
+                        return
                 phase = _AGENT_EVENT_TO_UI_PHASE.get(event.type)
                 if phase is None:
                     return

--- a/tests/flyte/ai/agents/test_agent.py
+++ b/tests/flyte/ai/agents/test_agent.py
@@ -787,6 +787,82 @@ class TestRunLoop:
         assert "tool_start" in phases
         assert "tool_end" in phases
 
+    async def test_events_stamped_with_agent_and_run_id(self):
+        def make_agent() -> Agent:
+            llm = _make_llm(
+                [
+                    LLMMessage(
+                        content=None,
+                        tool_calls=[{"id": "c1", "name": "_add", "arguments": {"x": 1, "y": 2}}],
+                    ),
+                    LLMMessage(content="3.", tool_calls=[]),
+                ]
+            )
+            return Agent(name="stamped", instructions="I", tools=[_add], call_llm=llm)
+
+        events: list[AgentEvent] = []
+
+        async def on_event(event: AgentEvent) -> None:
+            events.append(event)
+
+        token = agent_progress_cb.set(on_event)
+        try:
+            await make_agent().run.aio("hi", [])
+            first_run_count = len(events)
+            await make_agent().run.aio("hi again", [])
+        finally:
+            agent_progress_cb.reset(token)
+
+        assert all(e.agent == "stamped" for e in events)
+        first_ids = {e.run_id for e in events[:first_run_count]}
+        second_ids = {e.run_id for e in events[first_run_count:]}
+        assert len(first_ids) == 1 and first_ids != {""}
+        assert len(second_ids) == 1 and second_ids != {""}
+        assert first_ids != second_ids
+
+    async def test_subagent_events_attributed_to_inner_run(self):
+        inner_llm = _make_llm([LLMMessage(content="inner answer", tool_calls=[])])
+        inner = Agent(name="inner", instructions="I", call_llm=inner_llm)
+
+        async def ask_inner(question: str) -> str:
+            """Delegate a question to the inner agent."""
+            result = await inner.run.aio(question, [])
+            return result.summary
+
+        outer_llm = _make_llm(
+            [
+                LLMMessage(
+                    content=None,
+                    tool_calls=[{"id": "c1", "name": "ask_inner", "arguments": {"question": "q"}}],
+                ),
+                LLMMessage(content="outer answer", tool_calls=[]),
+            ]
+        )
+        outer = Agent(name="outer", instructions="I", tools=[ask_inner], call_llm=outer_llm)
+
+        events: list[AgentEvent] = []
+
+        async def on_event(event: AgentEvent) -> None:
+            events.append(event)
+
+        token = agent_progress_cb.set(on_event)
+        try:
+            await outer.run.aio("go", [])
+        finally:
+            agent_progress_cb.reset(token)
+
+        by_agent = {name: [e for e in events if e.agent == name] for name in ("outer", "inner")}
+        assert {e.agent for e in events} == {"outer", "inner"}
+        assert {e.type for e in by_agent["inner"]} >= {"agent_start", "agent_end"}
+        assert len({e.run_id for e in by_agent["outer"]}) == 1
+        assert len({e.run_id for e in by_agent["inner"]}) == 1
+        assert by_agent["outer"][0].run_id != by_agent["inner"][0].run_id
+        # The outer run's identity is restored after the sub-agent finishes:
+        # events emitted after the inner agent_end (tool_end, turn_end,
+        # agent_end) still carry the outer run_id.
+        assert events[-1].agent == "outer"
+        assert events[-1].run_id == by_agent["outer"][0].run_id
+
     async def test_history_is_prepended(self):
         llm = _make_llm([LLMMessage(content="ack", tool_calls=[])])
         agent = Agent(name="t", instructions="I", call_llm=llm)

--- a/tests/flyte/ai/chat/test_app.py
+++ b/tests/flyte/ai/chat/test_app.py
@@ -99,6 +99,51 @@ class TestAgentChatAppEnvironment:
         assert last["summary"] == "echo:hi"
         assert last["elapsed_ms"] >= 0
 
+    @pytest.mark.asyncio
+    async def test_chat_stream_drops_subagent_progress_events(self):
+        """Sub-agent events (different ``run_id``) must not clobber the UI attempt
+        counter; unstamped events (custom agents) still pass through."""
+        from flyte.ai.agents.agent import AgentEvent, agent_progress_cb
+
+        class _SubAgentEventAgent:
+            @syncify
+            async def run(self, message: str, history: list[dict[str, str]]) -> AgentResult:
+                cb = agent_progress_cb.get()
+                assert cb is not None
+                await cb(AgentEvent("agent_start", {"name": "outer"}, agent="outer", run_id="run-outer"))
+                await cb(AgentEvent("turn_start", {"turn": 1, "max_turns": 5}, agent="outer", run_id="run-outer"))
+                # Sub-agent events carry a different run_id and must be dropped.
+                await cb(AgentEvent("turn_start", {"turn": 9, "max_turns": 25}, agent="inner", run_id="run-inner"))
+                await cb(AgentEvent("agent_end", {"turns": 9}, agent="inner", run_id="run-inner"))
+                await cb(AgentEvent("turn_start", {"turn": 2, "max_turns": 5}, agent="outer", run_id="run-outer"))
+                # Unstamped events (hand-built by custom agents) pass through.
+                await cb(AgentEvent("turn_start", {"turn": 3, "max_turns": 5}))
+                return AgentResult(summary="ok")
+
+            def tool_descriptions(self) -> list[dict[str, str]]:
+                return []
+
+        env = AgentChatAppEnvironment(name="test-app", image="auto", agent=_SubAgentEventAgent())
+        app = env.build_fastapi_app()
+        from starlette.testclient import TestClient
+
+        client = TestClient(app)
+        with client.stream(
+            "POST",
+            "/api/chat",
+            json={"message": "hi", "history": [], "stream": True},
+        ) as resp:
+            assert resp.status_code == 200
+            body = b"".join(resp.iter_bytes())
+        lines = [json.loads(ln) for ln in body.decode().split("\n") if ln.strip()]
+        progress = [ln for ln in lines if ln.get("type") == "progress"]
+        attempts = [p["attempt"] for p in progress if "attempt" in p]
+        assert attempts == [1, 2, 3]
+        # The sub-agent's agent_end must not flip the UI to "formatting".
+        assert not any(p["phase"] == "formatting" for p in progress)
+        assert lines[-1]["type"] == "done"
+        assert lines[-1]["summary"] == "ok"
+
     def test_container_command_empty(self):
         env = AgentChatAppEnvironment(name="test-app", image="auto", agent=_StubAgent())
         assert env.container_command(MagicMock()) == []


### PR DESCRIPTION
This pull request introduces robust tracking and attribution of agent events to individual agent runs, especially in concurrent and nested (sub-agent) scenarios. The changes ensure that each event is stamped with the correct `agent` and `run_id`, so consumers (such as the UI) can reliably distinguish between events from different runs or agents. The UI now ignores progress events from sub-agents to prevent them from interfering with the main agent's display, while still allowing custom/unstamped events to pass through. Comprehensive tests are added to verify these behaviors.

**Agent run identity and event attribution:**
- Added a `_RunIdentity` dataclass and a context variable `_current_run` to track the current agent and run ID for each event, ensuring that concurrent and nested agent runs do not conflate their events. The `_run_loop` method sets and resets this context for each run, and `_emit` automatically stamps `agent` and `run_id` onto every `AgentEvent`. (`src/flyte/ai/agents/agent.py`)
- Updated the `AgentEvent` class to include `agent` and `run_id` fields, and documented that these are now stamped automatically. (`src/flyte/ai/agents/agent.py`)

**UI and event filtering:**
- Modified the chat UI event handler so that only events from the top-level (first) run are processed; events from sub-agents (with a different `run_id`) are dropped to prevent them from interfering with the UI state, while unstamped events still pass through. (`src/flyte/ai/chat/app.py`)

**Testing:**
- Added tests to verify that all events are correctly stamped with the agent name and run ID, that sub-agent events are attributed to their own runs without interfering with the outer agent, and that the run identity context is properly restored after sub-agent execution. (`tests/flyte/ai/agents/test_agent.py`)
- Added a test to ensure that the chat stream drops sub-agent progress events (with a different `run_id`) but allows unstamped events, and that sub-agent events do not clobber the UI attempt counter or phase. (`tests/flyte/ai/chat/test_app.py`)