### PR TITLE
Update relation fields

### DIFF
--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -190,8 +190,8 @@ class _Runner:
         self._debug = debug
         # Recover (reuse a prior run's succeeded actions). `True` = recover from the run being rerun;
         # a run-name string = recover from that named run (the only form valid on a plain run()).
-        # Carried on RunSpec.recover; remote-only; gated in _apply_overrides until the flyteidl2 field
-        # + backend ship. See _resolve_recover_ref.
+        # Carried on RunSpec.relation with RELATION_TYPE_RECOVER; remote-only; gated in
+        # _apply_overrides until the flyteidl2 field + backend ship. See _resolve_recover_ref.
         self._recover = recover
 
     def _resolve_recover_ref(self, rerun_run_name: str | None) -> str | None:
@@ -213,28 +213,23 @@ class _Runner:
             return rerun_run_name
         return r  # explicit run-name string
 
-    def _resolve_related_to(self, source_run: Any = None) -> Any | None:
-        """Resolve the provenance pointer (``RunSpec.related_to``) for the run being created.
+    def _resolve_spawn_parent(self) -> Any | None:
+        """Resolve the implicit *spawn* provenance parent (``Relation.related_to``, ``SPAWN``).
 
-        An explicit ``source_run`` (the rerun path) wins; otherwise, when invoked from inside a
-        running remote task container (``TaskContext.is_in_cluster()``), the current run is the
-        parent. The effective source scope is the source's ids with empty fields inherited from
-        the init config; the pointer is stamped only when that scope equals the new run's target
-        scope exactly and all four id fields are non-empty (the server requires min_len=1 on
-        each, and related_to is same-org/project/domain as the new run by contract). Returns
-        None otherwise — a provenance pointer must never fail run creation. Pure resolution,
-        no I/O.
+        When a fresh run is created from inside a running remote task container
+        (``TaskContext.is_in_cluster()``), the invoking run is the parent that spawned it. The
+        pointer is stamped only when the invoking run's scope equals the new run's target scope
+        exactly and all four id fields are non-empty (the server requires min_len=1 on each, and
+        ``Relation.related_to`` is same-org/project/domain as the new run by contract). Returns
+        None otherwise — provenance must never fail run creation. Pure resolution, no I/O.
         """
         from flyteidl2.common import identifier_pb2
 
-        if source_run is not None:
-            org, project, domain, name = source_run.org, source_run.project, source_run.domain, source_run.name
-        else:
-            tctx = internal_ctx().data.task_context
-            if tctx is None or not tctx.is_in_cluster():
-                return None
-            action = tctx.action
-            org, project, domain, name = action.org or "", action.project or "", action.domain or "", action.run_name
+        tctx = internal_ctx().data.task_context
+        if tctx is None or not tctx.is_in_cluster():
+            return None
+        action = tctx.action
+        org, project, domain, name = action.org or "", action.project or "", action.domain or "", action.run_name
 
         cfg = get_init_config()
         org = org or cfg.org or ""
@@ -243,10 +238,10 @@ class _Runner:
 
         target = (cfg.org or "", self._project or cfg.project or "", self._domain or cfg.domain or "")
         if (org, project, domain) != target:
-            logger.debug(f"Skipping RunSpec.related_to: source scope {(org, project, domain)} != target {target}")
+            logger.debug(f"Skipping spawn relation: source scope {(org, project, domain)} != target {target}")
             return None
         if not (org and project and domain and name):
-            logger.debug("Skipping RunSpec.related_to: incomplete source run identifier")
+            logger.debug("Skipping spawn relation: incomplete source run identifier")
             return None
         return identifier_pb2.RunIdentifier(org=org, project=project, domain=domain, name=name)
 
@@ -410,17 +405,16 @@ class _Runner:
             )
         return None, identifier_pb2.ProjectIdentifier(name=project, domain=domain, organization=org)
 
-    def _apply_overrides(
-        self, base: Any, *, task: Any = None, recover_ref: str | None = None, related_to: Any = None
-    ) -> Any:
+    def _apply_overrides(self, base: Any, *, task: Any = None, relation: Tuple[Any, str] | None = None) -> Any:
         """Build the ``RunSpec`` for ``create_run``.
 
         ``base is None`` -> a fresh spec from runner config (the run / recover path).
         ``base`` set     -> deep-copy a prior run's ``RunSpec`` and merge runner overrides by key
         (the rerun path: env merge + explicitly-set field overrides). Pure proto assembly, no I/O.
