### PR TITLE
Fix integration tests

### DIFF
--- a/examples/apps/single_script_fastapi.py
+++ b/examples/apps/single_script_fastapi.py
@@ -27,7 +27,7 @@ env = FastAPIAppEnvironment(
     description="A FastAPI app demonstrating UV inline script capabilities.",
     image=flyte.Image.from_uv_script(__file__, name="fastapi-script"),
     resources=flyte.Resources(cpu=1, memory="512Mi"),
-    requires_auth=False,
+    requires_auth=True,
 )
 
 

--- a/examples/genai/sglang/sglang_app.py
+++ b/examples/genai/sglang/sglang_app.py
@@ -75,7 +75,7 @@ sglang_app = SGLangAppEnvironment(
         replicas=(0, 1),  # (min_replicas, max_replicas)
         scaledown_after=300,  # Scale down after 5 minutes of inactivity
     ),
-    requires_auth=False,
+    requires_auth=True,
     extra_args=["--context-length", "8192"],  # Limit context length for smaller GPU memory
 )
 

--- a/examples/genai/vllm/vllm_app.py
+++ b/examples/genai/vllm/vllm_app.py
@@ -65,7 +65,7 @@ vllm_app = VLLMAppEnvironment(
         replicas=(0, 1),  # (min_replicas, max_replicas)
         scaledown_after=300,  # Scale down after 5 minutes of inactivity
     ),
-    requires_auth=False,
+    requires_auth=True,
     extra_args=["--max-model-len 8192"],  # Limit context length for smaller GPU memory
 )
 


### PR DESCRIPTION
## Why
https://github.com/flyteorg/flyte-sdk/actions/runs/30445275384

The FastAPI, SGLang, and vLLM app examples were set to `requires_auth=False`, and it's not supported in the cluster where we run the integration tests

## What

Flip `requires_auth` to `True` in:
- `examples/apps/single_script_fastapi.py`
- `examples/genai/sglang/sglang_app.py`
- `examples/genai/vllm/vllm_app.py`
