### PR TITLE
feat: make MCP transport="stdio" actually serve stdio

### DIFF
--- a/examples/mcp/flyte_mcp_app.py
+++ b/examples/mcp/flyte_mcp_app.py
@@ -16,12 +16,15 @@ Usage:
 
     $ python examples/mcp/flyte_mcp_app.py
 
-    Or serve locally for development (recommended: `uvx`)
+    Or serve locally for development (recommended: `uvx`). This binds
+    http://localhost:8080/flyte-mcp/mcp; pass `--transport stdio` instead when an
+    MCP client launches the server as a subprocess.
 
     $ uvx --from "flyte[mcp]" flyte-mcp
 
-    If you're running from this repo checkout:
-    $ uvx --from . flyte-mcp
+    If you're running from this repo checkout (note the `[mcp]` extra -- without it
+    the server exits with "mcp is not installed"):
+    $ uvx --from ".[mcp]" flyte-mcp
 
     ------------------------------
     Connect from Claude Code
@@ -31,7 +34,8 @@ Usage:
     configuring Claude Code to launch the server via `uvx` (process-based setup).
 
     Add as a local stdio MCP server:
-    $ claude mcp add --transport stdio flyte-mcp -- uvx --with "flyte[mcp]" flyte-mcp
+    $ claude mcp add --transport stdio flyte-mcp -- \
+      uvx --from "flyte[mcp]" flyte-mcp --transport stdio
 
     If you deploy this app remotely (so it has a public base URL), use that URL instead.
     With default ``transport="streamable-http"`` and ``mcp_mount_path="/flyte-mcp"``, the MCP
@@ -56,7 +60,7 @@ Usage:
       "mcp": {
         "flyte-mcp": {
           "type": "local",
-          "command": ["uvx", "--with", "flyte[mcp]", "flyte-mcp"],
+          "command": ["uvx", "--from", "flyte[mcp]", "flyte-mcp", "--transport", "stdio"],
           "enabled": true
         }
       }

--- a/examples/mcp/flyte_mcp_app_filtered.py
+++ b/examples/mcp/flyte_mcp_app_filtered.py
@@ -42,7 +42,8 @@ Usage:
     configuring Claude Code to launch the server via `uvx` (process-based setup).
 
     Add as a local stdio MCP server:
-    $ claude mcp add --transport stdio flyte-mcp-filtered -- uvx --with "flyte[mcp]" flyte-mcp
+    $ claude mcp add --transport stdio flyte-mcp-filtered -- \
+      uvx --from "flyte[mcp]" flyte-mcp --transport stdio
 
     If you deploy this app remotely (so it has a public base URL), use that URL instead.
     With default ``transport="streamable-http"`` and ``mcp_mount_path="/flyte-mcp"``, use the
@@ -67,7 +68,10 @@ Usage:
       "mcp": {
         "flyte-mcp-filtered": {
           "type": "local",
-          "command": ["uvx", "--with", "flyte[mcp]", "flyte-mcp", "--tool-groups", "task,run,search"],
+          "command": [
+            "uvx", "--from", "flyte[mcp]", "flyte-mcp",
+            "--transport", "stdio", "--tool-groups", "task,run,search"
+          ],
           "enabled": true
         }
       }

--- a/src/flyte/_bin/mcp.py
+++ b/src/flyte/_bin/mcp.py
@@ -7,10 +7,16 @@ import subprocess
 import sys
 import time
 import urllib.request
+from typing import TYPE_CHECKING
 
 import click
 
 import flyte
+
+if TYPE_CHECKING:
+    # Annotation-only: `from __future__ import annotations` keeps this out of the
+    # runtime import path, so `flyte-mcp --help` still works without the mcp extra.
+    from flyte.ai.mcp._mcp_app import MCPTransport
 
 _FLYTE_SDK_REPO = "https://github.com/flyteorg/flyte-sdk.git"
 _UNIONAI_EXAMPLES_REPO = "https://github.com/unionai/unionai-examples.git"
