### PR TITLE
Preserve DRA resource claims when overriding task resources

### DIFF
--- a/src/flyte/_internal/runtime/task_serde.py
+++ b/src/flyte/_internal/runtime/task_serde.py
@@ -418,10 +418,6 @@ def _get_k8s_pod(primary_container: tasks_pb2.Container, pod_template: PodTempla
                 existing = container.resources or V1ResourceRequirements()
                 merged_limits = {**(existing.limits or {}), **limits}
                 merged_requests = {**(existing.requests or {}), **requests}
-                # Preserve ``.claims`` (Dynamic Resource Allocation links, e.g. a GPU
-                # claimed through a ResourceClaimTemplate). These can only be expressed
-                # through the pod template, and rebuilding V1ResourceRequirements without
-                # them would silently drop the claim so the pod schedules with no device.
                 container.resources = V1ResourceRequirements(
                     limits=merged_limits,
                     requests=merged_requests,

--- a/src/flyte/_internal/runtime/task_serde.py
+++ b/src/flyte/_internal/runtime/task_serde.py
@@ -418,7 +418,15 @@ def _get_k8s_pod(primary_container: tasks_pb2.Container, pod_template: PodTempla
                 existing = container.resources or V1ResourceRequirements()
                 merged_limits = {**(existing.limits or {}), **limits}
                 merged_requests = {**(existing.requests or {}), **requests}
-                container.resources = V1ResourceRequirements(limits=merged_limits, requests=merged_requests)
+                # Preserve ``.claims`` (Dynamic Resource Allocation links, e.g. a GPU
+                # claimed through a ResourceClaimTemplate). These can only be expressed
+                # through the pod template, and rebuilding V1ResourceRequirements without
+                # them would silently drop the claim so the pod schedules with no device.
+                container.resources = V1ResourceRequirements(
+                    limits=merged_limits,
+                    requests=merged_requests,
+                    claims=existing.claims,
+                )
 
             if primary_container.env is not None:
                 container.env = [V1EnvVar(name=e.key, value=e.value) for e in primary_container.env] + (

--- a/src/flyte/remote/_task.py
+++ b/src/flyte/remote/_task.py
@@ -79,8 +79,6 @@ def _apply_overrides_to_primary_container(
                 rr["requests"] = requests
             if limits:
                 rr["limits"] = limits
-            # Preserve DRA ``claims`` (e.g. a GPU claimed through a ResourceClaimTemplate)
-            # from the pod template.
             if existing.get("claims"):
                 rr["claims"] = existing["claims"]
             target["resources"] = rr

--- a/src/flyte/remote/_task.py
+++ b/src/flyte/remote/_task.py
@@ -73,11 +73,16 @@ def _apply_overrides_to_primary_container(
         if proto_res is not None:
             requests = {_sanitize_resource_name(e): e.value for e in proto_res.requests}
             limits = {_sanitize_resource_name(e): e.value for e in proto_res.limits}
+            existing = target.get("resources") or {}
             rr: Dict[str, Any] = {}
             if requests:
                 rr["requests"] = requests
             if limits:
                 rr["limits"] = limits
+            # Preserve DRA ``claims`` (e.g. a GPU claimed through a ResourceClaimTemplate)
+            # from the pod template.
+            if existing.get("claims"):
+                rr["claims"] = existing["claims"]
             target["resources"] = rr
 
     if env_vars:

--- a/tests/flyte/internal/runtime/test_task_serde.py
+++ b/tests/flyte/internal/runtime/test_task_serde.py
@@ -9,10 +9,13 @@ from flyteidl2.core.security_pb2 import Secret as ProtoSecret
 from flyteidl2.core.security_pb2 import SecurityContext
 from flyteidl2.task import common_pb2, environment_pb2
 from kubernetes.client import (
+    CoreV1ResourceClaim,
     V1Container,
     V1EnvVar,
     V1LocalObjectReference,
+    V1PodResourceClaim,
     V1PodSpec,
+    V1ResourceRequirements,
 )
 
 import flyte
@@ -277,6 +280,61 @@ def test_get_proto_k8s_pod_task():
 
     with pytest.raises(ValueError):
         get_proto_task(t2, context)
+
+
+def test_get_k8s_pod_preserves_dra_claims_with_task_resources():
+    """A DRA resource claim on the pod template's primary container must survive
+    even when the task also declares cpu/memory via Resources(...)."""
+    pod_template = PodTemplate(
+        pod_spec=V1PodSpec(
+            resource_claims=[
+                V1PodResourceClaim(name="gpu", resource_claim_template_name="flyte-task-gpu-x2")
+            ],
+            containers=[
+                V1Container(
+                    name="primary",
+                    resources=V1ResourceRequirements(claims=[CoreV1ResourceClaim(name="gpu")]),
+                )
+            ],
+        ),
+    )
+
+    env = flyte.TaskEnvironment(
+        name="test_env",
+        image="python:3.10",
+        # Declaring cpu/memory is exactly what used to strip the .claims link.
+        resources=flyte.Resources(cpu="24", memory="490Gi"),
+        pod_template=pod_template,
+    )
+
+    @env.task(short_name="dra_task")
+    async def t1(a: int) -> int:
+        return a
+
+    context = SerializationContext(
+        project="test-project",
+        domain="test-domain",
+        version="test-version",
+        org="test-org",
+        input_path="/tmp/inputs",
+        output_path="/tmp/outputs",
+        image_cache=None,
+        code_bundle=None,
+        root_dir=pathlib.Path.cwd(),
+    )
+
+    from google.protobuf import json_format
+
+    k8s_pod = _get_k8s_pod(_get_urun_container(context, t1), pod_template)
+    pod_spec = json_format.MessageToDict(k8s_pod.pod_spec)
+    primary = next(c for c in pod_spec["containers"] if c["name"] == "primary")
+    resources = primary["resources"]
+
+    # The DRA claim link is preserved...
+    assert resources["claims"] == [{"name": "gpu"}]
+    # ...alongside the task-declared cpu/memory.
+    assert resources["requests"]["cpu"] == "24"
+    assert resources["requests"]["memory"] == "490Gi"
 
 
 @pytest.fixture(scope="module")

--- a/tests/flyte/internal/runtime/test_task_serde.py
+++ b/tests/flyte/internal/runtime/test_task_serde.py
@@ -287,9 +287,7 @@ def test_get_k8s_pod_preserves_dra_claims_with_task_resources():
     even when the task also declares cpu/memory via Resources(...)."""
     pod_template = PodTemplate(
         pod_spec=V1PodSpec(
-            resource_claims=[
-                V1PodResourceClaim(name="gpu", resource_claim_template_name="flyte-task-gpu-x2")
-            ],
+            resource_claims=[V1PodResourceClaim(name="gpu", resource_claim_template_name="flyte-task-gpu-x2")],
             containers=[
                 V1Container(
                     name="primary",

--- a/tests/flyte/remote/test_task.py
+++ b/tests/flyte/remote/test_task.py
@@ -289,6 +289,45 @@ class TestTaskDetailsOverrideResources:
         side = next(c for c in spec["containers"] if c["name"] == "sidecar")
         assert not side.get("resources")
 
+    def test_resource_override_on_pod_template_preserves_dra_claims(self):
+        # Regression: a resource override on a pod-template task must not drop a
+        # DRA claim (e.g. a GPU claimed through a ResourceClaimTemplate). The
+        # claim can only be expressed via the pod template; without it the pod
+        # schedules with no device.
+        from flyteidl2.task import task_definition_pb2
+        from google.protobuf import json_format
+
+        from flyte._pod import _PRIMARY_CONTAINER_NAME_FIELD
+
+        pb2 = task_definition_pb2.TaskDetails()
+        tmpl = pb2.spec.task_template
+        tmpl.config[_PRIMARY_CONTAINER_NAME_FIELD] = "primary"
+        spec = {
+            "resourceClaims": [{"name": "gpu", "resourceClaimTemplateName": "flyte-task-gpu-x2"}],
+            "containers": [
+                {
+                    "name": "primary",
+                    "image": "example:latest",
+                    "resources": {
+                        "requests": {"cpu": "1", "memory": "1Gi"},
+                        "claims": [{"name": "gpu"}],
+                    },
+                },
+            ],
+        }
+        json_format.ParseDict(spec, tmpl.k8s_pod.pod_spec)
+        td = TaskDetails(pb2)
+
+        out = td.override(resources=flyte.Resources(cpu="24", memory="490Gi"))
+        tmpl = out.pb2.spec.task_template
+
+        spec = json_format.MessageToDict(tmpl.k8s_pod.pod_spec)
+        primary = next(c for c in spec["containers"] if c["name"] == "primary")
+        resources = primary["resources"]
+        assert resources["claims"] == [{"name": "gpu"}], f"DRA claim dropped: {resources}"
+        assert resources["requests"]["cpu"] == "24"
+        assert resources["requests"]["memory"] == "490Gi"
+
     def test_env_override_on_pod_template_sets_container_env(self):
         # Regression: env_vars overrides on a pod-template task were silently
         # dropped — they were only applied to template.container, which a


### PR DESCRIPTION
## Problem

For GPU tasks that claim devices through Kubernetes **Dynamic Resource Allocation**
(a `ResourceClaimTemplate` linked via the primary container's `resources.claims`),
declaring a task-level `Resources(cpu=..., memory=...)` silently dropped that claim.

Both resource paths rebuilt the container resources with only `limits`/`requests`
and left `.claims` out:

- **Build path** — `task_serde._get_k8s_pod`: when a task declares cpu/mem it merges
  those into the pod template's primary container but rebuilt
  `V1ResourceRequirements(limits=, requests=)` without `claims`.
- **Remote override path** — `_apply_overrides_to_primary_container` (reached from
  `TaskDetails.override(resources=...)` on a `k8s_pod` task): fully replaced the
  container's `resources`, discarding `claims`.

Result: the DRA claim link was lost, so the pod scheduled with no GPU (or failed to
schedule). Users had to work around it by never setting `resources=` on GPU tasks.

## Fix

Preserve the existing `.claims` when rebuilding the container resources on both paths.
cpu/mem/gpu overrides now merge in alongside the DRA claim instead of replacing it.

## Tests

- `test_get_k8s_pod_preserves_dra_claims_with_task_resources` — build path keeps the
  claim next to task-declared cpu/memory.
- `test_resource_override_on_pod_template_preserves_dra_claims` — `.override(resources=...)`
  on a pod-template task keeps the claim.