### PR TITLE
fix(trigger): render trigger automation without crashing in `flyte get trigger`

### DIFF
--- a/src/flyte/remote/_trigger.py
+++ b/src/flyte/remote/_trigger.py
@@ -20,6 +20,37 @@ from ._common import ToJSONMixin
 from ._task import Task, TaskDetails
 
 
+def _describe_automation(automation: common_pb2.TriggerAutomationSpec) -> str:
+    """
+    Render a trigger's automation specification as a single human-readable line.
+
+    One line (rather than one field per automation kind) keeps the columns aligned when a list of
+    triggers with differing automations is formatted as a table.
+    """
+    if automation.type == common_pb2.TriggerAutomationSpecType.TYPE_NONE:
+        return "none"
+    if automation.type != common_pb2.TriggerAutomationSpecType.TYPE_SCHEDULE:
+        return common_pb2.TriggerAutomationSpecType.Name(automation.type)
+
+    schedule = automation.schedule
+    # `schedule` is a message, so its sub-messages are never None; the oneof tag is what says
+    # which kind of schedule was actually set.
+    match schedule.WhichOneof("expression"):
+        case "cron":
+            return f"cron: {schedule.cron.expression} ({schedule.cron.timezone or 'UTC'})"
+        case "cron_expression":
+            return f"cron: {schedule.cron_expression}"
+        case "rate":
+            rate = schedule.rate
+            unit = common_pb2.FixedRateUnit.Name(rate.unit).removeprefix("FIXED_RATE_UNIT_").lower()
+            if rate.value != 1:
+                unit += "s"
+            start = rate.start_time.ToDatetime() if rate.HasField("start_time") else "now"
+            return f"every {rate.value} {unit} starting at {start}"
+        case _:
+            return "schedule: unset"
+
+
 @dataclass
 class TriggerDetails(ToJSONMixin):
     pb2: trigger_definition_pb2.TriggerDetails
@@ -367,20 +398,7 @@ class Trigger(ToJSONMixin):
         """
         Generate rich representation fields for the automation specification.
         """
