### PR TITLE
feat(agents): use flyte-native conditions for HITL tool approval

### DIFF
--- a/examples/agents/flyte_agent/README.md
+++ b/examples/agents/flyte_agent/README.md
@@ -19,8 +19,8 @@ The harness deeply integrates with Flyte 2:
   optimistic concurrency).
 - **Triggers** wake the agent on a schedule (cron, fixed-rate) or via a
   webhook.
-- **HITL** support pauses the loop and asks a human via
-  `flyteplugins-hitl` before sensitive tools execute.
+- **HITL** support pauses the loop on a flyte-native condition
+  (`flyte.new_condition`) before sensitive tools execute.
 
 ## How it works
 
@@ -68,7 +68,7 @@ requests are routed to the agent directly (without a parent task entrypoint).
 | `basic_agent.py` | Minimal agent — plain async tools, sync `agent.run()` from the CLI. |
 | `scheduled_triage_agent.py` | Agent that wakes daily via `flyte.Cron`, uses durable Flyte tasks. |
 | `agent_with_memory.py` | Pass a keyed `MemoryStore` into `agent.run(message, memory=...)`; the transcript is auto-saved and persists across runs. |
-| `hitl_approval_agent.py` | Gate sensitive tools behind human approval (`flyteplugins-hitl`). |
+| `hitl_approval_agent.py` | Gate sensitive tools behind human approval (`flyte.new_condition`). |
 | `agent_chat_ui.py` | Wrap an `Agent` in the built-in `AgentChatAppEnvironment` UI. |
 | `mcp_powered_agent.py` | Mix local Flyte task tools with remote MCP servers. |
 | `webhook_agent.py` | Trigger an agent run from an HTTP webhook (e.g. GitHub events). |

--- a/examples/agents/flyte_agent/hitl_approval_agent.py
+++ b/examples/agents/flyte_agent/hitl_approval_agent.py
@@ -1,7 +1,7 @@
 """HITL approval agent — pauses for a human before running sensitive tools.
 
-This example wires :class:`flyte.ai.agents.Agent` to the
-``flyteplugins-hitl`` plugin so that designated tools require explicit human
+This example uses :class:`flyte.ai.agents.Agent` with flyte-native conditions
+(:func:`flyte.new_condition`) so that designated tools require explicit human
 approval before they execute.
 
 Pattern
@@ -10,9 +10,11 @@ Pattern
 1. Mark sensitive tools with ``@tool(requires_approval=True)``.
 2. When the LLM asks the agent to run such a tool, the harness invokes the
    ``approval_callback`` and waits for a boolean decision.
-3. The default callback uses ``flyteplugins.hitl.new_event`` to spin up a
-   human-input web form scoped to the current run. If denied, the agent
-   receives a synthetic tool message explaining the rejection so it can
+3. The default callback registers a run-scoped condition via
+   ``flyte.new_condition`` and blocks until a human signals it — from the
+   Flyte UI, the CLI (``flyte signal condition <run> <action> true``), or
+   programmatically via ``flyte.remote.Condition.signal``. If denied, the
+   agent receives a synthetic tool message explaining the rejection so it can
    recover gracefully.
 
 Deploy::
@@ -26,8 +28,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import flyteplugins.hitl as hitl
-
 import flyte
 from flyte.ai.agents import Agent, tool
 
@@ -36,16 +36,11 @@ env = flyte.TaskEnvironment(
     image=(
         flyte.Image.from_debian_base(python_version=(3, 12), install_flyte=False).with_pip_packages(
             "flyte==2.4.4",
-            "flyteplugins-hitl==2.4.4",
-            "fastapi",
-            "uvicorn",
-            "python-multipart",
             "litellm",
         )
     ),
     resources=flyte.Resources(cpu=1, memory="512Mi"),
     secrets=[flyte.Secret(key="internal-anthropic-api-key", as_env_var="ANTHROPIC_API_KEY")],
-    depends_on=[hitl.env],
 )
 
 
@@ -111,4 +106,11 @@ async def concierge(request: str) -> str:
 
 if __name__ == "__main__":
     flyte.init_from_config()
-    flyte.run(concierge, request="Refund order #12345 to the customer.")
+    run = flyte.run(concierge, request="Refund order #12345 to the customer.")
+    print("run url:", run.url)
+    # The run pauses on an `approve_issue_refund_*` condition. Approve it from
+    # the UI, or programmatically:
+    #
+    #   import flyte.remote as remote
+    #   for condition in remote.Condition.listall(run_name=run.name):
+    #       condition.signal(True)

--- a/src/flyte/ai/agents/agent.py
+++ b/src/flyte/ai/agents/agent.py
@@ -23,8 +23,9 @@ Design goals
   letting the agent persist state across runs (e.g. across scheduled wake-ups
   or webhook invocations). Includes opt-in audit log, read-only prefixes, and
   optimistic concurrency for multi-agent / sleep-wake patterns.
-- **HITL**: opt-in per-tool human approval that pauses the loop and waits for a
-  human via the ``flyteplugins-hitl`` plugin before executing the tool.
+- **HITL**: opt-in per-tool human approval that pauses the loop on a
+  flyte-native condition (:func:`flyte.new_condition`) and waits for a human
+  to signal it before executing the tool.
 - **Flyte-native**: implements the :class:`AgentProtocol` so it works
   seamlessly with :class:`~flyte.ai.chat.AgentChatAppEnvironment` and is happy
   to be wrapped in ``@env.task(triggers=...)`` for scheduled or webhook-driven
@@ -229,32 +230,33 @@ def _load_skills(skills: Sequence[str | pathlib.Path]) -> str:
 ApprovalCallback = Callable[[AgentTool, dict[str, Any]], Awaitable[bool]]
 
 
-async def _hitl_approval(tool: AgentTool, args: dict[str, Any]) -> bool:
-    """Default HITL approval: ask the user via ``flyteplugins-hitl``.
+async def _condition_approval(tool: AgentTool, args: dict[str, Any]) -> bool:
+    """Default HITL approval: pause the run on a flyte-native condition.
 
-    Returns ``True`` if the user approves the tool call. When the plugin is not
-    installed (or the agent is running outside a Flyte task context), this
-    falls back to denying the call so that the agent can recover by trying a
-    different approach.
+    Registers a condition via :func:`flyte.new_condition` and blocks until a
+    human signals it — from the UI, ``flyte signal condition``, or
+    ``flyte.remote.Condition.signal``. Returns ``True`` if the user approves
+    the tool call. When the agent is running outside a Flyte task context
+    there is no backend to signal the condition, so this falls back to denying
+    the call so that the agent can recover by trying a different approach.
     """
