### PR TITLE
fix(image): Pixi: don't inject `--locked` when extra_args sets `--frozen`

### DIFF
--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -1396,7 +1396,10 @@ class Image:
         discovered the same way pixi discovers it (`pixi.toml` first, then `pyproject.toml`).
 
         By default, this method copies only the manifest and lock file into the image. When the lock file
-        is present, `pixi install --locked` is used so the build reproduces the lock exactly.
+        is present, `pixi install --locked` is used so the build reproduces the lock exactly. A `--frozen`
+        in `extra_args` replaces that `--locked`, since pixi rejects the two together; use it when the
+        manifest references path dependencies whose sources are not in the build context, which `--locked`
+        would otherwise reject as an out-of-date lock.
 
         If `project_install_mode` is "install_project", the entire directory containing the manifest is
         copied into the image instead. Use this when the manifest installs the project itself, e.g. a

--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -397,7 +397,8 @@ class PixiProjectHandler:
         secret_mounts = _get_secret_mounts_layer(layer.secret_mounts)
 
         install_args = []
-        if layer.pixi_lock is not None:
+        # --frozen and --locked are mutually exclusive. Honour a user-supplied --frozen.
+        if layer.pixi_lock is not None and "--frozen" not in (layer.extra_args or ""):
             install_args.append("--locked")
         if layer.extra_args:
             install_args.append(layer.extra_args)

--- a/src/flyte/_internal/imagebuild/utils.py
+++ b/src/flyte/_internal/imagebuild/utils.py
@@ -60,7 +60,8 @@ def pixi_project_to_primitive_layers(layer: PixiProject) -> List[Layer]:
         f"--manifest-path {manifest_dst}",
         f"--environment {layer.environment}",
     ]
-    if layer.pixi_lock is not None:
+    # --frozen and --locked are mutually exclusive. Honour a user-supplied --frozen.
+    if layer.pixi_lock is not None and "--frozen" not in (layer.extra_args or ""):
         pixi_install_parts.append("--locked")
     if layer.extra_args:
         pixi_install_parts.append(layer.extra_args)

--- a/tests/flyte/imagebuild/test_docker_builder.py
+++ b/tests/flyte/imagebuild/test_docker_builder.py
@@ -735,6 +735,38 @@ async def test_pixi_handler_named_environment_and_extra_args():
 
 
 @pytest.mark.asyncio
+async def test_pixi_handler_frozen_extra_args_suppress_locked():
+    """A user-supplied --frozen replaces the default --locked (mutually exclusive pixi flags),
+    so manifests with editable path deps absent from the context can install with --skip."""
+    with tempfile.TemporaryDirectory() as tmp_context, tempfile.TemporaryDirectory() as tmp_user:
+        context_path = Path(tmp_context)
+        user_folder = Path(tmp_user)
+
+        manifest = user_folder / "pixi.toml"
+        manifest.write_text("[project]\nname = 'test-project'")
+        pixi_lock = user_folder / "pixi.lock"
+        pixi_lock.write_text("version: 6")
+
+        pixi_project = PixiProject(
+            manifest=manifest.absolute(),
+            pixi_lock=pixi_lock.absolute(),
+            extra_args="--frozen --skip my-pkg",
+        )
+
+        result = await PixiProjectHandler.handle(
+            layer=pixi_project,
+            context_path=context_path,
+            dockerfile="FROM python:3.12\n",
+            docker_ignore_patterns=[],
+        )
+
+        assert "--locked" not in result
+        assert "--environment default --frozen --skip my-pkg" in result
+        # The lock file is still copied and honoured by --frozen.
+        assert " /opt/pixi-project/pixi.lock" in result
+
+
+@pytest.mark.asyncio
 async def test_pixi_handler_with_project_install():
     """install_project mode copies the whole project directory, but the manifest and
     lock file survive .dockerignore exclusions."""
@@ -812,6 +844,31 @@ def test_pixi_project_lowers_to_primitive_layers():
         assert envs["VIRTUAL_ENV"] == "/opt/pixi-project/.pixi/envs/default"
         assert envs["UV_PYTHON"] == "/opt/pixi-project/.pixi/envs/default/bin/python"
         assert envs["PATH"].startswith("/opt/pixi-project/.pixi/envs/default/bin:")
