### PR TITLE
fix(ci): run twine outside the project venv when publishing plugins

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,7 +127,7 @@ jobs:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          uv run python -m twine upload --verbose dist/*
+          uvx twine upload --verbose dist/*
       - name: Sleep until pypi is available
         if: ${{ github.event_name == 'release' }}
         id: pypiwait
@@ -296,7 +296,7 @@ jobs:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          uv run python -m twine upload --verbose dist/*
+          uvx twine upload --verbose dist/*
 
   build-and-push-flyte-docker-images:
     needs: [flyte-pypi, rs-controller-wheels]


### PR DESCRIPTION
## Why

18 of 34 plugin publish jobs failed in [run 30375593579](https://github.com/flyteorg/flyte-sdk/actions/runs/30375593579) with:

```
File ".../twine/package.py", line 23, in <module>
    from packaging import errors
ImportError: cannot import name 'errors' from 'packaging'
```

`packaging.errors` only exists in **packaging >= 26.2** (verified: 24.2, 25.0 and 26.0 do not have it). twine 7.0.0 imports it unconditionally.

The publish job did:

1. `uv pip install build twine setuptools wheel` into a bare venv → twine 7.0.0 + packaging 26.2 ✅
2. `uv run python -m build --wheel --installer uv` → `uv run` syncs the **project** environment. twine is not a project dependency, so its `packaging>=26.2` constraint is dropped and packaging is downgraded to whatever the plugin's own dep tree resolves to (`uv export` gives `packaging==26.0` for e.g. `plugins/agents/hermes`).
3. `uv run python -m twine upload` → boom.

The 16 plugins that passed simply happened to resolve packaging to 26.2 through their own dependencies.

## What

Use `uvx twine upload` instead of `uv run python -m twine upload` in both plugin publish steps. `uvx` runs twine in its own isolated tool environment, so a project sync can no longer downgrade its dependencies. This also matches the `flyte-pypi` job, which already runs a non-project twine and passed.

## Test

CI on this PR exercises build; the upload step only runs on `release`, so the real verification is the next release run.