### PR TITLE
feat(auth): FLYTE_USE_FILE_KEYRING opt-out of macOS keychain prompts

### DIFF
--- a/src/flyte/_keyring/file.py
+++ b/src/flyte/_keyring/file.py
@@ -1,3 +1,4 @@
+import os
 from base64 import decodebytes, encodebytes
 from configparser import ConfigParser, NoOptionError, NoSectionError
 from pathlib import Path
@@ -13,8 +14,12 @@ class SimplePlainTextKeyring(KeyringBackend):
     """
     Simple plain text keyring for remote notebook environments.
 
-    This backend is only active when running in IPython/Jupyter notebooks.
-    For local development, the system keyring is used instead.
+    This backend is only active when running in IPython/Jupyter notebooks, or
+    when FLYTE_USE_FILE_KEYRING=1 is set. The env var is an escape hatch for
+    macOS keychain password prompts: keychain ACLs are tied to the exact
+    interpreter binary, so ad-hoc-signed pythons (uv, python-build-standalone)
+    re-prompt for every new venv and "Always Allow" never sticks.
+    For local development the system keyring is used by default.
     """
 
     @property
@@ -23,6 +28,10 @@ class SimplePlainTextKeyring(KeyringBackend):
         Return priority based on whether we're in a notebook environment.
         Negative priority means this backend will be skipped by keyring.
         """
+        if os.getenv("FLYTE_USE_FILE_KEYRING", "").lower() in ("1", "true"):
+            # Explicitly requested - outrank the macOS keychain backend (priority 5)
+            return 10
+
         from flyte._tools import ipython_check
 
         if ipython_check():

--- a/tests/flyte/keyring/test_keyring.py
+++ b/tests/flyte/keyring/test_keyring.py
@@ -48,3 +48,17 @@ def test_password_delete_error(tmp_path):
     msg = "Password not found"
     with pytest.raises(PasswordDeleteError, match=msg):
         keyring.delete_password("my_servic", "wow")
+
+
+def test_priority_forced_by_env_var(tmp_path, monkeypatch):
+    keyring = _TestSimplePlainTextKeyring(home_root=tmp_path)
+
+    monkeypatch.delenv("FLYTE_USE_FILE_KEYRING", raising=False)
+    assert keyring.priority < 5  # system keyring (macOS = 5) wins by default
+
+    for value in ("1", "true", "True"):
+        monkeypatch.setenv("FLYTE_USE_FILE_KEYRING", value)
+        assert keyring.priority > 5  # forced: outranks the macOS keychain
+
+    monkeypatch.setenv("FLYTE_USE_FILE_KEYRING", "0")
+    assert keyring.priority < 5


### PR DESCRIPTION
Followup to #1292 — answers https://github.com/flyteorg/flyte-sdk/pull/1292#pullrequestreview-4696509642

## Why does "Always Allow" never always allow?

Two independent macOS keychain behaviors, both verified:

1. **python-keyring's macOS backend implements `set_password` as delete + `SecItemAdd`** (`keyring/backends/macOS/api.py`). Every token refresh recreates the keychain item from scratch with a fresh ACL, so the "Always Allow" grant is wiped on the next store.
2. **Keychain ACLs identify the client app by code signature.** uv / python-build-standalone interpreters are **ad-hoc signed with no identity** (`codesign -dv` → `Identifier=-`, `Signature=adhoc`), so the keychain can't build a durable app identity — every new venv (or uv python upgrade) is a "different app" and re-prompts for the login password even though the token is already cached.

Neither is fixable while tokens live in the macOS keychain.

## What changed

`FLYTE_USE_FILE_KEYRING=1` raises the priority of the existing `SimplePlainTextKeyring` backend (already shipped for notebook environments) above the macOS keychain backend, so tokens are stored in `~/.flyte/keyring.cfg` (created `0600`) — same model as `gcloud`/`aws`/`kubectl` credentials, zero prompts.

**Default behavior is unchanged**: without the env var the system keyring is still used, and notebook detection still works as before.

## Tests

- `test_priority_forced_by_env_var`: unset/"0" → below macOS priority; "1"/"true" → above.
- Manual: `FLYTE_USE_FILE_KEYRING=1` selects `SimplePlainTextKeyring` and round-trips a token through `~/.flyte/keyring.cfg`.
- `uv run pytest tests/flyte/keyring/ -q` → 22 passed.