-        This is the single place runner config maps onto a ``RunSpec``. ``recover_ref`` is the already-
-        resolved reference run to recover from (see ``_resolve_recover_ref``), or None. ``related_to``
-        is the already-resolved provenance pointer (see ``_resolve_related_to``), or None.
+        This is the single place runner config maps onto a ``RunSpec``. ``relation`` is the provenance
+        link to record on ``RunSpec.relation``: ``(parent RunIdentifier, "rerun" | "recover" | "spawn")``,
+        or None. The identifier must be fully qualified (org/project/domain/name) — the server rejects
+        partial ones.
         """
         from flyteidl2.core import literals_pb2, security_pb2
         from flyteidl2.task import run_pb2
@@ -482,6 +476,11 @@ class _Runner:
             # Deep-copy the fetched spec (it is shared/cached on the RunDetails); never mutate in place.
             run_spec = run_pb2.RunSpec()
             run_spec.CopyFrom(base)
+            # Provenance is per-run, never inherited: a rerun of a rerun must point at its immediate
+            # parent (set below from `relation`), not the grandparent captured in the prior spec.
+            for provenance_field in ("relation", "related_to"):
+                if provenance_field in run_pb2.RunSpec.DESCRIPTOR.fields_by_name:
+                    run_spec.ClearField(provenance_field)
             run_spec.envs.CopyFrom(env_kv)
             if self._interruptible is not None:
                 run_spec.interruptible.CopyFrom(wrappers_pb2.BoolValue(value=self._interruptible))
@@ -512,21 +511,28 @@ class _Runner:
             if notification_rules:
                 run_spec.notification_rules.CopyFrom(notification_rules)
 
-        # recover: gated until flyteidl2 ships RunSpec.recover (+ backend support). One-line set then.
-        if recover_ref:
-            if "recover" not in run_pb2.RunSpec.DESCRIPTOR.fields_by_name:
-                raise NotImplementedError(
-                    "recover is not yet supported by this backend "
-                    "(RunSpec.recover is unavailable in this flyteidl2 build)."
-                )
-            from flyteidl2.common import identifier_pb2
+        # relation: gated until the flyteidl2 pin includes RunSpec.relation. Recover semantics depend
+        # on the field, so recover fails loudly without it; rerun/spawn provenance is best-effort.
+        if relation:
+            ref, kind = relation
+            if "relation" not in run_pb2.RunSpec.DESCRIPTOR.fields_by_name:
+                if kind == "recover":
+                    raise NotImplementedError(
+                        "recover is not yet supported by this backend "
+                        "(RunSpec.relation is unavailable in this flyteidl2 build)."
+                    )
+            else:
+                from flyteidl2.common import run_pb2 as common_run_pb2
 
-            run_spec.recover.CopyFrom(run_pb2.Recover(run_id=identifier_pb2.RunIdentifier(name=recover_ref)))
-
-        # related_to: implicit provenance (rerun source, or the invoking in-cluster run).
-        run_spec.ClearField("related_to")  # never inherit a rerun base's stale (grandparent) pointer
-        if related_to is not None:
-            run_spec.related_to.CopyFrom(related_to)
+                relation_type = {
+                    "rerun": common_run_pb2.RELATION_TYPE_RERUN,
+                    "recover": common_run_pb2.RELATION_TYPE_RECOVER,
+                    # SPAWN ships in a later flyteidl2 than RERUN/RECOVER; drop the pointer on
+                    # older builds rather than fail run creation.
+                    "spawn": getattr(common_run_pb2, "RELATION_TYPE_SPAWN", None),
+                }.get(kind)
+                if relation_type is not None:
+                    run_spec.relation.CopyFrom(common_run_pb2.Relation(related_to=ref, relation_type=relation_type))
 
         return run_spec
 
@@ -668,12 +674,23 @@ class _Runner:
                 if task_spec.task_template.id.version == "":
                     task_spec.task_template.id.version = version
 
-            run_spec = self._apply_overrides(
-                None,
-                task=task,
-                recover_ref=self._resolve_recover_ref(None),
-                related_to=self._resolve_related_to(),
-            )
+            # Provenance for a fresh run: an explicit recover target wins; otherwise, when launched
+            # from inside a running remote task, record a spawn link to the invoking run.
+            recover_ref = self._resolve_recover_ref(None)
+            relation: Tuple[Any, str] | None
+            if recover_ref:
+                from flyteidl2.common import identifier_pb2
+
+                # Relation identifiers must be fully qualified; the parent is scoped to the same
+                # org/project/domain as the new run.
+                relation = (
+                    identifier_pb2.RunIdentifier(org=cfg.org, project=project, domain=domain, name=recover_ref),
+                    "recover",
+                )
+            else:
+                spawn_parent = self._resolve_spawn_parent()
+                relation = (spawn_parent, "spawn") if spawn_parent is not None else None
+            run_spec = self._apply_overrides(None, task=task, relation=relation)
             return await self._submit_remote(
                 task_spec=task_spec,
                 task_id=task_id,
@@ -1060,7 +1077,9 @@ class _Runner:
 
         The prior run's `RunSpec` is inherited and merged with this context's overrides
         (`with_runcontext(env_vars=..., interruptible=..., recover=...)` etc.), so debug/recover
-        compose with rerun. Currently remote-only.
+        compose with rerun. Provenance is recorded on `RunSpec.relation` — RERUN pointing at
+        `run_name`, or RECOVER when recovering (when the flyteidl2 build supports it). Currently
+        remote-only.
 
         :param run_name: Name of the prior run to re-run.
         :param action_name: Action within the prior run to source the task + inputs from (default `a0`).
@@ -1128,18 +1147,17 @@ class _Runner:
             if tt_id.version == "":
                 tt_id.version = version
 
-        # Provenance: the run being rerun. Explicit source wins entirely over any ambient task
-        # context (a rerun triggered from inside a task points at the rerun source, not the
-        # invoking run). The fetched id can be empty in degenerate cases; fall back to run_name.
+        # Every rerun records provenance to the run being rerun; recover upgrades it to RECOVER.
+        # Relation identifiers must be fully qualified; the parent is scoped to the same
+        # org/project/domain as the new run.
         from flyteidl2.common import identifier_pb2
 
-        src = action_details.pb2.id.run
-        related_to = self._resolve_related_to(
-            identifier_pb2.RunIdentifier(org=src.org, project=src.project, domain=src.domain, name=src.name or run_name)
+        recover_ref = self._resolve_recover_ref(run_name)
+        relation = (
+            identifier_pb2.RunIdentifier(org=cfg.org, project=project, domain=domain, name=recover_ref or run_name),
+            "recover" if recover_ref else "rerun",
         )
-        run_spec = self._apply_overrides(
-            base_run_spec, recover_ref=self._resolve_recover_ref(run_name), related_to=related_to
-        )
+        run_spec = self._apply_overrides(base_run_spec, relation=relation)
         return await self._submit_remote(
             task_spec=task_spec,
             task_id=None,
@@ -1268,7 +1286,7 @@ def with_runcontext(
         changed). ``True`` recovers from the run being rerun — only valid with ``.rerun(...)``; a
         run-name string recovers from that named run and is the only form valid on ``.run(...)``.
         Remote-only. Not yet supported by the backend (raises NotImplementedError at submit until
-        flyteidl2 RunSpec.recover ships).
+        flyteidl2 RunSpec.relation ships).
     :param _tracker: This is an internal only parameter used by the CLI to render the TUI.
 
     :return: runner

--- a/src/flyte/remote/_action.py
+++ b/src/flyte/remote/_action.py
@@ -42,6 +42,21 @@ from flyte.syncify import syncify
 
 WaitFor = Literal["terminal", "running", "logs-ready"]
 
+# ActionMetadata.relation is not available until the flyteidl2 pin is bumped past the release
+# that ships common.Relation; gate all access on the descriptor so both versions work.
+_RELATION_SUPPORTED = "relation" in run_definition_pb2.ActionMetadata.DESCRIPTOR.fields_by_name
+
+
+def _relation_repr(metadata: run_definition_pb2.ActionMetadata) -> str:
+    """Human-readable provenance, e.g. ``rerun of my-run``, or empty when unset."""
+    if not _RELATION_SUPPORTED or not metadata.HasField("relation"):
+        return ""
+    from flyteidl2.common import run_pb2 as common_run_pb2
+
+    rel = metadata.relation
+    kind = common_run_pb2.RelationType.Name(rel.relation_type).removeprefix("RELATION_TYPE_").lower()
+    return f"{kind} of {rel.related_to.name}"
+
 
 @rich.repr.auto
 @dataclass
@@ -111,6 +126,7 @@ def _action_rich_repr(action: run_definition_pb2.Action) -> rich.repr.Result:
     yield from _action_time_phase(action)
     yield "group", action.metadata.group
     yield "parent", action.metadata.parent
+    yield "related to", _relation_repr(action.metadata)
     yield "attempts", action.status.attempts
 
 
@@ -140,6 +156,7 @@ def _action_details_rich_repr(
     yield "phase", phase_pb2.ActionPhase.Name(action.status.phase)
     yield "group", action.metadata.group
     yield "parent", action.metadata.parent
+    yield "related to", _relation_repr(action.metadata)
 
 
 def _action_done_check(phase: phase_pb2.ActionPhase) -> bool:
@@ -343,6 +360,17 @@ class Action(ToJSONMixin):
         """
         if self.pb2.metadata.HasField("task") and self.pb2.metadata.task.HasField("id"):
             return self.pb2.metadata.task.id.name
