### PR TITLE
debugger: change download dir to cwd instead of home

### DIFF
--- a/src/flyte/_debug/constants.py
+++ b/src/flyte/_debug/constants.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 # Where the code-server tar and plugins are downloaded to
 EXECUTABLE_NAME = "code-server"
-DOWNLOAD_DIR = Path.home() / ".code-server"
+DOWNLOAD_DIR = Path.cwd() / ".code-server"
 HOURS_TO_SECONDS = 60 * 60
 DEFAULT_UP_SECONDS = 10 * HOURS_TO_SECONDS  # 10 hours
 DEFAULT_CODE_SERVER_REMOTE_PATHS = {


### PR DESCRIPTION
Some container environments, like in openshift,  do not allow writing to the home directory.

This PR changes the debugger download dir from home to the current working directory. This way the user has control over where to download the vscode packages to by adjusting the work dir with pod templates or in `flyte.Image` definition itself.

Tested without changing working directory:
``` python
import flyte

env = flyte.TaskEnvironment(
    "test",
    image=flyte.Image.from_debian_base()
    .with_apt_packages("git")
    .with_pip_packages(
        "git+https://github.com/flyteorg/flyte-sdk.git@jan/debugger-download-dir"
    )
)


@env.task
async def main() -> str:
    msg = "Hello World"
    import os

    cwd = os.getcwd()

    print("Current Working Directory:", cwd)

    print(msg)
    return msg


if __name__ == "__main__":
    flyte.init_from_config("demo.yaml")
    run = flyte.run(main)
    print(run.url)
```
--> [[flyte] INFO DOWNLOAD_DIR: /home/flyte/.code-server ](https://demo.hosted.unionai.cloud/v2/domain/development/project/jan-playground/runs/usp4x2jm5bmcwpjbv2vg)

Tested with changing working directory:

``` python
env = flyte.TaskEnvironment(
    "test",
    image=flyte.Image.from_debian_base()
    .with_apt_packages("git")
    .with_pip_packages(
        "git+https://github.com/flyteorg/flyte-sdk.git@jan/debugger-download-dir"
    )
    .with_workdir("/tmp"),
)
```
--> [[flyte] INFO DOWNLOAD_DIR: /tmp/.code-server](https://demo.hosted.unionai.cloud/v2/domain/development/project/jan-playground/runs/uj55c596gnz8nctghsls?i=a0&tab=logs)