### PR TITLE
fix: don't crash when devbox unpause loses the paused-state race (FLYTE-SDK-6W)

### DIFF
--- a/src/flyte/cli/_devbox.py
+++ b/src/flyte/cli/_devbox.py
@@ -111,6 +111,28 @@ def _container_is_paused(container_name: str) -> bool:
     return container_name in result.stdout
 
 
+def _resume_container(container_name: str) -> bool:
+    """Unpause a container, returning False if it turned out not to be paused after all.
+
+    Checking `status=paused` and unpausing are two separate docker calls, so the container can
+    leave the paused state in between (a concurrent `docker unpause`, a daemon restart, the
+    container exiting). Docker then fails with "container not paused", which is a state race
+    rather than an SDK bug — report it back so the caller can fall through to the normal start
+    path. Any other failure becomes a user-facing message.
+    """
+    result = subprocess.run(["docker", "unpause", container_name], capture_output=True, text=True, check=False)
+    if result.returncode == 0:
+        return True
+    details = (result.stderr or result.stdout or "").strip()
+    if "not paused" in details.lower():
+        return False
+    raise click.ClickException(
+        f"Failed to resume paused devbox container '{container_name}'.\n{details}"
+        if details
+        else f"Failed to resume paused devbox container '{container_name}'."
+    )
+
+
 def _is_local_image(image: str) -> bool:
     """Check if the image is local (no registry prefix)."""
     name = image.split(":", maxsplit=1)[0]
@@ -288,7 +310,10 @@ def stop_devbox() -> None:
     if not _container_is_running(_CONTAINER_NAME):
         console.print("[yellow]Devbox cluster is not running.[/yellow]")
         return
-    subprocess.run(["docker", "pause", _CONTAINER_NAME], check=True, capture_output=True)
+    _run_docker(
+        ["docker", "pause", _CONTAINER_NAME],
+        f"Failed to pause devbox container '{_CONTAINER_NAME}'.",
+    )
     console.print("[green]Devbox cluster stopped.[/green] Run [bold]flyte start devbox[/bold] to resume.")
 
 