+        return None
+
+    @property
+    def relation(self):
+        """
+        Provenance link (``flyteidl2.common.run_pb2.Relation``: related_to + relation_type) if this
+        run was derived from another (rerun/recover), otherwise None. Only set on root actions;
+        requires a flyteidl2 build that ships ActionMetadata.relation.
+        """
+        if _RELATION_SUPPORTED and self.pb2.metadata.HasField("relation"):
+            return self.pb2.metadata.relation
         return None
 
     @property
@@ -795,6 +823,17 @@ class ActionDetails(ToJSONMixin):
         Get the metadata of the action.
         """
         return self.pb2.metadata
+
+    @property
+    def relation(self):
+        """
+        Provenance link (``flyteidl2.common.run_pb2.Relation``: related_to + relation_type) if this
+        run was derived from another (rerun/recover), otherwise None. Only set on root actions;
+        requires a flyteidl2 build that ships ActionMetadata.relation.
+        """
+        if _RELATION_SUPPORTED and self.pb2.metadata.HasField("relation"):
+            return self.pb2.metadata.relation
+        return None
 
     @property
     def status(self) -> run_definition_pb2.ActionStatus:

--- a/tests/flyte/remote/test_action_relation.py
+++ b/tests/flyte/remote/test_action_relation.py
@@ -1,0 +1,80 @@
+"""Tests for surfacing ActionMetadata.relation (related_to + relation_type) in run/action output.
+
+Relation-bearing cases are gated on the flyteidl2 build shipping ActionMetadata.relation; the
+unset-relation behavior (empty column, None property) must hold on every build.
+"""
+
+import pytest
+from flyteidl2.workflow import run_definition_pb2
+
+from flyte.remote._action import (
+    _RELATION_SUPPORTED,
+    Action,
+    ActionDetails,
+    _action_details_rich_repr,
+    _action_rich_repr,
+    _relation_repr,
+)
+
+needs_relation = pytest.mark.skipif(not _RELATION_SUPPORTED, reason="flyteidl2 build lacks ActionMetadata.relation")
+
+
+def test_relation_repr_empty_when_unset():
+    assert _relation_repr(run_definition_pb2.ActionMetadata()) == ""
+
+
+def test_action_rich_repr_always_has_related_to_column():
+    action = run_definition_pb2.Action()
+    keys = [k for k, _ in _action_rich_repr(action)]
+    assert "related to" in keys
+    assert dict(_action_rich_repr(action))["related to"] == ""
+
+    details = run_definition_pb2.ActionDetails()
+    keys = [k for k, _ in _action_details_rich_repr(details)]
+    assert "related to" in keys
+    assert dict(_action_details_rich_repr(details))["related to"] == ""
+
+
+def test_relation_property_none_when_unset():
+    assert Action(pb2=run_definition_pb2.Action()).relation is None
+    assert ActionDetails(pb2=run_definition_pb2.ActionDetails()).relation is None
+
+
+def _metadata_with_relation(kind) -> run_definition_pb2.ActionMetadata:
+    from flyteidl2.common import identifier_pb2
+    from flyteidl2.common import run_pb2 as common_run_pb2
+
+    return run_definition_pb2.ActionMetadata(
+        relation=common_run_pb2.Relation(
+            related_to=identifier_pb2.RunIdentifier(name="parent-run"),
+            relation_type=kind,
+        )
+    )
+
+
+@needs_relation
+@pytest.mark.parametrize("kind,expected", [(1, "rerun of parent-run"), (2, "recover of parent-run")])
+def test_relation_repr_formats_kind_and_parent(kind, expected):
+    assert _relation_repr(_metadata_with_relation(kind)) == expected
+
+
+@needs_relation
+def test_relation_appears_in_rich_reprs():
+    metadata = _metadata_with_relation(1)
+    action = run_definition_pb2.Action(metadata=metadata)
+    assert dict(_action_rich_repr(action))["related to"] == "rerun of parent-run"
+
+    details = run_definition_pb2.ActionDetails(metadata=metadata)
+    assert dict(_action_details_rich_repr(details))["related to"] == "rerun of parent-run"
+
+
+@needs_relation
+def test_relation_property_returns_proto():
+    action = Action(pb2=run_definition_pb2.Action(metadata=_metadata_with_relation(2)))
+    assert action.relation is not None
+    assert action.relation.related_to.name == "parent-run"
+    assert action.relation.relation_type == 2
+
+    details = ActionDetails(pb2=run_definition_pb2.ActionDetails(metadata=_metadata_with_relation(2)))
+    assert details.relation is not None
+    assert details.relation.related_to.name == "parent-run"

--- a/tests/flyte/test_related_to.py
+++ b/tests/flyte/test_related_to.py
@@ -1,6 +1,7 @@
-"""Unit tests for _Runner._resolve_related_to: the provenance pointer (RunSpec.related_to)
-resolution rules. These run on any flyteidl2 build — the resolver only constructs a
-RunIdentifier; the descriptor-gated stamping is covered in test_run_runspec_chars.py."""
+"""Unit tests for _Runner._resolve_spawn_parent: the implicit spawn-provenance parent
+(Relation.related_to) resolution rules. These run on any flyteidl2 build — the resolver only
+constructs a RunIdentifier; the descriptor-gated stamping (relation_type=SPAWN) is covered in
+test_run_runspec_chars.py."""
 
 import pytest
 from flyteidl2.common import identifier_pb2
@@ -28,17 +29,18 @@ def _fake_task_ctx(mode="remote", org="o", project="p", domain="d", run_name="pa
 
 
 @pytest.mark.asyncio
-async def test_no_ctx_no_source_returns_none():
+async def test_no_ctx_returns_none():
+    """No in-container task context -> nothing spawned this run -> no pointer."""
     await _init_for_testing(project="p", domain="d", org="o")
-    assert _Runner(force_mode="remote")._resolve_related_to() is None
+    assert _Runner(force_mode="remote")._resolve_spawn_parent() is None
 
 
 @pytest.mark.asyncio
 async def test_remote_ctx_stamps_current_run():
     await _init_for_testing(project="p", domain="d", org="o")
     with _fake_task_ctx(mode="remote"):
-        related_to = _Runner(force_mode="remote")._resolve_related_to()
-    assert related_to == identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="parent-run")
+        parent = _Runner(force_mode="remote")._resolve_spawn_parent()
+    assert parent == identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="parent-run")
 
 
 @pytest.mark.asyncio
@@ -47,33 +49,23 @@ async def test_non_remote_ctx_not_stamped(mode):
     """Only a true in-container (remote) execution links its child runs."""
     await _init_for_testing(project="p", domain="d", org="o")
     with _fake_task_ctx(mode=mode):
-        assert _Runner(force_mode="remote")._resolve_related_to() is None
-
-
-@pytest.mark.asyncio
-async def test_explicit_source_wins_over_ctx():
-    """The rerun path passes the source run explicitly; ambient ctx must not leak in."""
-    await _init_for_testing(project="p", domain="d", org="o")
-    source = identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="src-run")
-    with _fake_task_ctx(mode="remote", run_name="ctx-run"):
-        related_to = _Runner(force_mode="remote")._resolve_related_to(source)
-    assert related_to is not None
-    assert related_to.name == "src-run"
+        assert _Runner(force_mode="remote")._resolve_spawn_parent() is None
 
 
 @pytest.mark.asyncio
 async def test_scope_mismatch_runner_project_override():
-    """related_to is same-scope by contract: a run targeting another project is not linked."""
+    """Spawn link is same-scope by contract: a child targeting another project is not linked."""
     await _init_for_testing(project="p", domain="d", org="o")
-    source = identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="src-run")
-    assert _Runner(force_mode="remote", project="other")._resolve_related_to(source) is None
+    with _fake_task_ctx(mode="remote"):
+        assert _Runner(force_mode="remote", project="other")._resolve_spawn_parent() is None
 
 
 @pytest.mark.asyncio
 async def test_scope_mismatch_source_org():
+    """An invoking run in a different org than the new run's target is not linked."""
     await _init_for_testing(project="p", domain="d", org="o")
