### PR TITLE
fix(auth): store tokens in one keychain item to avoid double password prompt

### DIFF
--- a/src/flyte/remote/_client/auth/_keyring.py
+++ b/src/flyte/remote/_client/auth/_keyring.py
@@ -58,7 +58,8 @@ class KeyringStore:
     # Both tokens live in ONE keychain item so macOS only prompts for the
     # keychain password once per retrieve (one prompt per item otherwise).
     _tokens_key = "tokens"
-    # Legacy per-token keys, only used for cleanup in delete().
+    # JSON field names inside the tokens item; also the legacy per-token
+    # keychain keys cleaned up in delete().
     _access_token_key = "access_token"
     _refresh_token_key = "refresh_token"
 
@@ -87,8 +88,8 @@ class KeyringStore:
                 KeyringStore._tokens_key,
                 json.dumps(
                     {
-                        "access_token": credentials.access_token,
-                        "refresh_token": credentials.refresh_token,
+                        KeyringStore._access_token_key: credentials.access_token,
+                        KeyringStore._refresh_token_key: credentials.refresh_token,
                     }
                 ),
             )
@@ -135,8 +136,8 @@ class KeyringStore:
         except (json.JSONDecodeError, TypeError) as e:
             logger.debug(f"Failed to parse tokens from keyring. Error: {e}")
             return None
-        access_token = tokens.get("access_token")
-        refresh_token = tokens.get("refresh_token")
+        access_token = tokens.get(KeyringStore._access_token_key)
+        refresh_token = tokens.get(KeyringStore._refresh_token_key)
 
         if not access_token:
             if not refresh_token:

--- a/src/flyte/remote/_client/auth/_keyring.py
+++ b/src/flyte/remote/_client/auth/_keyring.py
@@ -55,11 +55,10 @@ class KeyringStore:
     Methods to access Keyring Store.
     """
 
-    # Both tokens live in ONE keychain item so macOS only prompts for the
+    # Both tokens live in ONE keychain item, so macOS only prompts for the
     # keychain password once per retrieve (one prompt per item otherwise).
     _tokens_key = "tokens"
-    # JSON field names inside the tokens item; also the legacy per-token
-    # keychain keys cleaned up in delete().
+    # JSON field names inside the tokens item;
     _access_token_key = "access_token"
     _refresh_token_key = "refresh_token"
 

--- a/src/flyte/remote/_client/auth/_keyring.py
+++ b/src/flyte/remote/_client/auth/_keyring.py
@@ -1,4 +1,5 @@
 import hashlib  # Added import for hashing
+import json
 import typing
 from urllib.parse import urlparse  # Added import
 
@@ -54,6 +55,10 @@ class KeyringStore:
     Methods to access Keyring Store.
     """
 
+    # Both tokens live in ONE keychain item so macOS only prompts for the
+    # keychain password once per retrieve (one prompt per item otherwise).
+    _tokens_key = "tokens"
+    # Legacy per-token keys, only used for cleanup in delete().
     _access_token_key = "access_token"
     _refresh_token_key = "refresh_token"
 
@@ -77,16 +82,15 @@ class KeyringStore:
         from keyring.errors import NoKeyringError
 
         try:
-            if credentials.refresh_token:
-                keyring.set_password(
-                    credentials.for_endpoint,
-                    KeyringStore._refresh_token_key,
-                    credentials.refresh_token,
-                )
             keyring.set_password(
                 credentials.for_endpoint,
-                KeyringStore._access_token_key,
-                credentials.access_token,
+                KeyringStore._tokens_key,
+                json.dumps(
+                    {
+                        "access_token": credentials.access_token,
+                        "refresh_token": credentials.refresh_token,
+                    }
+                ),
             )
         except NoKeyringError as e:
             logger.debug(f"KeyRing not available, tokens will not be cached. Error: {e}")
@@ -114,16 +118,25 @@ class KeyringStore:
         from keyring.errors import NoKeyringError
 
         for_endpoint = strip_scheme(for_endpoint)
-        access_token: str | None = None
         try:
-            refresh_token = keyring.get_password(for_endpoint, KeyringStore._refresh_token_key)
-            access_token = keyring.get_password(for_endpoint, KeyringStore._access_token_key)
+            tokens_json = keyring.get_password(for_endpoint, KeyringStore._tokens_key)
         except NoKeyringError as e:
             logger.debug(f"KeyRing not available, tokens will not be cached. Error: {e}")
             return None
         except Exception as e:
             logger.debug(f"Failed to retrieve tokens from keyring. Error: {e}")
             return None
+
+        if not tokens_json:
+            logger.debug("No tokens found in keyring.")
+            return None
+        try:
+            tokens = json.loads(tokens_json)
+        except (json.JSONDecodeError, TypeError) as e:
+            logger.debug(f"Failed to parse tokens from keyring. Error: {e}")
+            return None
+        access_token = tokens.get("access_token")
+        refresh_token = tokens.get("refresh_token")
 
         if not access_token:
             if not refresh_token:
@@ -175,5 +188,7 @@ class KeyringStore:
             except Exception as e:
                 logger.debug(f"Failed to delete key {key} from keyring. Error: {e}")
 