@@ -298,8 +323,8 @@ def launch_devbox(image_name: str, is_dev_mode: bool, gpu: bool = False, log_for
     _ensure_volume(_VOLUME_NAME)
     if _container_is_paused(_CONTAINER_NAME):
         console.print("[cyan]Resuming paused devbox cluster...[/cyan]")
-        subprocess.run(["docker", "unpause", _CONTAINER_NAME], check=True, capture_output=True)
-        return
+        if _resume_container(_CONTAINER_NAME):
+            return
 
     if _container_is_running(_CONTAINER_NAME):
         console.print("[yellow]Flyte devbox cluster is already running.[/yellow]")

--- a/tests/cli/test_devbox.py
+++ b/tests/cli/test_devbox.py
@@ -722,3 +722,75 @@ class TestGetDevboxCommand:
 
         assert result.exit_code == 0, result.output
         assert mock_status.call_args.kwargs == {"check_ready": False, "check_stats": False}
+
+
+class TestPauseResume:
+    """`docker pause`/`unpause` failures must not surface as raw CalledProcessError."""
+
+    def test_resume_container_success(self):
+        from flyte.cli._devbox import _resume_container
+
+        with patch("flyte.cli._devbox.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="flyte-devbox\n", stderr="")
+            assert _resume_container("flyte-devbox") is True
+            assert mock_run.call_args.args[0] == ["docker", "unpause", "flyte-devbox"]
+
+    def test_resume_container_not_paused_is_not_an_error(self):
+        """The paused check and the unpause are separate docker calls; losing that race
+        (`container not paused`) must fall through, not crash."""
+        from flyte.cli._devbox import _resume_container
+
+        with patch("flyte.cli._devbox.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1,
+                stdout="",
+                stderr=(
+                    "Error response from daemon: Cannot unpause container 06fcfce7dc99: "
+                    "OCI runtime resume failed: container not paused\n"
+                ),
+            )
+            assert _resume_container("flyte-devbox") is False
+
+    def test_resume_container_other_failure_raises_click_exception(self):
+        import click
+
+        from flyte.cli._devbox import _resume_container
+
+        with patch("flyte.cli._devbox.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="No such container: flyte-devbox")
+            with pytest.raises(click.ClickException) as excinfo:
+                _resume_container("flyte-devbox")
+            assert "No such container" in str(excinfo.value.message)
+
+    def test_launch_devbox_falls_through_when_resume_loses_the_race(self):
+        """A container that stopped being paused should be treated like a fresh start."""
+        from flyte.cli._devbox import launch_devbox
+
+        with (
+            patch("flyte.cli._devbox._ensure_docker_available"),
+            patch("flyte.cli._devbox._ensure_volume"),
+            patch("flyte.cli._devbox._container_is_paused", return_value=True),
+            patch("flyte.cli._devbox._resume_container", return_value=False),
+            patch("flyte.cli._devbox._container_is_running", return_value=False),
+            patch("flyte.cli._devbox.subprocess.run"),
+            patch("flyte.cli._devbox.Path.mkdir"),
+            patch("flyte.cli._devbox.Path.unlink"),
+            patch("flyte.cli._devbox._launch_devbox_rich") as mock_launch,
+        ):
+            launch_devbox("cr.flyte.org/flyteorg/flyte-devbox:latest", is_dev_mode=False)
+            mock_launch.assert_called_once()
+
+    def test_stop_devbox_pause_failure_raises_click_exception(self):
+        import click
+
+        from flyte.cli._devbox import stop_devbox
+
+        with (
+            patch("flyte.cli._devbox._container_is_paused", return_value=False),
+            patch("flyte.cli._devbox._container_is_running", return_value=True),
+            patch("flyte.cli._devbox.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="container is not running")
+            with pytest.raises(click.ClickException) as excinfo:
+                stop_devbox()
+            assert "Failed to pause devbox container" in str(excinfo.value.message)


### PR DESCRIPTION
## Why

[FLYTE-SDK-6W](https://union-ai.sentry.io/issues/7641095882/) (2 events, on the latest release **2.5.15**):

```
CalledProcessError: Command '['docker', 'unpause', 'flyte-devbox']' returned non-zero exit status 1.
  flyte/cli/_devbox.py in launch_devbox
```

with docker's stderr from the captured event:

```
Error response from daemon: Cannot unpause container 06fcfce7dc99...:
OCI runtime resume failed: container not paused
```

`launch_devbox` checks `docker ps --filter status=paused` and then runs `docker unpause` as **two separate docker calls**. If the container leaves the paused state in between — a concurrent `docker unpause`, a daemon restart, the container exiting — docker fails with "container not paused" and the `check=True` call raises a raw `CalledProcessError` out of a function wrapped in `@_sentry.capture_errors`. A local docker state race got reported as an SDK crash.

Every other docker invocation in this module already goes through `_run_docker()`, which turns failures into a user-facing `click.ClickException` (filtered from Sentry by `_is_user_error`). `pause` and `unpause` were the two calls that were missed when that helper was introduced.

## What

- New `_resume_container()`: treats `not paused` in docker's output as a lost race and returns `False`, so `launch_devbox` falls through to the normal running/start path instead of crashing. Any other unpause failure becomes a `ClickException` carrying docker's stderr.
- `stop_devbox` routes `docker pause` through the existing `_run_docker` helper.

## Tests

5 new tests in `tests/cli/test_devbox.py::TestPauseResume` — unpause success, the "container not paused" race (reproducing the exact stderr from the Sentry event), a non-race unpause failure, `launch_devbox` falling through to a fresh start when the race is lost, and `stop_devbox` surfacing a pause failure as a `ClickException`. All 5 verified to **fail** on `main` without the source change; 24/24 pass with it.

fixes FLYTE-SDK-6W