-    source = identifier_pb2.RunIdentifier(org="different", project="p", domain="d", name="src-run")
-    assert _Runner(force_mode="remote")._resolve_related_to(source) is None
+    with _fake_task_ctx(mode="remote", org="different"):
+        assert _Runner(force_mode="remote")._resolve_spawn_parent() is None
 
 
 @pytest.mark.asyncio
@@ -81,13 +73,13 @@ async def test_empty_org_returns_none():
     """All four id fields are server-required (min_len=1); no org configured -> no pointer."""
     await _init_for_testing(project="p", domain="d")
     with _fake_task_ctx(mode="remote", org=None):
-        assert _Runner(force_mode="remote")._resolve_related_to() is None
+        assert _Runner(force_mode="remote")._resolve_spawn_parent() is None
 
 
 @pytest.mark.asyncio
 async def test_source_scope_filled_from_cfg():
-    """A name-only source (degenerate fetched id) inherits the init config's scope."""
+    """An invoking action with empty scope fields inherits the init config's scope."""
     await _init_for_testing(project="p", domain="d", org="o")
-    source = identifier_pb2.RunIdentifier(name="src-run")
-    related_to = _Runner(force_mode="remote")._resolve_related_to(source)
-    assert related_to == identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="src-run")
+    with _fake_task_ctx(mode="remote", org="", project="", domain=""):
+        parent = _Runner(force_mode="remote")._resolve_spawn_parent()
+    assert parent == identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="parent-run")