@@ -228,7 +234,7 @@ def main(
     name: str,
     title: str | None,
     instructions: str | None,
-    transport: str,
+    transport: "MCPTransport",
     port: int,
     mcp_mount_path: str,
     tool_groups: list[str] | None,
@@ -283,7 +289,7 @@ def _build_env(
     name: str,
     title: str | None,
     instructions: str | None,
-    transport: str,
+    transport: "MCPTransport",
     port: int,
     mcp_mount_path: str,
     tool_groups: list[str] | None,

--- a/src/flyte/_bin/mcp.py
+++ b/src/flyte/_bin/mcp.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import contextlib
 import pathlib
 import shutil
 import subprocess
+import sys
 import time
 import urllib.request
 
@@ -163,11 +165,25 @@ def _prepare_search_corpus(
     return sdk_examples_path, docs_examples_path, full_docs_path
 
 
-@click.command(help="Serve a Flyte MCP server locally over HTTP (FastMCP + Starlette).")
+@click.command(
+    help=(
+        "Serve a Flyte MCP server locally, over HTTP (FastMCP + Starlette) or over stdio.\n"
+        "\n"
+        "Use --transport stdio when an MCP client launches this as a subprocess; the "
+        "default streamable-http binds --port instead."
+    )
+)
 @click.option("--name", default="flyte-mcp-server", show_default=True, help="App name.")
 @click.option("--title", default=None, help="Optional MCP server title (defaults to --name).")
 @click.option("--instructions", default=None, help="Optional MCP server instructions string.")
-@click.option("--port", type=int, default=8080, show_default=True, help="HTTP port to bind.")
+@click.option(
+    "--transport",
+    type=click.Choice(["stdio", "sse", "streamable-http"]),
+    default="streamable-http",
+    show_default=True,
+    help="MCP transport. 'stdio' speaks JSON-RPC on stdin/stdout and ignores --port/--mcp-mount-path.",
+)
+@click.option("--port", type=int, default=8080, show_default=True, help="HTTP port to bind (HTTP transports only).")
 @click.option("--mcp-mount-path", default="/flyte-mcp", show_default=True, help="Mount path for MCP endpoint.")
 @click.option(
     "--tool-groups",
@@ -212,6 +228,7 @@ def main(
     name: str,
     title: str | None,
     instructions: str | None,
+    transport: str,
     port: int,
     mcp_mount_path: str,
     tool_groups: list[str] | None,
@@ -223,6 +240,62 @@ def main(
     init_from_config: bool,
     requires_auth: bool,
 ) -> None:
+    stdio = transport == "stdio"
+
+    if stdio and requires_auth:
+        click.echo(
+            "warning: --requires-auth has no effect with --transport stdio. The server "
+            "speaks to whichever process launched it and runs with your own credentials.",
+            err=True,
+        )
+
+    # Under stdio, stdout is the JSON-RPC channel: a single stray byte of setup chatter
+    # (click.echo here, a print or progress bar in a dependency) makes the client's first
+    # parse fail. Divert stdout to stderr while building the environment -- but *not*
+    # while running it, since run_stdio() needs the real stdout to answer on.
+    with contextlib.redirect_stdout(sys.stderr) if stdio else contextlib.nullcontext():
+        env = _build_env(
+            name=name,
+            title=title,
+            instructions=instructions,
+            transport=transport,
+            port=port,
+            mcp_mount_path=mcp_mount_path,
+            tool_groups=tool_groups,
+            tools=tools,
+            sdk_examples_path=sdk_examples_path,
+            docs_examples_path=docs_examples_path,
+            full_docs_path=full_docs_path,
+            refresh_cache=refresh_cache,
+            init_from_config=init_from_config,
+            requires_auth=requires_auth,
+        )
+
+    if stdio:
+        env.run_stdio()
+        return
+
+    _serve_http(env, mcp_mount_path)
+
+
+def _build_env(
+    *,
+    name: str,
+    title: str | None,
+    instructions: str | None,
+    transport: str,
+    port: int,
+    mcp_mount_path: str,
+    tool_groups: list[str] | None,
+    tools: list[str] | None,
+    sdk_examples_path: str | None,
+    docs_examples_path: str | None,
+    full_docs_path: str | None,
+    refresh_cache: bool,
+    init_from_config: bool,
+    requires_auth: bool,
+):
+    """Initialize Flyte, materialize the search corpus, and build the app environment."""
     if init_from_config:
         flyte.init_from_config()
 
@@ -254,10 +327,11 @@ def main(
     elif refresh_cache:
         click.echo("--refresh-cache had no effect: no cached corpus assets needed for this configuration.")
 
-    env = FlyteMCPAppEnvironment(
+    return FlyteMCPAppEnvironment(
         name=name,
         title=title,
         instructions=instructions,
+        transport=transport,
         port=port,
         mcp_mount_path=mcp_mount_path,
         tool_groups=tool_groups,
@@ -268,6 +342,9 @@ def main(
         requires_auth=requires_auth,
     )
 
+
+def _serve_http(env, mcp_mount_path: str) -> None:
+    """Serve an HTTP-transport environment locally until interrupted."""
     serve_ctx = flyte.with_servecontext(mode="local")
     app = serve_ctx.serve(env)
 
@@ -275,8 +352,8 @@ def main(
     # and returns immediately; block the foreground here so the CLI process
     # keeps the server alive until the user interrupts.
     app.activate(wait=True)
-    mcp_session_path = f"{mcp_mount_path}/mcp"
-    click.echo(f"MCP server listening at {app.endpoint}{mcp_session_path}")
+    suffix = "/sse" if env.transport == "sse" else "/mcp"
+    click.echo(f"MCP server listening at {app.endpoint}{mcp_mount_path}{suffix}")
     click.echo("Press Ctrl+C to stop.")
     try:
         while not app.is_deactivated():

--- a/src/flyte/ai/mcp/_mcp_app.py
+++ b/src/flyte/ai/mcp/_mcp_app.py
@@ -18,6 +18,10 @@ if TYPE_CHECKING:
     from starlette.applications import Starlette
     from starlette.middleware import Middleware
 
+# Named so the CLI and any other caller can share one definition instead of
+# repeating the literal and letting the two drift apart.
+MCPTransport = Literal["stdio", "sse", "streamable-http"]
+
 
 @dataclass(kw_only=True, repr=True)
 class MCPAppEnvironment(flyte.app.AppEnvironment):
@@ -56,7 +60,7 @@ class MCPAppEnvironment(flyte.app.AppEnvironment):
     mcp: FastMCP
 
     mcp_mount_path: str = "/mcp"
-    transport: Literal["stdio", "sse", "streamable-http"] = "streamable-http"
+    transport: MCPTransport = "streamable-http"
     uvicorn_config: uvicorn.Config | None = None
 
     _starlette_app: Starlette | None = field(init=False, default=None)
@@ -101,8 +105,12 @@ class MCPAppEnvironment(flyte.app.AppEnvironment):
     async def run_stdio_async(self) -> None:
         """Serve MCP over this process's stdin/stdout until the client disconnects.
 
+        Validates the transport and then delegates to the wrapped :class:`FastMCP`,
+        whose method of the same name does the actual serving.
+
         :raises ValueError: if ``transport`` is not ``"stdio"``.
         """
+
         if self.transport != "stdio":
             raise ValueError(
                 f"run_stdio_async() requires transport='stdio', got {self.transport!r}. "

--- a/src/flyte/ai/mcp/_mcp_app.py
+++ b/src/flyte/ai/mcp/_mcp_app.py
@@ -21,17 +21,34 @@ if TYPE_CHECKING:
 
 @dataclass(kw_only=True, repr=True)
 class MCPAppEnvironment(flyte.app.AppEnvironment):
-    """Serve a FastMCP server over HTTP (Starlette + Uvicorn).
+    """Serve a FastMCP server over HTTP (Starlette + Uvicorn) or over stdio.
 
     Pass a configured ``FastMCP`` instance and optional HTTP layout settings.
     Install extras with ``pip install 'flyte[mcp]'``.
 
-    **HTTP layout**
+    **HTTP layout** (``transport="streamable-http"`` or ``"sse"``)
 
     - ``GET /health`` — liveness/readiness JSON ``{"status": "healthy"}``.
     - The MCP ASGI app is mounted at ``mcp_mount_path`` (default ``/mcp``). With
       ``transport="streamable-http"``, the session endpoint is ``{mcp_mount_path}/mcp``.
       SSE transport uses ``{mcp_mount_path}/sse`` instead.
+
+    **stdio** (``transport="stdio"``)
+
+    Speaks JSON-RPC over the current process's stdin/stdout, for MCP clients that
+    launch the server as a subprocess. There is no HTTP surface at all: no Starlette
+    app, no ``/health`` route, no links, and ``mcp_mount_path`` is unused.
+
+    stdio is a *local* transport and cannot be deployed or served via
+    :func:`flyte.serve` — that path runs the server on a background thread and polls
+    an HTTP health check, neither of which applies to a process-bound stdio stream.
+    Run it directly instead::
+
+        env = MCPAppEnvironment(name="my-mcp", mcp=mcp, transport="stdio")
+        env.run_stdio()
+
+    Anything written to stdout corrupts the JSON-RPC stream, so route logging and
+    diagnostics to stderr.
     """
 
     type: str = "MCPApp"
@@ -58,6 +75,13 @@ class MCPAppEnvironment(flyte.app.AppEnvironment):
         if not isinstance(self.mcp_mount_path, str) or not self.mcp_mount_path.startswith("/"):
             raise ValueError("mcp_mount_path must be an absolute path starting with '/'.")
 
+        if self.transport == "stdio":
+            # No HTTP surface exists for stdio, so build no Starlette app and advertise
+            # no links. ``_server`` stays ``None``: flyte.serve() would run it on a
+            # background thread and wait on an HTTP health check that never comes up, so
+            # we let serve() fail fast rather than hang. Callers use run_stdio().
+            return
+
         self._starlette_app = self._create_starlette_app()
 
         mcp_link = self.mcp_mount_path
@@ -73,6 +97,24 @@ class MCPAppEnvironment(flyte.app.AppEnvironment):
         ]
 
         self._server = self._starlette_app_server
+
+    async def run_stdio_async(self) -> None:
+        """Serve MCP over this process's stdin/stdout until the client disconnects.
+
+        :raises ValueError: if ``transport`` is not ``"stdio"``.
+        """
+        if self.transport != "stdio":
+            raise ValueError(
+                f"run_stdio_async() requires transport='stdio', got {self.transport!r}. "
+                "Serve HTTP transports with flyte.serve() instead."
+            )
+        await self.mcp.run_stdio_async()
+
+    def run_stdio(self) -> None:
+        """Blocking wrapper around :meth:`run_stdio_async`, for use as a process entry point."""
+        import anyio
+
+        anyio.run(self.run_stdio_async)
 
     @property
     def _mcp_server(self) -> FastMCP:

--- a/tests/flyte/ai/mcp/test_mcp_app_environment.py
+++ b/tests/flyte/ai/mcp/test_mcp_app_environment.py
@@ -1,5 +1,7 @@
 """Tests for generic :class:`MCPAppEnvironment`."""
 
+import contextlib
+
 import pytest
 
 import flyte.app
@@ -61,3 +63,92 @@ class TestMCPAppEnvironmentBasics:
         mcp = FastMCP(name="unit-test")
         env = MCPAppEnvironment(name="generic-mcp", mcp=mcp)
         assert isinstance(env, flyte.app.AppEnvironment)
+
+
+class TestStdioTransport:
+    """``transport="stdio"`` builds no HTTP surface and runs on stdin/stdout."""
+
+    @staticmethod
+    def _env(**kwargs):
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP(name="unit-test")
+
+        @mcp.tool()
+        def ping() -> str:
+            return "pong"
+
+        return MCPAppEnvironment(name="stdio-mcp", mcp=mcp, transport="stdio", **kwargs)
+
+    def test_builds_no_starlette_app(self):
+        assert self._env()._starlette_app is None
+
+    def test_advertises_no_http_links(self):
+        # A stdio server has no reachable URL, so surfacing /health or a mount path
+        # in the console would point at nothing.
+        assert self._env().links == []
+
+    def test_leaves_server_unset_so_serve_fails_fast(self):
+        # flyte.serve() would run _server on a background thread and then poll an HTTP
+        # health check that can never succeed. Leaving _server unset makes serve() raise
+        # immediately instead of hanging forever.
+        assert self._env()._server is None
+
+    def test_http_transports_still_build_starlette_app(self):
+        from mcp.server.fastmcp import FastMCP
+
+        for transport in ("streamable-http", "sse"):
+            env = MCPAppEnvironment(name="http-mcp", mcp=FastMCP(name="unit-test"), transport=transport)
+            assert env._starlette_app is not None, transport
+            assert env._server is not None, transport
+            assert env.links, transport
+
+    def test_run_stdio_async_rejects_non_stdio_transport(self):
+        import asyncio
+
+        from mcp.server.fastmcp import FastMCP
+
+        env = MCPAppEnvironment(name="http-mcp", mcp=FastMCP(name="unit-test"))
+        with pytest.raises(ValueError, match="requires transport='stdio'"):
+            asyncio.run(env.run_stdio_async())
+
+    def test_run_stdio_async_serves_a_session(self):
+        """Drive a real initialize/tools-list handshake over in-memory streams."""
+        import asyncio
+        from unittest.mock import patch
+
+        import anyio
+        import mcp.types as types
+        from mcp.shared.memory import create_client_server_memory_streams
+
+        async def exercise():
+            env = self._env()
+            async with create_client_server_memory_streams() as (client_streams, server_streams):
+                client_read, client_write = client_streams
+
+                # run_stdio_async() binds the process's stdin/stdout; swap in the paired
+                # in-memory streams so the test drives a genuine session.
+                def fake_stdio_server():
+                    @contextlib.asynccontextmanager
+                    async def _cm():
+                        yield server_streams
+
+                    return _cm()
+
+                async with anyio.create_task_group() as tg:
+                    with patch("mcp.server.fastmcp.server.stdio_server", fake_stdio_server):
+                        tg.start_soon(env.run_stdio_async)
+
+                        from mcp.client.session import ClientSession
+
+                        async with ClientSession(client_read, client_write) as session:
+                            init = await session.initialize()
+                            assert init.serverInfo.name == "unit-test"
+                            listed = await session.list_tools()
+                            assert [t.name for t in listed.tools] == ["ping"]
+                            called = await session.call_tool("ping", {})
+                            assert isinstance(called.content[0], types.TextContent)
+                            assert called.content[0].text == "pong"
+                    tg.cancel_scope.cancel()
+
+        asyncio.run(exercise())


### PR DESCRIPTION
## Problem

`MCPAppEnvironment` accepts `transport="stdio"` and validates it, but never implements it. `__post_init__` builds the Starlette app and sets `_server = self._starlette_app_server` for *every* transport value, so `"stdio"` silently serves streamable-HTTP:

```python
env = FlyteMCPAppEnvironment(name="x", transport="stdio", tool_groups=["run"])
env._server.__name__        # -> '_starlette_app_server'
env._starlette_app is None  # -> False
```

The `flyte-mcp` CLI had no `--transport` flag either, so the only way to reach that path was to build the environment by hand.

The practical consequence: there was no way to run a Flyte MCP server for clients that launch it as a subprocess, which is how most MCP clients (Claude Code, Codex, Cursor) prefer to run a local server. Anyone following the "local MCP" path got an HTTP server on `:8080` and had to attach to it separately.

## Changes

### 1. Real stdio support

- **`transport="stdio"` builds no HTTP surface** — no Starlette app, no `/health`, no links. `mcp_mount_path` is unused.
- **New `run_stdio()` / `run_stdio_async()`** on `MCPAppEnvironment`.
- **`_server` is deliberately left unset for stdio.** `flyte.serve()` runs the server on a background thread and then polls an HTTP health check (`_LocalApp.is_active()` GETs `http://host:port/health`), so it can never host a process-bound stdio stream. Leaving `_server` unset makes `serve()` fail fast rather than hang forever waiting on a health check that will never pass.
- **`flyte-mcp --transport {stdio,sse,streamable-http}`**, default `streamable-http` (unchanged).
- **stdout protection under stdio.** stdout is the JSON-RPC channel, and the CLI `click.echo`s progress during setup (corpus cache, clone/download). One stray byte breaks the client's first parse, so setup-phase stdout is redirected to stderr. The redirect covers setup only — `stdio_server()` re-wraps `sys.stdout.buffer` at call time, so leaving it active would have sent the entire protocol to stderr.
- **`--requires-auth` warns under stdio**, where it has no effect: the server talks only to the process that launched it and runs with the caller's own credentials.
- **Drive-by:** the HTTP startup banner printed `{mount_path}/mcp` even for `sse`, sending sse users to a nonexistent path. It now matches the transport.

### 2. Fix three broken `uvx` invocations in the MCP examples

Separate from stdio, and worth reviewing on its own — every local-setup command in `examples/mcp/` was broken:

- **`uvx --with "flyte[mcp]" flyte-mcp` runs the wrong package.** `uvx <cmd>` is shorthand for `uvx --from <cmd> <cmd>`, so the package is resolved from the *command name* — and [`flyte-mcp`](https://pypi.org/project/flyte-mcp/) is a real, unrelated third-party project on PyPI ("MCP server exposing Flyte V2 SDK knowledge"). Anyone following our own examples installed and ran **someone else's MCP server**, with `flyte[mcp]` attached only as an extra dependency. The adjacent line in the same docstring already used `--from` correctly, so this was a slip rather than intent.
- **Missing `--transport stdio`** — the commands are presented as stdio setup but would start an HTTP server.
- **`uvx --from . flyte-mcp` omits the `[mcp]` extra**, so the repo-checkout path fails immediately with `ModuleNotFoundError: mcp is not installed`. Found by actually running it; now `uvx --from ".[mcp]" flyte-mcp`.

## Usage

```bash
flyte-mcp --transport stdio --tool-groups run,task
```

```jsonc
// MCP client config
{ "mcpServers": { "flyte": { "command": "uvx",
  "args": ["--from", "flyte[mcp]", "flyte-mcp", "--transport", "stdio"] } } }
```

## Testing

`tests/flyte/ai/mcp/test_mcp_app_environment.py` gains a `TestStdioTransport` class that drives a **real** `initialize` → `tools/list` → `tools/call` session over in-memory streams (asserting the tool actually returns `"pong"`), plus assertions that the HTTP transports are unmodified and that `run_stdio_async()` rejects non-stdio transports.

Verified manually end-to-end by speaking JSON-RPC to the CLI over a pipe:

```
INIT   : {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18",...
TOOLS  : ['abort_run', 'get_run', 'get_run_io', 'list_runs', 'wait_for_run']
STDERR : warning: --requires-auth has no effect with --transport stdio...
```

(the warning correctly landing on stderr, leaving stdout clean). The corrected example command was run the same way and returns a valid handshake plus the expected tool list. Both HTTP transports still serve — `/health` returns `{"status":"healthy"}` and sse now banners `http://localhost:8098/flyte-mcp/sse`.

`tests/flyte/ai/` + `tests/flyte/app/`: **588 passed**.

## Compatibility

No behavior change for `streamable-http` or `sse`. `transport="stdio"` previously served HTTP by accident; it now serves stdio, and `flyte.serve()` on such an environment raises instead of silently starting an HTTP server. Anyone depending on the accidental behavior was passing `"stdio"` and getting HTTP, so the fix surfaces a latent misconfiguration rather than breaking a working setup.

## Follow-ups (not in this PR)

- `flyte-mcp` has no `--project` / `--domain`, and no check that they resolved. Without them the control-plane tools fail at call time with `project_id.domain: must be at least 1 characters`, which reads as a tool bug rather than missing setup.
- `Config.auto()` returns `Config()` and never consults environment variables when no config file is found, contradicting its own docstring ("First try to read from the relevant environment variable"). A pure-env-var setup silently resolves to nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)