### PR TITLE
fix: serialize optional None task defaults

### DIFF
--- a/src/flyte/_internal/runtime/convert.py
+++ b/src/flyte/_internal/runtime/convert.py
@@ -119,7 +119,7 @@ async def convert_upload_default_inputs(
     vars = []
     literal_coros = []
     for input_name, (input_type, default_value) in interface.inputs.items():
-        if default_value is not None and default_value is not inspect.Parameter.empty:
+        if default_value is not inspect.Parameter.empty:
             if isinstance(default_value, _trigger_time):
                 raise ValueError(
                     f"Input '{input_name}' uses flyte.TriggerTime as its default value. "

--- a/tests/flyte/internal/runtime/test_convert.py
+++ b/tests/flyte/internal/runtime/test_convert.py
@@ -1376,7 +1376,7 @@ async def test_convert_upload_default_inputs_with_defaults():
     result = await convert.convert_upload_default_inputs(interface)
 
     # Expect one NamedParameter per default, in signature order
-    assert [p.name for p in result] == ["a", "b"]
+    assert [p.name for p in result] == ["a", "b", "c"]
 
     named = {p.name: p for p in result}
     # a -> integer literal == 10
@@ -1385,6 +1385,9 @@ async def test_convert_upload_default_inputs_with_defaults():
     # b -> string literal == "default"
     assert named["b"].parameter.required is False
     assert named["b"].parameter.default.scalar.primitive.string_value == "default"
+    # c -> optional None literal
+    assert named["c"].parameter.required is False
+    assert named["c"].parameter.default.scalar.union.value.scalar.HasField("none_type")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What/Why

Task parameters annotated as optional with a `None` default are currently omitted from uploaded `default_inputs`. After registration, remote clients consequently treat those parameters as required even though their Python signatures allow omission.

This conflicts with the documented task contract: [parameters with Python defaults can be omitted and their defaults are part of the task input schema](https://www.union.ai/docs/v2/flyte/user-guide/task-configuration/additional-task-settings/), and [an `Optional[...]` input or any input with a default is not required](https://www.union.ai/docs/v2/flyte/user-guide/task-deployment/run-command-options/). During deployment, Flyte [analyzes and serializes task parameter metadata into a `TaskTemplate`](https://www.union.ai/docs/v2/flyte/user-guide/task-deployment/how-task-deployment-works/), so the `None` default must survive this conversion.

<details>
<summary>Minimal reproducer</summary>

Run from the Flyte SDK repository root. On `main`, this raises the same error observed when launching the RasterFlow integration workflow: `ValueError: Missing required inputs: intermediate_storage_uri, storage_uri`. It completes successfully on this branch.

```shell
uvx --from uv==0.9.21 uv run python - <<"PY"
import asyncio

from flyte._internal.runtime.convert import (
    convert_from_native_to_inputs,
    convert_upload_default_inputs,
)
from flyte._internal.runtime.types_serde import transform_native_to_typed_interface
from flyte.models import NativeInterface
from flyte.types import guess_interface


def task(
    intermediate_storage_uri: str | None = None,
    storage_uri: str | None = None,
) -> None:
    pass


async def main() -> None:
    local_interface = NativeInterface.from_callable(task)
    uploaded_defaults = await convert_upload_default_inputs(local_interface)
    remote_interface = guess_interface(
        transform_native_to_typed_interface(local_interface),
        uploaded_defaults,
    )
    await convert_from_native_to_inputs(remote_interface)


asyncio.run(main())
PY
```

</details>

## How

Serialize every declared default except `inspect.Parameter.empty`. Extend the existing default-input conversion test to verify that an optional `None` default is uploaded as the union `NONE` literal.