### PR TITLE
fix: point users to ruff install when import analysis is unavailable

### DIFF
--- a/src/flyte/_code_bundle/_utils.py
+++ b/src/flyte/_code_bundle/_utils.py
@@ -400,6 +400,7 @@ def list_imported_modules_as_files_with_ruff(source_path: str, modules: List[Mod
     return list(_collect_transitive_dependencies(set(all_files), graph, source_path, invalid_directories))
 
 
+@lru_cache
 def _ruff_is_available() -> bool:
     """Return True if the `ruff` executable is on PATH.
 
@@ -407,10 +408,10 @@ def _ruff_is_available() -> bool:
     discovery alone, which cannot see lazily/conditionally imported local modules.
     """
     if shutil.which("ruff") is None:
-        logger.debug(
-            "ruff not found on PATH; skipping static import graph analysis and falling back to runtime "
-            "sys.modules discovery. Lazily/conditionally imported local modules may be omitted from the "
-            "code bundle."
+        logger.info(
+            "ruff not found on PATH: lazily and conditionally imported local modules may be omitted "
+            "from the code bundle, surfacing on the cluster as ModuleNotFoundError. "
+            "Install ruff (`pip install ruff`) to include them."
         )
         return False
 


### PR DESCRIPTION
## Issue

#1265 added static import analysis via `ruff analyze graph` so that lazily and conditionally imported local modules get bundled. However, ruff is not a dependency of `flyte` and with it not preinstalled, flyte would fallback to the runtime sys.modules discovery method.

The fallback was also silent (`logger.debug`), so there was no signal that the bundle might be incomplete. The failure only shows up later, on the cluster, as a `ModuleNotFoundError` with nothing pointing back at the cause.

## Changes

ruff stays out of the dependency tree and users who want the behavior install it themselves. This PR makes that choice discoverable by users.

- **`logger.debug` → `logger.info`**, naming the consequence and the remedy:

  > ruff not found on PATH: lazily and conditionally imported local modules may be omitted from the code bundle, surfacing on the cluster as ModuleNotFoundError. Install ruff (`pip install ruff`) to include them.

- **`@lru_cache` on `_ruff_is_available()`** so the PATH lookup and the notice happen once per process rather than once per bundle.

This prevents the cause of `ModuleNotFoundError` on cluster from being silent and hard to trace back.
