### PR TITLE
fix: sync local sys paths for deploy

### DIFF
--- a/src/flyte/_deploy.py
+++ b/src/flyte/_deploy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import hashlib
 import os
 import pathlib
@@ -14,6 +15,7 @@ import rich.repr
 from flyte.models import ActionID, NativeInterface, RawDataPath, SerializationContext, TaskContext
 from flyte.syncify import syncify
 
+from ._constants import FLYTE_SYS_PATH
 from ._environment import Environment
 from ._image import Image
 from ._initialize import ensure_client, get_client, get_init_config, requires_initialization
@@ -163,6 +165,23 @@ class Deployment:
         return tuples
 
 
+def _with_local_sys_paths(task: TaskTemplate, root_dir: pathlib.Path) -> TaskTemplate:
+    """Return a task copy whose runtime env mirrors local imports under ``root_dir``."""
+    if not get_init_config().sync_local_sys_paths:
+        return task
+
+    root_dir_abs = pathlib.Path(root_dir).resolve()
+    env_vars = dict(task.env_vars or {})
+    env_vars[FLYTE_SYS_PATH] = ":".join(
+        f"./{pathlib.Path(path).relative_to(root_dir_abs)}"
+        for path in sys.path
+        if pathlib.Path(path).is_relative_to(root_dir_abs)
+    )
+    task_copy = copy.copy(task)
+    task_copy.env_vars = env_vars
+    return task_copy
+
+
 async def _deploy_task(
     task: TaskTemplate, serialization_context: SerializationContext, dryrun: bool = False
 ) -> DeployedTask:
@@ -181,6 +200,8 @@ async def _deploy_task(
     from ._internal.runtime.task_serde import lookup_image_in_cache, translate_task_to_wire
     from ._internal.runtime.trigger_serde import offload_trigger_inputs, to_task_trigger
 
+    assert serialization_context.root_dir is not None
+    task = _with_local_sys_paths(task, serialization_context.root_dir)
     assert task.parent_env_name is not None
     if isinstance(task.image, Image):
         image_uri: str | None = lookup_image_in_cache(serialization_context, task.parent_env_name, task.image)

--- a/tests/flyte/test_deploy.py
+++ b/tests/flyte/test_deploy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import pathlib
 import sys
 import types
 from dataclasses import replace
@@ -15,6 +16,7 @@ from flyte._deploy import (
     _build_image_bg,
     _build_images,
     _check_duplicate_env,
+    _deploy_task,
     _get_documentation_entity,
     _recursive_discover,
     _update_interface_inputs_and_outputs_docstring,
@@ -25,7 +27,32 @@ from flyte._docstring import Docstring
 from flyte._image import CodeBundleLayer, resolve_code_bundle_layer
 from flyte._internal.imagebuild.image_builder import ImageCache
 from flyte._internal.runtime.types_serde import transform_native_to_typed_interface
-from flyte.models import NativeInterface
+from flyte.models import NativeInterface, SerializationContext
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sync_local_sys_paths", [True, False])
+async def test_deploy_task_syncs_local_sys_paths(sync_local_sys_paths, monkeypatch):
+    root_dir = pathlib.Path(__file__).parents[2].resolve()
+    monkeypatch.setattr(sys, "path", [str(root_dir / "src"), *sys.path])
+
+    env = flyte.TaskEnvironment(name="test_env", image="python:3.10")
+
+    @env.task()
+    async def task() -> None:
+        pass
+
+    context = SerializationContext(version="v1", root_dir=root_dir)
+    config = Mock(sync_local_sys_paths=sync_local_sys_paths)
+    with patch("flyte._deploy.ensure_client"), patch("flyte._deploy.get_init_config", return_value=config):
+        deployed = await _deploy_task(task, context, dryrun=True)
+
+    runtime_env = {item.key: item.value for item in deployed.deployed_task.task_template.container.env}
+    if sync_local_sys_paths:
+        assert "./src" in runtime_env["_F_SYS_PATH"].split(":")
+    else:
+        assert "_F_SYS_PATH" not in runtime_env
+    assert task.env_vars is None
 
 
 def test_get_description_entity_both_descriptions_truncated():


### PR DESCRIPTION
Fixes flyteorg/flyte#7675

## Summary
- persist bundle-relative local import paths in deployed task environments
- honor the no-sync-local-sys-paths configuration for deploys
- keep the original task environment variables unchanged

## Testing
- uv run python -m pytest tests/flyte/test_deploy.py -q (24 passed)
- uv run python -m ruff check src/flyte/_deploy.py tests/flyte/test_deploy.py
- uv run python -m ruff format --check src/flyte/_deploy.py tests/flyte/test_deploy.py