--- a/tests/flyte/test_rerun.py
+++ b/tests/flyte/test_rerun.py
@@ -16,6 +16,12 @@ from mock.mock import AsyncMock, MagicMock
 import flyte
 from flyte._initialize import _init_for_testing
 
+# RunSpec.relation (provenance: related_to + relation_type) ships in a flyteidl2 release newer
+# than the current pin; relation-bearing assertions are gated on the installed build.
+_RELATION_SUPPORTED = "relation" in run_pb2.RunSpec.DESCRIPTOR.fields_by_name
+
+needs_relation = pytest.mark.skipif(not _RELATION_SUPPORTED, reason="flyteidl2 build lacks RunSpec.relation")
+
 
 def _mock_client_with_run():
     """Mock client whose create_run captures the request and get_action_data returns prior inputs."""
@@ -129,6 +135,66 @@ async def test_rerun_changed_inputs_converts_against_fetched_interface():
     assert upload_req.inputs.literals[0].value.scalar.primitive.string_value == "changed"
 
 
+@needs_relation
+@pytest.mark.asyncio
+async def test_rerun_records_rerun_relation_and_clears_inherited_provenance():
+    from flyteidl2.common import identifier_pb2
+
+    mock_client, mock_run_service, _mock_dataproxy, _ = _mock_client_with_run()
+    await _init_for_testing(client=mock_client, project="test", domain="test")
+
+    # The prior run was itself derived from a grandparent; that link must not be inherited.
+    prior = _fake_prior_run()
+    prior.pb2.run_spec.relation.CopyFrom(
+        common_run_pb2.Relation(
+            related_to=identifier_pb2.RunIdentifier(name="grandparent"),
+            relation_type=common_run_pb2.RELATION_TYPE_RERUN,
+        )
+    )
+
+    with mock.patch("flyte.remote._run.RunDetails") as RD:
+        RD.get.aio = AsyncMock(return_value=prior)
+        await flyte.with_runcontext(mode="remote").rerun.aio("r1")
+
+    req: run_service_pb2.CreateRunRequest = mock_run_service.create_run.call_args[0][0]
+    assert req.run_spec.HasField("relation")
+    assert req.run_spec.relation.related_to.name == "r1"
+    # The identifier must be fully qualified (server validates org/project/domain min_len=1).
+    assert req.run_spec.relation.related_to.project == "test"
+    assert req.run_spec.relation.related_to.domain == "test"
+    assert req.run_spec.relation.relation_type == common_run_pb2.RELATION_TYPE_RERUN
+
+
+@needs_relation
+@pytest.mark.asyncio
+async def test_rerun_with_recover_records_recover_relation():
+    mock_client, mock_run_service, _mock_dataproxy, _ = _mock_client_with_run()
+    await _init_for_testing(client=mock_client, project="test", domain="test")
+
+    with mock.patch("flyte.remote._run.RunDetails") as RD:
+        RD.get.aio = AsyncMock(return_value=_fake_prior_run())
+        await flyte.with_runcontext(mode="remote", recover=True).rerun.aio("r1")
+
+    req: run_service_pb2.CreateRunRequest = mock_run_service.create_run.call_args[0][0]
+    assert req.run_spec.relation.related_to.name == "r1"
+    assert req.run_spec.relation.related_to.project == "test"
+    assert req.run_spec.relation.related_to.domain == "test"
+    assert req.run_spec.relation.relation_type == common_run_pb2.RELATION_TYPE_RECOVER
+
+
+@pytest.mark.skipif(_RELATION_SUPPORTED, reason="only applies to flyteidl2 builds without RunSpec.relation")
+@pytest.mark.asyncio
+async def test_recover_raises_without_relation_field():
+    """On old flyteidl2, plain rerun still works (provenance skipped) but recover fails loudly."""
+    mock_client, _mock_run_service, _mock_dataproxy, _ = _mock_client_with_run()
+    await _init_for_testing(client=mock_client, project="test", domain="test")
+
+    with mock.patch("flyte.remote._run.RunDetails") as RD:
+        RD.get.aio = AsyncMock(return_value=_fake_prior_run())
+        with pytest.raises(NotImplementedError, match="recover is not yet supported"):
+            await flyte.with_runcontext(mode="remote", recover=True).rerun.aio("r1")
+
+
 @pytest.mark.asyncio
 async def test_rerun_rejects_non_remote_mode():
     await flyte.init.aio()
