### PR TITLE
fix: reject unusable access tokens from external auth command (FLYTE-SDK-6Y)

### DIFF
--- a/src/flyte/remote/_client/auth/_authenticators/base.py
+++ b/src/flyte/remote/_client/auth/_authenticators/base.py
@@ -17,6 +17,27 @@ class AuthHeaders:
     headers: dict[str, str]
 
 
+def is_usable_access_token(access_token: typing.Optional[str]) -> bool:
+    """
+    Return True if ``access_token`` can be sent verbatim in an ``Authorization`` header.
+
+    A bearer token is a single opaque string. Anything else — an empty value, an
+    interactive prompt captured from a helper command's stdout, a multi-line blob, a
+    stray control character — makes the header invalid, and the HTTP transport rejects
+    it with an opaque ``ValueError: Invalid header value`` far from the real cause.
+
+    :param access_token: The candidate access token
+    :return: True if the token is usable as a header value
+    """
+    if not access_token:
+        return False
+    try:
+        access_token.encode("latin-1")
+    except UnicodeEncodeError:
+        return False
+    return not any(c.isspace() or ord(c) < 0x20 or ord(c) == 0x7F for c in access_token)
+
+
 class Authenticator(object):
     """
     Base authenticator for all authentication flows
@@ -134,6 +155,20 @@ class Authenticator(object):
         """
         creds = self.get_credentials()
         if creds:
+            if not is_usable_access_token(creds.access_token):
+                # A malformed token can reach us from the keyring, where it was cached by
+                # an earlier run before it was ever used in a request. Treating it as "no
+                # credentials" lets the normal unauthenticated path trigger a refresh,
+                # which re-runs the auth flow and surfaces a real error, instead of
+                # wedging the user until they clear the keyring by hand.
+                from flyte._logging import logger
+
+                logger.warning(
+                    f"Ignoring cached credentials for {self._endpoint}: the stored access token cannot be sent"
+                    f" as an Authorization header. Re-authenticating."
+                )
+                return None
+
             header_key = self._default_header_key
             if self._resolved_config is not None:
                 # We only resolve the config during authentication flow, to avoid unnecessary network calls

--- a/src/flyte/remote/_client/auth/_authenticators/external_command.py
+++ b/src/flyte/remote/_client/auth/_authenticators/external_command.py
@@ -2,7 +2,7 @@ import asyncio
 import typing
 
 from flyte._logging import logger
-from flyte.remote._client.auth._authenticators.base import Authenticator
+from flyte.remote._client.auth._authenticators.base import Authenticator, is_usable_access_token
 from flyte.remote._client.auth._keyring import Credentials
 from flyte.remote._client.auth.errors import AuthenticationError
 
