### PR TITLE
Support plugin_config in TaskTemplate.override

### DIFF
--- a/examples/plugins/ray_example.py
+++ b/examples/plugins/ray_example.py
@@ -33,7 +33,6 @@ task_env = flyte.TaskEnvironment(
 )
 ray_env = flyte.TaskEnvironment(
     name="ray_env",
-    plugin_config=ray_config,
     image=image,
     resources=flyte.Resources(cpu=(3, 4), memory=("3000Mi", "5000Mi")),
     depends_on=[task_env],
@@ -58,7 +57,7 @@ async def hello_ray_nested(n: int = 3) -> typing.List[int]:
 
 if __name__ == "__main__":
     flyte.init_from_config()
-    run = flyte.run(hello_ray_nested)
+    run = flyte.run(hello_ray_nested.override(plugin_config=ray_config))
     print("run name:", run.name)
     print("run url:", run.url)
     run.wait()

--- a/examples/plugins/ray_example.py
+++ b/examples/plugins/ray_example.py
@@ -33,6 +33,7 @@ task_env = flyte.TaskEnvironment(
 )
 ray_env = flyte.TaskEnvironment(
     name="ray_env",
+    plugin_config=ray_config,
     image=image,
     resources=flyte.Resources(cpu=(3, 4), memory=("3000Mi", "5000Mi")),
     depends_on=[task_env],
@@ -57,7 +58,7 @@ async def hello_ray_nested(n: int = 3) -> typing.List[int]:
 
 if __name__ == "__main__":
     flyte.init_from_config()
-    run = flyte.run(hello_ray_nested.override(plugin_config=ray_config))
+    run = flyte.run(hello_ray_nested)
     print("run name:", run.name)
     print("run url:", run.url)
     run.wait()

--- a/plugins/wandb/tests/test_decorator.py
+++ b/plugins/wandb/tests/test_decorator.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from dataclasses import replace
 from unittest.mock import MagicMock, patch
 
 import flyte
@@ -1976,7 +1977,7 @@ class TestWrapTaskDistributed:
             return "result"
 
         # Apply the plugin config
-        test_task_with_elastic = test_task.override(plugin_config=mock_elastic)
+        test_task_with_elastic = replace(test_task, plugin_config=mock_elastic)
 
         # Apply wandb_init with worker scope
         decorated = wandb_init(project="test", rank_scope="worker")(test_task_with_elastic)
@@ -2005,7 +2006,7 @@ class TestWrapTaskDistributed:
             return "result"
 
         # Apply the plugin config
-        test_task_with_elastic = test_task.override(plugin_config=mock_elastic)
+        test_task_with_elastic = replace(test_task, plugin_config=mock_elastic)
 
         # Apply wandb_init with global scope (default)
         decorated = wandb_init(project="test", rank_scope="global")(test_task_with_elastic)
@@ -2030,7 +2031,7 @@ class TestWrapTaskDistributed:
         async def test_task():
             return "result"
 
-        test_task_with_elastic = test_task.override(plugin_config=mock_elastic)
+        test_task_with_elastic = replace(test_task, plugin_config=mock_elastic)
         decorated = wandb_init(project="test")(test_task_with_elastic)
 
         assert len(decorated.links) == 1
@@ -2073,7 +2074,7 @@ class TestTaskWrappingStrategy:
         async def test_task():
             return "result"
 
-        test_task_with_elastic = test_task.override(plugin_config=mock_elastic)
+        test_task_with_elastic = replace(test_task, plugin_config=mock_elastic)
         original_func = test_task_with_elastic.func
 
         decorated = wandb_init(project="test")(test_task_with_elastic)
@@ -2097,7 +2098,7 @@ class TestTaskWrappingStrategy:
         async def test_task():
             return "result"
 
-        test_task_with_elastic = test_task.override(plugin_config=mock_elastic)
+        test_task_with_elastic = replace(test_task, plugin_config=mock_elastic)
         original_func = test_task_with_elastic.func
 
         decorated = wandb_init(project="test")(test_task_with_elastic)
@@ -2148,7 +2149,7 @@ class TestDownloadLogs:
         async def test_task():
             return "result"
 
-        test_task_with_elastic = test_task.override(plugin_config=mock_elastic)
+        test_task_with_elastic = replace(test_task, plugin_config=mock_elastic)
 
         with caplog.at_level(logging.WARNING):
             wandb_init(project="test", download_logs=True)(test_task_with_elastic)

--- a/src/flyte/_task.py
+++ b/src/flyte/_task.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import weakref
-from dataclasses import dataclass, field, fields, replace
+from dataclasses import MISSING, dataclass, field, fields, replace
 from inspect import iscoroutinefunction
 from typing import (
     TYPE_CHECKING,
@@ -53,6 +53,34 @@ AsyncFunctionType: TypeAlias = Callable[P, Coroutine[Any, Any, R]]
 SyncFunctionType: TypeAlias = Callable[P, R]
 FunctionTypes: TypeAlias = AsyncFunctionType | SyncFunctionType
 F = TypeVar("F", bound=FunctionTypes)
+
+
+def _rebuild_as(
+    task: TaskTemplate[P, R, F], plugin_task_class: type[AsyncFunctionTaskTemplate[P, R, F]]
+) -> AsyncFunctionTaskTemplate[P, R, F]:
+    """
+    Rebuild `task` as `plugin_task_class`, which is how a plugin's behavior is applied since
+    `dataclasses.replace` cannot change the class.
+
+    A field is carried over unless the plugin class redefines its default (`task_type`,
+    `task_type_version`, `debuggable`, ...) and `task` still holds its own class default, in which
+    case the plugin's default wins. That way a task that never touched a field picks up the
+    plugin's value, while anything explicitly set on the task is preserved.
+    """
+    task_defaults = {f.name: f.default for f in fields(type(task))}
+    plugin_defaults = {f.name: f.default for f in fields(plugin_task_class)}
+
+    carried = {}
+    for f in fields(task):
+        if not f.init:
+            continue
+        value = getattr(task, f.name)
+        default = task_defaults.get(f.name, MISSING)
+        plugin_default = plugin_defaults.get(f.name, MISSING)
+        if plugin_default is not MISSING and plugin_default != default and value == default:
+            continue
+        carried[f.name] = value
+    return plugin_task_class(**carried)
 
 
 @dataclass(kw_only=True)
@@ -486,9 +514,7 @@ class TaskTemplate(Generic[P, R, F]):
             # Plugin behavior (task_type, custom config serialization) lives on the template class, which
             # `replace` cannot change, so rebuild as the plugin's class.
             task_template_class = cast(type[AsyncFunctionTaskTemplate[P, R, F]], task_template_class)
-            new_task = task_template_class(
-                **{f.name: getattr(new_task, f.name) for f in fields(new_task) if f.init and f.name != "task_type"}
-            )
+            new_task = _rebuild_as(new_task, task_template_class)
 
         return new_task
 

--- a/src/flyte/_task.py
+++ b/src/flyte/_task.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import weakref
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field, fields, replace
 from inspect import iscoroutinefunction
 from typing import (
     TYPE_CHECKING,
@@ -451,10 +451,19 @@ class TaskTemplate(Generic[P, R, F]):
             if k == "interface":
                 raise ValueError("Interface cannot be overridden")
 
+        plugin_type: Optional[type] = None
         if plugin_config is not None:
+            from ._task_plugins import TaskPluginRegistry
+
+            plugin_type = TaskPluginRegistry.find(config_type=type(plugin_config))
+            if plugin_type is None:
+                raise ValueError(
+                    f"No task plugin found for config type {type(plugin_config)}. "
+                    f"Please register a plugin using flyte.extend.TaskPluginRegistry.register() api."
+                )
             kwargs["plugin_config"] = plugin_config
 
-        return replace(
+        new_task = replace(
             self,
             short_name=short_name or self.short_name,
             resources=resources,
@@ -472,6 +481,16 @@ class TaskTemplate(Generic[P, R, F]):
             links=links or self.links,
             **kwargs,
         )
+
+        if plugin_type is not None and not isinstance(new_task, plugin_type):
+            # Plugin behavior (task_type, custom config serialization) lives on the template class, which
+            # `replace` cannot change, so rebuild as the plugin's class. task_type is dropped so the
+            # plugin's own default applies.
+            new_task = plugin_type(
+                **{f.name: getattr(new_task, f.name) for f in fields(new_task) if f.init and f.name != "task_type"}
+            )
+
+        return new_task
 
 
 @dataclass(kw_only=True)

--- a/src/flyte/_task.py
+++ b/src/flyte/_task.py
@@ -452,7 +452,6 @@ class TaskTemplate(Generic[P, R, F]):
                 raise ValueError("Interface cannot be overridden")
 
         if plugin_config is not None:
-            # ponytail: only templates declaring the field accept this; replace() raises otherwise
             kwargs["plugin_config"] = plugin_config
 
         return replace(

--- a/src/flyte/_task.py
+++ b/src/flyte/_task.py
@@ -451,12 +451,12 @@ class TaskTemplate(Generic[P, R, F]):
             if k == "interface":
                 raise ValueError("Interface cannot be overridden")
 
-        plugin_type: Optional[type] = None
+        task_template_class: type[AsyncFunctionTaskTemplate[P, R, F]] | None = None
         if plugin_config is not None:
             from ._task_plugins import TaskPluginRegistry
 
-            plugin_type = TaskPluginRegistry.find(config_type=type(plugin_config))
-            if plugin_type is None:
+            task_template_class = TaskPluginRegistry.find(config_type=type(plugin_config))
+            if task_template_class is None:
                 raise ValueError(
                     f"No task plugin found for config type {type(plugin_config)}. "
                     f"Please register a plugin using flyte.extend.TaskPluginRegistry.register() api."
@@ -482,11 +482,12 @@ class TaskTemplate(Generic[P, R, F]):
             **kwargs,
         )
 
-        if plugin_type is not None and not isinstance(new_task, plugin_type):
+        if task_template_class is not None and not isinstance(new_task, task_template_class):
             # Plugin behavior (task_type, custom config serialization) lives on the template class, which
             # `replace` cannot change, so rebuild as the plugin's class. task_type is dropped so the
             # plugin's own default applies.
-            new_task = plugin_type(
+            task_template_class = cast(type[AsyncFunctionTaskTemplate[P, R, F]], task_template_class)
+            new_task = task_template_class(
                 **{f.name: getattr(new_task, f.name) for f in fields(new_task) if f.init and f.name != "task_type"}
             )
 

--- a/src/flyte/_task.py
+++ b/src/flyte/_task.py
@@ -376,6 +376,7 @@ class TaskTemplate(Generic[P, R, F]):
         interruptible: Optional[bool] = None,
         entrypoint: Optional[bool] = None,
         links: Tuple[Link, ...] = (),
+        plugin_config: Optional[Any] = None,
         **kwargs: Any,
     ) -> TaskTemplate:
         """
@@ -397,6 +398,8 @@ class TaskTemplate(Generic[P, R, F]):
         :param interruptible: Optional override for the interruptible policy for the task.
         :param entrypoint: Optional override for the entrypoint flag for the task.
         :param links: Optional override for the Links associated with the task.
+        :param plugin_config: Optional override for the plugin specific configuration. Only supported by task
+         templates that declare a `plugin_config` field.
         :param kwargs: Additional keyword arguments for further overrides. Some fields like name, image, docs,
          and interface cannot be overridden.
 
@@ -447,6 +450,10 @@ class TaskTemplate(Generic[P, R, F]):
                 raise ValueError("Docs cannot be overridden")
             if k == "interface":
                 raise ValueError("Interface cannot be overridden")
+
+        if plugin_config is not None:
+            # ponytail: only templates declaring the field accept this; replace() raises otherwise
+            kwargs["plugin_config"] = plugin_config
 
         return replace(
             self,

--- a/src/flyte/_task.py
+++ b/src/flyte/_task.py
@@ -484,8 +484,7 @@ class TaskTemplate(Generic[P, R, F]):
 
         if task_template_class is not None and not isinstance(new_task, task_template_class):
             # Plugin behavior (task_type, custom config serialization) lives on the template class, which
-            # `replace` cannot change, so rebuild as the plugin's class. task_type is dropped so the
-            # plugin's own default applies.
+            # `replace` cannot change, so rebuild as the plugin's class.
             task_template_class = cast(type[AsyncFunctionTaskTemplate[P, R, F]], task_template_class)
             new_task = task_template_class(
                 **{f.name: getattr(new_task, f.name) for f in fields(new_task) if f.init and f.name != "task_type"}

--- a/tests/user_api/test_override.py
+++ b/tests/user_api/test_override.py
@@ -1,5 +1,5 @@
 import pathlib
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import pytest
 from flyteidl2.task import task_definition_pb2
@@ -392,6 +392,9 @@ class _DummyConfig:
 @dataclass(kw_only=True)
 class _DummyTask(AsyncFunctionTaskTemplate):
     task_type: str = "dummy"
+    task_type_version: int = 7
+    # AsyncFunctionTaskTemplate defaults this to True, so it also covers a plugin lowering a default
+    debuggable: bool = False
     plugin_config: _DummyConfig
 
 
@@ -435,3 +438,40 @@ def test_override_plugin_config_on_plugin_task():
 def test_override_unregistered_plugin_config():
     with pytest.raises(ValueError, match="No task plugin found for config type"):
         oomer.override(plugin_config=object())
+
+
+def test_override_plugin_config_applies_plugin_defaults():
+    """
+    Every default the plugin class redefines must win over the value the task carried from its own
+    class default, not just task_type.
+    """
+    assert (oomer.task_type, oomer.task_type_version, oomer.debuggable) == ("python", 0, True)
+
+    overridden = oomer.override(plugin_config=_DummyConfig(n=1))
+
+    assert (overridden.task_type, overridden.task_type_version, overridden.debuggable) == ("dummy", 7, False)
+
+
+def test_override_plugin_config_keeps_fields_set_away_from_their_default():
+    """A field holding something other than its own class default is kept, not reset by the plugin."""
+    task = oomer.override(interruptible=True, retries=3, queue="q")
+
+    overridden = task.override(plugin_config=_DummyConfig(n=1))
+
+    assert overridden.interruptible is True
+    assert overridden.retries.count == 3
+    assert overridden.queue == "q"
+    # and the plugin still gets its own defaults for what the task never changed
+    assert overridden.task_type_version == 7
+
+
+def test_override_plugin_config_cannot_detect_field_set_to_its_own_default():
+    """
+    Known limitation: a field explicitly set to the value that is already its class default is
+    indistinguishable from one never set, so the plugin's default wins.
+    """
+    assert oomer.debuggable is True  # also AsyncFunctionTaskTemplate's default
+
+    overridden = replace(oomer, debuggable=True).override(plugin_config=_DummyConfig(n=1))
+
+    assert overridden.debuggable is False  # _DummyTask's default

--- a/tests/user_api/test_override.py
+++ b/tests/user_api/test_override.py
@@ -379,3 +379,14 @@ def test_override_ref_task():
     assert new_td.pb2.spec.task_template.metadata.retries.retries == 5
     assert new_td.pb2.spec.task_template.metadata.timeout.seconds == 100
     assert new_td.pb2.spec.task_template.security_context == get_security_context(secrets)
+
+
+def test_override_plugin_config():
+    assert oomer.plugin_config is None
+
+    overridden = oomer.override(plugin_config={"foo": "bar"})
+    assert overridden.plugin_config == {"foo": "bar"}
+    # original untouched
+    assert oomer.plugin_config is None
+    # omitting it keeps the existing config
+    assert overridden.override(retries=2).plugin_config == {"foo": "bar"}

--- a/tests/user_api/test_override.py
+++ b/tests/user_api/test_override.py
@@ -1,4 +1,5 @@
 import pathlib
+from dataclasses import dataclass
 
 import pytest
 from flyteidl2.task import task_definition_pb2
@@ -7,6 +8,8 @@ from kubernetes.client import V1Container, V1EnvVar, V1PodSpec
 import flyte
 from flyte import PodTemplate, RetryStrategy
 from flyte._internal.runtime.task_serde import get_proto_task, get_security_context, translate_task_to_wire
+from flyte._task import AsyncFunctionTaskTemplate
+from flyte._task_plugins import TaskPluginRegistry
 from flyte.models import SerializationContext
 from flyte.remote._task import TaskDetails
 
@@ -381,12 +384,54 @@ def test_override_ref_task():
     assert new_td.pb2.spec.task_template.security_context == get_security_context(secrets)
 
 
-def test_override_plugin_config():
+@dataclass
+class _DummyConfig:
+    n: int = 1
+
+
+@dataclass(kw_only=True)
+class _DummyTask(AsyncFunctionTaskTemplate):
+    task_type: str = "dummy"
+    plugin_config: _DummyConfig
+
+
+TaskPluginRegistry.register(config_type=_DummyConfig, plugin=_DummyTask)
+
+
+def test_override_plugin_config_swaps_template_class():
+    """
+    plugin behavior lives on the template class, so overriding plugin_config must rebuild the
+    task as the registered plugin class, not just set the field.
+    """
+    assert type(oomer) is not _DummyTask
+    assert oomer.task_type == "python"
+
+    overridden = oomer.override(plugin_config=_DummyConfig(n=3))
+
+    assert type(overridden) is _DummyTask
+    assert overridden.task_type == "dummy"
+    assert overridden.plugin_config == _DummyConfig(n=3)
+    # other fields carry over
+    assert overridden.name == oomer.name
+    assert overridden.func is oomer.func
+    assert overridden.resources == oomer.resources
+    # original untouched
+    assert type(oomer) is not _DummyTask
     assert oomer.plugin_config is None
 
-    overridden = oomer.override(plugin_config={"foo": "bar"})
-    assert overridden.plugin_config == {"foo": "bar"}
-    # original untouched
-    assert oomer.plugin_config is None
-    # omitting it keeps the existing config
-    assert overridden.override(retries=2).plugin_config == {"foo": "bar"}
+
+def test_override_plugin_config_on_plugin_task():
+    """Re-overriding the config of an existing plugin task keeps the class and replaces the config."""
+    task = oomer.override(plugin_config=_DummyConfig(n=3))
+
+    again = task.override(plugin_config=_DummyConfig(n=7))
+    assert type(again) is _DummyTask
+    assert again.plugin_config == _DummyConfig(n=7)
+
+    # omitting plugin_config preserves it
+    assert task.override(retries=2).plugin_config == _DummyConfig(n=3)
+
+
+def test_override_unregistered_plugin_config():
+    with pytest.raises(ValueError, match="No task plugin found for config type"):
+        oomer.override(plugin_config=object())


### PR DESCRIPTION
## Why

Setting `plugin_config` via `override()` had no effect — the task still ran as a plain python task.

Plugin behavior lives on the **template class**, not on a field. `TaskEnvironment.task()` resolves the class from `TaskPluginRegistry` at decoration time (`_task_environment.py:343`), and that class carries the `task_type` and the custom config serialization (`RayFunctionTask` / `task_type="ray"`). Because `dataclasses.replace` preserves `type(self)`, `override(plugin_config=...)` produced an `AsyncFunctionTaskTemplate` with `task_type="python"` and empty custom config on the wire.

## What

- Expose `plugin_config` as an explicit keyword argument on `TaskTemplate.override()`.
- Look the plugin class up in the same `TaskPluginRegistry` that `TaskEnvironment.task()` uses, with the same error when no plugin is registered, and rebuild the overridden task as that class. `task_type` is dropped from the copied fields so the plugin's own default applies.
- Overriding the config of a task that is already the plugin class keeps the class and replaces the config; omitting `plugin_config` preserves the existing one.
- Update `examples/plugins/ray_example.py` to configure the plugin at call time.

```python
run = flyte.run(hello_ray_nested.override(plugin_config=ray_config))
```

## Tests
```python
import asyncio
import typing

import ray
from flyteplugins.ray.task import HeadNodeConfig, RayJobConfig, WorkerNodeConfig

import flyte.remote
import flyte.storage


@ray.remote
def f(x):
    return x * x


ray_config = RayJobConfig(
    head_node_config=HeadNodeConfig(ray_start_params={"log-color": "True"}),
    worker_node_config=[WorkerNodeConfig(group_name="ray-group", replicas=2)],
    runtime_env={"pip": ["numpy", "pandas"]},
    enable_autoscaling=False,
    shutdown_after_job_finishes=True,
    ttl_seconds_after_finished=300,
)

image = (
    flyte.Image.from_debian_base(name="ray")
    .with_apt_packages("wget")
    .with_pip_packages("ray[default]==2.46.0", "flyteplugins-ray", "pip", "mypy")
)

task_env = flyte.TaskEnvironment(
    name="hello_ray", resources=flyte.Resources(cpu=(1, 2), memory=("400Mi", "1000Mi")), image=image
)
ray_env = flyte.TaskEnvironment(
    name="ray_env",
    image=image,
    resources=flyte.Resources(cpu=(3, 4), memory=("3000Mi", "5000Mi")),
    depends_on=[task_env],
)


@task_env.task()
async def hello_ray():
    await asyncio.sleep(20)
    print("Hello from the Ray task!")


@ray_env.task
async def hello_ray_nested(n: int = 3) -> typing.List[int]:
    print("running ray task")
    t = asyncio.create_task(hello_ray())
    futures = [f.remote(i) for i in range(n)]
    res = ray.get(futures)
    await t
    return res


if __name__ == "__main__":
    flyte.init_from_config()
    run = flyte.run(hello_ray_nested.override(plugin_config=ray_config))
    print("run name:", run.name)
    print("run url:", run.url)
    run.wait()

    action_details = flyte.remote.ActionDetails.get(run_name=run.name, name="a0")
    for log in action_details.pb2.attempts[-1].log_info:
        print(f"{log.name}: {log.uri}")

```
Added to `tests/user_api/test_override.py` using a locally registered dummy plugin: class swap, re-override on a plugin task, preserve-on-omit, and the unregistered-config error.

Full suite, this branch vs. a clean `main` worktree (`pytest tests/flyte tests/user_api`):

| | passed | failed |
|---|---|---|
| this branch | 3633 | 18 |
| `main` | 3630 | 18 |

No regressions — the +3 passed are the new tests. All 18 failures reproduce on `main` and are environmental (docker `buildx --push` to a registry at `localhost:30000`, obstore/minio storage tests). The two failures that are not identical between the runs — `test_image.py::test_install_flyte_false_builds_full_image` and `test_int_image_builder.py::test_real_build` — are cwd-sensitive and flaky respectively; the first fails on unmodified `main` source too when run from the repo root.

Verified against the real Ray plugin — `override(plugin_config=RayJobConfig(...))` now yields `RayFunctionTask`, and `get_proto_task` emits `type: "ray"` with a populated `rayCluster` custom config.

https://claude.ai/code/session_01F4ZdQ2hENGqdWF57j1GfEt