### PR TITLE
fix: restore original std streams while cloudpickling for version derivation

### DIFF
--- a/src/flyte/_deploy.py
+++ b/src/flyte/_deploy.py
@@ -526,19 +526,27 @@ async def apply(deployment_plan: DeploymentPlan, copy_style: CopyFiles, dryrun: 
 
             import click
 
+            from ._utils import original_std_streams
+
             h = hashlib.md5()
             try:
-                h.update(cloudpickle.dumps(deployment_plan.envs))
-                h.update(code_bundle.computed_version.encode("utf-8"))
-                h.update(cloudpickle.dumps(image_cache))
+                # Pickle with the original std streams in place: a UI spinner (rich Live)
+                # may have swapped sys.stdout/sys.stderr for proxies, which breaks
+                # cloudpickle's identity-based handling of stream references held by
+                # module globals (e.g. loguru's default sink).
+                with original_std_streams():
+                    h.update(cloudpickle.dumps(deployment_plan.envs))
+                    h.update(code_bundle.computed_version.encode("utf-8"))
+                    h.update(cloudpickle.dumps(image_cache))
             except (_pickle.PicklingError, TypeError) as e:
                 raise click.ClickException(
-                    "Failed to compute deployment version: your task or environment captures an "
-                    f"unpicklable object ({type(e).__name__}: {e}). This is usually caused by closing "
-                    "over `sys.stdin` / `sys.stdout` / `sys.stderr`, an open file handle, a thread, "
-                    "or a lock from module-level code. Move the captured value inside the task "
-                    "function, or pass an explicit `version=...` to `flyte.deploy(...)` to skip "
-                    "version derivation."
+                    "Failed to compute deployment version: the deployment captures an "
+                    f"unpicklable object ({type(e).__name__}: {e}). This is usually caused by a "
+                    "reference to `sys.stdin` / `sys.stdout` / `sys.stderr`, an open file handle, "
+                    "a thread, or a lock reachable from module-level code — either in your task "
+                    "module or in a third-party library it imports. If the value is yours, move it "
+                    "inside the task function; otherwise pass an explicit `version=...` to "
+                    "`flyte.deploy(...)` to skip version derivation."
                 ) from e
             version = h.hexdigest()
 

--- a/src/flyte/_serve.py
+++ b/src/flyte/_serve.py
@@ -668,11 +668,18 @@ class _Serve:
         elif app_deployment.version:
             version = app_deployment.version
         else:
+            from ._utils import original_std_streams
+
             h = hashlib.md5()
-            h.update(cloudpickle.dumps(app_deployment.envs))
-            if code_bundle:
-                h.update(code_bundle.computed_version.encode("utf-8"))
-            h.update(cloudpickle.dumps(image_cache))
+            # Pickle with the original std streams in place: a UI spinner (rich Live)
+            # may have swapped sys.stdout/sys.stderr for proxies, which breaks
+            # cloudpickle's identity-based handling of stream references held by
+            # module globals (e.g. loguru's default sink).
+            with original_std_streams():
+                h.update(cloudpickle.dumps(app_deployment.envs))
+                if code_bundle:
+                    h.update(code_bundle.computed_version.encode("utf-8"))
+                h.update(cloudpickle.dumps(image_cache))
             version = h.hexdigest()
 
         # Create serialization context

--- a/src/flyte/_utils/__init__.py
+++ b/src/flyte/_utils/__init__.py
@@ -7,7 +7,7 @@ Except for logging, modules in this package should not depend on any other part 
 from .async_cache import AsyncLRUCache
 from .coro_management import run_coros
 from .file_handling import filehash_update, update_hasher_for_source
-from .helpers import str2bool
+from .helpers import original_std_streams, str2bool
 from .lazy_module import lazy_module
 from .module_loader import adjust_sys_path, load_python_modules
 from .org_discovery import hostname_from_url, org_from_endpoint, sanitize_endpoint
@@ -22,6 +22,7 @@ __all__ = [
     "lazy_module",
     "load_python_modules",
     "org_from_endpoint",
+    "original_std_streams",
     "parse_uv_script_file",
     "run_coros",
     "sanitize_endpoint",

--- a/src/flyte/_utils/helpers.py
+++ b/src/flyte/_utils/helpers.py
@@ -1,5 +1,6 @@
 import os
 import string
+import sys
 import typing
 from contextlib import contextmanager
 from pathlib import Path
@@ -50,6 +51,28 @@ def base36_encode(byte_data: bytes) -> str:
         num, rem = divmod(num, 36)
         base36.append(BASE36_ALPHABET[rem])
     return "".join(reversed(base36))
+
+
+@contextmanager
+def original_std_streams():
+    """
+    Temporarily rebind ``sys.stdout`` / ``sys.stderr`` to the interpreter's original streams.
+
+    cloudpickle only pickles the standard streams by reference when the object it encounters
+    *is* the current ``sys.stdout`` / ``sys.stderr``; any other write-mode file raises
+    ``PicklingError``. UI layers such as rich's Live/status spinner rebind those names to
+    proxies for their duration, so cloudpickling an object graph that holds the real stderr
+    (e.g. loguru's default sink, captured at import time) fails while a spinner is active.
+    Wrap ``cloudpickle.dumps`` of user-supplied object graphs in this context so the identity
+    check sees the original streams again.
+    """
+    captured_stdout, captured_stderr = sys.stdout, sys.stderr
+    sys.stdout = sys.__stdout__ if sys.__stdout__ is not None else captured_stdout
+    sys.stderr = sys.__stderr__ if sys.__stderr__ is not None else captured_stderr
+    try:
+        yield
+    finally:
+        sys.stdout, sys.stderr = captured_stdout, captured_stderr
 
 
 @contextmanager

--- a/tests/flyte/test_deploy.py
+++ b/tests/flyte/test_deploy.py
@@ -526,3 +526,55 @@ async def test_apply_unpicklable_env_raises_click_exception():
             await apply(plan, copy_style="loaded_modules", dryrun=True)
     assert "unpicklable" in excinfo.value.message
     assert "version=" in excinfo.value.message
+
+
+@pytest.mark.asyncio
+async def test_apply_version_derivation_under_redirected_std_streams():
+    """Regression test for https://github.com/flyteorg/flyte/issues/7660.
+
+    The CLI runs apply() inside a rich status spinner, which rebinds sys.stdout/sys.stderr
+    to FileProxy objects. cloudpickle only pickles streams by reference via an identity
+    check against the *current* sys.stdout/sys.stderr, so an env graph holding the real
+    stderr (like loguru's default sink does) raised PicklingError. Version derivation must
+    restore the original streams around cloudpickle.dumps.
+    """
+    import io
+    import pathlib
+
+    from flyte._deploy import apply
+
+    class _StderrSink:
+        """Mimics loguru's default handler: captures the real stderr at import time."""
+
+        def __init__(self):
+            self._stream = sys.__stderr__
+
+    plan = DeploymentPlan(envs={"e": _StderrSink()}, version=None)  # type: ignore[dict-item]
+
+    fake_bundle = Mock()
+    fake_bundle.computed_version = "test-bundle-version"
+
+    fake_cfg = Mock()
+    fake_cfg.root_dir = pathlib.Path("/tmp")
+    fake_cfg.images = {}
+    fake_cfg.project = "p"
+    fake_cfg.domain = "d"
+    fake_cfg.org = "o"
+
+    deployed_env = Mock()
+    deployed_env.get_name.return_value = "e"
+
+    with (
+        patch("flyte._initialize.is_initialized", return_value=True),
+        patch("flyte._deploy.get_init_config", return_value=fake_cfg),
+        patch("flyte._deploy._build_images", new=AsyncMock(return_value={})),
+        patch("flyte._code_bundle._includes.collect_env_include_files", return_value=[]),
+        patch("flyte._code_bundle.build_code_bundle", new=AsyncMock(return_value=fake_bundle)),
+        patch("flyte._deployer.get_deployer", return_value=AsyncMock(return_value=deployed_env)),
+        # Simulate rich's Live display swapping the std streams for proxies.
+        patch.object(sys, "stdout", io.StringIO()),
+        patch.object(sys, "stderr", io.StringIO()),
+    ):
+        deployment = await apply(plan, copy_style="loaded_modules", dryrun=True)
+
+    assert "e" in deployment.envs


### PR DESCRIPTION
## Why are the changes needed?

Fixes flyteorg/flyte#7660.

`flyte deploy` fails with `PicklingError: Cannot pickle files that are not opened for reading: w` whenever any task module's globals hold a reference to the real `sys.stderr` — loguru's default logger being the common case.

Two things interact:

1. `apply()` derives the deployment version by `cloudpickle.dumps(deployment_plan.envs)`. Task functions are pickled by value, so module globals they reference (e.g. loguru's `logger`, whose default sink holds the original stderr) are pulled into the pickle graph.
2. The CLI runs `apply()` inside a rich status spinner, which rebinds `sys.stdout`/`sys.stderr` to `FileProxy` objects for its duration. cloudpickle only pickles streams by reference via an identity check against the *current* `sys.stdout`/`sys.stderr`, so the captured real stderr misses the check, falls through to the write-mode check, and raises.

Reproduced on main with a task module holding a stream reference (loguru-style) pickled inside `console.status(...)` — fails exactly as reported; succeeds outside the spinner or with `--output-format table-simple`.

## What changes were proposed in this pull request?

- Add `flyte._utils.original_std_streams()`, a context manager that temporarily rebinds `sys.stdout`/`sys.stderr` to `sys.__stdout__`/`sys.__stderr__`.
- Wrap the version-hash `cloudpickle.dumps` calls in `flyte/_deploy.py` (`apply()`) and `flyte/_serve.py` with it, so cloudpickle's identity-based stream handling sees the original streams even while a spinner is active.
- Reword the version-derivation error message: the unpicklable object is frequently a third-party module global the user cannot move, so it no longer attributes the capture to "your task or environment" unconditionally.

## How was this patch tested?

- New regression test `test_apply_version_derivation_under_redirected_std_streams`: an env graph holding `sys.__stderr__` (mimicking loguru's default sink) is deployed while `sys.stdout`/`sys.stderr` are swapped for proxies. It fails on main with the exact error from the issue and passes with this change.
- `tests/flyte/test_deploy.py`, `tests/flyte/test_serve.py`, `tests/utils/` all pass (81 tests).
- ruff format/check and mypy (pre-commit) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)