### PR TITLE
fix(trigger): pass task_name when `Trigger.get_details` fetches details

### DIFF
--- a/src/flyte/remote/_trigger.py
+++ b/src/flyte/remote/_trigger.py
@@ -383,8 +383,7 @@ class Trigger(ToJSONMixin):
         Get detailed information about this trigger.
         """
         if not self.details:
-            details = await TriggerDetails.get.aio(name=self.pb2.id.name.name)
-            self.details = details
+            self.details = await TriggerDetails.get.aio(name=self.name, task_name=self.task_name)
         return self.details
 
     @property

--- a/tests/flyte/remote/test_trigger_get_details.py
+++ b/tests/flyte/remote/test_trigger_get_details.py
@@ -1,0 +1,85 @@
+"""Tests for Trigger.get_details, which fetches (and caches) a trigger's TriggerDetails."""
+
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from flyteidl2.common import identifier_pb2
+from flyteidl2.trigger import trigger_definition_pb2, trigger_service_pb2
+
+from flyte.remote._trigger import Trigger, TriggerDetails
+
+
+def _trigger() -> Trigger:
+    pb2 = trigger_definition_pb2.Trigger(active=True)
+    pb2.id.name.name = "t"
+    pb2.id.name.task_name = "my_task"
+    return Trigger(pb2=pb2)
+
+
+def _details_response() -> trigger_service_pb2.GetTriggerDetailsResponse:
+    return trigger_service_pb2.GetTriggerDetailsResponse(
+        trigger=trigger_definition_pb2.TriggerDetails(
+            id=identifier_pb2.TriggerIdentifier(
+                name=identifier_pb2.TriggerName(name="t", task_name="my_task", org="o", project="p", domain="d")
+            )
+        )
+    )
+
+
+@contextmanager
+def _mocked_client(client: MagicMock):
+    cfg = MagicMock(org="o", project="p", domain="d")
+    with (
+        patch("flyte.remote._trigger.ensure_client"),
+        patch("flyte.remote._trigger.get_init_config", return_value=cfg),
+        patch("flyte.remote._trigger.get_client", return_value=client),
+    ):
+        yield
+
+
+@pytest.mark.asyncio
+async def test_get_details_requests_the_trigger_by_name_and_task_name():
+    client = MagicMock()
+    client.trigger_service.get_trigger_details = AsyncMock(return_value=_details_response())
+
+    with _mocked_client(client):
+        details = await _trigger().get_details()
+
+    assert isinstance(details, TriggerDetails)
+    assert details.name == "t"
+
+    # Both halves of the trigger's identity have to be sent; the name alone does not identify it.
+    req = client.trigger_service.get_trigger_details.await_args.kwargs["request"]
+    assert req.name.name == "t"
+    assert req.name.task_name == "my_task"
+    assert (req.name.org, req.name.project, req.name.domain) == ("o", "p", "d")
+
+
+@pytest.mark.asyncio
+async def test_get_details_caches_the_fetched_details():
+    client = MagicMock()
+    client.trigger_service.get_trigger_details = AsyncMock(return_value=_details_response())
+
+    trigger = _trigger()
+    with _mocked_client(client):
+        first = await trigger.get_details()
+        second = await trigger.get_details()
+
+    assert first is second is trigger.details
+    client.trigger_service.get_trigger_details.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_details_returns_preloaded_details_without_a_request():
+    client = MagicMock()
+    client.trigger_service.get_trigger_details = AsyncMock(return_value=_details_response())
+
+    preloaded = TriggerDetails(pb2=_details_response().trigger)
+    trigger = _trigger()
+    trigger.details = preloaded
+
+    with _mocked_client(client):
+        assert await trigger.get_details() is preloaded
+
+    client.trigger_service.get_trigger_details.assert_not_awaited()


### PR DESCRIPTION
## Why are the changes needed?

`Trigger.get_details()` raises `TypeError` on every call:

```python
TypeError: TriggerDetails.get() missing 1 required keyword-only argument: 'task_name'
```

A trigger is identified by `TriggerName{name, task_name, org, project, domain}` — the trigger name
alone is not unique — and `TriggerDetails.get` requires both halves as keyword-only arguments.
`Trigger.get_details` passes only `name`, so the call fails before it ever reaches the backend.

Found while fixing #1343; it is off the `flyte get trigger` code path (the CLI goes through
`Trigger.get`), so it was left for a separate PR.

## What changes were proposed in this pull request?

Pass `task_name` alongside `name`, sourcing both from the existing `Trigger.name` / `Trigger.task_name`
properties rather than reaching into `self.pb2.id.name` directly, and assign the result straight to
`self.details` instead of via a temporary.

## How was this patch tested?

- New `tests/flyte/remote/test_trigger_get_details.py`: asserts the request carries both `name` and
  `task_name` (plus org/project/domain), that the fetched details are cached so a second call issues
  no further request, and that preloaded details short-circuit the fetch entirely. Two of the three
  fail with `TypeError` on `main`.
- `pytest tests/flyte/remote tests/flyte/cli tests/flyte/internal/runtime/test_trigger_serde.py` —
  544 passed.
- `ruff format --check`, `ruff check`, `mypy`, and `ty check` clean on the changed files.

### Labels

fixed

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

- #1343 — fixes the trigger-automation rendering crash in the same module.