@@ -52,8 +52,8 @@ class AsyncCommandAuthenticator(Authenticator):
 
         :raises AuthenticationError: If the command fails to execute or returns a non-zero exit code
         """
-        cmd_joined = " ".join(typing.cast(str, self._cmd))
-        logger.debug("Starting external process to generate id token. Command `{}`".format(" ".join(cmd_joined)))
+        cmd_joined = " ".join(typing.cast(typing.List[str], self._cmd))
+        logger.debug(f"Starting external process to generate id token. Command `{cmd_joined}`")
         try:
             # Use asyncio subprocess for non-blocking operation
             process = await asyncio.create_subprocess_exec(
@@ -70,7 +70,24 @@ class AsyncCommandAuthenticator(Authenticator):
                     f" Please execute this command in your terminal to debug."
                 )
 
-            return Credentials(for_endpoint=self._endpoint, access_token=stdout.decode().strip())
+            access_token = stdout.decode().strip()
+            if not is_usable_access_token(access_token):
+                # The command exited 0 but printed something that cannot be sent as a
+                # bearer token — typically an interactive prompt ("Please visit this URL
+                # to authorize this application: ...") or a usage/help message. Putting
+                # it in an Authorization header raises a confusing ValueError deep inside
+                # the HTTP transport, so fail here with an actionable message instead.
+                # Deliberately do not echo the output: it may contain a real token.
+                raise AuthenticationError(
+                    f"Command `{cmd_joined}` did not return a usable access token."
+                    f" Please execute this command in your terminal to debug: it must print the token alone"
+                    f" on stdout. If it prints a prompt or an authorization URL, complete that login"
+                    f" interactively first so the command can return a token non-interactively."
+                )
+
+            return Credentials(for_endpoint=self._endpoint, access_token=access_token)
+        except AuthenticationError:
+            raise
         except Exception as e:
             logger.error(f"Failed to generate token from command `{cmd_joined}`. Error: {e!s}")
             raise AuthenticationError(

--- a/tests/flyte/remote/test_command_authenticator.py
+++ b/tests/flyte/remote/test_command_authenticator.py
@@ -1,0 +1,122 @@
+"""Tests for external-command auth token validation (FLYTE-SDK-6Y)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from flyte.remote._client.auth._authenticators.base import Authenticator, is_usable_access_token
+from flyte.remote._client.auth._authenticators.external_command import AsyncCommandAuthenticator
+from flyte.remote._client.auth._keyring import Credentials
+from flyte.remote._client.auth.errors import AuthenticationError
+
+# The stdout that triggered FLYTE-SDK-6Y: an interactive helper printed its prompt on
+# stdout and exited 0, so the prompt was used verbatim as the bearer token.
+OAUTH_PROMPT = (
+    "Please visit this URL to authorize this application: "
+    "https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=1166.apps.googleusercontent.com"
+)
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "abc123",
+        "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIn0.sig",
+        "ya29.a0-_dashes.and.dots~tilde",
+    ],
+)
+def test_usable_tokens(token):
+    assert is_usable_access_token(token)
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        None,
+        "",
+        OAUTH_PROMPT,
+        "token with spaces",
+        "token\nwith-newline",
+        "token\twith-tab",
+        "token\rwith-cr",
+        "token\x00with-nul",
+        "token\x7fwith-del",
+        "tökén-with-non-latin1-中",
+    ],
+)
+def test_unusable_tokens(token):
+    assert not is_usable_access_token(token)
+
+
+def _authenticator(command):
+    with patch("flyte.remote._client.auth._authenticators.base.KeyringStore.retrieve", return_value=None):
+        return AsyncCommandAuthenticator(command=command, endpoint="dns:///fake.union.ai")
+
+
+async def _run_command_auth(stdout: bytes, returncode: int = 0):
+    auth = _authenticator(["fake-token-helper"])
+    process = AsyncMock()
+    process.communicate = AsyncMock(return_value=(stdout, b""))
+    process.returncode = returncode
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)):
+        return await auth._do_refresh_credentials()
+
+
+@pytest.mark.asyncio
+async def test_command_returning_prompt_raises_authentication_error():
+    """An interactive prompt on stdout must not become a bearer token."""
+    with pytest.raises(AuthenticationError) as exc_info:
+        await _run_command_auth(OAUTH_PROMPT.encode())
+
+    message = str(exc_info.value)
+    assert "did not return a usable access token" in message
+    # The output may contain a real secret, so it must not be echoed back.
+    assert "accounts.google.com" not in message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stdout", [b"", b"   \n", b"usage: helper [-h]\n  --flag\n"])
+async def test_command_returning_junk_raises_authentication_error(stdout):
+    with pytest.raises(AuthenticationError):
+        await _run_command_auth(stdout)
+
+
+@pytest.mark.asyncio
+async def test_command_returning_token_succeeds():
+    creds = await _run_command_auth(b"  a-real-token\n")
+    assert creds.access_token == "a-real-token"
+
+
+@pytest.mark.asyncio
+async def test_nonzero_exit_keeps_its_specific_message():
+    """The command-failed error must not be re-wrapped by the generic handler."""
+    with pytest.raises(AuthenticationError) as exc_info:
+        await _run_command_auth(b"", returncode=1)
+
+    assert "Failed to refresh token" in str(exc_info.value)
+
+
+class _StubAuthenticator(Authenticator):
+    async def _do_refresh_credentials(self) -> Credentials:  # pragma: no cover - not exercised
+        raise NotImplementedError
+
+
+def _stub_with_token(token: str) -> _StubAuthenticator:
+    creds = Credentials(for_endpoint="dns:///fake.union.ai", access_token=token)
+    with patch("flyte.remote._client.auth._authenticators.base.KeyringStore.retrieve", return_value=creds):
+        return _StubAuthenticator(endpoint="dns:///fake.union.ai")
+
+
+@pytest.mark.asyncio
+async def test_cached_malformed_token_is_ignored():
+    """A poisoned keyring entry must not be injected as a header."""
+    auth = _stub_with_token(OAUTH_PROMPT)
+    assert await auth.get_auth_headers() is None
+
+
+@pytest.mark.asyncio
+async def test_cached_valid_token_is_used():
+    auth = _stub_with_token("a-real-token")
+    headers = await auth.get_auth_headers()
+    assert headers is not None
+    assert headers.headers["authorization"] == "Bearer a-real-token"


