### PR TITLE
Add status filter to App.listall() and --status flag to flyte get apps

### DIFF
--- a/src/flyte/cli/_get.py
+++ b/src/flyte/cli/_get.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Tuple, Union
 
 import rich_click as click
+from flyteidl2.app import app_definition_pb2
 from rich.pretty import pretty_repr
 
 import flyte.remote as remote
@@ -698,6 +699,19 @@ def trigger(
 @click.argument("name", type=str, required=False)
 @click.option("--limit", type=int, default=100, help="Limit the number of apps to fetch when listing.")
 @click.option("--only-mine", is_flag=True, default=False, help="Show only apps created by the current user (you).")
+@click.option(
+    "--status",
+    type=click.Choice(
+        [
+            n[len("DEPLOYMENT_STATUS_") :].lower()
+            for n in app_definition_pb2.Status.DeploymentStatus.keys()
+            if n != "DEPLOYMENT_STATUS_UNSPECIFIED"
+        ],
+        case_sensitive=False,
+    ),
+    default=None,
+    help="Filter apps by deployment status.",
+)
 @click.pass_obj
 def app(
     cfg: common.CLIConfig,
@@ -706,6 +720,7 @@ def app(
     domain: str | None = None,
     limit: int = 100,
     only_mine: bool = False,
+    status: str | None = None,
 ):
     """
     Get a list of all apps, or details of a specific app by name.
@@ -727,7 +742,7 @@ def app(
         console.print(
             common.format(
                 "Apps",
-                remote.App.listall(limit=limit, created_by_subject=subject),
+                remote.App.listall(limit=limit, created_by_subject=subject, in_status=status),
                 cfg.output_format,
             )
         )

--- a/src/flyte/remote/_app.py
+++ b/src/flyte/remote/_app.py
@@ -36,6 +36,28 @@ def _is_deactivated(state: app_definition_pb2.Status.DeploymentStatus) -> bool:
     ]
 
 
+_DEPLOYMENT_STATUS_PREFIX = "DEPLOYMENT_STATUS_"
+# The backend filters apps on this field by enum *name* (e.g. "DEPLOYMENT_STATUS_ACTIVE"),
+# not the integer enum value.
+_STATUS_FILTER_FIELD = "status_phase"
+
+
+def _status_filter(in_status: str | Tuple[str, ...]) -> list_pb2.Filter:
+    statuses = (in_status,) if isinstance(in_status, str) else in_status
+    names = []
+    for s in statuses:
+        name = s.upper()
+        if not name.startswith(_DEPLOYMENT_STATUS_PREFIX):
+            name = f"{_DEPLOYMENT_STATUS_PREFIX}{name}"
+        app_definition_pb2.Status.DeploymentStatus.Value(name)  # raises ValueError on unknown status
+        names.append(name)
+    return list_pb2.Filter(
+        function=list_pb2.Filter.Function.VALUE_IN if len(names) > 1 else list_pb2.Filter.Function.EQUAL,
+        field=_STATUS_FILTER_FIELD,
+        values=names,
+    )
+
+
 class App(ToJSONMixin):
     pb2: app_definition_pb2.App
 
@@ -370,13 +392,25 @@ class App(ToJSONMixin):
         created_by_subject: str | None = None,
         sort_by: Tuple[str, Literal["asc", "desc"]] | None = None,
         limit: int = 100,
+        in_status: str | Tuple[str, ...] | None = None,
     ) -> AsyncIterator[App]:
+        """
+        List all apps, optionally filtered.
+
+        :param created_by_subject: Only return apps created by this subject.
+        :param sort_by: Sorting criteria, in the format (field, order).
+        :param limit: Maximum number of apps to return.
+        :param in_status: Filter apps by one or more deployment statuses, e.g. "active" or
+            ("active", "failed"). Accepts short names (case-insensitive) or full
+            DEPLOYMENT_STATUS_* names.
+        """
         ensure_client()
         cfg = get_init_config()
         i = 0
         token = None
         sort_pb2 = sorting(sort_by)
-        filters = filtering(created_by_subject)
+        extra_filters = [_status_filter(in_status)] if in_status else []
+        filters = filtering(created_by_subject, *extra_filters)
         project = None
         if cfg.project:
             project = identifier_pb2.ProjectIdentifier(

--- a/tests/flyte/remote/test_app.py
+++ b/tests/flyte/remote/test_app.py
@@ -1,8 +1,8 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from flyteidl2.app import app_definition_pb2
-from flyteidl2.common import identity_pb2
+from flyteidl2.common import identity_pb2, list_pb2
 
 from flyte.remote._app import App
 
@@ -674,3 +674,63 @@ class TestAppDeploymentStatus:
         )
         app = App(app_pb2)
         assert app.deployment_status == app_definition_pb2.Status.DeploymentStatus.DEPLOYMENT_STATUS_ACTIVE
+
+
+class TestAppListallStatusFilter:
+    """Verify that App.listall() forwards status filters to the AppService stub."""
+
+    def _call_listall(self, **kwargs):
+        resp = MagicMock()
+        resp.apps = []
+        resp.token = ""
+        client = MagicMock()
+        client.app_service.list = AsyncMock(return_value=resp)
+        cfg = MagicMock()
+        cfg.org = "test-org"
+        cfg.project = "test-project"
+        cfg.domain = "development"
+        with (
+            patch("flyte.remote._app.ensure_client"),
+            patch("flyte.remote._app.get_client", return_value=client),
+            patch("flyte.remote._app.get_init_config", return_value=cfg),
+        ):
+            list(App.listall(**kwargs))
+        req = client.app_service.list.call_args.kwargs["request"]
+        return list(req.request.filters)
+
+    def test_no_status_sends_no_status_filter(self):
+        filters = self._call_listall()
+        assert all(f.field != "status_phase" for f in filters)
+
+    def test_single_status_uses_equal(self):
+        filters = self._call_listall(in_status="active")
+        assert len(filters) == 1
+        f = filters[0]
+        assert f.field == "status_phase"
+        assert f.function == list_pb2.Filter.Function.EQUAL
+        assert list(f.values) == ["DEPLOYMENT_STATUS_ACTIVE"]
+
+    def test_status_is_case_insensitive(self):
+        filters = self._call_listall(in_status="FaIlEd")
+        assert list(filters[0].values) == ["DEPLOYMENT_STATUS_FAILED"]
+
+    def test_full_prefixed_name_is_accepted(self):
+        filters = self._call_listall(in_status="DEPLOYMENT_STATUS_STOPPED")
+        assert list(filters[0].values) == ["DEPLOYMENT_STATUS_STOPPED"]
+
+    def test_multiple_statuses_use_value_in(self):
+        filters = self._call_listall(in_status=("active", "failed"))
+        assert len(filters) == 1
+        f = filters[0]
+        assert f.field == "status_phase"
+        assert f.function == list_pb2.Filter.Function.VALUE_IN
+        assert list(f.values) == ["DEPLOYMENT_STATUS_ACTIVE", "DEPLOYMENT_STATUS_FAILED"]
+
+    def test_invalid_status_raises(self):
+        with pytest.raises(ValueError):
+            self._call_listall(in_status="bogus")
+
+    def test_status_combines_with_created_by_subject(self):
+        filters = self._call_listall(in_status="active", created_by_subject="user-123")
+        fields = {f.field for f in filters}
+        assert fields == {"status_phase", "created_by"}


### PR DESCRIPTION
## Motivation

  There was no way to filter apps by deployment status server-side. App.listall() only accepted created_by_subject, sort_by, and limit, even though the underlying list_pb2.ListRequest supports arbitrary filters — users had to fetch everything and filter client-side on app.pb2.status.deployment_status.

 ## Summary
  
  SDK (src/flyte/remote/_app.py)
  - App.listall() accepts a new optional in_status: str | Tuple[str, ...] | None parameter, e.g.  in_status="active" or in_status=("active", "failed").
  - Status names are case-insensitive and accepted with or without the DEPLOYMENT_STATUS_ prefix; unknown names raise ValueError.
  - A single status produces an EQUAL filter, multiple statuses produce VALUE_IN, passed through the existing filtering() helper.

  **CLI (src/flyte/cli/_get.py)**
  - flyte get apps gains a --status flag with choices generated from the proto enum (unassigned, assigned, pending, stopped, started, failed, active, scaling_up, scaling_down, deploying).
  - Single-value for now, matching the existing --in-phase precedent; the SDK API already accepts tuples
  so multiple=True can be added later.

  flyte get apps --status active
  flyte get apps --status failed --only-mine
  
  Wire contract (verified against a live backend)

  The backend's app list endpoint filters on field="status_phase" and matches by enum name (e.g.  "DEPLOYMENT_STATUS_ACTIVE"), not the integer enum value. This differs from the Action.listall phase
  filter, which sends stringified integers — integer values silently return zero rows here, and
  alternative field names (deployment_status, status) are rejected by the backend. Both EQUAL and
  VALUE_IN were verified to return exact matches.

  ## Testing
  
  - New TestAppListallStatusFilter unit tests mock app_service.list and assert the exact filter protos
  sent: no filter when omitted, EQUAL/VALUE_IN shapes, case-insensitivity, prefixed names, invalid-value
  error, and combination with created_by_subject.
  - Live smoke test: flyte get apps --status active returns only ACTIVE apps; server-side results match
  client-side filtering on deployment_status.
  - ruff and mypy clean.