### PR TITLE
fix: keep multi-level ../ source paths inside the image build context (FLYTE-SDK-6B)

### DIFF
--- a/src/flyte/_internal/imagebuild/utils.py
+++ b/src/flyte/_internal/imagebuild/utils.py
@@ -124,11 +124,33 @@ def copy_files_to_context(src: Path, context_path: Path, ignore_patterns: list[s
             "reachable from where you are running `flyte deploy`."
         )
 
-    if src.is_absolute() or ".." in str(src):
+    if src.is_absolute():
+        # ``parts[1:]`` strips the anchor ("/" on posix, "C:\\" on Windows).
         rel_path = PurePath(*src.parts[1:])
+        dst_path = context_path / "_flyte_abs_context" / rel_path
+    elif ".." in src.parts:
+        # Relative paths that walk out of the cwd get re-rooted too. Stripping ``parts[1:]``
+        # (correct for an absolute path's anchor) only removes the *first* ``..``, so
+        # ``../../../pkg`` kept two of them and the ``os.path.normpath`` below walked the
+        # destination back out of the build context entirely — files were copied next to the
+        # context instead of into it, and the caller's ``dst_path.relative_to(context_path)``
+        # then blew up with a raw ValueError (FLYTE-SDK-6B). Drop every traversal component.
+        # Note this checks ``src.parts``, not ``str(src)``: a directory legitimately named
+        # ``my..pkg`` is not a traversal.
+        rel_path = PurePath(*[part for part in src.parts if part not in ("..", ".")])
         dst_path = context_path / "_flyte_abs_context" / rel_path
     else:
         dst_path = context_path / src
+
+    dst_path = Path(os.path.normpath(dst_path))
+    if not dst_path.is_relative_to(context_path):
+        # Defense in depth: never copy outside the build context, whatever the caller passed.
+        raise ImageBuildError(
+            f"Cannot copy '{src}' into the image build context: it resolves to '{dst_path}', "
+            f"which is outside the context directory '{context_path}'. Pass a path inside your "
+            "project to your image layer (e.g. with_requirements, with_source_folder, "
+            "with_pyproject)."
+        )
 
     if src.is_dir():
         from .docker import PatternMatcher
@@ -176,7 +198,7 @@ def copy_files_to_context(src: Path, context_path: Path, ignore_patterns: list[s
         dst_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(src, dst_path)
 
-    return Path(os.path.normpath(dst_path))
+    return dst_path
 
 
 def get_and_list_dockerignore(image: Image) -> List[str]:

--- a/tests/flyte/imagebuild/test_utils.py
+++ b/tests/flyte/imagebuild/test_utils.py
@@ -367,3 +367,104 @@ def test_extract_editables_surfaces_missing_uv_binary():
 
     assert "uv" in str(exc_info.value).lower()
     assert "not found" in str(exc_info.value).lower()
+
+
+def test_copy_files_to_context_multi_level_parent_traversal_stays_in_context():
+    """A source folder reached via several ``..`` hops must land inside the build context.
+
+    ``copy_files_to_context`` re-roots escaping paths under ``_flyte_abs_context``, but it used to
+    drop only the first path component, so ``../../../pkg`` kept two ``..`` and ``os.path.normpath``
+    walked the destination straight back out of the context. The files were copied next to the
+    context directory and the caller's ``dst_path.relative_to(context_path)`` raised a raw
+    ValueError (FLYTE-SDK-6B).
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        pkg = root / "pxPyFactory" / "pxpyfactory"
+        pkg.mkdir(parents=True)
+        (pkg / "mod.py").write_text("x = 1")
+
+        context_dir = root / "build.uc-image-builder"
+        context_dir.mkdir()
+
+        cwd = root / "a" / "b" / "c"
+        cwd.mkdir(parents=True)
+
+        old_cwd = os.getcwd()
+        os.chdir(cwd)
+        try:
+            dst = copy_files_to_context(Path("../../../pxPyFactory/pxpyfactory"), context_dir)
+        finally:
+            os.chdir(old_cwd)
+
+        assert dst.is_relative_to(context_dir), f"{dst} escaped the build context {context_dir}"
+        # This is the call that used to raise ValueError in remote_builder._get_layers_proto.
+        assert str(dst.relative_to(context_dir)) == os.path.join("_flyte_abs_context", "pxPyFactory", "pxpyfactory")
+        assert (dst / "mod.py").read_text() == "x = 1"
+
+
+def test_copy_files_to_context_single_parent_traversal_unchanged():
+    """The already-working single-``..`` case must keep its destination."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "requirements.txt").write_text("flyte\n")
+        context_dir = root / "context"
+        context_dir.mkdir()
+        cwd = root / "project"
+        cwd.mkdir()
+
+        old_cwd = os.getcwd()
+        os.chdir(cwd)
+        try:
+            dst = copy_files_to_context(Path("../requirements.txt"), context_dir)
+        finally:
+            os.chdir(old_cwd)
+
+        assert dst == context_dir / "_flyte_abs_context" / "requirements.txt"
+        assert dst.read_text() == "flyte\n"
+
+
+def test_copy_files_to_context_dotdot_in_directory_name_is_not_a_traversal():
+    """A directory legitimately named ``my..pkg`` should not be treated as an escape.
+
+    The old guard was a substring check on ``str(src)``, which re-rooted this path unnecessarily.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        context_dir = root / "context"
+        context_dir.mkdir()
+        pkg = root / "my..pkg"
+        pkg.mkdir()
+        (pkg / "mod.py").write_text("y = 2")
+
+        old_cwd = os.getcwd()
+        os.chdir(root)
+        try:
+            dst = copy_files_to_context(Path("my..pkg"), context_dir)
+        finally:
+            os.chdir(old_cwd)
+
+        assert dst == context_dir / "my..pkg"
+        assert (dst / "mod.py").read_text() == "y = 2"
+
+
+def test_copy_files_to_context_absolute_path_escape_raises_image_build_error():
+    """Defense in depth: a destination outside the context is a user-facing error, not a crash."""
+    import pytest
+
+    from flyte.errors import ImageBuildError
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        context_dir = root / "context"
+        context_dir.mkdir()
+        src = root / "src.txt"
+        src.write_text("hi")
+
+        # A context path that is itself relative to nothing sane: force the escape by handing
+        # copy_files_to_context a context directory nested under the destination it computes.
+        with patch("flyte._internal.imagebuild.utils.os.path.normpath", return_value=str(root / "elsewhere")):
+            with pytest.raises(ImageBuildError) as excinfo:
+                copy_files_to_context(src, context_dir)
+
+        assert "outside the context directory" in str(excinfo.value)


### PR DESCRIPTION
## Why

[FLYTE-SDK-6B](https://union-ai.sentry.io/issues/7591817898/) — `flyte deploy` crashes with a raw `ValueError` out of `pathlib`:

```
ValueError: 'C:\...\Temp\58627233-...\pxPyFactory\pxpyfactory' is not in the subpath of
            'C:\...\Temp\58627233-...\build.uc-image-builder'
  flyte/_internal/imagebuild/remote_builder.py in _get_layers_proto
```

The event's frame locals tell the whole story:

```
context_path = .../Temp/58627233-.../build.uc-image-builder
dst_path     = .../Temp/58627233-.../pxPyFactory/pxpyfactory      # <- outside the context!
layer        = CopyConfig(1, WindowsPath('../../../pxPyFactory/pxpyfactory'), './pxpyfactory')
```

`copy_files_to_context` re-roots paths that would escape the docker build context under `_flyte_abs_context`:

```python
if src.is_absolute() or ".." in str(src):
    rel_path = PurePath(*src.parts[1:])
    dst_path = context_path / "_flyte_abs_context" / rel_path
```

`parts[1:]` is right for an **absolute** path — it strips the anchor (`/`, or `C:\` on Windows). It is wrong for a **relative** path with `..`, because it strips only the *first* component. For `../../../pxPyFactory/pxpyfactory` that leaves two `..` behind:

```
<context>/_flyte_abs_context/../../pxPyFactory/pxpyfactory
```

and the `os.path.normpath(...)` at the end of the function collapses that straight back out of the context — exactly the `dst_path` in the Sentry event. Two things go wrong:

1. The layer's files are copied **next to** the build context rather than into it, so the built image silently misses them (or picks up a stale copy).
2. `_get_layers_proto` then calls `dst_path.relative_to(context_path)`, which raises `ValueError` and is crash-reported as an SDK bug.

This is not Windows-specific — the same `../../..` source folder reproduces it on posix. (It was previously triaged as a user error on the basis of the Windows path in the title; it isn't.)

## What

- Split the absolute and relative branches. The relative branch drops **every** `..`/`.` component, so the destination always lands under `_flyte_abs_context`.
- Check `".." in src.parts` instead of `".." in str(src)` — the old substring test also re-rooted a directory legitimately named `my..pkg`.
- Normalize `dst_path` *before* copying and raise `ImageBuildError` (a `RuntimeUserError`, so it is a clean user-facing message rather than a crash report) if it still resolves outside the context. Defense in depth for anything this function is handed in the future.

Behavior for the paths that already worked is unchanged: `/abs/requirements.txt` → `_flyte_abs_context/abs/requirements.txt`, `../requirements.txt` → `_flyte_abs_context/requirements.txt`, `pkg/` → `pkg/`.

## Tests

4 new tests in `tests/flyte/imagebuild/test_utils.py`: the multi-level traversal reproducing the Sentry case (asserting the destination stays in the context **and** that `relative_to(context_path)` — the call that crashed — now succeeds), a regression guard on the single-`..` case, the `my..pkg` false positive, and the `ImageBuildError` escape hatch. 3 of the 4 verified to **fail** on `main` without the source change (the 4th is the unchanged-behavior guard). 18/18 in the file pass.

fixes FLYTE-SDK-6B