-    try:
-        import flyteplugins.hitl as hitl
-    except ImportError:
+    if not flyte.ctx():
         logger.warning(
-            "Tool %s requires approval but `flyteplugins-hitl` is not installed; denying by default.",
+            "Tool %s requires approval but there is no active Flyte task context "
+            "to register a condition with; denying by default.",
             tool.name,
         )
         return False
 
     pretty_args = json.dumps(args, indent=2, default=str)
-    prompt = f"Approve tool call `{tool.name}`?\n\nArguments:\n{pretty_args}"
-    event = await hitl.new_event.aio(
+    prompt = f"Approve tool call `{tool.name}`?\n\nArguments:\n```json\n{pretty_args}\n```"
+    condition = await flyte.new_condition.aio(
         f"approve_{tool.name}_{uuid.uuid4().hex[:6]}",
-        data_type=bool,
-        scope="run",
         prompt=prompt,
+        prompt_type="markdown",
+        data_type=bool,
     )
-    decision = await event.wait.aio()
+    decision = await condition.wait.aio()
     return bool(decision)
 
 
@@ -297,7 +299,7 @@ class Agent:
     approval_callback:
         Optional async callback ``(tool, args) -> bool`` invoked when a tool
         with ``requires_approval=True`` is about to run. Defaults to a HITL
-        prompt via ``flyteplugins-hitl``.
+        prompt via a flyte-native condition (:func:`flyte.new_condition`).
     parallel_tool_calls:
         When ``True`` (default) tool calls returned in a single assistant
         message are executed concurrently. Set to ``False`` to force strict
@@ -326,7 +328,7 @@ class Agent:
     skills: Sequence[str | pathlib.Path] = field(default_factory=tuple)
     max_turns: int = 25
     call_llm: LLMCallable = field(default=_default_call_llm)
-    approval_callback: ApprovalCallback = field(default=_hitl_approval)
+    approval_callback: ApprovalCallback = field(default=_condition_approval)
     parallel_tool_calls: bool = True
     code_mode: bool = False
 

--- a/tests/flyte/ai/agents/test_agent.py
+++ b/tests/flyte/ai/agents/test_agent.py
@@ -7,7 +7,7 @@ import hashlib
 import json
 import pathlib
 import sys
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -34,7 +34,7 @@ from flyte.ai.agents._tools import (
 )
 from flyte.ai.agents.agent import (
     _abbreviate,
-    _hitl_approval,
+    _condition_approval,
     _resolve_tools,
     _stringify_tool_result,
     _summarize_signature,
@@ -1860,23 +1860,54 @@ class TestMemoryPersistenceOnFailure:
 
 
 # ----------------------------------------------------------------------------
-# Default HITL approval callback
+# Default HITL approval callback (flyte-native conditions)
 # ----------------------------------------------------------------------------
 
 
+def _sensitive_tool() -> AgentTool:
+    return AgentTool(
+        name="sensitive",
+        description="d",
+        parameters={"type": "object", "properties": {}},
+        execute=AsyncMock(),
+        requires_approval=True,
+    )
+
+
+def _mock_new_condition(decision: bool) -> MagicMock:
+    """A stand-in for ``flyte.new_condition`` whose condition resolves to *decision*."""
+    condition = MagicMock()
+    condition.wait.aio = AsyncMock(return_value=decision)
+    new_condition = MagicMock()
+    new_condition.aio = AsyncMock(return_value=condition)
+    return new_condition
+
+
 @pytest.mark.asyncio
-class TestDefaultHitlApproval:
-    async def test_denies_when_hitl_plugin_missing(self):
-        t = AgentTool(
-            name="sensitive",
-            description="d",
-            parameters={"type": "object", "properties": {}},
-            execute=AsyncMock(),
-            requires_approval=True,
-        )
-        # Force ``import flyteplugins.hitl`` to raise ImportError.
-        with patch.dict(sys.modules, {"flyteplugins.hitl": None}):
-            approved = await _hitl_approval(t, {"k": "v"})
+class TestDefaultConditionApproval:
+    async def test_denies_outside_task_context(self):
+        # flyte.ctx() is falsy outside a task, so the callback denies without
+        # registering a condition.
+        approved = await _condition_approval(_sensitive_tool(), {"k": "v"})
+        assert approved is False
+
+    async def test_waits_on_condition_and_approves(self):
+        new_condition = _mock_new_condition(decision=True)
+        with patch("flyte.ctx", return_value=MagicMock()), patch("flyte.new_condition", new_condition):
+            approved = await _condition_approval(_sensitive_tool(), {"k": "v"})
+        assert approved is True
+        name = new_condition.aio.call_args.args[0]
+        assert name.startswith("approve_sensitive_")
+        kwargs = new_condition.aio.call_args.kwargs
+        assert kwargs["data_type"] is bool
+        assert kwargs["prompt_type"] == "markdown"
+        assert "`sensitive`" in kwargs["prompt"]
+        assert '"k": "v"' in kwargs["prompt"]
+
+    async def test_waits_on_condition_and_denies(self):
+        new_condition = _mock_new_condition(decision=False)
+        with patch("flyte.ctx", return_value=MagicMock()), patch("flyte.new_condition", new_condition):
+            approved = await _condition_approval(_sensitive_tool(), {"k": "v"})
         assert approved is False
 
 


### PR DESCRIPTION
## Summary

Migrates the `flyte.ai.agents` human-in-the-loop approval flow off the `flyteplugins-hitl` plugin and onto the flyte-native Condition API (`flyte.new_condition`).

- **`src/flyte/ai/agents/agent.py`** — the default `approval_callback` (`_condition_approval`, formerly `_hitl_approval`) now registers a run-scoped bool condition with a markdown prompt showing the tool name and JSON arguments, then blocks on `condition.wait()` until a human signals it — from the UI, the CLI (`flyte signal condition <run> <action> true`), or `flyte.remote.Condition.signal`. Outside a task context (no backend to signal the condition) it logs a warning and denies, mirroring the old plugin-missing fallback so the agent can recover by trying a different approach.
- **`examples/agents/flyte_agent/hitl_approval_agent.py`** — drops the `flyteplugins-hitl` dependency, `depends_on=[hitl.env]`, and the `fastapi`/`uvicorn`/`python-multipart` packages that existed only for the plugin's web form; the `__main__` block now shows how to signal the pending approval condition programmatically.
- **`examples/agents/flyte_agent/README.md`** — updated HITL references to `flyte.new_condition`.
- **`tests/flyte/ai/agents/test_agent.py`** — replaced the plugin-missing test with `TestDefaultConditionApproval`, covering deny-outside-task-context, approve, and decline paths (asserting condition name, `data_type=bool`, markdown prompt type, and args in the prompt).

Notes:
- The task-context check uses truthiness (`if not flyte.ctx()`) rather than `is None`, so it remains correct if/when `flyte.ctx()` returns a falsy null object instead of `None`.
- `examples/genai/autoresearch/autoresearch_agent.py` still uses `flyteplugins.hitl` directly for its loop-continuation gate; that's independent of the agent harness and left for a follow-up.

## Test plan

- [x] `uv run pytest tests/flyte/ai/agents/test_agent.py` — 178 passed
- [x] `uv run ruff check` / `ruff format --check` on changed files
- [x] `uv run mypy src/flyte/ai/agents/agent.py`
- [x] `py_compile` on the updated example

🤖 Generated with [Claude Code](https://claude.com/claude-code)