### PR TITLE
fix: route Dir.download_sync through obstore-aware storage.get

### DIFF
--- a/examples/basics/dir_download_sync_repro.py
+++ b/examples/basics/dir_download_sync_repro.py
@@ -1,7 +1,4 @@
 """
-Reproduction for ENG26-937:
-https://linear.app/unionai/issue/ENG26-937/bug-reading-a-dir-input-from-a-sync-task-via-dirdownload-sync-fails
-
 Reading a ``Dir`` input from a *sync* task via ``Dir.download_sync()`` used to fail with::
 
     Object at location <dir-uri> not found
@@ -54,8 +51,6 @@ async def create_remote_directory() -> Dir:
 def download_directory_sync(d: Dir) -> list[str]:
     """
     The failing path: a *sync* task receives a Dir input and calls ``download_sync()``.
-
-    This is the exact scenario from ENG26-937.
     """
     local_path = d.download_sync()
     print(f"Downloaded dir sync to: {local_path}")

--- a/examples/basics/dir_download_sync_repro.py
+++ b/examples/basics/dir_download_sync_repro.py
@@ -1,23 +1,4 @@
-"""
-Reading a ``Dir`` input from a *sync* task via ``Dir.download_sync()`` used to fail with::
-
-    Object at location <dir-uri> not found
-
-even though the directory and its files exist in object storage. The async equivalent,
-``await Dir.download()``, on the same ``Dir`` works. The sync path bypassed the SDK's
-obstore-aware ``storage.get()`` and called the raw fsspec ``fs.get(..., recursive=True)``,
-which the obstore backend resolves as a single-object GET on the directory prefix instead of
-listing + downloading its contents.
-
-IMPORTANT: this bug only manifests against real object storage (S3/GCS/ABFS), i.e. an
-obstore-backed filesystem. Run it against a remote storage config, not the local filesystem::
-
-    flyte run --project <p> --domain <d> examples/basics/dir_download_sync_repro.py main
-
-Expected behavior *after* the fix: ``download_directory_sync`` downloads the directory
-(including the nested subdirectory) and prints the local files. Before the fix, it raised
-``FileNotFoundError: Object at location ... not found``.
-"""
+"""Example to download directory content with Dir.download_sync()"""
 
 import os
 import tempfile

--- a/examples/basics/dir_download_sync_repro.py
+++ b/examples/basics/dir_download_sync_repro.py
@@ -1,0 +1,82 @@
+"""
+Reproduction for ENG26-937:
+https://linear.app/unionai/issue/ENG26-937/bug-reading-a-dir-input-from-a-sync-task-via-dirdownload-sync-fails
+
+Reading a ``Dir`` input from a *sync* task via ``Dir.download_sync()`` used to fail with::
+
+    Object at location <dir-uri> not found
+
+even though the directory and its files exist in object storage. The async equivalent,
+``await Dir.download()``, on the same ``Dir`` works. The sync path bypassed the SDK's
+obstore-aware ``storage.get()`` and called the raw fsspec ``fs.get(..., recursive=True)``,
+which the obstore backend resolves as a single-object GET on the directory prefix instead of
+listing + downloading its contents.
+
+IMPORTANT: this bug only manifests against real object storage (S3/GCS/ABFS), i.e. an
+obstore-backed filesystem. Run it against a remote storage config, not the local filesystem::
+
+    flyte run --project <p> --domain <d> examples/basics/dir_download_sync_repro.py main
+
+Expected behavior *after* the fix: ``download_directory_sync`` downloads the directory
+(including the nested subdirectory) and prints the local files. Before the fix, it raised
+``FileNotFoundError: Object at location ... not found``.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+import flyte
+from flyte.io import Dir
+
+env = flyte.TaskEnvironment(name="dir_download_sync_repro")
+
+
+@env.task
+async def create_remote_directory() -> Dir:
+    """Create a small local directory (with a nested subdirectory) and upload it to object storage."""
+    temp_dir = tempfile.mkdtemp(prefix="flyte_eng26_937_")
+
+    with open(os.path.join(temp_dir, "root.txt"), "w") as f:  # noqa: ASYNC230
+        f.write("root level file")
+
+    nested = os.path.join(temp_dir, "nested")
+    os.makedirs(nested)
+    with open(os.path.join(nested, "child.txt"), "w") as f:  # noqa: ASYNC230
+        f.write("file in nested subdirectory")
+
+    uploaded_dir = await Dir.from_local(temp_dir)
+    print(f"Uploaded {temp_dir} to remote: {uploaded_dir.path}")
+    return uploaded_dir
+
+
+@env.task
+def download_directory_sync(d: Dir) -> list[str]:
+    """
+    The failing path: a *sync* task receives a Dir input and calls ``download_sync()``.
+
+    This is the exact scenario from ENG26-937.
+    """
+    local_path = d.download_sync()
+    print(f"Downloaded dir sync to: {local_path}")
+
+    downloaded = sorted(str(p.relative_to(local_path)) for p in Path(local_path).rglob("*") if p.is_file())
+    print(f"Downloaded files: {downloaded}")
+
+    # Sanity-check that the recursive contents actually made it to disk.
+    assert (Path(local_path) / "root.txt").exists(), "root.txt missing after download_sync"
+    assert (Path(local_path) / "nested" / "child.txt").exists(), "nested/child.txt missing after download_sync"
+    return downloaded
+
+
+@env.task
+async def main() -> list[str]:
+    remote_dir = await create_remote_directory()
+    # Pass the Dir as an input to a sync task, which downloads it via download_sync().
+    return download_directory_sync(d=remote_dir)
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    r = flyte.run(main)
+    print(r.url)

