### PR TITLE
fix: treat an empty device authorization endpoint as unavailable (FLYTE-SDK-6P)

### DIFF
--- a/src/flyte/remote/_client/auth/_authenticators/device_code.py
+++ b/src/flyte/remote/_client/auth/_authenticators/device_code.py
@@ -53,8 +53,13 @@ class DeviceCodeAuthenticator(Authenticator):
         """
         cfg = await self._resolve_config()
 
-        # These always come from the public client config
-        if cfg.device_authorization_endpoint is None:
+        # These always come from the public client config. The remote config store fills this in
+        # from the OAuth2 metadata proto, where an unadvertised endpoint arrives as "" rather than
+        # None -- so an `is None` check let the empty string through and `httpx.post("")` blew up
+        # with `UnsupportedProtocol: Request URL is missing an 'http://' or 'https://' protocol.`
+        # instead of the actionable message below (FLYTE-SDK-6P). Treat empty as absent, matching
+        # `ClientConfig.merge`, which already uses `or` on this field.
+        if not cfg.device_authorization_endpoint:
             raise AuthenticationError(
                 "Device Authentication is not available on the Flyte backend / authentication server"
             )

--- a/tests/flyte/remote/test_device_code_auth.py
+++ b/tests/flyte/remote/test_device_code_auth.py
@@ -1,0 +1,39 @@
+"""Tests for DeviceCodeAuthenticator config validation."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from flyte.remote._client.auth._authenticators.device_code import DeviceCodeAuthenticator
+from flyte.remote._client.auth._client_config import ClientConfig
+from flyte.remote._client.auth.errors import AuthenticationError
+
+
+def _cfg(device_authorization_endpoint):
+    return ClientConfig(
+        token_endpoint="https://example.com/oauth2/token",
+        authorization_endpoint="https://example.com/oauth2/authorize",
+        redirect_uri="http://localhost:53593/callback",
+        client_id="flytepropeller",
+        scopes=["all"],
+        device_authorization_endpoint=device_authorization_endpoint,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", [None, ""])
+async def test_refresh_rejects_missing_device_authorization_endpoint(endpoint):
+    """FLYTE-SDK-6P: an unadvertised device endpoint arrives as "" from the OAuth2
+    metadata proto, not None. Both must raise the actionable AuthenticationError
+    rather than falling through to httpx.post("")."""
+    auth = DeviceCodeAuthenticator(endpoint="https://example.com")
+
+    with (
+        patch.object(DeviceCodeAuthenticator, "_resolve_config", AsyncMock(return_value=_cfg(endpoint))),
+        patch(
+            "flyte.remote._client.auth._token_client.get_device_code",
+            AsyncMock(side_effect=AssertionError("must not be called")),
+        ),
+    ):
+        with pytest.raises(AuthenticationError, match="Device Authentication is not available"):
+            await auth._do_refresh_credentials()


### PR DESCRIPTION
`RemoteClientConfigStore.get_client_config` fills `device_authorization_endpoint` from the OAuth2 metadata proto. When the auth server does not advertise one, proto3 gives back the default `""` — not `None`.

`DeviceCodeAuthenticator._do_refresh_credentials` guarded with `is None`, so the empty string fell straight through to `token_client.get_device_code("")` and httpx raised:

```
UnsupportedProtocol: Request URL is missing an 'http://' or 'https://' protocol.
```

which then bubbled up as `RuntimeError: SelectCluster failed for operation=1: Request URL is missing an 'http://' ...` → `RuntimeSystemError: Upload failed for ...` and got crash-reported to Sentry as an SDK bug, instead of hitting the actionable `AuthenticationError` that is already right there.

**Fix:** guard on falsiness. This matches `ClientConfig.merge`, which already uses `or` on the same field, so `""` was always intended to mean "absent".

Tests: parametrized regression test over `None` and `""` asserting `get_device_code` is never reached and the actionable `AuthenticationError` is raised. The `""` case fails on `main`.

fixes FLYTE-SDK-6P