@@ -141,75 +207,7 @@ def test_replay_is_removed():
     assert not hasattr(flyte, "replay")
 
 
-# --- related_to provenance pointer (see _apply_overrides) -------------------------------
-
-
-def _full_action_id(org="testorg", project="test", domain="test", run_name="r1"):
-    from flyteidl2.common import identifier_pb2
-
-    return identifier_pb2.ActionIdentifier(
-        run=identifier_pb2.RunIdentifier(org=org, project=project, domain=domain, name=run_name),
-        name="a0",
-    )
-
-
-async def _rerun_and_capture(prior_run, org="testorg", run_name="r1", **runcontext_kwargs):
-    """Rerun `run_name` against a mocked fetch of `prior_run`; return the CreateRunRequest."""
-    mock_client, mock_run_service, _, _ = _mock_client_with_run()
-    await _init_for_testing(client=mock_client, project="test", domain="test", org=org)
-
-    with mock.patch("flyte.remote._run.RunDetails") as RD:
-        RD.get.aio = AsyncMock(return_value=prior_run)
-        run = await flyte.with_runcontext(mode="remote", **runcontext_kwargs).rerun.aio(run_name)
-
-    assert run
-    req: run_service_pb2.CreateRunRequest = mock_run_service.create_run.call_args[0][0]
-    return req
-
-
-@pytest.mark.asyncio
-async def test_rerun_stamps_source_run():
-    from flyteidl2.common import identifier_pb2
-
-    req = await _rerun_and_capture(_fake_prior_run(action_id=_full_action_id()))
-    assert req.run_spec.related_to == identifier_pb2.RunIdentifier(
-        org="testorg", project="test", domain="test", name="r1"
-    )
-
-
-@pytest.mark.asyncio
-async def test_rerun_of_rerun_overwrites_grandparent():
-    """A rerun of a rerun points at its immediate source, not the inherited grandparent."""
-    from flyteidl2.common import identifier_pb2
-
-    base = run_pb2.RunSpec(cluster="orig")
-    base.related_to.CopyFrom(
-        identifier_pb2.RunIdentifier(org="testorg", project="test", domain="test", name="grandparent")
-    )
-    req = await _rerun_and_capture(_fake_prior_run(action_id=_full_action_id(), base_run_spec=base))
-    assert req.run_spec.related_to.name == "r1"
-
-
-@pytest.mark.asyncio
-async def test_rerun_scope_mismatch_clears_related_to():
-    """Cross-scope rerun: no pointer stamped, and the inherited one is cleared, not propagated."""
-    from flyteidl2.common import identifier_pb2
-
-    base = run_pb2.RunSpec(cluster="orig")
-    base.related_to.CopyFrom(
-        identifier_pb2.RunIdentifier(org="testorg", project="test", domain="test", name="grandparent")
-    )
-    req = await _rerun_and_capture(_fake_prior_run(action_id=_full_action_id(), base_run_spec=base), project="other")
-    assert not req.run_spec.HasField("related_to")
-
-
-@pytest.mark.asyncio
-async def test_rerun_empty_fetched_id_falls_back_to_run_name():
-    """A degenerate fetch (empty action id) still yields provenance: name from the rerun
-    argument, scope from the init config."""
-    from flyteidl2.common import identifier_pb2
-
-    req = await _rerun_and_capture(_fake_prior_run())
-    assert req.run_spec.related_to == identifier_pb2.RunIdentifier(
-        org="testorg", project="test", domain="test", name="r1"
-    )
+# Provenance for rerun/recover is asserted on RunSpec.relation by
+# test_rerun_records_rerun_relation_and_clears_inherited_provenance and
+# test_rerun_with_recover_records_recover_relation (both gated on flyteidl2 shipping the field).
+# The former related_to-based rerun tests were removed with that migration.