+        _delete_key(KeyringStore._tokens_key)
+        # Clean up legacy per-token items from before tokens were combined.
         _delete_key(KeyringStore._access_token_key)
         _delete_key(KeyringStore._refresh_token_key)

--- a/tests/flyte/keyring/test_keyring_store.py
+++ b/tests/flyte/keyring/test_keyring_store.py
@@ -66,28 +66,19 @@ def test_store_skips_when_disabled():
     assert result is creds
 
 
-def test_store_writes_access_and_refresh_when_enabled():
+def test_store_writes_single_keychain_item():
+    """One keychain item for both tokens = one macOS keychain prompt on retrieve."""
+    import json
+
     from flyte.remote._client.auth._keyring import Credentials, KeyringStore
 
     creds = Credentials(access_token="tok", for_endpoint="foo", refresh_token="rtok")
     with patch("keyring.set_password") as mock_set:
         KeyringStore.store(creds, disable=False)
 
-    # Expect both refresh_token and access_token writes.
-    assert mock_set.call_count == 2
-    call_args = {call.args[1]: call.args[2] for call in mock_set.call_args_list}
-    assert call_args == {"access_token": "tok", "refresh_token": "rtok"}
-
-
-def test_store_writes_only_access_when_no_refresh():
-    from flyte.remote._client.auth._keyring import Credentials, KeyringStore
-
-    creds = Credentials(access_token="tok", for_endpoint="foo")
-    with patch("keyring.set_password") as mock_set:
-        KeyringStore.store(creds, disable=False)
-
     assert mock_set.call_count == 1
-    assert mock_set.call_args.args[1] == "access_token"
+    assert mock_set.call_args.args[1] == "tokens"
+    assert json.loads(mock_set.call_args.args[2]) == {"access_token": "tok", "refresh_token": "rtok"}
 
 
 def test_store_swallows_no_keyring_error():
@@ -121,18 +112,27 @@ def test_retrieve_returns_none_when_no_tokens_stored():
 
 
 def test_retrieve_returns_credentials_when_access_token_present():
+    import json
+
     from flyte.remote._client.auth._keyring import KeyringStore
 
-    def fake_get(endpoint, key):
-        return {"access_token": "a", "refresh_token": "r"}.get(key)
-
-    with patch("keyring.get_password", side_effect=fake_get):
+    stored = json.dumps({"access_token": "a", "refresh_token": "r"})
+    with patch("keyring.get_password", return_value=stored) as mock_get:
         creds = KeyringStore.retrieve("https://flyte.example.com", disable=False)
 
+    # Exactly one keychain read = exactly one macOS keychain prompt.
+    assert mock_get.call_count == 1
     assert creds is not None
     assert creds.access_token == "a"
     assert creds.refresh_token == "r"
     assert creds.for_endpoint == "flyte.example.com"  # scheme stripped
+
+
+def test_retrieve_returns_none_on_unparseable_tokens():
+    from flyte.remote._client.auth._keyring import KeyringStore
+
+    with patch("keyring.get_password", return_value="not-json"):
+        assert KeyringStore.retrieve("foo", disable=False) is None
 
 
 def test_retrieve_strips_scheme_before_lookup():
@@ -164,15 +164,14 @@ def test_delete_skips_when_disabled():
     mock_del.assert_not_called()
 
 
-def test_delete_removes_both_keys_when_enabled():
+def test_delete_removes_tokens_and_legacy_keys_when_enabled():
     from flyte.remote._client.auth._keyring import KeyringStore
 
     with patch("keyring.delete_password") as mock_del:
         KeyringStore.delete("https://flyte.example.com", disable=False)
 
-    assert mock_del.call_count == 2
     keys_deleted = {call.args[1] for call in mock_del.call_args_list}
-    assert keys_deleted == {"access_token", "refresh_token"}
+    assert keys_deleted == {"tokens", "access_token", "refresh_token"}
 
 
 def test_delete_swallows_password_delete_error():


### PR DESCRIPTION
## Why

On macOS, running a workflow prompted for the keychain password **twice**. macOS prompts once per keychain item accessed, and `KeyringStore` stored `access_token` and `refresh_token` as two separate keychain items — so every credential retrieve triggered two prompts.

## What changed

- `KeyringStore.store()` now writes both tokens as a single JSON blob under one `tokens` key → `retrieve()` does exactly one keychain read, so at most one password prompt (zero after "Always Allow").
- `retrieve()` parses the JSON blob; unparseable/missing data falls back to `None` (same as no cached credentials).
- `delete()` removes the new `tokens` key and also cleans up the legacy per-token `access_token`/`refresh_token` items.
- Public API unchanged; callers in `_authenticators/base.py` are untouched.

Note: previously cached tokens (old two-item format) are intentionally not read back — a legacy fallback would require a second keychain read, which is the exact bug. Users get one fresh browser login after upgrading, then a single prompt thereafter.

## Tests

Updated `tests/flyte/keyring/test_keyring_store.py`:
- single `set_password` call with JSON payload on store
- exactly one `get_password` call on retrieve
- unparseable blob returns `None`
- delete removes `tokens` + legacy keys

`uv run pytest tests/flyte/keyring/ -q` → all passing.

## Summary by Bito

Fixes double macOS keychain password prompts by consolidating access and refresh tokens into a single keychain item, ensuring credential retrieval performs exactly one keychain read.