### PR TITLE
fix(trigger): use task interface type for trigger input literals

### DIFF
--- a/src/flyte/_internal/runtime/trigger_serde.py
+++ b/src/flyte/_internal/runtime/trigger_serde.py
@@ -71,7 +71,13 @@ async def process_default_inputs(
                 f"Available inputs: {list(variables_dict.keys())}"
             )
         else:
-            literal_coros.append(flyte.types.TypeEngine.to_literal(v, type(v), variables_dict[k].type))
+            # Use the task interface's type to derive the Python type so that
+            # generic containers (e.g. plain `list`) are correctly mapped to
+            # their typed equivalents (e.g. `List[int]`).  Using `type(v)`
+            # alone loses the element type, causing TypeEngine to fall back to
+            # PickleFile and then fail the deploy-time type-compatibility check.
+            python_type = flyte.types.TypeEngine.guess_python_type(variables_dict[k].type)
+            literal_coros.append(flyte.types.TypeEngine.to_literal(v, python_type, variables_dict[k].type))
             keys.append(k)
 
     final_literals: list[literals_pb2.Literal] = await asyncio.gather(*literal_coros, return_exceptions=True)

--- a/tests/flyte/internal/runtime/test_trigger_serde.py
+++ b/tests/flyte/internal/runtime/test_trigger_serde.py
@@ -184,6 +184,40 @@ class TestProcessDefaultInputs:
         assert result[1].value.scalar.primitive.string_value == "default_b"
 
     @pytest.mark.asyncio
+    async def test_collection_default_input(self):
+        """Trigger inputs with a plain Python list must be converted using the
+        task interface's type (List[int]), not type(value) which would be bare
+        `list` and cause TypeEngine to fall back to PickleFile/BINARY."""
+        task_inputs = interface_pb2.VariableMap(
+            variables=[
+                VariableEntry(
+                    key="x_list",
+                    value=interface_pb2.Variable(
+                        type=types_pb2.LiteralType(
+                            collection_type=types_pb2.LiteralType(
+                                simple=types_pb2.SimpleType.INTEGER
+                            )
+                        )
+                    ),
+                )
+            ]
+        )
+
+        default_inputs = {"x_list": list(range(5))}
+
+        result = await process_default_inputs(default_inputs, "test_task", task_inputs, [])
+
+        assert len(result) == 1
+        assert result[0].name == "x_list"
+        # Must be a collection of integer primitives, not a PickleFile scalar
+        assert result[0].value.HasField("collection"), (
+            "Expected collection literal but got scalar (PickleFile); "
+            "trigger_serde must use the task interface type, not type(value)"
+        )
+        assert len(result[0].value.collection.literals) == 5
+        assert result[0].value.collection.literals[0].scalar.primitive.integer == 0
+
+    @pytest.mark.asyncio
     async def test_trigger_defaults_override_task_defaults(self):
         """Test that trigger defaults override task defaults"""
         task_inputs = interface_pb2.VariableMap(


### PR DESCRIPTION
## Problem

`process_default_inputs` in `trigger_serde.py` calls:

```python
TypeEngine.to_literal(v, type(v), variables_dict[k].type)
```

When `v` is a plain Python list (e.g. `list(range(10))`), `type(v)` returns `<class 'list'>` with no element type. TypeEngine falls back to PickleFile/BINARY, which fails the deploy-time type-compatibility check:

```
trigger inputs: wrong input "x_list" type,
expected "collection_type:{simple:INTEGER}", got "simple:BINARY" instead
```

## Fix

Replace `type(v)` with `TypeEngine.guess_python_type(literal_type)` so the conversion uses the type declared in the task interface (e.g. `List[int]`) rather than the runtime value's bare type.

## Test

Added `test_collection_default_input` to `TestProcessDefaultInputs` covering a `List[int]` trigger input. All 6 tests in the class pass.
