### PR TITLE
Network/handle deadline exceeded

### DIFF
--- a/src/flyte/_internal/controllers/remote/_client.py
+++ b/src/flyte/_internal/controllers/remote/_client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from flyteidl2.actions.actions_service_connect import ActionsServiceClient
 from flyteidl2.workflow.queue_service_connect import QueueServiceClient
 from flyteidl2.workflow.state_service_connect import StateServiceClient
@@ -9,16 +11,76 @@ from flyte.remote._client.auth._session import SessionConfig, create_session_con
 from ._service_protocol import ActionsService, QueueService, StateService, use_actions_service
 
 
+class _SwappableHTTPClient:
+    """HTTP client facade whose underlying client (and its connection pool) can be replaced.
+
+    connectrpc service clients accept an ``http_client`` at construction and invoke a request
+    method on it per RPC. Handing them this stable facade lets the controller abandon a
+    suspected-dead connection pool without reaching into connectrpc internals: ``replace``
+    installs a fresh client for future requests, while requests and streams already in flight
+    keep the old client alive until they finish.
+
+    Methods delegate explicitly (rather than via ``__getattr__``) so that even a bound method
+    captured by a caller resolves the current client at call time.
+    """
+
+    def __init__(self, inner: Any):
+        self._inner = inner
+
+    def replace(self, inner: Any) -> None:
+        self._inner = inner
+
+    def delete(self, *args, **kwargs):
+        return self._inner.delete(*args, **kwargs)
+
+    def execute(self, *args, **kwargs):
+        return self._inner.execute(*args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        return self._inner.get(*args, **kwargs)
+
+    def head(self, *args, **kwargs):
+        return self._inner.head(*args, **kwargs)
+
+    def options(self, *args, **kwargs):
+        return self._inner.options(*args, **kwargs)
+
+    def patch(self, *args, **kwargs):
+        return self._inner.patch(*args, **kwargs)
+
+    def post(self, *args, **kwargs):
+        return self._inner.post(*args, **kwargs)
+
+    def put(self, *args, **kwargs):
+        return self._inner.put(*args, **kwargs)
+
+    def stream(self, *args, **kwargs):
+        return self._inner.stream(*args, **kwargs)
+
+
 class ControllerClient:
     """
     A client for the Controller API.
     """
 
     def __init__(self, session_cfg: SessionConfig):
-        shared = session_cfg.connect_kwargs()
+        self._session_cfg = session_cfg
+        self._http_client = _SwappableHTTPClient(session_cfg.http_client)
+        shared = {**session_cfg.connect_kwargs(), "http_client": self._http_client}
         self._state_service = StateServiceClient(**shared)
         self._queue_service = QueueServiceClient(**shared)
         self._actions_service = ActionsServiceClient(**shared) if use_actions_service() else None
+
+    def replace_http_client(self) -> None:
+        """Abandon pooled connections by installing a fresh HTTP client behind the facade.
+
+        Used when the shared connection pool is suspected dead (e.g. a black-holed TCP flow
+        that times out every request without ever surfacing a transport error). The
+        state/queue/actions service clients — and the informers, which share those same
+        objects — all send requests through the one facade, so the replacement takes effect
+        everywhere on their next call.
+        """
+        self._http_client.replace(self._session_cfg.new_http_client())
 
     @classmethod
     async def for_endpoint(cls, endpoint: str, insecure: bool = False, **kwargs) -> ControllerClient:

--- a/src/flyte/_internal/controllers/remote/_controller.py
+++ b/src/flyte/_internal/controllers/remote/_controller.py
@@ -134,7 +134,7 @@ class RemoteController(Controller):
         self,
         client_coro: Awaitable[ClientSet],
         workers: int = 20,
-        max_system_retries: int = 10,
+        max_system_retries: int = 100,
     ):
         """ """
         super().__init__(

--- a/src/flyte/_internal/controllers/remote/_core.py
+++ b/src/flyte/_internal/controllers/remote/_core.py
@@ -47,7 +47,7 @@ class Controller:
         self,
         client_coro: Awaitable[ClientSet],
         workers: int = 20,
-        max_system_retries: int = 10,
+        max_system_retries: int = 100,
         resource_log_interval_sec: float = 10.0,
         min_backoff_on_err_sec: float = 0.5,
         thread_wait_timeout_sec: float = 5.0,
@@ -56,7 +56,11 @@ class Controller:
         """
         Create a new controller instance.
         :param workers: Number of worker threads.
-        :param max_system_retries: Maximum number of system retries.
+        :param max_system_retries: Maximum number of retries for retryable (system) failures. With backoff capped
+            at _F_MAX_BFF_ON_ERR (10s), this bounds how long a transient outage the controller rides out
+            (~100 retries is roughly 20-25 minutes). It must comfortably exceed control-plane rollouts and the
+            kernel's ~15 minute abandonment of a black-holed TCP connection, since a parent that has run for
+            hours should not be failed by a minutes-long blip.
         :param resource_log_interval_sec: Interval for logging resource stats.
         :param min_backoff_on_err_sec: Minimum backoff time on error.
         :param thread_wait_timeout_sec: Timeout for waiting for the controller thread to start.
@@ -528,7 +532,7 @@ class Controller:
                     action.retries += 1
                     if action.retries > self._max_retries:
                         raise
-                    backoff = min(self._min_backoff_on_err * (2 ** (action.retries - 1)), self._max_backoff_on_err)
+                    backoff = min(self._min_backoff_on_err * (2 ** min(action.retries - 1, 20)), self._max_backoff_on_err)
                     logger.warning(
                         f"[{worker_id}] Backing off for {backoff} [retry {action.retries}/{self._max_retries}] "
                         f"on action {action.name} due to error: {e}"

--- a/src/flyte/_internal/controllers/remote/_core.py
+++ b/src/flyte/_internal/controllers/remote/_core.py
@@ -558,7 +558,9 @@ class Controller:
                     action.retries += 1
                     if action.retries > self._max_retries:
                         raise
-                    backoff = min(self._min_backoff_on_err * (2 ** min(action.retries - 1, 20)), self._max_backoff_on_err)
+                    backoff = min(
+                        self._min_backoff_on_err * (2 ** min(action.retries - 1, 20)), self._max_backoff_on_err
+                    )
                     logger.warning(
                         f"[{worker_id}] Backing off for {backoff} [retry {action.retries}/{self._max_retries}] "
                         f"on action {action.name} due to error: {e}"

--- a/src/flyte/_internal/controllers/remote/_core.py
+++ b/src/flyte/_internal/controllers/remote/_core.py
@@ -24,6 +24,12 @@ from ._action import Action
 from ._informer import InformerCache
 from ._service_protocol import ActionsService, ClientSet, QueueService, StateService
 
+# A request that dies at its client-side deadline may be riding a dead pooled connection
+# (a severed NAT/conntrack flow drops packets without RST, so the transport keeps reusing
+# the connection and every request on it hangs). After this many launch timeouts in a row,
+# the controller replaces the HTTP client so the next attempt opens a fresh connection.
+_LAUNCH_TIMEOUTS_BEFORE_NEW_CONNECTION = 3
+
 
 def _actions_metadata(action: Action) -> dict[str, str]:
     """Build request headers for Actions service calls."""
@@ -79,6 +85,7 @@ class Controller:
         self._client_coro = client_coro
         self._failure_event: Event | None = None
         self._enqueue_timeout = enqueue_timeout_sec
+        self._consecutive_launch_timeouts = 0
         self._informer_start_wait_timeout = thread_wait_timeout_sec
         max_qps = int(os.getenv("_F_MAX_QPS", "100"))
         self._rate_limiter = AsyncLimiter(max_qps, 1.0)
@@ -224,6 +231,7 @@ class Controller:
         self._running = True
         logger.debug("Waiting for Service Client to be ready")
         client_set = await self._client_coro
+        self._client_set: ClientSet = client_set
         self._state_service: StateService = client_set.state_service
         self._queue_service: QueueService = client_set.queue_service
         self._actions_service: ActionsService | None = client_set.actions_service
@@ -461,6 +469,7 @@ class Controller:
                             timeout_ms=int(self._enqueue_timeout * 1000),
                         )
                     logger.info(f"Successfully launched action: {action.name}")
+                    self._consecutive_launch_timeouts = 0
                 except httpx.TransportError as e:
                     # Transport-level failure (e.g. ConnectTimeout reaching the IDP during auth refresh,
                     # ReadTimeout, DNS failure). These never produced an HTTP response, so they bypass
@@ -471,6 +480,23 @@ class Controller:
                     )
                     raise flyte.errors.SlowDownError(f"Transient transport error ({type(e).__name__}): {e}") from e
                 except ConnectError as e:
+                    if e.code == Code.DEADLINE_EXCEEDED:
+                        self._consecutive_launch_timeouts += 1
+                        if self._consecutive_launch_timeouts >= _LAUNCH_TIMEOUTS_BEFORE_NEW_CONNECTION:
+                            logger.warning(
+                                f"{self._consecutive_launch_timeouts} consecutive launch timeouts; "
+                                "replacing the HTTP connection pool in case the pooled connection is dead."
+                            )
+                            self._consecutive_launch_timeouts = 0
+                            try:
+                                self._client_set.replace_http_client()
+                            except Exception:
+                                # Never let a failed replacement escape: it would bypass the
+                                # SlowDownError retry path and fail the action immediately.
+                                logger.exception("Failed to replace the HTTP client; keeping the existing one")
+                    else:
+                        # The server responded, so the connection is alive.
+                        self._consecutive_launch_timeouts = 0
                     if e.code == Code.ALREADY_EXISTS:
                         logger.info(f"Action {action.name} already exists, continuing to monitor.")
                         return

--- a/src/flyte/_internal/controllers/remote/_informer.py
+++ b/src/flyte/_internal/controllers/remote/_informer.py
@@ -139,7 +139,8 @@ class Informer:
         min_watch_backoff: float = 1.0,
         max_watch_backoff: float = 30.0,
         watch_conn_timeout_sec: float = 5.0,
-        max_watch_retries: int = 10,
+        # Consecutive failures; ~20+ min at the 30s backoff cap, same rationale as max_system_retries.
+        max_watch_retries: int = 40,
     ):
         self.name = self.mkname(run_name=run_id.name, parent_action_name=parent_action_name)
         self.parent_action_name = parent_action_name
@@ -288,7 +289,7 @@ class Informer:
                 logger.exception(f"Watch error: {self.name}", exc_info=e)
                 last_exc = e
                 retries += 1
-            backoff = min(self._min_watch_backoff * (2**retries), self._max_watch_backoff)
+            backoff = min(self._min_watch_backoff * (2 ** min(retries, 20)), self._max_watch_backoff)
             logger.warning(f"Watch for {self.name} failed, retrying in {backoff} seconds...")
             await asyncio.sleep(backoff)
 

--- a/src/flyte/_internal/controllers/remote/_service_protocol.py
+++ b/src/flyte/_internal/controllers/remote/_service_protocol.py
@@ -88,3 +88,6 @@ class ClientSet(Protocol):
     @property
     def actions_service(self: ClientSet) -> ActionsService | None:
         """Unified actions service (replaces QueueService + StateService when available)"""
+
+    def replace_http_client(self) -> None:
+        """Give every service client a fresh HTTP client, abandoning pooled connections."""

--- a/src/flyte/remote/_client/auth/_session.py
+++ b/src/flyte/remote/_client/auth/_session.py
@@ -35,9 +35,15 @@ class SessionConfig:
     # This is used to rebuild a `SessionConfig` for a per-cluster endpoint
     # without losing the configured auth mode.
     auth_kwargs: typing.Mapping[str, Any] = field(default_factory=dict)
+    # CA bundle `http_client` was built with; kept so `new_http_client` can build an identical client.
+    tls_ca_cert: typing.Optional[bytes] = None
 
     def connect_kwargs(self) -> dict[str, Any]:
         return {"address": self.endpoint, "interceptors": self.interceptors, "http_client": self.http_client}
+
+    def new_http_client(self) -> Any:
+        """Build a fresh HTTP client identical to `http_client`, with its own connection pool."""
+        return _build_pyqwest_client(self.tls_ca_cert)
 
 
 def normalize_rpc_endpoint(endpoint: str, *, insecure: bool = False) -> str:
@@ -292,4 +298,5 @@ async def create_session_config(
         http_client=http_client,
         api_key=api_key,
         auth_kwargs=captured_auth_kwargs,
+        tls_ca_cert=tls_ca_cert,
     )

--- a/tests/internal/controllers/test_remote_controller.py
+++ b/tests/internal/controllers/test_remote_controller.py
@@ -939,3 +939,89 @@ async def test_submit_task_reparents_to_task_action_inside_trace():
         # The submit semaphore is keyed by the real task action, not the trace pseudo-action.
         assert unique_action_name(tctx.task_action) in controller._parent_action_semaphore
         assert unique_action_name(tctx.action) not in controller._parent_action_semaphore
+
+
+@pytest.mark.asyncio
+async def test_bg_launch_replaces_connection_after_consecutive_timeouts():
+    """Consecutive enqueue deadline timeouts replace the HTTP client (dead pooled connection);
+    any response from the server resets the streak."""
+    from aiolimiter import AsyncLimiter
+    from connectrpc.code import Code
+    from connectrpc.errors import ConnectError
+
+    from flyte._internal.controllers.remote._core import _LAUNCH_TIMEOUTS_BEFORE_NEW_CONNECTION
+
+    controller = object.__new__(Controller)
+    controller._rate_limiter = AsyncLimiter(100, 1.0)
+    controller._enqueue_timeout = 0.01
+    controller._consecutive_launch_timeouts = 0
+    controller._client_set = MagicMock()
+    controller._actions_service = AsyncMock()
+    controller._actions_service.enqueue.side_effect = ConnectError(Code.DEADLINE_EXCEEDED, "Request timed out")
+
+    action = Action(
+        parent_action_name="parent",
+        action_id=identifier_pb2.ActionIdentifier(
+            name="child",
+            run=identifier_pb2.RunIdentifier(name="run"),
+        ),
+        type="trace",
+    )
+
+    for i in range(_LAUNCH_TIMEOUTS_BEFORE_NEW_CONNECTION):
+        with pytest.raises(flyte.errors.SlowDownError):
+            await controller._bg_launch(action)
+        if i < _LAUNCH_TIMEOUTS_BEFORE_NEW_CONNECTION - 1:
+            controller._client_set.replace_http_client.assert_not_called()
+
+    controller._client_set.replace_http_client.assert_called_once()
+    assert controller._consecutive_launch_timeouts == 0
+
+    # A response from the server (even an error) proves the connection is alive and resets the streak.
+    controller._actions_service.enqueue.side_effect = ConnectError(Code.DEADLINE_EXCEEDED, "Request timed out")
+    with pytest.raises(flyte.errors.SlowDownError):
+        await controller._bg_launch(action)
+    assert controller._consecutive_launch_timeouts == 1
+
+    controller._actions_service.enqueue.side_effect = ConnectError(Code.ALREADY_EXISTS, "exists")
+    await controller._bg_launch(action)
+    assert controller._consecutive_launch_timeouts == 0
+    controller._client_set.replace_http_client.assert_called_once()
+
+
+def test_swappable_http_client_delegates_to_current_inner(monkeypatch):
+    """The facade handed to connectrpc never changes; replace() only redirects which
+    client serves the next request — even through a bound method captured earlier."""
+    monkeypatch.setenv("_U_USE_ACTIONS", "1")
+    from flyte._internal.controllers.remote._client import ControllerClient, _SwappableHTTPClient
+    from flyte.remote._client.auth._session import SessionConfig
+
+    class FakeInner:
+        def __init__(self):
+            self.posts = 0
+
+        def post(self, *args, **kwargs):
+            self.posts += 1
+            return self
+
+    first, second = FakeInner(), FakeInner()
+    facade = _SwappableHTTPClient(first)
+    bound_post = facade.post  # captured before the swap, like connectrpc might
+    assert bound_post() is first
+    facade.replace(second)
+    assert bound_post() is second
+    assert (first.posts, second.posts) == (1, 1)
+
+    # ControllerClient hands the same facade to all service clients and swaps it in place.
+    cfg = SessionConfig(
+        endpoint="https://example.test",
+        insecure=False,
+        insecure_skip_verify=False,
+        interceptors=(),
+        http_client=first,
+    )
+    cc = ControllerClient(cfg)
+    facade = cc._http_client
+    assert facade._inner is first
+    cc.replace_http_client()
+    assert facade._inner is not first  # fresh real client, same facade object


### PR DESCRIPTION
## Background

19-hour customer run died because of 11 consecutive child-launch `Enqueue` time outs at their 5s deadline, exhausting the controller's ~2-minute retry budget; the platform-level retry kicked in but took many hours to catch back up. The control plane was healthy the whole time, the same org was successfully enqueuing from other pods. The failing pod's pooled HTTP/2 connection had been silently black-holed (severed NAT/conntrack flow: packets vanish, no RST). The kernel by default doesn't declare such a socket dead for ~15 minutes, and the pool kept multiplexing every retry onto it - so no retry count could have saved the run.

Prior art: Kubernetes maybe experienced a similar issue with kubelet↔apiserver heartbeats ([kubernetes#48638](https://github.com/kubernetes/kubernetes/issues/48638)) and converged on two mitigations ([#63492](https://github.com/kubernetes/kubernetes/pull/63492), [#95981](https://github.com/kubernetes/kubernetes/pull/95981)).

## Changes

**1. Launch retry budget 10 → 100.** Backoff is capped at 10s, so this rides out ~20 minutes of transient failure instead of ~2 — longer than a control-plane rollout, and longer than the kernel needs to kill a dead socket.  Also clamp the backoff exponent so a large `_F_MAX_RETRIES` can't overflow.

**2. Replace the connection pool after 3 consecutive deadline timeouts.** The state/queue/actions clients now share one swappable HTTP-client facade; three straight `DEADLINE_EXCEEDED`s install a fresh client behind it, so the next retry opens a new TCP connection instead of riding the dead one. Any response from the server — even an error — proves the connection alive and resets the streak.

The facade exists to avoid touching connectrpc internals (it goes in via the public `http_client` constructor arg); in-flight requests and streams keep the old client alive until they finish; informers share the same service objects, so the swap covers their reconnects automatically.

Should also use HTTP/2 keepalive PINGs at the transport, the grpc client had this but pyqwest doesn't.

## Testing
Run a long running parent task, and then attach a network capable container to the pod
### Testing resetting with a new http client
```
kubectl debug -it <pod> -n <ns> --image=nicolaka/netshoot --profile=netadmin -- bash
```

Inside that
```
ss -tn state established '( dport = :443 )'   # to find the local port, 43782
iptables -I OUTPUT 1 -p tcp --sport 43782 -j DROP
```

use `dig +short <host>` to figure out the relevant IPs.

After multiple failures the connection should be recycled and a new connection used.
```
Jul 15 14:14:27.971 [flyte] ERROR Failed to launch action: 337bsrx8w3igt0a3ijcy5flit, Code: Code.DEADLINE_EXCEEDED, Details Request timed out backing off...
Jul 15 14:14:27.971 [flyte] WARNING [worker-6] Backing off for 0.5 [retry 1/100] on action 337bsrx8w3igt0a3ijcy5flit due to error: Failed to launch action: Request timed out
Jul 15 14:14:28.472 [flyte] WARNING [worker-6] Retrying action 337bsrx8w3igt0a3ijcy5flit after backoff
Jul 15 14:14:33.477 [flyte] ERROR Failed to launch action: 337bsrx8w3igt0a3ijcy5flit, Code: Code.DEADLINE_EXCEEDED, Details Request timed out backing off...
Jul 15 14:14:33.478 [flyte] WARNING [worker-6] Backing off for 1.0 [retry 2/100] on action 337bsrx8w3igt0a3ijcy5flit due to error: Failed to launch action: Request timed out
Jul 15 14:14:34.479 [flyte] WARNING [worker-6] Retrying action 337bsrx8w3igt0a3ijcy5flit after backoff
Jul 15 14:14:39.484 [flyte] WARNING 3 consecutive launch timeouts; replacing the HTTP connection pool in case the pooled connection is dead.
```
### Testing full network partition
Same setup as before then
```
CP_IPS=$(dig +short dogfood.cloud-staging.union.ai)
for ip in $CP_IPS; do iptables -I OUTPUT 1 -d $ip -j DROP && echo "BLOCKED $ip"; done
```
should see messages like
```
[ulh9sxvs9whsmgx5l8qx][a0] [flyte] WARNING Watch for ulh9sxvs9whsmgx5l8qx.a0 failed, retrying in 30.0 seconds...
[flyte] WARNING [worker-0] Retrying action ayj9zzqmhjkpp26o2dkkj4cdy after backoff
[flyte] ERROR Failed to launch action: ayj9zzqmhjkpp26o2dkkj4cdy, Code: Code.DEADLINE_EXCEEDED, Details Request timed out backing off...
[flyte] WARNING [worker-0] Backing off for 10.0 [retry 44/100] on action ayj9zzqmhjkpp26o2dkkj4cdy due to error: Failed to launch action: Request timed out
[flyte] WARNING [worker-0] Retrying action ayj9zzqmhjkpp26o2dkkj4cdy after backoff
[flyte] WARNING 3 consecutive launch timeouts; replacing the HTTP connection pool in case the pooled connection is dead.
[flyte] ERROR Failed to launch action: ayj9zzqmhjkpp26o2dkkj4cdy, Code: Code.DEADLINE_EXCEEDED, Details Request timed out backing off...
[flyte] WARNING [worker-0] Backing off for 10.0 [retry 45/100] on action ayj9zzqmhjkpp26o2dkkj4cdy due to error: Failed to launch action: Request timed out
```
then
```
for ip in $CP_IPS; do iptables -D OUTPUT -d $ip -j DROP && echo "UNBLOCKED $ip"; done
```