### PR TITLE
fix(lance): regenerate stale plugins/lance/uv.lock (unblocks check uv.lock CI)

### DIFF
--- a/plugins/lance/uv.lock
+++ b/plugins/lance/uv.lock
@@ -344,7 +344,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -453,6 +453,7 @@ dev = [
     { name = "setuptools-scm", specifier = ">=8.2.0" },
     { name = "starlette" },
     { name = "textual", specifier = ">=0.80" },
+    { name = "ty", specifier = ">=0.0.59" },
     { name = "types-aiofiles" },
     { name = "types-pyyaml" },
     { name = "uvicorn" },
@@ -635,7 +636,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [


### PR DESCRIPTION
## Problem

The `check uv.lock` CI gate is **failing on every PR based on current main**. The lance plugin lockfile added in #1313 is out of date with `plugins/lance/pyproject.toml`:

```
The lockfile at `uv.lock` needs to be updated, but `--check` was provided.
```

Reproduced on a clean `origin/main` checkout with `uv lock --check --directory plugins/lance`.

## Cause

The committed `plugins/lance/uv.lock` predates:
- the repo-wide `ty` type-check dev dependency (#1298) — now expected in the dev group
- two refined platform markers (`typing-extensions`, `zipp`)

## Fix

Regenerated with `uv lock --directory plugins/lance` (3 insertions, 2 deletions — no version bumps of runtime deps). `uv lock --check` now passes.

Not a Sentry fix — this is a main-branch CI breakage that blocks the batch of open `sentry-fix` PRs (and any other PR) from going green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)