### PR TITLE
[Devbox] Extend devbox init timeout

### DIFF
--- a/src/flyte/cli/_devbox.py
+++ b/src/flyte/cli/_devbox.py
@@ -142,7 +142,7 @@ def _run_container(
         raise click.ClickException(f"Failed to start container:\n{result.stderr.strip()}")
 
 
-def _wait_for_console_ready(url: str, timeout: int = 300, poll_interval: float = 3.0) -> None:
+def _wait_for_console_ready(url: str, timeout: int = 600, poll_interval: float = 3.0) -> None:
     deadline = time.monotonic() + timeout
     while True:
         try:

--- a/src/flyte/cli/_devbox.py
+++ b/src/flyte/cli/_devbox.py
@@ -142,7 +142,7 @@ def _run_container(
         raise click.ClickException(f"Failed to start container:\n{result.stderr.strip()}")
 
 
-def _wait_for_console_ready(url: str, timeout: int = 600, poll_interval: float = 3.0) -> None:
+def _wait_for_console_ready(url: str, timeout: int = 1800, poll_interval: float = 3.0) -> None:
     deadline = time.monotonic() + timeout
     while True:
         try:


### PR DESCRIPTION
## Goal
We originally set a 300 seconds timeout for devbox init, which is too short for some users as the network and local environment can be different. In this PR we extend it to 30 mins in order to make the buffer longer.

## Test
Local devbox test