### PR TITLE
docs: fix inverted/inaccurate reset_root_logger docstrings

### DIFF
--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -234,7 +234,10 @@ async def init(
       defaults to the editable install directory if the cwd is in a Python editable install, else just the cwd.
     :param log_level: Optional logging level for the logger, default is set using the default initialization policies
     :param log_format: Optional logging format for the logger, default is "console"
-    :param reset_root_logger: By default, we clear out root logger handlers and set up our own.
+    :param reset_root_logger: If True, wipe the root logger's existing handlers and install Flyte's own
+        handler (JSON or Rich, matching ``log_format``) at the root, so logs from third-party libraries that
+        propagate to the root logger are captured in Flyte's format. Defaults to False, which leaves the root
+        logger's handlers in place, wrapping them so their output carries run/action context.
     :param api_key: Optional API key for authentication
     :param endpoint: Optional API endpoint URL
     :param headless: Optional Whether to run in headless mode

--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -1242,7 +1242,10 @@ def with_runcontext(
     :param log_level: Optional Log level to set for the run. If not provided, it will be set to the default log level
         set using `flyte.init()`
     :param log_format: Optional Log format to set for the run. If not provided, it will be set to the default log format
-    :param reset_root_logger: If true, the root logger will be preserved and not modified by Flyte.
+    :param reset_root_logger: If True, wipe the root logger's existing handlers and install Flyte's own
+        handler (JSON or Rich, matching ``log_format``) at the root, so logs from third-party libraries that
+        propagate to the root logger are captured in Flyte's format. Defaults to False, which leaves the root
+        logger's handlers in place, wrapping them so their output carries run/action context.
     :param disable_run_cache: Optional If true, the run cache will be disabled. This is useful for testing purposes.
     :param queue: Optional The queue to use for the run. This is used to specify the cluster to use for the run.
     :param max_action_concurrency: Optional Maximum number of actions that can run concurrently within this run.


### PR DESCRIPTION
## What

The `reset_root_logger` parameter docstrings describe the **opposite** of the actual behavior:

- **`_run.py`** (`with_runcontext`): *"If true, the root logger will be preserved and not modified by Flyte."* — but `reset_root_logger=True` **wipes** the root logger's handlers and installs Flyte's own (`_logging._setup_root_logger` → `root.handlers.clear()` + `root.addHandler(...)`).
- **`_initialize.py`** (`init`): *"By default, we clear out root logger handlers and set up our own."* — but the **default is `False`**, which leaves the root handlers in place (they're wrapped, not cleared).

## Fix

Rewrite both docstrings to match the code, consistently:

> If True, wipe the root logger's existing handlers and install Flyte's own handler (JSON or Rich, matching `log_format`) at the root, so logs from third-party libraries that propagate to the root logger are captured in Flyte's format. Defaults to False, which leaves the root logger's handlers in place, wrapping them so their output carries run/action context.

Docstring-only (no behavior change). These surface in the generated API reference. Verified against `_logging._setup_root_logger` on `main`.

*Surfaced by the Union.ai docs team while documenting JSON logging + `FLYTE_RESET_ROOT_LOGGER` (unionai-docs#1234 / DOC-1257) — the docs had to follow the code because the docstrings were inverted.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)