### PR TITLE
fix: degrade gracefully when keyring package is missing (FLYTE-SDK-6N)

### DIFF
--- a/src/flyte/remote/_client/auth/_keyring.py
+++ b/src/flyte/remote/_client/auth/_keyring.py
@@ -78,8 +78,12 @@ class KeyringStore:
         if disable:
             logger.debug("Keyring is disabled, skipping token store.")
             return credentials
-        import keyring
-        from keyring.errors import NoKeyringError
+        try:
+            import keyring
+            from keyring.errors import NoKeyringError
+        except ImportError as e:
+            logger.debug(f"keyring package not available, tokens will not be cached. Error: {e}")
+            return credentials
 
         try:
             keyring.set_password(
@@ -114,8 +118,12 @@ class KeyringStore:
         if disable:
             logger.debug("Keyring is disabled, skipping token retrieve.")
             return None
-        import keyring
-        from keyring.errors import NoKeyringError
+        try:
+            import keyring
+            from keyring.errors import NoKeyringError
+        except ImportError as e:
+            logger.debug(f"keyring package not available, tokens will not be cached. Error: {e}")
+            return None
 
         for_endpoint = strip_scheme(for_endpoint)
         try:
@@ -166,8 +174,12 @@ class KeyringStore:
         if disable:
             logger.debug("Keyring is disabled, skipping token delete.")
             return
-        import keyring
-        from keyring.errors import NoKeyringError, PasswordDeleteError
+        try:
+            import keyring
+            from keyring.errors import NoKeyringError, PasswordDeleteError
+        except ImportError as e:
+            logger.debug(f"keyring package not available, skipping token delete. Error: {e}")
+            return
 
         for_endpoint = strip_scheme(for_endpoint)
 

--- a/tests/flyte/keyring/test_keyring_store.py
+++ b/tests/flyte/keyring/test_keyring_store.py
@@ -197,3 +197,35 @@ def test_strip_scheme(raw, expected):
     from flyte.remote._client.auth._keyring import strip_scheme
 
     assert strip_scheme(raw) == expected
+
+
+# `keyring` is a declared dependency, but a broken/slim environment can still be
+# missing it. Token caching is best-effort, so a missing package must degrade
+# gracefully instead of raising ModuleNotFoundError up through the auth flow and
+# crashing SelectCluster/upload/run (see FLYTE-SDK-6N).
+
+
+def test_store_degrades_when_keyring_not_installed():
+    from flyte.remote._client.auth._keyring import Credentials, KeyringStore
+
+    creds = Credentials(access_token="tok", for_endpoint="foo")
+    # Setting a module to None in sys.modules makes `import keyring` raise ImportError.
+    with patch.dict(sys.modules, {"keyring": None}):
+        # Must return the credentials unchanged, not raise.
+        assert KeyringStore.store(creds, disable=False) is creds
+
+
+def test_retrieve_degrades_when_keyring_not_installed():
+    from flyte.remote._client.auth._keyring import KeyringStore
+
+    with patch.dict(sys.modules, {"keyring": None}):
+        # Must return None (no cached tokens), not raise.
+        assert KeyringStore.retrieve("foo", disable=False) is None
+
+
+def test_delete_degrades_when_keyring_not_installed():
+    from flyte.remote._client.auth._keyring import KeyringStore
+
+    with patch.dict(sys.modules, {"keyring": None}):
+        # Must be a no-op, not raise.
+        KeyringStore.delete("foo", disable=False)


### PR DESCRIPTION
## Problem

`KeyringStore` token caching is best-effort: `store`/`retrieve`/`delete` already swallow `NoKeyringError` and other keyring backend failures so auth can proceed without a cached token. But the `import keyring` at each call site was **unguarded**, so a broken/slim environment missing the `keyring` package raised `ModuleNotFoundError: No module named 'keyring'` that escaped through the auth flow.

Sentry **FLYTE-SDK-6N** (on 2.5.6): the missing package surfaced as a hard crash of the entire `SelectCluster -> upload -> run` path:

```
ModuleNotFoundError: No module named 'keyring'
  @ _keyring.retrieve
  @ client_credentials.__init__
  @ factory.get_async_authenticator
-> RuntimeError: SelectCluster failed for operation=1: No module named 'keyring'
-> RuntimeSystemError: Upload failed for /tmp/.../spec.pb (org='archipelago', ...)
```

`keyring>=25.6.0` is a declared dependency, but partial/slim installs can still be missing it. Token caching is purely an optimization — a missing backend must degrade gracefully, not take down the run.

## Fix

Guard the `import keyring` in all three call sites (`store`/`retrieve`/`delete`). A missing keyring package now degrades to "no cached tokens" (return credentials unchanged / `None` / no-op), exactly matching how `NoKeyringError` is already handled.

## Tests

3 new regression tests force `import keyring` to raise `ImportError` (via `sys.modules["keyring"] = None`) and assert each method degrades instead of raising. 22/22 keyring-store tests pass.

fixes FLYTE-SDK-6N

🤖 Generated with [Claude Code](https://claude.com/claude-code)