### PR TITLE
fix: filter pyqwest transport errors from Sentry (FLYTE-SDK-6H)

### DIFF
--- a/src/flyte/_sentry.py
+++ b/src/flyte/_sentry.py
@@ -170,6 +170,8 @@ def _is_transient_network_error(exc: BaseException) -> bool:
     - FLYTE-SDK-36: ``httpx.ReadError`` during the signed-URL upload
     - FLYTE-SDK-4M: ``httpx.RemoteProtocolError`` ("Server disconnected without
       sending a response") — the object store dropped the PUT mid-flight
+    - FLYTE-SDK-6H: ``pyqwest.StreamError`` ("Error reading content") — the
+      HTTP/2 stream carrying a control-plane RPC was reset mid-body
 
     Transient ConnectError status codes (DEADLINE_EXCEEDED / UNAVAILABLE) are
     handled by ``_is_user_actionable_connect_error`` and intentionally not
@@ -192,6 +194,22 @@ def _is_transient_network_error(exc: BaseException) -> bool:
         import httpx
 
         if isinstance(exc, (httpx.TimeoutException, httpx.NetworkError, httpx.RemoteProtocolError)):
+            return True
+    except ImportError:
+        pass
+
+    # pyqwest is the HTTP transport underneath connectrpc, so control-plane RPCs
+    # (SelectCluster, CreateRun, ...) surface transport failures as its errors
+    # rather than httpx's. ReadError/WriteError are the socket-level read/write
+    # failures and StreamError is an HTTP/2 stream reset (RST_STREAM) — every
+    # StreamErrorCode describes a connection/protocol condition between client
+    # and server, never an SDK bug. They are plain Exception subclasses (not
+    # OSError), so they need an explicit check. pyqwest is a transitive
+    # dependency, hence the guarded import.
+    try:
+        import pyqwest
+
+        if isinstance(exc, (pyqwest.ReadError, pyqwest.WriteError, pyqwest.StreamError)):
             return True
     except ImportError:
         pass

--- a/tests/flyte/test_sentry.py
+++ b/tests/flyte/test_sentry.py
@@ -447,6 +447,39 @@ def test_capture_exception_skips_httpx_transport_errors(httpx_exc_name):
     init_mock.assert_not_called()
 
 
+@pytest.mark.parametrize("pyqwest_exc_name", ["ReadError", "WriteError"])
+def test_capture_exception_skips_pyqwest_transport_errors(pyqwest_exc_name):
+    """pyqwest is the HTTP transport under connectrpc, so control-plane RPCs report
+    socket-level read/write failures as its own errors rather than httpx's."""
+    import pyqwest
+
+    err = _wrap_as_upload_system_error(getattr(pyqwest, pyqwest_exc_name)("boom"))
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()
+
+
+def test_capture_exception_skips_pyqwest_stream_error():
+    """FLYTE-SDK-6H: the HTTP/2 stream carrying a control-plane RPC is reset mid-body
+    ('Error reading content'), surfacing as ConnectError <- pyqwest.StreamError.
+    A stream reset is a transport condition, not an SDK bug."""
+    from connectrpc.code import Code
+    from connectrpc.errors import ConnectError
+    from pyqwest import StreamError, StreamErrorCode
+
+    try:
+        try:
+            raise StreamError("Error reading content", StreamErrorCode.INTERNAL_ERROR)
+        except StreamError as stream_err:
+            raise ConnectError(Code.UNKNOWN, "Error reading content") from stream_err
+    except ConnectError as e:
+        err = _wrap_as_upload_system_error(e)
+
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()
+
+
 def test_capture_exception_still_reports_connect_error_internal_in_upload_chain():
     """ConnectError(INTERNAL) — a backend 500 (FLYTE-SDK-43) — is intentionally NOT
     treated as transient: it can be a real backend bug, so it still reaches Sentry."""


### PR DESCRIPTION
connectrpc's HTTP transport is **pyqwest**, so control-plane RPCs (`SelectCluster`, `CreateRun`, ...) surface transport failures as `pyqwest.ReadError` / `WriteError` / `StreamError` rather than the `httpx` equivalents that `_is_transient_network_error` already filters.

**FLYTE-SDK-6H** (17 events) is an HTTP/2 stream reset mid-body — `ConnectError: Error reading content` with `pyqwest.StreamError("Error reading content")` as its cause, raised out of `connectrpc/_client_async.py:_send_request_bidi_stream` through the auth/retry interceptors. Every `StreamErrorCode` (PROTOCOL_ERROR, STREAM_CLOSED, REFUSED_STREAM, CANCEL, ...) describes a connection/protocol condition between client and server, never an SDK bug — the same class of failure as `httpx.RemoteProtocolError`, which is already filtered.

## Changes
- Add `pyqwest.ReadError`, `pyqwest.WriteError`, `pyqwest.StreamError` to `_is_transient_network_error`. They are plain `Exception` subclasses (not `OSError`), so they need an explicit `isinstance` check; the import is guarded like the existing `httpx` one since pyqwest is a transitive dependency.
- 3 tests: the two socket-level errors via the standard upload-wrapper helper, plus one reproducing 6H's exact `RuntimeSystemError <- RuntimeError <- ConnectError <- StreamError` chain.

Verified the new tests fail without the filter change and pass with it. 41/41 `test_sentry.py` pass.

Connect-level `INTERNAL`/`UNKNOWN` codes remain unfiltered — this only covers transport-layer errors.

fixes FLYTE-SDK-6H