--- a/src/flyte/io/_dir.py
+++ b/src/flyte/io/_dir.py
@@ -28,6 +28,7 @@ import flyte.storage as storage
 from flyte._context import internal_ctx
 from flyte._logging import logger
 from flyte.io._file import File
+from flyte.syncify import syncify
 from flyte.types import TypeEngine, TypeTransformer, TypeTransformerFailedError
 
 # Type variable for the directory format
@@ -596,9 +597,12 @@ class Dir(BaseModel, Generic[T], SerializableType):
                 shutil.copytree(self.path, local_dest, dirs_exist_ok=True)
                 return local_dest
 
-        fs = storage.get_underlying_filesystem(path=self.path)
-        fs.get(self.path, local_dest, recursive=True)
-        return local_dest
+        # Route through the obstore-aware storage.get (via syncify) rather than the raw fsspec
+        # fs.get(..., recursive=True). For obstore-backed filesystems the raw call resolves the
+        # directory prefix as a single-object GET and fails with "Object at location <uri> not
+        # found", whereas storage.get lists + downloads the prefix contents. This mirrors the
+        # async download() above.
+        return syncify(storage.get)(self.path, local_dest, recursive=True)
 
     @classmethod
     async def from_local(

--- a/tests/flyte/io_types/test_dirs.py
+++ b/tests/flyte/io_types/test_dirs.py
@@ -357,6 +357,8 @@ async def test_download_dir_sync_no_local_target(
     assert os.path.isdir(downloaded_path)
     assert os.path.exists(os.path.join(downloaded_path, "root.txt"))
     assert os.path.isdir(os.path.join(downloaded_path, "sibling"))
+    assert os.path.exists(os.path.join(downloaded_path, "sibling", "sibling_file.txt"))
+    assert os.path.exists(os.path.join(downloaded_path, "nested1", "nested2", "file2.txt"))
     suffix = uploaded_dir.path.split("/")[-1]
     assert downloaded_path.endswith(suffix)
 

--- a/tests/flyte/io_types/test_dirs.py
+++ b/tests/flyte/io_types/test_dirs.py
@@ -306,6 +306,62 @@ async def test_download_dir_with_no_local_target(
     assert downloaded_path.endswith(suffix)
 
 
+@pytest.mark.sandbox
+@pytest.mark.asyncio
+async def test_download_dir_sync(tmp_path, tmp_dir_structure, ctx_with_test_local_s3_stack_raw_data_path):
+    """
+    Regression test for ENG26-937: Dir.download_sync() on an obstore-backed (S3) directory used to
+    fail with "Object at location <dir-uri> not found" because it called the raw fsspec
+    fs.get(..., recursive=True), which obstore resolves as a single-object GET on the directory
+    prefix. It must route through the obstore-aware storage.get and download the prefix contents,
+    matching the async Dir.download().
+    """
+    from flyte.storage import S3
+
+    await flyte.init.aio(storage=S3.for_sandbox())
+
+    # Upload to S3
+    uploaded_dir = await Dir.from_local(tmp_dir_structure)
+
+    # Download the whole directory synchronously into a target directory
+    download_dir = tmp_path / "downloaded_sync"
+    download_dir.mkdir(parents=True, exist_ok=True)
+    downloaded_path = uploaded_dir.download_sync(str(download_dir))
+
+    # Verify the directory contents (including nested subdirectories) were downloaded
+    assert downloaded_path == str(download_dir)
+    assert os.path.isdir(downloaded_path)
+    assert os.path.exists(os.path.join(downloaded_path, "root.txt"))
+    assert os.path.isdir(os.path.join(downloaded_path, "sibling"))
+    assert os.path.exists(os.path.join(downloaded_path, "sibling", "sibling_file.txt"))
+    assert os.path.exists(os.path.join(downloaded_path, "nested1", "nested2", "file2.txt"))
+
+
+@pytest.mark.sandbox
+@pytest.mark.asyncio
+async def test_download_dir_sync_no_local_target(
+    tmp_path, tmp_dir_structure, ctx_with_test_local_s3_stack_raw_data_path
+):
+    """
+    Regression test for ENG26-937: Dir.download_sync() without a target path should download the
+    directory (recursively) from S3 to a generated temporary location.
+    """
+    from flyte.storage import S3
+
+    await flyte.init.aio(storage=S3.for_sandbox())
+
+    uploaded_dir = await Dir.from_local(tmp_dir_structure)
+
+    downloaded_path = uploaded_dir.download_sync()
+
+    assert downloaded_path is not None
+    assert os.path.isdir(downloaded_path)
+    assert os.path.exists(os.path.join(downloaded_path, "root.txt"))
+    assert os.path.isdir(os.path.join(downloaded_path, "sibling"))
+    suffix = uploaded_dir.path.split("/")[-1]
+    assert downloaded_path.endswith(suffix)
+
+
 @pytest.mark.asyncio
 async def test_download_dir_with_name_local(tmp_path, tmp_dir_structure, ctx_with_test_raw_data_path):
     """

--- a/tests/flyte/io_types/test_dirs.py
+++ b/tests/flyte/io_types/test_dirs.py
@@ -310,11 +310,10 @@ async def test_download_dir_with_no_local_target(
 @pytest.mark.asyncio
 async def test_download_dir_sync(tmp_path, tmp_dir_structure, ctx_with_test_local_s3_stack_raw_data_path):
     """
-    Regression test for ENG26-937: Dir.download_sync() on an obstore-backed (S3) directory used to
-    fail with "Object at location <dir-uri> not found" because it called the raw fsspec
-    fs.get(..., recursive=True), which obstore resolves as a single-object GET on the directory
-    prefix. It must route through the obstore-aware storage.get and download the prefix contents,
-    matching the async Dir.download().
+    Dir.download_sync() on an obstore-backed (S3) directory must route through the obstore-aware
+    storage.get and download the prefix contents, matching the async Dir.download(). The raw fsspec
+    fs.get(..., recursive=True) resolves the directory prefix as a single-object GET and fails with
+    "Object at location <dir-uri> not found".
     """
     from flyte.storage import S3
 
@@ -343,8 +342,8 @@ async def test_download_dir_sync_no_local_target(
     tmp_path, tmp_dir_structure, ctx_with_test_local_s3_stack_raw_data_path
 ):
     """
-    Regression test for ENG26-937: Dir.download_sync() without a target path should download the
-    directory (recursively) from S3 to a generated temporary location.
+    Dir.download_sync() without a target path should download the directory (recursively) from S3
+    to a generated temporary location.
     """
     from flyte.storage import S3
 


### PR DESCRIPTION
## Summary

Fixes [ENG26-937](https://linear.app/unionai/issue/ENG26-937/bug-reading-a-dir-input-from-a-sync-task-via-dirdownload-sync-fails).

Reading a `Dir` input from a **sync** task via `Dir.download_sync()` failed with `Object at location <dir-uri> not found`, even though the directory and its files exist in object storage. The async equivalent, `await Dir.download()`, on the same `Dir` worked.

### Root cause

`Dir.download_sync()` bypassed the SDK's obstore-aware `storage.get()` and called the raw fsspec `fs.get(self.path, local_dest, recursive=True)`. For obstore-backed filesystems (S3/GCS/ABFS), the obstore backend resolves `recursive=True` on a directory prefix as a **single-object GET** on that prefix, which 404s. The async `Dir.download()` didn't hit this because it routes through `storage.get()`, which detects obstore protocols and lists + downloads the prefix contents.

### Fix

`download_sync` now mirrors the async path, running the obstore-aware `storage.get()` synchronously via the existing `syncify` bridge:

```python
return syncify(storage.get)(self.path, local_dest, recursive=True)
```

The local-filesystem and `local_path is None` branches are unchanged.

## Tests

Added two `@pytest.mark.sandbox` regression tests in `tests/flyte/io_types/test_dirs.py`:
- `test_download_dir_sync` — downloads an S3 dir to a target path, asserting nested subdirectory contents arrive.
- `test_download_dir_sync_no_local_target` — downloads without a target path.

Both were verified to **fail with the original `FileNotFoundError`** when the fix is reverted and **pass** with it (run against a local minio S3 backend).

## Reproduction example

Added `examples/basics/dir_download_sync_repro.py`, which builds a multi-file `Dir` (with a nested subdirectory) in an async task and downloads it from a **sync** task via `download_sync()` — the exact scenario from the issue. It only manifests the bug against real object storage; the docstring notes it must be run against a remote storage config.

## Test plan

- [x] `test_download_dir_sync` / `test_download_dir_sync_no_local_target` fail without the fix, pass with it (minio S3)
- [x] Full non-integration io_types suite passes (54 tests)
- [x] Reproduction example fails without the fix, succeeds with it
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)