### PR TITLE
fix: json-raw CLI output tolerates non-serializable values like pathlib.Path (FLYTE-SDK-6G)

### DIFF
--- a/src/flyte/cli/_common.py
+++ b/src/flyte/cli/_common.py
@@ -450,7 +450,10 @@ def format(title: str, vals: Iterable[Any], of: OutputFormat = "table") -> Table
         case "json-raw":
             if not vals:
                 return "[]"
-            return json.dumps([v.to_dict() if hasattr(v, "to_dict") else dict(v) for v in vals])
+            # default=str lets values that aren't natively JSON serializable (e.g. pathlib.Path
+            # module paths surfaced in deploy output) fall back to their string form instead of
+            # raising a raw TypeError.
+            return json.dumps([v.to_dict() if hasattr(v, "to_dict") else dict(v) for v in vals], default=str)
 
     raise click.ClickException("Unknown output format. Supported formats are: table, table-simple, json.")
 

--- a/tests/flyte/cli/test_common_format.py
+++ b/tests/flyte/cli/test_common_format.py
@@ -1,0 +1,22 @@
+"""Tests for JSON output serialization in flyte.cli._common.format."""
+
+import json
+from pathlib import Path
+
+from flyte.cli._common import format
+
+
+def test_json_raw_serializes_pathlib_values():
+    # The deploy command renders failed module loads as [("Path", <Path>), ("Err", <str>)].
+    # With -o json-raw the values are json.dumps'd; a pathlib.Path must not raise
+    # "Object of type PosixPath is not JSON serializable" (FLYTE-SDK-6G).
+    vals = [[("Path", Path("/tmp/some/module.py")), ("Err", "boom")]]
+
+    out = format("Modules", vals, of="json-raw")
+
+    parsed = json.loads(out)
+    assert parsed == [{"Path": "/tmp/some/module.py", "Err": "boom"}]
+
+
+def test_json_raw_empty_returns_empty_list():
+    assert format("Modules", [], of="json-raw") == "[]"


### PR DESCRIPTION
## Problem

`flyte deploy -o json-raw` crashes with a raw `TypeError: Object of type PosixPath is not JSON serializable` (Sentry **FLYTE-SDK-6G**, seen on 2.3.9).

`cli/_common.format` renders the `json-raw` format with a bare `json.dumps(...)`. When a deploy surfaces failed module loads, the rows are built as `[("Path", p), ("Err", e)]` (see `cli/_deploy.py:195`) where `p` is a `pathlib.Path`. `dict(v)` then yields `{"Path": PosixPath(...)}`, which stdlib `json.dumps` cannot serialize, so the exception leaks to the user (and to Sentry).

## Fix

Pass `default=str` to `json.dumps` so any value that isn't natively JSON serializable (Path and friends) falls back to its string form instead of raising. Mirrors what the rich-based `json` branch already tolerates.

## Test

`tests/flyte/cli/test_common_format.py` — asserts a `Path` value serializes to its string form via `json-raw`, plus the empty-list case.

fixes FLYTE-SDK-6G

🤖 Generated with [Claude Code](https://claude.com/claude-code)