### PR TITLE
docs(hitl): add deprecation notice pointing to flyte-native conditions

### DIFF
--- a/plugins/hitl/README.md
+++ b/plugins/hitl/README.md
@@ -1,5 +1,33 @@
 # Flyte HITL Plugin
 
+> [!WARNING]
+> **Deprecated.** This plugin has been deprecated in favor of flyte-native
+> conditions (`flyte.new_condition`), which are built into the `flyte` SDK and
+> require no extra dependency, no `depends_on=[hitl.env]` app infrastructure,
+> and no web-form serving. Conditions pause a run until they are signaled from
+> the Flyte UI, the CLI (`flyte signal condition <run> <action> <value>`), or
+> programmatically via `flyte.remote.Condition.signal`.
+>
+> Migration is mostly one-to-one — replace `hitl.new_event` with
+> `flyte.new_condition`:
+>
+> ```python
+> # Before
+> event = await hitl.new_event.aio(
+>     "integer_input_event", data_type=int, scope="run", prompt="What should I add to x?"
+> )
+> y = await event.wait.aio()
+>
+> # After
+> condition = await flyte.new_condition.aio(
+>     "integer_input_condition", data_type=int, prompt="What should I add to x?"
+> )
+> y = await condition.wait.aio()
+> ```
+>
+> See `examples/advanced/conditions.py` for markdown prompts, timeouts,
+> webhook notifications, and signaling conditions programmatically.
+
 Human-in-the-Loop (HITL) plugin for Flyte. This plugin provides an event-based API for pausing workflows and waiting for human input.
 
 ## Installation


### PR DESCRIPTION
## Summary

Adds a deprecation warning banner to `plugins/hitl/README.md`: the `flyteplugins-hitl` event API is superseded by flyte-native conditions (`flyte.new_condition`), which are built into the SDK and require no extra dependency, no `depends_on=[hitl.env]` app infrastructure, and no web-form serving.

The banner includes:
- A one-to-one migration snippet (`hitl.new_event` → `flyte.new_condition`). The plugin's `scope="run"` argument has no `new_condition` equivalent since conditions are inherently run-scoped, so it's simply dropped.
- The three ways to signal a condition: the Flyte UI, the CLI (`flyte signal condition <run> <action> <value>`), and `flyte.remote.Condition.signal`.
- A pointer to `examples/advanced/conditions.py` for markdown prompts, timeouts, webhook notifications, and programmatic signaling.

Follow-up to #1306, which migrated the `flyte.ai.agents` HITL approval flow off this plugin.

## Test plan

- [x] Docs-only change; verified the `> [!WARNING]` admonition renders as GitHub-flavored markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)