+
+
+def test_pixi_project_lowers_frozen_extra_args_suppress_locked():
+    """The primitive-layer lowering honours a user-supplied --frozen the same way the
+    docker builder does."""
+    from flyte._internal.imagebuild.utils import pixi_project_to_primitive_layers
+
+    with tempfile.TemporaryDirectory() as tmp_user:
+        user_folder = Path(tmp_user)
+        manifest = user_folder / "pixi.toml"
+        manifest.write_text("[project]\nname = 'test-project'")
+        pixi_lock = user_folder / "pixi.lock"
+        pixi_lock.write_text("version: 6")
+
+        layer = PixiProject(
+            manifest=manifest.absolute(),
+            pixi_lock=pixi_lock.absolute(),
+            extra_args="--frozen --skip my-pkg",
+        )
+        lowered = pixi_project_to_primitive_layers(layer)
+
+        commands = [cmd for lyr in lowered if isinstance(lyr, Commands) for cmd in lyr.commands]
+        install_cmd = next(cmd for cmd in commands if "pixi install" in cmd)
+        assert "--locked" not in install_cmd
+        assert "--frozen --skip my-pkg" in install_cmd
 
 
 def test_remote_builder_layers_proto_for_pixi_project():


### PR DESCRIPTION
## Problem

`Image.with_pixi_project(..., project_install_mode="dependencies_only")` cannot build an image from a pixi manifest that declares path `pypi-dependencies` — typically editable, as in the standard pixi monorepo layout. Two behaviours combine to cause it:

1. In `dependencies_only` mode only the manifest and `pixi.lock` are copied into the build context. Unlike `UVProjectHandler`, there is no analogue of `get_uv_editable_install_mounts`, so those packages' source trees are absent at build time.
2. `--locked` is appended to `pixi install` unconditionally whenever a lock file exists, in both `PixiProjectHandler.handle` and the remote-builder lowering `pixi_project_to_primitive_layers`. It is placed ahead of `extra_args`, so `extra_args` can add flags but never remove it.

This makes `PixiProjectHandler` the only project handler that injects a lock flag: `UVProjectHandler` passes `extra_args` through untouched, which is why the analogous uv invocation — `uv sync --frozen --no-install-workspace`, excluding first-party workspace members while still installing their third-party dependencies — works today with no special handling. The pixi path has no way to express the same thing.

With those sources missing, `pixi install --locked` fails its up-to-date check:

```
Error: lock file not up-to-date with the workspace
```

pixi has the right invocation for this case: `pixi install --frozen --skip <pkg>` installs every third-party dependency from the lock and skips the absent first-party ones — which, in flyte's model, arrive in the container via the code bundle anyway. But `--frozen` cannot be passed through `extra_args` today, because `--frozen` and `--locked` are mutually exclusive pixi flags and the injected `--locked` makes pixi reject the pair. `PIXI_FROZEN=true` via `with_env_vars` doesn't help either — the explicit flag wins.

```python
image = flyte.Image.from_debian_base().with_pixi_project(
    "pixi.toml",
    environment="my-workflow",
    extra_args="--frozen --skip my-workflow --skip my-sdk",  # rejected: conflicts with injected --locked
)
```

## Fix

Only inject the default `--locked` when `extra_args` does not already carry `--frozen`, in both code paths. `--locked` remains the default, so behaviour is unchanged for every existing caller, and `--frozen` still honours the lock exactly — reproducibility is preserved. Docstring updated.

Two alternatives I considered and didn't take, in case you'd prefer one:

- **Declare the lock mode instead of inspecting `extra_args`** — a `lock_mode: Literal["locked", "frozen"] = "locked"` field on `PixiProject`, surfaced through `with_pixi_project`. Same size and no string matching, at the cost of new public API surface. Happy to switch to this if you'd rather not key off `extra_args`.
- **Mirror `get_uv_editable_install_mounts` and copy the editable sources into the build context**, which would make `--locked` work as-is. This does work, but it's costlier for pixi than the uv equivalent: pixi's lock check is workspace-wide rather than environment-scoped, so it isn't enough to copy the path dependencies the selected environment uses — *every* path dependency in the manifest has to be present. On a monorepo with one environment per package that means copying all members' sources into every image's build context (20 members, ~1 MB → ~15 MB in my case) to satisfy a check for packages the code bundle delivers anyway. Keeping the default `--locked` and letting callers opt into `--frozen` leaves the context at manifest + lock.
