### PR TITLE
fix: redact signed-URL credentials from upload error messages (FLYTE-SDK-6R)

### DIFF
--- a/src/flyte/remote/_data.py
+++ b/src/flyte/remote/_data.py
@@ -76,6 +76,23 @@ def _parse_retry_after(value: typing.Optional[str], cap_sec: float) -> typing.Op
     return min(seconds, cap_sec)
 
 
+def _redact_signed_url(url: str) -> str:
+    """Strip the query string off a pre-signed object-store URL.
+
+    The query string of a pre-signed URL carries the credential material that makes
+    it usable: ``X-Amz-Signature``, ``X-Amz-Credential`` and, for STS-issued
+    locations, a full ``X-Amz-Security-Token``. Embedding it verbatim in an
+    exception message leaks those into logs and crash reports (FLYTE-SDK-6R). The
+    scheme/host/path is the part that is actually diagnostic — it tells you which
+    bucket and key the PUT targeted — so keep that and drop the rest.
+
+    Doubles as a grouping fix: the signature and expiry differ on every attempt, so
+    the un-redacted message made every failure a unique Sentry fingerprint.
+    """
+    base, sep, _ = url.partition("?")
+    return f"{base}?<redacted>" if sep else base
+
+
 async def _upload_with_retry(
     fp: Path,
     signed_url: str,
@@ -148,7 +165,7 @@ async def _upload_with_retry(
                         # Non-retryable HTTP error
                         raise RuntimeSystemError(
                             "UploadFailed",
-                            f"Failed to upload {fp} to {signed_url}, {last_error}",
+                            f"Failed to upload {fp} to {_redact_signed_url(signed_url)}, {last_error}",
                         )
         except RuntimeSystemError:
             raise

--- a/tests/flyte/remote/test_upload_retry.py
+++ b/tests/flyte/remote/test_upload_retry.py
@@ -6,7 +6,7 @@ import httpx
 import pytest
 
 from flyte.errors import RuntimeSystemError
-from flyte.remote._data import _UPLOAD_TIMEOUT, _upload_with_retry
+from flyte.remote._data import _UPLOAD_TIMEOUT, _redact_signed_url, _upload_with_retry
 
 
 @pytest.fixture
@@ -252,3 +252,44 @@ async def test_upload_429_without_retry_after_uses_exponential(upload_file):
         assert result.status_code == 200
         # Exponential value for the first retry: min_backoff_sec * 2**0 = 0.01
         mock_sleep.assert_awaited_once_with(0.01)
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("https://bucket.s3.amazonaws.com/org/key.tar.gz", "https://bucket.s3.amazonaws.com/org/key.tar.gz"),
+        (
+            "https://bucket.s3.amazonaws.com/org/key.tar.gz?X-Amz-Signature=deadbeef&X-Amz-Security-Token=secret",
+            "https://bucket.s3.amazonaws.com/org/key.tar.gz?<redacted>",
+        ),
+        ("https://bucket.s3.amazonaws.com/key?", "https://bucket.s3.amazonaws.com/key?<redacted>"),
+    ],
+)
+def test_redact_signed_url(url, expected):
+    assert _redact_signed_url(url) == expected
+
+
+@pytest.mark.asyncio
+async def test_upload_client_error_message_redacts_signed_url(upload_file):
+    """FLYTE-SDK-6R: the non-retryable-error message must not leak signed-URL credentials."""
+    signed_url = (
+        "https://bucket.s3.us-west-2.amazonaws.com/org/proj/bundle.tar.gz"
+        "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAEXAMPLE"
+        "&X-Amz-Security-Token=SUPERSECRETTOKEN&X-Amz-Signature=deadbeef"
+    )
+    with patch("flyte.remote._data.httpx.AsyncClient") as mock_cls:
+        client = AsyncMock()
+        client.put.return_value = httpx.Response(403, text="forbidden")
+        ctx = AsyncMock()
+        ctx.__aenter__.return_value = client
+        ctx.__aexit__.return_value = False
+        mock_cls.return_value = ctx
+
+        with pytest.raises(RuntimeSystemError) as exc_info:
+            await _upload_with_retry(upload_file, signed_url, {}, verify=True, max_retries=0)
+
+    message = str(exc_info.value)
+    assert "SUPERSECRETTOKEN" not in message
+    assert "X-Amz-Signature" not in message
+    # The bucket/key is still there, so the message stays diagnostic.
+    assert "https://bucket.s3.us-west-2.amazonaws.com/org/proj/bundle.tar.gz?<redacted>" in message


### PR DESCRIPTION
The non-retryable-error branch of `_upload_with_retry` embedded the full pre-signed object-store URL in the `RuntimeSystemError` message:

```
Failed to upload /tmp/.../fast48d4...tar.gz to https://...s3.us-west-2.amazonaws.com/...?X-Amz-Algorithm=...&X-Amz-Credential=ASIA...&X-Amz-Security-Token=IQoJb3JpZ2luX2Vj...
```

That query string is the part that makes a pre-signed URL usable — `X-Amz-Signature`, `X-Amz-Credential`, and for STS-issued upload locations a complete `X-Amz-Security-Token`. So every failed bundle/spec upload leaked short-lived credentials into local logs *and* into Sentry crash reports.

**Fix:** keep scheme/host/path (the diagnostic part — it identifies the bucket and key the PUT targeted) and replace the query string with `?<redacted>`.

Side benefit: the signature and expiry differ on every attempt, so the un-redacted message gave each failure a unique Sentry fingerprint. Redacting collapses these into a single groupable issue.

Tests: unit coverage for `_redact_signed_url` plus a regression test asserting the token/signature never appear in the raised message.

fixes FLYTE-SDK-6R