### PR TITLE
restore system CA trust on pyqwest 0.7+

### DIFF
--- a/src/flyte/remote/_client/auth/_session.py
+++ b/src/flyte/remote/_client/auth/_session.py
@@ -1,4 +1,6 @@
 import asyncio
+import functools
+import inspect
 import os
 import socket
 import typing
@@ -160,22 +162,46 @@ def _use_system_dns() -> bool:
     return os.environ.get(_USE_PYQWEST_DNS_RESOLVER_ENV, "").lower() not in _TRUE_ENV_VALUES
 
 
+@functools.lru_cache(maxsize=1)
+def _supports_system_certs() -> bool:
+    """Whether this pyqwest exposes the opt-in flag for the system trust store.
+
+    pyqwest 0.7.0 added tls_include_system_certs and defaults it to False, so an
+    explicitly constructed HTTPTransport no longer loads any root certificates.
+    Earlier versions have no such flag and always use the system trust store when
+    no CA bundle is supplied. pyqwest does not expose __version__, so detect the
+    parameter rather than comparing versions.
+    """
+    try:
+        return "tls_include_system_certs" in inspect.signature(pyqwest.HTTPTransport).parameters
+    except (TypeError, ValueError):  # pragma: no cover - signature unavailable
+        return False
+
+
 def _build_pyqwest_client(tls_ca_cert: bytes | None = None) -> pyqwest.Client:
     """Build a pyqwest Client with sensible transport defaults."""
     use_system_dns = _use_system_dns()
-    transport = pyqwest.HTTPTransport(
-        tls_ca_cert=tls_ca_cert,
-        timeout=None,
-        connect_timeout=30.0,
-        read_timeout=None,
-        pool_idle_timeout=90.0,
-        tcp_keepalive_interval=30.0,  # was grpc.keepalive_time_ms = 30000
+    kwargs: dict[str, Any] = {
+        "tls_ca_cert": tls_ca_cert,
+        "timeout": None,
+        "connect_timeout": 30.0,
+        "read_timeout": None,
+        "pool_idle_timeout": 90.0,
+        "tcp_keepalive_interval": 30.0,  # was grpc.keepalive_time_ms = 30000
         # Use the OS resolver by default so Flyte matches curl/browser behavior
         # on VPNs, split-DNS setups, captive portals, and broken IPv6 networks.
         # Server deployments can set _FLYTE_USE_PYQWEST_DNS_RESOLVER=true to opt
         # back into pyqwest's bundled resolver for app-owned DNS behavior.
-        use_system_dns=use_system_dns,
-    )
+        "use_system_dns": use_system_dns,
+    }
+    # Ask for the system trust store only when no CA bundle was supplied, which is
+    # the "use system defaults" case described in _resolve_tls_ca_cert. A supplied
+    # bundle keeps meaning "trust exactly this and nothing else" on every pyqwest
+    # version, so requesting system certs alongside it would widen trust for
+    # private-CA and insecure_skip_verify users.
+    if tls_ca_cert is None and _supports_system_certs():
+        kwargs["tls_include_system_certs"] = True
+    transport = pyqwest.HTTPTransport(**kwargs)
     return pyqwest.Client(transport=transport)
 
 

--- a/tests/flyte/remote/test_session.py
+++ b/tests/flyte/remote/test_session.py
@@ -9,6 +9,7 @@ from flyte.remote._client.auth._session import (
     _bootstrap_ssl_from_server,
     _build_pyqwest_client,
     _resolve_tls_ca_cert,
+    _supports_system_certs,
     create_session_config,
 )
 
@@ -239,6 +240,38 @@ class TestBuildPyqwestClient:
         _build_pyqwest_client(None)
 
         assert mock_transport.call_args.kwargs["use_system_dns"] is True
+
+    def test_detects_system_cert_support_from_signature(self):
+        import inspect
+
+        expected = "tls_include_system_certs" in inspect.signature(pyqwest.HTTPTransport).parameters
+        assert _supports_system_certs() is expected
+
+    @patch("flyte.remote._client.auth._session._supports_system_certs", return_value=True)
+    @patch("flyte.remote._client.auth._session.pyqwest.Client")
+    @patch("flyte.remote._client.auth._session.pyqwest.HTTPTransport")
+    def test_requests_system_certs_when_no_ca_supplied(self, mock_transport, mock_client, _mock_supported):
+        _build_pyqwest_client(None)
+
+        assert mock_transport.call_args.kwargs["tls_include_system_certs"] is True
+
+    @patch("flyte.remote._client.auth._session._supports_system_certs", return_value=True)
+    @patch("flyte.remote._client.auth._session.pyqwest.Client")
+    @patch("flyte.remote._client.auth._session.pyqwest.HTTPTransport")
+    def test_does_not_widen_trust_when_ca_supplied(self, mock_transport, mock_client, _mock_supported):
+        # A supplied bundle means "trust exactly this", so the system store must stay out.
+        _build_pyqwest_client(_make_valid_cert_pem())
+
+        assert "tls_include_system_certs" not in mock_transport.call_args.kwargs
+
+    @patch("flyte.remote._client.auth._session._supports_system_certs", return_value=False)
+    @patch("flyte.remote._client.auth._session.pyqwest.Client")
+    @patch("flyte.remote._client.auth._session.pyqwest.HTTPTransport")
+    def test_omits_flag_on_older_pyqwest(self, mock_transport, mock_client, _mock_supported):
+        # Versions before 0.7.0 have no such parameter and would raise TypeError.
+        _build_pyqwest_client(None)
+
+        assert "tls_include_system_certs" not in mock_transport.call_args.kwargs
 
 
 _SESSION_MOD = "flyte.remote._client.auth._session"


### PR DESCRIPTION
pyqwest 0.7.0 added `tls_include_system_certs` to `HTTPTransport` and defaults it to `False`, so an explicitly constructed transport loads no root certificates at all. Earlier versions have no such parameter and always use the system trust store when no CA bundle is supplied.

## Fix 
Feature-detect the parameter and request the system trust store only when no CA bundle was supplied:

```python
if tls_ca_cert is None and _supports_system_certs():
    kwargs["tls_include_system_certs"] = True
```