-        if automation.type == common_pb2.TriggerAutomationSpec.type.TYPE_NONE:
-            yield "none", None
-        elif automation.type == common_pb2.TriggerAutomationSpec.type.TYPE_SCHEDULE:
-            if automation.schedule.cron is not None:
-                yield "cron", automation.schedule.cron
-            elif automation.schedule.rate is not None:
-                r = automation.schedule.rate
-                yield (
-                    "fixed_rate",
-                    (
-                        f"Every [{r.value}] {r.unit} starting at "
-                        f"{r.start_time.ToDatetime() if automation.HasField('start_time') else 'now'}"
-                    ),
-                )
+        yield "automation", _describe_automation(automation)
 
     def __rich_repr__(self):
         """

--- a/tests/flyte/remote/test_trigger_rich_repr.py
+++ b/tests/flyte/remote/test_trigger_rich_repr.py
@@ -1,0 +1,107 @@
+"""Tests for the rich-repr rendering path used by `flyte get trigger`."""
+
+from datetime import datetime
+
+import pytest
+from flyteidl2.task import common_pb2
+from flyteidl2.trigger import trigger_definition_pb2
+from google.protobuf.timestamp_pb2 import Timestamp
+
+from flyte.cli._common import format
+from flyte.remote._trigger import Trigger
+
+
+def _timestamp(dt: datetime) -> Timestamp:
+    ts = Timestamp()
+    ts.FromDatetime(dt)
+    return ts
+
+
+def _trigger(automation: common_pb2.TriggerAutomationSpec | None, name: str = "t") -> Trigger:
+    pb2 = trigger_definition_pb2.Trigger(active=True)
+    pb2.id.name.name = name
+    pb2.id.name.task_name = "my_task"
+    if automation is not None:
+        pb2.automation_spec.CopyFrom(automation)
+    return Trigger(pb2=pb2)
+
+
+def _schedule(**kwargs) -> common_pb2.TriggerAutomationSpec:
+    return common_pb2.TriggerAutomationSpec(
+        type=common_pb2.TriggerAutomationSpecType.TYPE_SCHEDULE,
+        schedule=common_pb2.Schedule(**kwargs),
+    )
+
+
+@pytest.mark.parametrize(
+    "automation, expected",
+    [
+        pytest.param(None, "TYPE_UNSPECIFIED", id="unset"),
+        pytest.param(
+            common_pb2.TriggerAutomationSpec(type=common_pb2.TriggerAutomationSpecType.TYPE_NONE),
+            "none",
+            id="none",
+        ),
+        pytest.param(
+            _schedule(cron=common_pb2.Cron(expression="0 * * * *", timezone="US/Pacific")),
+            "cron: 0 * * * * (US/Pacific)",
+            id="cron",
+        ),
+        pytest.param(
+            _schedule(cron=common_pb2.Cron(expression="0 * * * *")),
+            "cron: 0 * * * * (UTC)",
+            id="cron-default-timezone",
+        ),
+        pytest.param(
+            _schedule(cron_expression="*/5 * * * *"),
+            "cron: */5 * * * *",
+            id="cron-expression",
+        ),
+        pytest.param(
+            _schedule(rate=common_pb2.FixedRate(value=60, unit=common_pb2.FIXED_RATE_UNIT_MINUTE)),
+            "every 60 minutes starting at now",
+            id="fixed-rate",
+        ),
+        pytest.param(
+            _schedule(
+                rate=common_pb2.FixedRate(
+                    value=1,
+                    unit=common_pb2.FIXED_RATE_UNIT_DAY,
+                    start_time=_timestamp(datetime(2026, 7, 29, 17, 0, 0)),
+                )
+            ),
+            "every 1 day starting at 2026-07-29 17:00:00",
+            id="fixed-rate-with-start-time",
+        ),
+        pytest.param(
+            common_pb2.TriggerAutomationSpec(type=common_pb2.TriggerAutomationSpecType.TYPE_SCHEDULE),
+            "schedule: unset",
+            id="schedule-without-expression",
+        ),
+    ],
+)
+def test_rich_repr_automation(automation, expected):
+    assert list(_trigger(automation).__rich_repr__()) == [
+        ("task_name", "my_task"),
+        ("name", "t"),
+        ("automation", expected),
+        ("auto_activate", True),
+    ]
+
+
+def test_format_table_columns_are_stable_across_automation_kinds():
+    """Triggers with different automations must share one column set, or rows misalign."""
+    triggers = [
+        _trigger(common_pb2.TriggerAutomationSpec(type=common_pb2.TriggerAutomationSpecType.TYPE_NONE), name="a"),
+        _trigger(_schedule(cron=common_pb2.Cron(expression="0 * * * *")), name="b"),
+        _trigger(_schedule(rate=common_pb2.FixedRate(value=5, unit=common_pb2.FIXED_RATE_UNIT_HOUR)), name="c"),
+    ]
+
+    table = format("Triggers", triggers)
+
+    assert [c.header for c in table.columns] == ["Task_name", "Name", "Automation", "Auto_activate"]
+    assert list(table.columns[2].cells) == [
+        "none",
+        "cron: 0 * * * * (UTC)",
+        "every 5 hours starting at now",
+    ]


### PR DESCRIPTION
## Why are the changes needed?

`flyte get trigger` crashes for any project that has triggers:

```
$ flyte get trigger -p ketan -d development
...
AttributeError: type
```

`Trigger.__rich_repr__` is called for every trigger in the list, and it delegates to
`_rich_automation`, which reads the automation type enum off the *message class*:

```python
if automation.type == common_pb2.TriggerAutomationSpec.type.TYPE_NONE:
```

`TriggerAutomationSpec` has no `type` attribute — in the generated `flyteidl2.task.common_pb2`
the enum is the module-level `TriggerAutomationSpecType` (`TYPE_UNSPECIFIED`/`TYPE_NONE`/`TYPE_SCHEDULE`).
Listing triggers is therefore unusable in every output format (`table`, `table-simple`, `json`).

Fixing only the enum accessor still renders the wrong thing, because the rest of the function has
three more defects:

1. `automation.schedule.cron is not None` — `cron` is a sub-message, so it is *never* `None`. Every
   schedule takes the cron branch and yields an (often empty) `Cron` message as the value; the
   fixed-rate branch is dead code.
2. `automation.HasField('start_time')` raises `ValueError: Protocol message TriggerAutomationSpec has
   no "start_time" field` — `start_time` lives on `FixedRate`, not on the automation spec. So the
   fixed-rate branch would crash if it were reachable.
3. The `cron_expression` member of the `Schedule.expression` oneof is never handled.

## What changes were proposed in this pull request?

- Read the automation type from the module-level `TriggerAutomationSpecType` enum.
- Select the schedule kind from the oneof tag (`schedule.WhichOneof("expression")`) instead of
  `is not None` checks on sub-messages, and handle all three members (`cron`, `cron_expression`,
  `rate`).
- Read `start_time` off the `FixedRate` message, and render the rate unit by enum name rather than as
  a raw int.
- Yield a single `automation` field describing the schedule in one line, instead of a different field
  name per automation kind. `flyte.cli._common._table_format` takes its column headers from the first
  row, so variable field names misalign columns when a project mixes cron, fixed-rate, and
  unautomated triggers.

Sample output, previously an unconditional crash:

```
                                    Triggers
┌──────────────────────────────────────┬───────────────────┬─────────┬─────────┐
│ Task_name                            │ Name              │ Automat │ Auto_ac │
│                                      │                   │ ion     │ tivate  │
╞══════════════════════════════════════╪═══════════════════╪═════════╪═════════╡
│ sdk_version_tester.test_all_versions │ test_sdk_every_5m │ every 5 │ True    │
│                                      │                   │ minutes │         │
│                                      │                   │ startin │         │
│                                      │                   │ g at    │         │
│                                      │                   │ now     │         │
└──────────────────────────────────────┴───────────────────┴─────────┴─────────┘
```

## How was this patch tested?

- New `tests/flyte/remote/test_trigger_rich_repr.py`: parametrized coverage of every automation
  branch (unset type, `TYPE_NONE`, `cron` with and without a timezone, `cron_expression`, fixed rate
  with and without `start_time`, and `TYPE_SCHEDULE` with no expression set), plus a test asserting
  the CLI table keeps one stable column set across mixed automation kinds.
- `pytest tests/flyte/remote tests/flyte/cli` — 496 passed.
- Full `pytest -k "not integration and not sandbox" tests` — the only failures are pre-existing in
  this environment (`tests/flyte/ai/mcp`, `test_caller_frame_resolution`, `test_keyring_store`);
  they fail identically with this change stashed.
- `ruff format --check`, `ruff check`, `mypy`, and `ty check` clean on the changed files.
- Verified live against a real trigger (`flyte get trigger -p ketan -d development` on a canary
  deployment) in `table`, `table-simple`, and `json` output formats, plus the single-trigger detail
  view.

### Labels

fixed

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