### PR DESCRIPTION
## Problem

`AsyncCommandAuthenticator` (auth mode `external_process`) uses the stdout of the configured command **verbatim** as the bearer token. If that command is an interactive helper, it can exit `0` while printing a prompt rather than a token:

```
Please visit this URL to authorize this application: https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=...
```

`.strip()` only removes the *surrounding* whitespace, so the interior newline survives into `Authorization: Bearer <prompt>`. connectrpc's `pyqwest` transport then rejects it:

```
ValueError: Invalid header value 'Bearer Please visit this URL to authorize this application: ...'
```

raised deep in `_send_request_unary`, far from the real cause. It gets wrapped as `RuntimeError: SelectCluster failed for operation=1` → `RuntimeSystemError: Upload failed for ...`, which reads like an upload bug and is reported to Sentry as an SDK crash.

Confirmed the exact mechanism against the installed transport — `pyqwest.Headers` rejects newlines and NUL, and accepts spaces:

| value | result |
|---|---|
| `Bearer a\nb` | `ValueError: Invalid header value` |
| `Bearer a\x00b` | `ValueError: Invalid header value` |
| `Bearer a b` | accepted (silent 401 later) |
| `Bearer abc123` | accepted |

## Fix

1. **Reject at the source.** Validate the command output before it becomes a credential and raise `AuthenticationError` with an actionable message. The output is deliberately **not** echoed back — it may contain a genuine token. `AuthenticationError` is already classified user-facing by `_sentry._is_user_error`, so this stops the Sentry noise as well as fixing the UX.

2. **Un-poison the keyring.** The bad token was written to the keyring *before* it was ever used in a request, so affected users stayed broken on every subsequent run — `_do_refresh_credentials` was never re-entered, so fixing only the command path would leave them wedged until they cleared the keyring by hand. `get_auth_headers` now treats a cached token that cannot be sent as a header as if there were no credentials; the normal unauthenticated path then triggers a refresh, which re-runs the command and surfaces the real error. This is a general guard, not command-specific.

Validation is a deliberate superset of what the transport rejects: a bearer token is a single opaque string (RFC 6750 restricts it to `[A-Za-z0-9-._~+/=]`), so rejecting all whitespace and non-latin-1 also converts what would be a confusing silent 401 into a clear message, with no risk of rejecting a legitimate token.

Two incidental fixes in the same function: the non-zero-exit `AuthenticationError` was being caught and re-wrapped by the generic `except Exception` handler, losing its specific message; and the debug log did `" ".join(cmd_joined)` on an already-joined string, logging the command character by character.

## Testing

21 new tests in `tests/flyte/remote/test_command_authenticator.py` covering token validation, the prompt-as-token case (including that the message does not leak the output), empty/usage-message output, the non-zero-exit path, and both cached-token behaviours.

Verified the bug reproduces on unpatched `main` — the authenticator accepts the prompt as a token and builds the header from it — and that the fix rejects it. Full `tests/flyte/remote/` suite: 487 passed; the 2 failures in `test_trigger_create_offload.py` are pre-existing on clean `main` and unrelated.

fixes FLYTE-SDK-6Y