--- a/tests/flyte/test_run_runspec_chars.py
+++ b/tests/flyte/test_run_runspec_chars.py
@@ -338,8 +338,9 @@ async def test_apply_overrides_inherited_merges_env_and_keys():
 
 
 @pytest.mark.asyncio
-async def test_apply_overrides_recover_gated():
-    """recover raises until flyteidl2 RunSpec.recover ships (field absent today)."""
+async def test_apply_overrides_recover_stamps_relation():
+    """recover is recorded as RunSpec.relation with RELATION_TYPE_RECOVER (gated on the field)."""
+    from flyteidl2.common import identifier_pb2
     from flyteidl2.task import run_pb2
 
     from flyte._run import _Runner
@@ -349,10 +350,14 @@ async def test_apply_overrides_recover_gated():
 
     runner = _Runner(force_mode="remote")
 
-    if "recover" in run_pb2.RunSpec.DESCRIPTOR.fields_by_name:
-        pytest.skip("RunSpec.recover is available; gating no longer applies")
-    with pytest.raises(NotImplementedError, match="recover is not yet supported"):
-        runner._apply_overrides(None, recover_ref="some-run")
+    ref = identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="r1")
+    if "relation" not in run_pb2.RunSpec.DESCRIPTOR.fields_by_name:
+        with pytest.raises(NotImplementedError, match="recover is not yet supported"):
+            runner._apply_overrides(None, relation=(ref, "recover"))
+        return
+    out = runner._apply_overrides(None, relation=(ref, "recover"))
+    assert out.relation.related_to == ref
+    assert out.relation.relation_type == common_run_pb2.RELATION_TYPE_RECOVER
 
 
 def test_resolve_recover_ref_semantics():
@@ -378,7 +383,12 @@ async def test_recover_rejected_in_local_mode():
         await flyte.with_runcontext(mode="local", recover="r1").run.aio(task1, "hello")
 
 
-# --- related_to provenance pointer (implicit) ------------
+# --- relation provenance pointer ------------
+
+needs_spawn = pytest.mark.skipif(
+    not hasattr(common_run_pb2, "RELATION_TYPE_SPAWN"),
+    reason="flyteidl2 build lacks RELATION_TYPE_SPAWN",
+)
 
 
 def _fake_remote_task_ctx(org="testorg", project="test", domain="test", run_name="parent-run"):
@@ -401,7 +411,7 @@ def _fake_remote_task_ctx(org="testorg", project="test", domain="test", run_name
 
 
 @pytest.mark.asyncio
-async def test_apply_overrides_related_to_stamped_overwritten_cleared():
+async def test_apply_overrides_relation_stamped_overwritten_cleared():
     """Fresh path stamps; base-copy overwrites a stale (grandparent) pointer; None clears it."""
     from flyteidl2.common import identifier_pb2
     from flyteidl2.task import run_pb2
@@ -412,35 +422,47 @@ async def test_apply_overrides_related_to_stamped_overwritten_cleared():
     await _init_for_testing(client=mock_client, project="test", domain="test")
     runner = _Runner(force_mode="remote")
 
-    related = identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="r1")
-    fresh = runner._apply_overrides(None, related_to=related)
-    assert fresh.related_to == related
+    if "relation" not in run_pb2.RunSpec.DESCRIPTOR.fields_by_name:
+        pytest.skip("RunSpec.relation unavailable in this flyteidl2 build")
+
+    ref = identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="r1")
+    fresh = runner._apply_overrides(None, relation=(ref, "rerun"))
+    assert fresh.relation.related_to == ref
+    assert fresh.relation.relation_type == common_run_pb2.RELATION_TYPE_RERUN
 
     base = run_pb2.RunSpec()
-    base.related_to.CopyFrom(identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="grandparent"))
-    overwritten = runner._apply_overrides(base, related_to=related)
-    assert overwritten.related_to.name == "r1"
+    base.relation.CopyFrom(
+        common_run_pb2.Relation(
+            related_to=identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="grandparent"),
+            relation_type=common_run_pb2.RELATION_TYPE_RERUN,
+        )
+    )
+    overwritten = runner._apply_overrides(base, relation=(ref, "rerun"))
+    assert overwritten.relation.related_to.name == "r1"
 
-    cleared = runner._apply_overrides(base, related_to=None)
-    assert not cleared.HasField("related_to")
+    cleared = runner._apply_overrides(base, relation=None)
+    assert not cleared.HasField("relation")
 
 
 @pytest.mark.asyncio
+@needs_spawn
 @_patch_build
-async def test_runspec_related_to_from_task_ctx(mock_code_bundler, mock_build_image_bg):
-    """flyte.run from inside a remote task container stamps the invoking run as related_to."""
+async def test_runspec_spawn_relation_from_task_ctx(mock_code_bundler, mock_build_image_bg):
+    """flyte.run from inside a remote task container records the invoking run as a SPAWN relation."""
     with _fake_remote_task_ctx():
         req = await _run_and_capture(mock_build_image_bg, mock_code_bundler, _org="testorg")
     from flyteidl2.common import identifier_pb2
 
-    assert req.run_spec.related_to == identifier_pb2.RunIdentifier(
+    assert req.run_spec.relation.related_to == identifier_pb2.RunIdentifier(
         org="testorg", project="test", domain="test", name="parent-run"
     )
+    assert req.run_spec.relation.relation_type == common_run_pb2.RELATION_TYPE_SPAWN
 
 
 @pytest.mark.asyncio
 @_patch_build
-async def test_runspec_related_to_unset_without_ctx(mock_code_bundler, mock_build_image_bg):
+async def test_runspec_relation_unset_without_ctx(mock_code_bundler, mock_build_image_bg):
     """A plain remote run (no task context) carries no provenance pointer."""
     req = await _run_and_capture(mock_build_image_bg, mock_code_bundler, _org="testorg")
-    assert not req.run_spec.HasField("related_to")
+    if "relation" in run_pb2.RunSpec.DESCRIPTOR.fields_by_name:
+        assert not req.run_spec.HasField("relation")


### PR DESCRIPTION
Update the rerun method to use the relation type enum set to RERUN and use the new relation message instead of the old related_to field