### PR TITLE
Add control-plane reporting for tracked runs (flyte run --tracked)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,7 +214,6 @@ mypy_path = ["src"]
 
 [tool.uv]
 exclude-newer = "5 days"
-
 # Opt flyteorg packages out of the global recency cutoff so freshly published
 # flyteidl2/flyte_controller_base releases can be picked up immediately.
 [tool.uv.exclude-newer-package]

--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -43,6 +43,8 @@ class CommonInit:
     source_config_path: Optional[Path] = None  # Only used for documentation
     sync_local_sys_paths: bool = True
     local_persistence: bool = False
+    local_tracked: bool = False
+    local_tracked_strict: bool = False
 
 
 @dataclass(init=True, kw_only=True, repr=True, eq=True, frozen=True)
@@ -233,6 +235,8 @@ async def init(
     sync_local_sys_paths: bool = True,
     load_plugin_type_transformers: bool = True,
     local_persistence: bool = False,
+    local_tracked: bool = False,
+    local_tracked_strict: bool = False,
 ) -> None:
     """
     Initialize the Flyte system with the given configuration. This method should be called before any other Flyte
@@ -280,6 +284,11 @@ async def init(
         load_plugin_type_transformers: If enabled (default True), load the type transformer plugins registered under
             the "flyte.plugins.types" entry point group.
         local_persistence: Whether to enable SQLite persistence for local run metadata (default: False).
+        local_tracked: Whether to report tracked run state to the Flyte control plane
+            (default: False). Requires an initialized client and a configured project/domain.
+        local_tracked_strict: Strict tracked-run reporting for debugging (default: False). Any
+            reporting failure fails the run loudly instead of being logged and swallowed. Only takes
+            effect when reporting is enabled.
         disable_keyring: Disable storage of tokens in local keyring.
 
     Returns:
@@ -341,6 +350,8 @@ async def init(
             source_config_path=source_config_path,
             sync_local_sys_paths=sync_local_sys_paths,
             local_persistence=local_persistence,
+            local_tracked=local_tracked,
+            local_tracked_strict=local_tracked_strict,
         )
 
         logger.info(f"Flyte initialized with config: {_init_config}")
@@ -435,6 +446,8 @@ async def init_from_config(
         source_config_path=cfg_path,
         sync_local_sys_paths=sync_local_sys_paths,
         local_persistence=cfg.local.persistence,
+        local_tracked=cfg.local.tracked,
+        local_tracked_strict=cfg.local.tracked_strict,
         # disable_keyring is threaded outside _platform_to_client_kwargs
         # because the helper output is also spread into
         # create_remote_controller from init_in_cluster, and the
@@ -779,6 +792,22 @@ def is_persistence_enabled() -> bool:
     if cfg is None:
         return False
     return cfg.local_persistence
+
+
+def is_local_tracked_enabled() -> bool:
+    """Check if reporting tracked run state to the control plane is enabled."""
+    cfg = _get_init_config()
+    if cfg is None:
+        return False
+    return cfg.local_tracked
+
+
+def is_local_tracked_strict() -> bool:
+    """Check if strict tracked-run reporting (fail the run on any reporting failure) is enabled."""
+    cfg = _get_init_config()
+    if cfg is None:
+        return False
+    return cfg.local_tracked_strict
 
 
 def initialize_in_cluster() -> None:

--- a/src/flyte/_internal/controllers/_local_controller.py
+++ b/src/flyte/_internal/controllers/_local_controller.py
@@ -221,6 +221,8 @@ class LocalController(ControllerProtocol):
             short_name=_task.short_name if _task.short_name != _task.name else None,
             parent_id=parent_id,
             inputs=native_inputs,
+            proto_inputs=inputs.proto_inputs,
+            task=_task,
             output_path=sub_action_output_path,
             has_report=_task.report,
             cache_enabled=cache_enabled,
@@ -374,6 +376,8 @@ class LocalController(ControllerProtocol):
                 task_name=func_name,
                 parent_id=task_action.name,
                 inputs=native_inputs,
+                proto_inputs=converted_inputs.proto_inputs,
+                trace_interface=_interface,
                 output_path=action_output_path,
             )
 
@@ -406,7 +410,8 @@ class LocalController(ControllerProtocol):
             self._recorder.record_failure(action_id=info.action.name, error=str(info.error))
         else:
             converted_outputs = None
-            if info.interface.outputs and info.output:
+            # Presence, not truthiness: falsy results (0, "", [], False) are real outputs.
+            if info.interface.outputs and info.output is not None:
                 _ctx = ctx.new_in_driver_literal_conversion(True) if ctx.is_task_context() else nullcontext()
                 with _ctx:
                     converted_outputs = await convert.convert_from_native_to_outputs(

--- a/src/flyte/_persistence/_recorder.py
+++ b/src/flyte/_persistence/_recorder.py
@@ -4,8 +4,9 @@ from typing import Any
 
 
 class RunRecorder:
-    """Unified proxy that delegates recording events to the TUI tracker and/or
-    the SQLite persistence layer (RunStore).
+    """Unified proxy that delegates recording events to the TUI tracker, the SQLite
+    persistence layer (RunStore) and/or the control-plane reporter
+    (`RemoteRunReporter`).
 
     The controller only talks to this single object — no more interleaved
     `if tracker` / `if persist` conditionals.
@@ -19,20 +20,25 @@ class RunRecorder:
         tracker: Any | None = None,
         persist: bool = False,
         run_name: str | None = None,
+        reporter: Any | None = None,
     ) -> None:
         self._tracker = tracker
         self._persist = persist and run_name is not None
         self._run_name: str = run_name or ""
+        self._reporter = reporter
 
     @property
     def is_active(self) -> bool:
         """True if at least one recording backend is enabled."""
-        return self._tracker is not None or self._persist
+        return self._tracker is not None or self._persist or self._reporter is not None
 
     def get_action(self, action_id: str) -> Any:
-        """Delegate to the tracker, or return None when tracker is absent."""
+        """Delegate to the tracker (or the reporter when no tracker is attached), or
+        return None when neither backend knows the action."""
         if self._tracker is not None:
             return self._tracker.get_action(action_id)
+        if self._reporter is not None:
+            return self._reporter.get_action(action_id)
         return None
 
     # ------------------------------------------------------------------
@@ -74,6 +80,9 @@ class RunRecorder:
         parent_id: str | None = None,
         short_name: str | None = None,
         inputs: dict | None = None,
+        proto_inputs: Any = None,
+        task: Any = None,
+        trace_interface: Any = None,
         output_path: str | None = None,
         has_report: bool = False,
         cache_enabled: bool = False,
@@ -121,6 +130,26 @@ class RunRecorder:
                 log_links=log_links,
             )
 
+        if self._reporter is not None:
+            # The reporter needs the raw proto inputs (when available) so it can
+            # offload the action's inputs.pb, and the task template / trace interface
+            # so the reported spec carries a typed interface (the console gates I/O
+            # rendering on it).
+            self._reporter.record_start(
+                action_id=action_id,
+                task_name=task_name,
+                parent_id=parent_id,
+                proto_inputs=proto_inputs,
+                task=task,
+                trace_interface=trace_interface,
+                output_path=output_path,
+                has_report=bool(has_report),
+                group=group,
+                cache_enabled=cache_enabled,
+                cache_hit=cache_hit,
+                disable_run_cache=disable_run_cache,
+            )
+
     def record_complete(self, *, action_id: str, outputs: Any = None) -> None:
         # Convert outputs to a display representation once, so both backends
         # receive the same pre-formatted data.
@@ -139,6 +168,10 @@ class RunRecorder:
                 action_name=action_id,
                 outputs=repr(display) if display is not None else None,
             )
+
+        if self._reporter is not None:
+            # The reporter needs the raw outputs (proto wrapper), not the display form.
+            self._reporter.record_complete(action_id=action_id, outputs=outputs)
 
     @staticmethod
     def _to_display(outputs: Any) -> Any:
@@ -173,6 +206,9 @@ class RunRecorder:
                 error=error,
             )
 
+        if self._reporter is not None:
+            self._reporter.record_failure(action_id=action_id, error=error)
+
     def record_attempt_start(self, *, action_id: str, attempt_num: int) -> None:
         if self._tracker is not None and hasattr(self._tracker, "record_attempt_start"):
             self._tracker.record_attempt_start(action_id=action_id, attempt_num=attempt_num)
@@ -185,6 +221,9 @@ class RunRecorder:
                 action_name=action_id,
                 attempt_num=attempt_num,
             )
+
+        if self._reporter is not None:
+            self._reporter.record_attempt_start(action_id=action_id, attempt_num=attempt_num)
 
     def record_attempt_complete(self, *, action_id: str, attempt_num: int, outputs: Any = None) -> None:
         display: Any = None
@@ -208,6 +247,9 @@ class RunRecorder:
                 outputs=repr(display) if display is not None else None,
             )
 
+        if self._reporter is not None:
+            self._reporter.record_attempt_complete(action_id=action_id, attempt_num=attempt_num, outputs=outputs)
+
     def record_attempt_failure(self, *, action_id: str, attempt_num: int, error: str) -> None:
         if self._tracker is not None and hasattr(self._tracker, "record_attempt_failure"):
             self._tracker.record_attempt_failure(
@@ -226,8 +268,11 @@ class RunRecorder:
                 error=error,
             )
 
+        if self._reporter is not None:
+            self._reporter.record_attempt_failure(action_id=action_id, attempt_num=attempt_num, error=error)
+
     # ------------------------------------------------------------------
-    # Root "a0" action (called by _run.py — persistence only)
+    # Root "a0" action (called by _run.py — persistence + reporter only)
     # ------------------------------------------------------------------
 
     def record_root_start(self, *, task_name: str) -> None:
@@ -241,6 +286,9 @@ class RunRecorder:
                 parent_id=None,
             )
 
+        if self._reporter is not None:
+            self._reporter.record_root_start(task_name=task_name)
+
     def record_root_complete(self) -> None:
         if self._persist:
             from flyte._persistence._run_store import RunStore
@@ -249,6 +297,9 @@ class RunRecorder:
                 run_name=self._run_name,
                 action_name="a0",
             )
+
+        if self._reporter is not None:
+            self._reporter.record_root_complete()
 
     def record_root_failure(self, *, error: str) -> None:
         if self._persist:
@@ -259,6 +310,9 @@ class RunRecorder:
                 action_name="a0",
                 error=error,
             )
+
+        if self._reporter is not None:
+            self._reporter.record_root_failure(error=error)
 
     # ------------------------------------------------------------------
     # Static helpers

--- a/src/flyte/_persistence/_remote_reporter.py
+++ b/src/flyte/_persistence/_remote_reporter.py
@@ -1,0 +1,1190 @@
+"""Report tracked-run state to the control plane via `TrackedRunService`.
+
+`RemoteRunReporter` is a third `RunRecorder`
+backend (next to the TUI tracker and the SQLite `RunStore`).
+
+Why the facade is synchronous when the SDK is async-first: the `RunRecorder`
+observer contract is synchronous by design and fires from async controller code
+*and* from the worker threads that run synchronous tasks — there is no single
+event loop the reporter could await on, and a recorder call must never block or
+fail the run it is observing. So every `record_*` call only captures a
+lightweight, fully-computed event and enqueues it on a thread-safe queue. All
+actual I/O is async: a dedicated background worker thread hosts its own event
+loop (the same shape as `flyte.syncify`'s `_BackgroundLoop` and the remote
+controller's worker model) and runs the async pipeline there — batching queued
+events into `TrackedRunService.ReportActions` calls on the async client and
+performing the outputs/report signed-URL uploads for terminal events. The
+dedicated loop also keeps the terminal flush working during interpreter
+shutdown and `KeyboardInterrupt`, when the caller's loop may already be gone.
+Async callers can use `aclose`; `close` is the sync barrier used at
+process-exit points.
+
+Reporting is strictly best-effort: enqueue methods never raise, the worker retries a
+bounded number of times and then drops the batch with a warning, and the terminal
+flush (`close`) waits a bounded amount of time so
+`flyte run --local` never hangs on a slow control plane.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import queue
+import threading
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from flyte._logging import logger
+
+if TYPE_CHECKING:
+    from flyteidl2.common import identifier_pb2
+    from flyteidl2.workflow import tracked_run_service_pb2
+
+    from flyte._task import TaskTemplate
+    from flyte.remote._client.controlplane import ClientSet
+
+ROOT_ACTION_NAME = "a0"
+_MAX_RUN_NAME_LENGTH = 30
+# Run names starting with these prefixes are reserved by the platform.
+_RESERVED_RUN_NAME_PREFIXES = ("u", "r")
+
+# `flyteidl2.common.ActionIdentifier.name` is capped at 30 characters. Local action ids
+# have no such bound — they are built by concatenating the parent id, the task name and a
+# sequence number — so nesting past the first level produces ids the API rejects.
+_MAX_ACTION_NAME_LENGTH = 30
+_ACTION_NAME_DIGEST_LENGTH = 8
+
+
+def _bounded_action_name(action_id: str) -> str:
+    """Shorten a local action id to something the control plane will accept.
+
+    Truncating alone would collide (sibling actions share long common prefixes, since the
+    parent id is a prefix of every child's), so the tail is a digest of the full id. The
+    result is a pure function of the input: two call sites that never coordinated — a
+    child reporting itself and its parent being referenced — still agree.
+    """
+    if len(action_id) <= _MAX_ACTION_NAME_LENGTH:
+        return action_id
+    digest = hashlib.sha256(action_id.encode("utf-8")).hexdigest()[:_ACTION_NAME_DIGEST_LENGTH]
+    keep = _MAX_ACTION_NAME_LENGTH - _ACTION_NAME_DIGEST_LENGTH - 1
+    return f"{action_id[:keep]}-{digest}"
+
+
+# flyteidl2.common.ActionPhase values (kept as plain ints so this module stays cheap to import).
+_PHASE_RUNNING = 4
+_PHASE_SUCCEEDED = 5
+_PHASE_FAILED = 6
+_PHASE_ABORTED = 7
+_TERMINAL_PHASES = (_PHASE_SUCCEEDED, _PHASE_FAILED, _PHASE_ABORTED)
+
+# flyteidl2.core.CatalogCacheStatus values (plain ints, same reasoning as the phases).
+_CACHE_DISABLED = 0
+_CACHE_MISS = 1
+_CACHE_HIT = 2
+_CACHE_POPULATED = 3
+
+_SEND_MAX_RETRIES = 3
+_SEND_BACKOFF_SEC = 0.5
+_DEFAULT_FLUSH_TIMEOUT_SEC = 30.0
+
+# Version used for task identifiers of locally executed tasks (mirrors the local
+# TaskContext version).
+_LOCAL_TASK_VERSION = "na"
+
+
+def generate_tracked_run_name() -> str:
+    """Generate a run name that satisfies the tracked-run naming contract.
+
+    The control plane requires run names of at most 30 characters that do not start
+    with a reserved prefix ('u' or 'r'). The `local-` prefix is deliberate and
+    load-bearing (the leading 'l' is what the platform keys off) — it is intentionally
+    not renamed along with the TrackedRunService rename.
+    """
+    return f"local-{uuid.uuid4().hex[:8]}"
+
+
+def validate_tracked_run_name(name: str) -> None:
+    """Validate a user-supplied run name against the tracked-run naming contract.
+
+    Raises:
+        ValueError: when the name is too long or starts with a reserved prefix.
+    """
+    if len(name) > _MAX_RUN_NAME_LENGTH:
+        raise ValueError(
+            f"Run name {name!r} is too long for tracked-run reporting "
+            f"({len(name)} > {_MAX_RUN_NAME_LENGTH} characters)."
+        )
+    if name.startswith(_RESERVED_RUN_NAME_PREFIXES):
+        raise ValueError(
+            f"Run name {name!r} is invalid for tracked-run reporting: names starting with "
+            f"{' or '.join(repr(p) for p in _RESERVED_RUN_NAME_PREFIXES)} are reserved by the platform."
+        )
+
+
+class TrackedRunReportingError(RuntimeError):
+    """A tracked-run reporting operation failed while strict reporting is enabled.
+
+    Under the default (best-effort) policy reporting failures are logged and
+    swallowed; strict mode surfaces the first failure loudly so reporting problems
+    can be debugged instead of silently degrading.
+    """
+
+
+class _Stop:
+    """Sentinel enqueued by `close` to stop the worker after a final drain."""
+
+
+_STOP = _Stop()
+
+# The reporter of the currently running tracked run, consulted by
+# `flyte.report.flush()` for live report write-through. A single slot: tracked runs
+# execute one at a time within a process; a second concurrent tracked run would
+# simply not get live report mirroring (its terminal upload still lands).
+_active_reporter: "RemoteRunReporter | None" = None
+
+
+def get_active_reporter() -> "RemoteRunReporter | None":
+    """The reporter of the currently running tracked run, if any."""
+    return _active_reporter
+
+
+@dataclass
+class _Event:
+    """A lightweight, fully-computed record of one recorder callback."""
+
+    action_name: str
+    phase: int
+    attempt: int
+    version: int
+    timestamp: datetime
+    error: str | None = None
+    # Serialized `flyteidl2.task.Outputs` bytes; serialized at enqueue time so the
+    # worker never touches protos shared with the caller thread.
+    outputs_bytes: bytes | None = None
+    # Serialized `flyteidl2.task.Inputs` bytes, carried on the action's first report.
+    inputs_bytes: bytes | None = None
+    # Serialized spec bytes for the action's first report: a `flyteidl2.task.TaskSpec`
+    # (spec_kind "task") or a `flyteidl2.task.TraceSpec` (spec_kind "trace"). Must
+    # carry a typed interface — the console gates I/O rendering on it.
+    spec_bytes: bytes | None = None
+    spec_kind: str = "task"
+    # First-report-only metadata.
+    first_report: bool = False
+    parent_name: str = ""
+    group: str = ""
+    task_name: str = ""
+    # Terminal-artifact metadata.
+    output_path: str | None = None
+    has_report: bool = False
+    start_time: datetime | None = None
+    # core.CatalogCacheStatus for this event (0 = CACHE_DISABLED, the proto default).
+    cache_status: int = _CACHE_DISABLED
+
+
+@dataclass
+class _ReportFlush:
+    """A live `flyte.report.flush()` mirror: upload the current report HTML for a
+    running attempt. Strictly report-scoped — raw file/directory data never uploads."""
+
+    action_name: str
+    attempt: int
+    html: bytes
+
+
+@dataclass
+class _ActionInfo:
+    """Per-action reporting state, mutated only under the reporter lock."""
+
+    task_name: str
+    parent_name: str
+    group: str
+    start_time: datetime
+    output_path: str | None = None
+    has_report: bool = False
+    attempt: int = 1
+    last_phase: int | None = None
+    started: bool = False
+    # core.CatalogCacheStatus for this action (CACHE_HIT / CACHE_MISS / CACHE_DISABLED).
+    cache_status: int = _CACHE_DISABLED
+    # Monotonic event-version counter per attempt.
+    versions: dict[int, int] = field(default_factory=dict)
+
+
+class RemoteRunReporter:
+    """Fire-and-forget sink that mirrors the `RunRecorder` surface onto `ReportActions`."""
+
+    def __init__(
+        self,
+        client: ClientSet,
+        run_id: identifier_pb2.RunIdentifier,
+        *,
+        flush_timeout_sec: float = _DEFAULT_FLUSH_TIMEOUT_SEC,
+        verify_ssl: bool = True,
+        root_dir: Any = None,
+        strict: bool = False,
+        data_cluster: str = "",
+    ) -> None:
+        self._client = client
+        self._run_id = run_id
+        self._flush_timeout = flush_timeout_sec
+        self._verify_ssl = verify_ssl
+        # The cluster the run's artifact uploads route to (from SelectCluster's
+        # OPERATION_TRACKED_RUN_DATA), stamped on every reported attempt event so later
+        # reads of outputs/reports route to the same cluster. "" means the control
+        # plane serves the data. All of a run's artifacts share one org/project/domain
+        # so they route identically; the bootstrap inputs upload seeds this and the
+        # first successful worker-side upload sets it otherwise. Only read/written on
+        # the worker thread (or before it can observe events), so no lock is needed.
+        self._data_cluster = data_cluster
+        # Needed by translate_task_to_wire's default task resolver (no code bundle locally).
+        self._root_dir = root_dir
+        # Strict mode: the first reporting failure is captured and re-raised on
+        # subsequent recorder calls and at the terminal flush barrier, so debugging
+        # sessions fail loudly instead of silently degrading.
+        self._strict = strict
+        self._failure: TrackedRunReportingError | None = None
+        self._queue: queue.SimpleQueue = queue.SimpleQueue()
+        self._lock = threading.Lock()
+        self._actions: dict[str, _ActionInfo] = {}
+        self._closed = threading.Event()
+        self._done = threading.Event()
+        # Artifacts (outputs/report) already uploaded, keyed by (action, attempt, kind).
+        self._uploaded: set[tuple[str, int, str]] = set()
+        # Local-name aliases. The local runner executes the run's driver task as a
+        # regular sub-action with a random deterministic id, but platform semantics
+        # have no separate root: the root action a0 IS the driver execution. The
+        # driver's local id is mapped onto a0 here, and every enqueue path resolves
+        # action ids and parent references through this map.
+        self._alias: dict[str, str] = {}
+        self._driver_mapped = False
+        # Serialized TaskSpec cache keyed by task name, so a fanout over the same task
+        # translates it once.
+        self._spec_cache: dict[str, bytes] = {}
+        self._worker = threading.Thread(
+            target=self._worker_main,
+            daemon=True,
+            name=f"flyte-tracked-run-reporter-{run_id.name}",
+        )
+        self._worker.start()
+        global _active_reporter  # noqa: PLW0603
+        _active_reporter = self
+
+    # ------------------------------------------------------------------
+    # RunRecorder-facing surface (synchronous, never raises, never blocks)
+    # ------------------------------------------------------------------
+
+    def _resolve_name(self, action_id: str) -> str:
+        """Map a local action id onto the name reported to the control plane.
+
+        Two rewrites happen here. The driver alias (see `_alias`) is one; the other is
+        the length bound. `ActionIdentifier.name` is capped at 30 characters by the API,
+        while local ids are built by concatenating the parent id, the task name and a
+        sequence number — so anything nested past the first level exceeds it and the whole
+        report batch is rejected.
+
+        Shortened here rather than by changing how local runs name their actions: the id is
+        an identifier (the console displays `task_name`), and local naming feeds caching
+        and output paths that have nothing to do with this transport. The derivation is
+        deterministic, so a parent reference and the action's own report agree even when
+        they are produced on different threads and neither consulted the alias map.
+        """
+        alias = self._alias.get(action_id)
+        if alias is not None:
+            return alias
+        return _bounded_action_name(action_id)
+
+    def get_action(self, action_id: str) -> Any:
+        """Return a truthy marker when the action was already reported (used by the
+        recorder for parent-chain detection when no TUI tracker is attached)."""
+        with self._lock:
+            return self._actions.get(self._resolve_name(action_id))
+
+    def _note_failure(self, operation: str, action: str, err: Any) -> None:
+        """Capture the first reporting failure (acted upon only in strict mode)."""
+        with self._lock:
+            if self._failure is None:
+                self._failure = TrackedRunReportingError(
+                    f"Tracked-run reporting failed during {operation} for action {action!r}: {err}"
+                )
+
+    def _raise_if_failed(self) -> None:
+        """Strict mode: re-raise the first captured reporting failure."""
+        if not self._strict:
+            return
+        with self._lock:
+            failure = self._failure
+        if failure is not None:
+            raise failure
+
+    def record_start(
+        self,
+        *,
+        action_id: str,
+        task_name: str,
+        parent_id: str | None = None,
+        proto_inputs: Any = None,
+        task: Any = None,
+        trace_interface: Any = None,
+        output_path: str | None = None,
+        has_report: bool = False,
+        group: str | None = None,
+        cache_enabled: bool = False,
+        cache_hit: bool = False,
+        disable_run_cache: bool = False,
+        **_: Any,
+    ) -> None:
+        self._raise_if_failed()
+        try:
+            now = datetime.now(timezone.utc)
+            # Serialize at enqueue time so the worker never touches protos shared with
+            # the caller thread. Actions without proto inputs (conditions) skip offload.
+            inputs_bytes = proto_inputs.SerializeToString() if proto_inputs is not None else None
+            # Full spec (with typed interface) for the first report; cached per task
+            # name so a fanout translates each task once. Computed outside the lock.
+            spec_bytes: bytes | None = None
+            spec_kind = "task"
+            if task is not None:
+                spec_bytes = self._task_spec_bytes(task)
+            elif trace_interface is not None:
+                spec_bytes = self._trace_spec_bytes(task_name, trace_interface)
+                spec_kind = "trace"
+            with self._lock:
+                action_name = self._resolve_name(action_id)
+                resolved_parent = self._resolve_name(parent_id) if parent_id else parent_id
+                info = self._actions.get(action_name)
+                if info is None and task is not None and not resolved_parent and not self._driver_mapped:
+                    # The first top-level task action IS the run's driver: platform
+                    # semantics have no separate root, so map it onto a0 (created by
+                    # CreateRun with the full task spec) instead of reporting a
+                    # duplicate action. Established here — before the driver executes —
+                    # so every child's parent reference resolves through the alias.
+                    root_info = self._actions.get(ROOT_ACTION_NAME)
+                    if root_info is None or root_info.task_name == task_name:
+                        self._alias[action_id] = ROOT_ACTION_NAME
+                        self._driver_mapped = True
+                        action_name = ROOT_ACTION_NAME
+                        info = root_info
+                if cache_enabled and not disable_run_cache:
+                    cache_status = _CACHE_HIT if cache_hit else _CACHE_MISS
+                else:
+                    cache_status = _CACHE_DISABLED
+                first = info is None
+                if info is None:
+                    # The root has no parent; every other action defaults to nesting under it.
+                    parent = "" if action_name == ROOT_ACTION_NAME else (resolved_parent or ROOT_ACTION_NAME)
+                    info = _ActionInfo(
+                        task_name=task_name,
+                        parent_name=parent,
+                        group=group or "",
+                        start_time=now,
+                        output_path=output_path,
+                        has_report=has_report,
+                        started=True,
+                        cache_status=cache_status,
+                    )
+                    self._actions[action_name] = info
+                else:
+                    # Mapped driver start: fold its terminal-artifact and cache metadata
+                    # into the pre-registered root info so they report under a0.
+                    if output_path:
+                        info.output_path = output_path
+                    if has_report:
+                        info.has_report = True
+                    if cache_status != _CACHE_DISABLED:
+                        info.cache_status = cache_status
+                ev = self._make_event(
+                    action_name,
+                    info,
+                    _PHASE_RUNNING,
+                    now,
+                    inputs_bytes=inputs_bytes if first else None,
+                    spec_bytes=spec_bytes if first else None,
+                    spec_kind=spec_kind,
+                    first_report=first,
+                )
+            self._put(ev)
+        except Exception as e:
+            logger.debug(f"Tracked-run reporter failed to record start for {action_id}: {e}")
+
+    def record_complete(self, *, action_id: str, outputs: Any = None) -> None:
+        self._raise_if_failed()
+        self._record_terminal(action_id, _PHASE_SUCCEEDED, outputs=outputs)
+
+    def record_failure(self, *, action_id: str, error: str) -> None:
+        # No strict fast-raise here: the action is already failing, and a reporting
+        # error must never mask the task's own error.
+        self._record_terminal(action_id, _PHASE_FAILED, error=error)
+
+    def record_attempt_start(self, *, action_id: str, attempt_num: int) -> None:
+        self._raise_if_failed()
+        try:
+            now = datetime.now(timezone.utc)
+            with self._lock:
+                action_name = self._resolve_name(action_id)
+                info = self._actions.get(action_name)
+                if info is None:
+                    return
+                info.attempt = max(attempt_num, 1)
+                if attempt_num <= 1:
+                    # record_start already reported RUNNING for attempt 1.
+                    return
+                ev = self._make_event(action_name, info, _PHASE_RUNNING, now)
+            self._put(ev)
+        except Exception as e:
+            logger.debug(f"Tracked-run reporter failed to record attempt start for {action_id}: {e}")
+
+    def record_attempt_complete(self, *, action_id: str, attempt_num: int, outputs: Any = None) -> None:
+        self._raise_if_failed()
+        self._record_terminal(action_id, _PHASE_SUCCEEDED, outputs=outputs, attempt_num=attempt_num)
+
+    def record_attempt_failure(self, *, action_id: str, attempt_num: int, error: str) -> None:
+        # An attempt failure is not necessarily action-terminal (a retry may follow);
+        # the subsequent record_attempt_start reports the next attempt as RUNNING,
+        # matching platform semantics. A final record_failure for the same attempt is
+        # deduplicated by the last_phase check in _record_terminal.
+        self._record_terminal(action_id, _PHASE_FAILED, error=error, attempt_num=attempt_num, terminal=False)
+
+    # -- Root ("a0") action ------------------------------------------------
+
+    def record_root_start(self, *, task_name: str) -> None:
+        self.record_start(action_id=ROOT_ACTION_NAME, task_name=task_name, parent_id="")
+
+    def record_root_complete(self) -> None:
+        self._raise_if_failed()
+        # Fallback-only synthesis: when the driver action (mapped onto a0) already
+        # delivered the root's terminal event — with its real outputs — the last_phase
+        # dedupe in _record_terminal makes this a no-op. It only materializes a
+        # terminal event when no driver action ever reported.
+        self._record_terminal(ROOT_ACTION_NAME, _PHASE_SUCCEEDED)
+
+    def record_root_failure(self, *, error: str) -> None:
+        # Fallback-only synthesis — see record_root_complete. A driver that already
+        # reported FAILED dedupes this; a pre-dispatch failure still lands on a0.
+        self._record_terminal(ROOT_ACTION_NAME, _PHASE_FAILED, error=error)
+
+    # -- Live report write-through and aborts ------------------------------
+
+    def report_flushed(self, action_id: str, html: bytes) -> None:
+        """Mirror a mid-run `flyte.report.flush()` to the control plane.
+
+        Uploads the current report HTML for the action's running attempt so the report
+        is visible while the run executes (the backend allows re-uploading reports);
+        the upload at attempt completion remains the final authoritative write.
+        Strictly report-scoped — raw file/directory data never uploads.
+        """
+        if self._closed.is_set():
+            return
+        self._raise_if_failed()
+        try:
+            with self._lock:
+                action_name = self._resolve_name(action_id)
+                info = self._actions.get(action_name)
+                if info is None:
+                    # Unknown action (e.g. the run-level context outside any task) —
+                    # nothing to attribute the report to.
+                    return
+                attempt = info.attempt
+            self._put(_ReportFlush(action_name=action_name, attempt=attempt, html=html))
+        except Exception as e:
+            logger.debug(f"Tracked-run reporter failed to enqueue report flush for {action_id}: {e}")
+
+    def abort_all(self, reason: str) -> None:
+        """Synthesize ABORTED events for every tracked non-terminal action (root
+        included). Called when the tracked run is interrupted (Ctrl+C / SIGTERM); the
+        caller follows up with a bounded `close` to flush them."""
+        try:
+            now = datetime.now(timezone.utc)
+            with self._lock:
+                events = [
+                    self._make_event(name, info, _PHASE_ABORTED, now, error=reason)
+                    for name, info in self._actions.items()
+                    if info.last_phase not in _TERMINAL_PHASES
+                ]
+            # Children first so the root's abort is the last transition observed.
+            events.sort(key=lambda e: e.action_name == ROOT_ACTION_NAME)
+            for ev in events:
+                self._put(ev)
+        except Exception as e:
+            logger.warning(f"Failed to record tracked-run abort: {e}")
+
+    # ------------------------------------------------------------------
+    # Flush / shutdown
+    # ------------------------------------------------------------------
+
+    def close(self, timeout: float | None = None) -> None:
+        """Flush all pending events and stop the worker. Bounded wait.
+
+        Never raises under the default policy. In strict mode, a flush timeout or any
+        previously captured reporting failure is re-raised as
+        `TrackedRunReportingError` so the run exits loudly.
+        """
+        global _active_reporter  # noqa: PLW0603
+        if _active_reporter is self:
+            _active_reporter = None
+        timed_out = False
+        try:
+            if not self._closed.is_set():
+                self._closed.set()
+                self._queue.put(_STOP)
+            timed_out = not self._done.wait(timeout if timeout is not None else self._flush_timeout)
+            if timed_out and not self._strict:
+                logger.warning(
+                    "Timed out flushing tracked-run reports to the control plane; "
+                    "the reported run state may be incomplete."
+                )
+        except Exception as e:
+            logger.warning(f"Failed to flush tracked-run reports: {e}")
+        if self._strict and timed_out:
+            raise TrackedRunReportingError(
+                "Timed out flushing tracked-run reports to the control plane; the reported run state may be incomplete."
+            )
+        self._raise_if_failed()
+
+    async def aclose(self, timeout: float | None = None) -> None:
+        """Async wrapper around `close` so callers on an event loop don't block it."""
+        import asyncio
+
+        try:
+            await asyncio.to_thread(self.close, timeout)
+        except TrackedRunReportingError:
+            raise
+        except Exception as e:
+            logger.warning(f"Failed to flush tracked-run reports: {e}")
+
+    # ------------------------------------------------------------------
+    # Internals — enqueue side
+    # ------------------------------------------------------------------
+
+    def _record_terminal(
+        self,
+        action_id: str,
+        phase: int,
+        *,
+        outputs: Any = None,
+        error: str | None = None,
+        attempt_num: int | None = None,
+        terminal: bool = True,
+    ) -> None:
+        try:
+            now = datetime.now(timezone.utc)
+            outputs_bytes: bytes | None = None
+            proto_outputs = getattr(outputs, "proto_outputs", None)
+            if proto_outputs is not None:
+                outputs_bytes = proto_outputs.SerializeToString()
+            with self._lock:
+                action_name = self._resolve_name(action_id)
+                info = self._actions.get(action_name)
+                if info is None:
+                    # Terminal report for an action we never saw start; register it so
+                    # the event still references a known parent chain.
+                    info = _ActionInfo(
+                        task_name=action_name,
+                        parent_name="" if action_name == ROOT_ACTION_NAME else ROOT_ACTION_NAME,
+                        group="",
+                        start_time=now,
+                    )
+                    self._actions[action_name] = info
+                if attempt_num is not None:
+                    info.attempt = max(attempt_num, 1)
+                if terminal and info.last_phase == phase:
+                    # e.g. record_complete right after record_attempt_complete, or a
+                    # synthesized record_root_* after the driver (mapped onto a0)
+                    # already delivered the root's terminal event — already reported.
+                    return
+                ev = self._make_event(
+                    action_name,
+                    info,
+                    phase,
+                    now,
+                    error=error,
+                    outputs_bytes=outputs_bytes,
+                )
+            self._put(ev)
+        except Exception as e:
+            logger.debug(f"Tracked-run reporter failed to record terminal event for {action_id}: {e}")
+
+    def _make_event(
+        self,
+        action_id: str,
+        info: _ActionInfo,
+        phase: int,
+        now: datetime,
+        *,
+        error: str | None = None,
+        outputs_bytes: bytes | None = None,
+        inputs_bytes: bytes | None = None,
+        spec_bytes: bytes | None = None,
+        spec_kind: str = "task",
+        first_report: bool = False,
+    ) -> _Event:
+        """Build the event under the caller's lock, advancing the per-attempt version."""
+        version = info.versions.get(info.attempt, 0)
+        info.versions[info.attempt] = version + 1
+        info.last_phase = phase
+        if phase == _PHASE_SUCCEEDED and info.cache_status == _CACHE_MISS:
+            # A succeeding cache-enabled action stores its outputs in the local cache.
+            info.cache_status = _CACHE_POPULATED
+        return _Event(
+            action_name=action_id,
+            phase=phase,
+            attempt=info.attempt,
+            version=version,
+            timestamp=now,
+            error=error,
+            outputs_bytes=outputs_bytes,
+            inputs_bytes=inputs_bytes,
+            spec_bytes=spec_bytes,
+            spec_kind=spec_kind,
+            first_report=first_report,
+            parent_name=info.parent_name,
+            group=info.group,
+            task_name=info.task_name,
+            output_path=info.output_path,
+            has_report=info.has_report,
+            start_time=info.start_time,
+            cache_status=info.cache_status,
+        )
+
+    def _task_spec_bytes(self, task: Any) -> bytes | None:
+        """Serialized full TaskSpec (typed interface included) for a task action's
+        first report. Cached per task name; never raises."""
+        try:
+            name = getattr(task, "name", "") or ""
+            with self._lock:
+                cached = self._spec_cache.get(name)
+            if cached is not None:
+                return cached
+            spec = _build_task_spec(
+                task,
+                org=self._run_id.org,
+                project=self._run_id.project,
+                domain=self._run_id.domain,
+                root_dir=self._root_dir,
+            )
+            data = spec.SerializeToString()
+            with self._lock:
+                self._spec_cache[name] = data
+            return data
+        except Exception as e:
+            logger.debug(f"Failed to serialize task spec for tracked-run reporting: {e}")
+            return None
+
+    def _trace_spec_bytes(self, name: str, native_interface: Any) -> bytes | None:
+        """Serialized `flyteidl2.task.TraceSpec` for a trace pseudo-action, carrying
+        its typed interface (reported via the `trace` oneof). Never raises."""
+        try:
+            cache_key = f"trace/{name}"
+            with self._lock:
+                cached = self._spec_cache.get(cache_key)
+            if cached is not None:
+                return cached
+            from flyteidl2.task import task_definition_pb2
+
+            from flyte._internal.runtime.types_serde import transform_native_to_typed_interface
+
+            spec = task_definition_pb2.TraceSpec(interface=transform_native_to_typed_interface(native_interface))
+            data = spec.SerializeToString()
+            with self._lock:
+                self._spec_cache[cache_key] = data
+            return data
+        except Exception as e:
+            logger.debug(f"Failed to serialize trace spec for tracked-run reporting: {e}")
+            return None
+
+    def _put(self, ev: _Event | _ReportFlush) -> None:
+        if self._closed.is_set():
+            logger.debug(f"Tracked-run reporter already closed; dropping event for {ev.action_name}")
+            return
+        self._queue.put(ev)
+
+    # ------------------------------------------------------------------
+    # Internals — worker side
+    # ------------------------------------------------------------------
+
+    def _worker_main(self) -> None:
+        import asyncio
+
+        loop = asyncio.new_event_loop()
+        try:
+            stop = False
+            while not stop:
+                item = self._queue.get()
+                batch: list[Any] = []
+                if isinstance(item, _Stop):
+                    stop = True
+                else:
+                    batch.append(item)
+                # Batch whatever else has already been queued.
+                while True:
+                    try:
+                        nxt = self._queue.get_nowait()
+                    except queue.Empty:
+                        break
+                    if isinstance(nxt, _Stop):
+                        stop = True
+                    else:
+                        batch.append(nxt)
+                if batch:
+                    try:
+                        loop.run_until_complete(self._process_batch(batch))
+                    except Exception as e:
+                        logger.warning(f"Failed to report {len(batch)} tracked-run event(s): {e}")
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(f"Tracked-run reporter worker stopped unexpectedly: {e}")
+        finally:
+            loop.close()
+            self._done.set()
+
+    async def _process_batch(self, items: list[Any]) -> None:
+        """Turn a drained batch of events / live report flushes into ReportActions
+        calls + artifact uploads.
+
+        Ordering matters: the control plane only creates an action when its first
+        report is acked, and outputs/report uploads require the target action to
+        already exist. So before uploading terminal artifacts (or a live report)
+        for an item, any accumulated updates (which include that action's earlier
+        reports) are flushed first. Inputs uploads have no existence requirement
+        (the root's are uploaded before CreateRun) and are resolved by
+        deterministic path, so they need neither ordering nor a URI on the event.
+        """
+        from flyteidl2.workflow import tracked_run_service_pb2
+
+        if self._strict:
+            # After the first strict failure, drop further work fast so close() never
+            # waits on doomed batches (the captured failure is what gets surfaced).
+            with self._lock:
+                if self._failure is not None:
+                    return
+
+        # Only the newest live report flush per (action, attempt) in this batch needs
+        # uploading — earlier ones are already stale.
+        newest_flush: set[tuple[str, int]] = set()
+        collapsed: list[Any] = []
+        for item in reversed(items):
+            if isinstance(item, _ReportFlush):
+                key = (item.action_name, item.attempt)
+                if key in newest_flush:
+                    continue
+                newest_flush.add(key)
+            collapsed.append(item)
+        collapsed.reverse()
+
+        pending: list = []
+
+        async def _flush() -> None:
+            nonlocal pending
+            if pending:
+                req = tracked_run_service_pb2.ReportTrackedActionsRequest(run_id=self._run_id, updates=pending)
+                pending = []
+                await self._send_with_retries(req)
+
+        for item in collapsed:
+            if isinstance(item, _ReportFlush):
+                await _flush()
+                await self._upload_live_report(item)
+                continue
+            ev = item
+            try:
+                output_uri = report_uri = ""
+                if ev.phase in _TERMINAL_PHASES and (
+                    ev.outputs_bytes is not None or (ev.has_report and ev.output_path)
+                ):
+                    await _flush()
+                    output_uri, report_uri = await self._upload_terminal_artifacts(ev)
+                pending.append(self._build_update(ev, output_uri=output_uri, report_uri=report_uri))
+                if ev.inputs_bytes is not None:
+                    await self._upload_inputs(ev)
+            except Exception as e:
+                logger.warning(f"Skipping tracked-run report for action {ev.action_name}: {e}")
+        await _flush()
+
+    def _note_cluster(self, cluster: str) -> None:
+        """Record the routing cluster of a successful artifact upload (first one wins)."""
+        if cluster and not self._data_cluster:
+            self._data_cluster = cluster
+
+    async def _upload_live_report(self, item: _ReportFlush) -> None:
+        """Upload a mid-run report snapshot for a running attempt. Best-effort."""
+        from flyte._persistence._remote_upload import upload_tracked_run_artifact
+
+        try:
+            _, cluster = await upload_tracked_run_artifact(
+                self._client.dataproxy_service,
+                kind="report",
+                run_id=self._run_id,
+                action_name=item.action_name,
+                attempt=item.attempt,
+                data=item.html,
+                verify=self._verify_ssl,
+                content_type="text/html",
+            )
+            self._note_cluster(cluster)
+        except Exception as e:
+            logger.warning(f"Failed live report upload for tracked-run action {item.action_name}: {e}")
+            self._note_failure("report upload", item.action_name, e)
+
+    async def _send_with_retries(self, req: tracked_run_service_pb2.ReportTrackedActionsRequest) -> None:
+        import asyncio
+
+        last_err: Exception | None = None
+        for attempt in range(_SEND_MAX_RETRIES):
+            try:
+                resp = await self._client.tracked_run_service.report_actions(req)
+                for i, status in enumerate(resp.statuses):
+                    if status.code != 0:
+                        action = req.updates[i].event.id.name if i < len(req.updates) else "?"
+                        logger.warning(
+                            f"Control plane rejected tracked-run report for action {action!r}: "
+                            f"{status.message} (code={status.code})"
+                        )
+                        self._note_failure("ReportActions", action, f"{status.message} (code={status.code})")
+                return
+            except Exception as e:
+                last_err = e
+                if attempt < _SEND_MAX_RETRIES - 1:
+                    await asyncio.sleep(_SEND_BACKOFF_SEC * (2**attempt))
+        logger.warning(
+            f"Dropping {len(req.updates)} tracked-run report(s) after {_SEND_MAX_RETRIES} attempts: {last_err}"
+        )
+        first_action = req.updates[0].event.id.name if req.updates else "?"
+        self._note_failure(
+            "ReportActions",
+            first_action,
+            f"dropped {len(req.updates)} report(s) after {_SEND_MAX_RETRIES} attempts: {last_err}",
+        )
+
+    def _build_update(
+        self, ev: _Event, *, output_uri: str = "", report_uri: str = ""
+    ) -> tracked_run_service_pb2.TrackedActionUpdate:
+        from flyteidl2.common import identifier_pb2, phase_pb2
+        from flyteidl2.core import catalog_pb2
+        from flyteidl2.task import common_pb2 as task_common_pb2
+        from flyteidl2.workflow import run_definition_pb2, tracked_run_service_pb2
+
+        # The events carry plain-int phase/cache-status values (this module avoids
+        # importing protos at module scope); resolve them to enum names here — the
+        # generated constructors accept the name form, keeping both checkers typed.
+        phase_name = phase_pb2.ActionPhase.Name(ev.phase)
+        cache_status_name = catalog_pb2.CatalogCacheStatus.Name(ev.cache_status)
+
+        event = run_definition_pb2.ActionEvent(
+            id=identifier_pb2.ActionIdentifier(run=self._run_id, name=ev.action_name),
+            attempt=ev.attempt,
+            phase=phase_name,
+            version=ev.version,
+            cache_status=cache_status_name,
+            # Stamp the artifact-routing cluster so reads of outputs/reports route to
+            # the cluster that stores them. Artifacts upload before the event carrying
+            # their URIs is built (uploads flush ahead of the terminal report), so the
+            # cluster is known by the time it matters; "" (control plane) otherwise.
+            cluster=self._data_cluster,
+        )
+        event.reported_time.FromDatetime(ev.timestamp)
+        event.updated_time.FromDatetime(ev.timestamp)
+        if ev.error:
+            event.error_info.message = ev.error
+            event.error_info.kind = run_definition_pb2.ErrorInfo.KIND_USER
+
+        if output_uri or report_uri:
+            event.outputs.CopyFrom(task_common_pb2.OutputReferences(output_uri=output_uri, report_uri=report_uri))
+
+        update = tracked_run_service_pb2.TrackedActionUpdate(event=event)
+        status = run_definition_pb2.ActionStatus(phase=phase_name, attempts=ev.attempt, cache_status=cache_status_name)
+        if ev.start_time is not None:
+            status.start_time.FromDatetime(ev.start_time)
+        if ev.phase in _TERMINAL_PHASES:
+            status.end_time.FromDatetime(ev.timestamp)
+        update.status.CopyFrom(status)
+        if ev.first_report:
+            update.parent_name = ev.parent_name
+            update.group = ev.group
+            if ev.action_name != ROOT_ACTION_NAME:
+                if ev.spec_bytes and ev.spec_kind == "trace":
+                    from flyteidl2.task import task_definition_pb2
+
+                    update.trace.CopyFrom(
+                        run_definition_pb2.TraceAction(
+                            name=ev.task_name,
+                            spec=task_definition_pb2.TraceSpec.FromString(ev.spec_bytes),
+                        )
+                    )
+                elif ev.spec_bytes:
+                    from flyteidl2.task import task_definition_pb2
+
+                    update.task.CopyFrom(
+                        run_definition_pb2.TaskAction(spec=task_definition_pb2.TaskSpec.FromString(ev.spec_bytes))
+                    )
+                else:
+                    # Last resort (e.g. condition pseudo-actions, which have no
+                    # interface): identifier-only spec so the console can still name
+                    # the action.
+                    update.task.CopyFrom(self._minimal_task_action(ev.task_name))
+        return update
+
+    async def _upload_inputs(self, ev: _Event) -> None:
+        """Offload an action's inputs.pb. The control plane resolves inputs by their
+        deterministic path, so no URI is attached to the reported event. Failures
+        never fail reporting."""
+        from flyte._persistence._remote_upload import upload_tracked_run_artifact
+
+        if ev.inputs_bytes is None:
+            return
+        try:
+            _, cluster = await upload_tracked_run_artifact(
+                self._client.dataproxy_service,
+                kind="inputs",
+                run_id=self._run_id,
+                action_name=ev.action_name,
+                attempt=None,
+                data=ev.inputs_bytes,
+                verify=self._verify_ssl,
+            )
+            self._note_cluster(cluster)
+        except Exception as e:
+            logger.warning(f"Failed to upload inputs for tracked-run action {ev.action_name}: {e}")
+            self._note_failure("inputs upload", ev.action_name, e)
+
+    async def _upload_terminal_artifacts(self, ev: _Event) -> tuple[str, str]:
+        """Upload outputs.pb / report.html for a terminal event, returning their native URLs.
+
+        Upload failures never fail reporting — the event is still sent, just without
+        the corresponding artifact reference.
+        """
+        import asyncio
+
+        from flyte._persistence._remote_upload import upload_tracked_run_artifact
+
+        output_uri = ""
+        report_uri = ""
+
+        if ev.outputs_bytes is not None and (ev.action_name, ev.attempt, "outputs") not in self._uploaded:
+            try:
+                output_uri, cluster = await upload_tracked_run_artifact(
+                    self._client.dataproxy_service,
+                    kind="outputs",
+                    run_id=self._run_id,
+                    action_name=ev.action_name,
+                    attempt=ev.attempt,
+                    data=ev.outputs_bytes,
+                    verify=self._verify_ssl,
+                )
+                self._note_cluster(cluster)
+                self._uploaded.add((ev.action_name, ev.attempt, "outputs"))
+            except Exception as e:
+                logger.warning(f"Failed to upload outputs for tracked-run action {ev.action_name}: {e}")
+                self._note_failure("outputs upload", ev.action_name, e)
+
+        if ev.has_report and ev.output_path and (ev.action_name, ev.attempt, "report") not in self._uploaded:
+            try:
+                # to_thread: the local file read must not block the worker loop
+                # mid-upload (report.html can reach tens of MB with embedded assets).
+                report_bytes = await asyncio.to_thread(self._read_report, ev.output_path)
+                if report_bytes:
+                    report_uri, cluster = await upload_tracked_run_artifact(
+                        self._client.dataproxy_service,
+                        kind="report",
+                        run_id=self._run_id,
+                        action_name=ev.action_name,
+                        attempt=ev.attempt,
+                        data=report_bytes,
+                        verify=self._verify_ssl,
+                        content_type="text/html",
+                    )
+                    self._note_cluster(cluster)
+                    self._uploaded.add((ev.action_name, ev.attempt, "report"))
+            except Exception as e:
+                logger.warning(f"Failed to upload report for tracked-run action {ev.action_name}: {e}")
+                self._note_failure("report upload", ev.action_name, e)
+
+        return output_uri, report_uri
+
+    @staticmethod
+    def _read_report(output_path: str) -> bytes | None:
+        import pathlib
+
+        from flyte._internal.runtime.io import _REPORT_FILE_NAME
+        from flyte.storage._storage import strip_file_header
+
+        report_file = pathlib.Path(strip_file_header(output_path)) / _REPORT_FILE_NAME
+        if report_file.is_file():
+            return report_file.read_bytes()
+        return None
+
+    def _minimal_task_action(self, task_name: str):
+        """A minimal TaskAction spec so the console can name the action.
+
+        The full local task template is not serializable without a deploy-time
+        serialization context, so only the identifier (and type) is carried.
+        """
+        from flyteidl2.core import identifier_pb2 as core_identifier_pb2
+        from flyteidl2.core import tasks_pb2
+        from flyteidl2.task import task_definition_pb2
+        from flyteidl2.workflow import run_definition_pb2
+
+        template = tasks_pb2.TaskTemplate(
+            id=core_identifier_pb2.Identifier(
+                resource_type=core_identifier_pb2.ResourceType.TASK,
+                org=self._run_id.org,
+                project=self._run_id.project,
+                domain=self._run_id.domain,
+                name=task_name,
+                version=_LOCAL_TASK_VERSION,
+            ),
+            type="python-task",
+        )
+        return run_definition_pb2.TaskAction(spec=task_definition_pb2.TaskSpec(task_template=template))
+
+
+async def start_tracked_run_reporting(
+    *,
+    client: ClientSet,
+    task: TaskTemplate,
+    run_name: str,
+    org: str | None,
+    project: str,
+    domain: str,
+    run_spec: Any,
+    labels: dict[str, str] | None,
+    run_start_time: datetime,
+    args: tuple,
+    kwargs: dict,
+    root_dir: Any = None,
+    verify_ssl: bool = True,
+    strict: bool = False,
+) -> RemoteRunReporter | None:
+    """Register a tracked run with the control plane and return its reporter sink.
+
+    Uploads the root inputs (when present), calls `TrackedRunService.CreateRun` and,
+    on success, constructs the `RemoteRunReporter` that streams subsequent
+    action state. Returns `None` (with a warning) on any failure — reporting must
+    never fail or block the local run — unless `strict` is set, in which case
+    bootstrap failures raise `TrackedRunReportingError`.
+    """
+    from flyteidl2.common import identifier_pb2
+    from flyteidl2.common import run_pb2 as common_run_pb2
+    from flyteidl2.workflow import tracked_run_service_pb2
+
+    from flyte._internal.runtime import convert
+    from flyte._persistence._remote_upload import upload_tracked_run_artifact
+
+    run_id = identifier_pb2.RunIdentifier(org=org or "", project=project, domain=domain, name=run_name)
+    data_cluster = ""
+
+    try:
+        task_spec = _build_task_spec(task, org=org, project=project, domain=domain, root_dir=root_dir)
+
+        offloaded: common_run_pb2.OffloadedInputData | None = None
+        inputs = await convert.convert_from_native_to_inputs(task.native_interface, *args, **kwargs)
+        if inputs.proto_inputs.literals:
+            inputs_bytes = inputs.proto_inputs.SerializeToString()
+            inputs_hash = convert.generate_inputs_hash_from_proto(inputs.proto_inputs)
+            if not inputs_hash:
+                import hashlib
+
+                inputs_hash = hashlib.md5(inputs_bytes).hexdigest()
+            native_url, data_cluster = await upload_tracked_run_artifact(
+                client.dataproxy_service,
+                kind="inputs",
+                run_id=run_id,
+                action_name=ROOT_ACTION_NAME,
+                attempt=None,
+                data=inputs_bytes,
+                verify=verify_ssl,
+            )
+            offloaded = common_run_pb2.OffloadedInputData(uri=native_url, inputs_hash=inputs_hash)
+
+        req = tracked_run_service_pb2.CreateTrackedRunRequest(
+            run_id=run_id,
+            task_spec=task_spec,
+            offloaded_input_data=offloaded,
+            run_spec=run_spec,
+            labels=labels or {},
+        )
+        req.run_start_time.FromDatetime(run_start_time)
+        await client.tracked_run_service.create_run(req)
+    except Exception as e:
+        if strict:
+            raise TrackedRunReportingError(
+                f"Failed to register tracked run {run_name!r} with the control plane: {e}"
+            ) from e
+        logger.warning(f"Failed to register tracked run {run_name!r} with the control plane; running unreported: {e}")
+        return None
+
+    return RemoteRunReporter(
+        client, run_id, verify_ssl=verify_ssl, root_dir=root_dir, strict=strict, data_cluster=data_cluster
+    )
+
+
+def _build_task_spec(task: TaskTemplate, *, org: str | None, project: str, domain: str, root_dir: Any = None) -> Any:
+    """Build the full TaskSpec for a locally-executed task (root or sub-action).
+
+    Prefers a full `translate_task_to_wire` serialization (no code bundle / image
+    cache — image references resolve to their locally computed URIs). Some local-only
+    task shapes cannot be serialized that way, so this falls back to a minimal spec
+    that still carries the typed interface — the console gates I/O rendering on the
+    spec's interface, so an interface-less spec would blank the action's I/O panels.
+    """
+    from flyte.models import SerializationContext
+
+    s_ctx = SerializationContext(
+        version=_LOCAL_TASK_VERSION,
+        org=org,
+        project=project,
+        domain=domain,
+        root_dir=root_dir,
+    )
+    try:
+        from flyte._internal.runtime.task_serde import translate_task_to_wire
+
+        return translate_task_to_wire(task, s_ctx)
+    except Exception as e:
+        logger.debug(f"Falling back to a minimal task spec for tracked-run reporting: {e}")
+
+    typed_interface = None
+    try:
+        from flyte._internal.runtime.types_serde import transform_native_to_typed_interface
+
+        typed_interface = transform_native_to_typed_interface(task.interface)
+    except Exception:
+        pass
+    return _interface_task_spec(
+        task.name,
+        org=org,
+        project=project,
+        domain=domain,
+        typed_interface=typed_interface,
+        task_type=getattr(task, "task_type", "python-task") or "python-task",
+        short_name=task.short_name[:63],
+    )
+
+
+def _interface_task_spec(
+    name: str,
+    *,
+    org: str | None,
+    project: str,
+    domain: str,
+    typed_interface: Any = None,
+    task_type: str = "python-task",
+    short_name: str | None = None,
+) -> Any:
+    """A minimal TaskSpec: identifier plus (when available) the typed interface."""
+    from flyteidl2.core import identifier_pb2 as core_identifier_pb2
+    from flyteidl2.core import tasks_pb2
+    from flyteidl2.task import task_definition_pb2
+
+    template = tasks_pb2.TaskTemplate(
+        id=core_identifier_pb2.Identifier(
+            resource_type=core_identifier_pb2.ResourceType.TASK,
+            org=org or "",
+            project=project,
+            domain=domain,
+            name=name,
+            version=_LOCAL_TASK_VERSION,
+        ),
+        type=task_type,
+    )
+    if typed_interface is not None:
+        template.interface.CopyFrom(typed_interface)
+    return task_definition_pb2.TaskSpec(task_template=template, short_name=short_name or name[:63])

--- a/src/flyte/_persistence/_remote_upload.py
+++ b/src/flyte/_persistence/_remote_upload.py
@@ -1,0 +1,158 @@
+"""Signed-PUT uploads for tracked-run metadata artifacts (inputs.pb / outputs.pb / report.html).
+
+Tracked-run artifacts are uploaded via `DataProxyService.CreateUploadLocation` routed
+through SelectCluster's `OPERATION_TRACKED_RUN_DATA` (the storage path is derived from a
+deterministic `tracked-runs/<run>/<action>[/<attempt>]` filename root), followed by an
+HTTP PUT to the returned signed URL. Unlike `flyte.remote._data._upload_single_file`
+this uploads in-memory bytes — the local runtime holds inputs/outputs protos in memory
+and reports are small HTML files.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import typing
+from base64 import b64encode
+from datetime import timedelta
+
+if typing.TYPE_CHECKING:
+    from flyteidl2.common import identifier_pb2
+
+    from flyte.remote._client._protocols import DataProxyService
+
+_UPLOAD_EXPIRES_IN = timedelta(seconds=60)
+
+# Artifact kind -> stored filename. The kind doubles as the caller-facing vocabulary
+# (the old dataproxy ArtifactType INPUTS/OUTPUTS enum values are gone).
+_KIND_FILENAMES = {
+    "inputs": "inputs.pb",
+    "outputs": "outputs.pb",
+    "report": "report.html",
+}
+
+
+async def upload_tracked_run_artifact(
+    dataproxy: DataProxyService,
+    *,
+    kind: str,
+    run_id: identifier_pb2.RunIdentifier,
+    action_name: str,
+    attempt: int | None,
+    data: bytes,
+    verify: bool = True,
+    max_retries: int = 3,
+    content_type: str | None = None,
+) -> tuple[str, str]:
+    """Upload one tracked-run metadata artifact, returning `(native_url, cluster)`.
+
+    Args:
+        dataproxy: The cluster-aware dataproxy client to request the signed URL from
+            (routed via SelectCluster's `OPERATION_TRACKED_RUN_DATA`).
+        kind: `"inputs"`, `"outputs"` or `"report"`. Inputs target an action
+            (`attempt` must be None); outputs / reports target an action attempt.
+        run_id: The tracked run the artifact belongs to (org/project/domain/name).
+        action_name: Target action name (e.g. `a0`).
+        attempt: Target attempt for outputs / reports; None for inputs.
+        data: The artifact content (serialized proto bytes or report HTML bytes).
+        verify: Whether to verify TLS certificates on the signed PUT.
+        max_retries: Maximum retry attempts for the signed PUT.
+        content_type: Optional Content-Type stored as object metadata (e.g. `text/html`
+            for reports so browsers render instead of download them). The dataproxy's presigned
+            URLs do not sign the content type, so sending the header is safe.
+
+    Returns:
+        `(native_url, cluster)` — the native storage URL (e.g. `s3://...`) of the
+        uploaded artifact and the routing cluster's name ("" when served by the control
+        plane), for stamping on reported attempt events.
+    """
+    from connectrpc.code import Code
+    from connectrpc.errors import ConnectError
+    from flyteidl2.dataproxy import dataproxy_service_pb2
+
+    from flyte.errors import RuntimeSystemError
+
+    filename = _KIND_FILENAMES.get(kind)
+    if filename is None:
+        raise ValueError(f"Unknown tracked-run artifact kind {kind!r}; expected one of {sorted(_KIND_FILENAMES)}")
+    if (kind == "inputs") != (attempt is None):
+        raise ValueError("attempt must be None for 'inputs' and set for 'outputs' / 'report'")
+
+    filename_root = f"tracked-runs/{run_id.name}/{action_name}"
+    if attempt is not None:
+        filename_root = f"{filename_root}/{attempt}"
+
+    md5_bytes = hashlib.md5(data).digest()
+    req = dataproxy_service_pb2.CreateUploadLocationRequest(
+        org=run_id.org,
+        project=run_id.project,
+        domain=run_id.domain,
+        filename_root=filename_root,
+        filename=filename,
+        content_md5=md5_bytes,
+        content_length=len(data),
+        add_content_md5_metadata=True,
+    )
+    req.expires_in.FromTimedelta(_UPLOAD_EXPIRES_IN)
+    try:
+        resp, cluster = await dataproxy.create_tracked_run_upload_location(req)
+    except ConnectError as e:
+        if e.code == Code.UNAVAILABLE:
+            raise RuntimeSystemError(
+                "SystemUnavailableError",
+                f"CreateUploadLocation({kind}) failed: service unavailable. {e.message}",
+            ) from e
+        raise RuntimeSystemError(e.code.value, f"CreateUploadLocation({kind}) failed: {e.message}") from e
+    except Exception as e:
+        raise RuntimeSystemError(type(e).__name__, f"CreateUploadLocation({kind}) failed: {e}") from e
+
+    from flyte.remote._data import get_extra_headers_for_protocol
+
+    headers = get_extra_headers_for_protocol(resp.native_url)
+    headers.update(resp.headers)
+    headers.update(
+        {
+            "Content-Length": str(len(data)),
+            "Content-MD5": b64encode(md5_bytes).decode("utf-8"),
+        }
+    )
+    if content_type:
+        headers["Content-Type"] = content_type
+    await _put_bytes_with_retry(
+        data,
+        signed_url=resp.signed_url,
+        extra_headers=headers,
+        verify=verify,
+        max_retries=max_retries,
+    )
+    return resp.native_url, cluster
+
+
+async def _put_bytes_with_retry(
+    data: bytes,
+    *,
+    signed_url: str,
+    extra_headers: dict,
+    verify: bool = True,
+    max_retries: int = 3,
+    min_backoff_sec: float = 0.5,
+    max_backoff_sec: float = 10.0,
+    retry_after_cap_sec: float = 60.0,
+) -> None:
+    """PUT in-memory bytes to a signed URL with exponential backoff retry.
+
+    Thin wrapper over `flyte.remote._data._put_signed_url_with_retry` (shared with
+    file uploads: retryable status codes, Retry-After handling, signed-URL redaction).
+    Raises `RuntimeSystemError` when the upload ultimately fails.
+    """
+    from flyte.remote._data import _put_signed_url_with_retry
+
+    await _put_signed_url_with_retry(
+        data,
+        signed_url,
+        extra_headers,
+        verify,
+        max_retries=max_retries,
+        min_backoff_sec=min_backoff_sec,
+        max_backoff_sec=max_backoff_sec,
+        retry_after_cap_sec=retry_after_cap_sec,
+    )

--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -261,6 +261,8 @@ class _Runner:
         preserve_original_types: bool | None = None,
         debug: bool = False,
         recover: bool | str | None = False,
+        tracked: bool = False,
+        tracked_strict: bool = False,
         recover_force_rerun_actions: Sequence[str] | None = None,
         allow_missing_source_outputs: bool = False,
         _tracker: Any = None,
@@ -316,6 +318,12 @@ class _Runner:
         # Carried on RunSpec.relation with RELATION_TYPE_RECOVER; remote-only; gated in
         # _apply_overrides until the flyteidl2 field + backend ship. See _resolve_recover_ref.
         self._recover = recover
+        # Report tracked run state to the control plane (TrackedRunService). Local-only; also
+        # enabled via the `local.tracked` config key / flyte.init(local_tracked=...).
+        self._tracked = tracked
+        # Strict reporting (debugging): any reporting failure fails the run loudly instead of
+        # being swallowed. Also enabled via the `local.tracked_strict` config key.
+        self._tracked_strict = tracked_strict
         # Escape hatch: actions that must re-execute in the recovery run even if they succeeded
         # in the source run (RunSpec.recover.force_rerun_actions). Only valid with recover.
         self._recover_force_rerun_actions = tuple(recover_force_rerun_actions or ())
@@ -1037,6 +1045,52 @@ class _Runner:
             domain=self._domain or "",
         )
 
+    def _resolve_tracked_report_scope(self) -> Tuple[str | None, str, str] | None:
+        """Resolve (org, project, domain) for tracked-run reporting, or None when reporting
+        should be skipped (with a single warning). Raises with a clear message when
+        reporting is requested but project/domain are not configured, or — in strict
+        mode — when no client is initialized."""
+        import flyte.errors
+        from flyte._initialize import is_local_tracked_enabled, is_local_tracked_strict
+
+        if not (self._tracked or is_local_tracked_enabled()):
+            # An explicit strict request without reporting is a caller error; a config-only
+            # `local.tracked_strict` with reporting disabled is simply inert.
+            if self._tracked_strict:
+                raise ValueError(
+                    "Strict tracked-run reporting (tracked_strict) requires reporting to be enabled: "
+                    "pass tracked=True / --tracked or set local.tracked in your config."
+                )
+            return None
+
+        init_config = _get_init_config()
+        if init_config is None or init_config.client is None:
+            if self._tracked_strict or is_local_tracked_strict():
+                raise flyte.errors.InitializationError(
+                    "ClientNotInitializedError",
+                    "user",
+                    "Strict tracked-run reporting requires an initialized client. Call flyte.init() "
+                    "with a valid endpoint/api-key or flyte.init_from_config().",
+                )
+            logger.warning(
+                "Tracked-run reporting was requested but no Flyte client is initialized; "
+                "running without reporting. Call flyte.init() with a valid endpoint/api-key "
+                "or flyte.init_from_config() to enable reporting."
+            )
+            return None
+
+        project = self._project or init_config.project
+        domain = self._domain or init_config.domain
+        if not project or not domain:
+            raise flyte.errors.InitializationError(
+                "ProjectDomainNotConfigured",
+                "user",
+                "Tracked-run reporting requires a project and domain. Set them in the 'task' section "
+                "of your config file, pass them to flyte.init(project=..., domain=...), or use "
+                "flyte run --project/--domain.",
+            )
+        return init_config.org, project, domain
+
     async def _run_local(self, obj: TaskTemplate[P, R, F], *args: P.args, **kwargs: P.kwargs) -> Run:
 
         from flyte._internal.controllers import create_controller
@@ -1045,16 +1099,26 @@ class _Runner:
 
         controller = cast(LocalController, create_controller("local"))
 
-        if self._name is None:
+        report_scope = self._resolve_tracked_report_scope()
+        if report_scope is not None:
+            from flyte._persistence._remote_reporter import generate_tracked_run_name, validate_tracked_run_name
+
+            org, project, domain = report_scope
+            if self._name is not None:
+                validate_tracked_run_name(self._name)
+                run_name = self._name
+            else:
+                run_name = generate_tracked_run_name()
+            action = ActionID(name=run_name, project=project, domain=domain, org=org)
+        elif self._name is None:
             action = ActionID.create_random()
         else:
             action = ActionID(name=self._name)
 
-        metadata_path = self._metadata_path
-        if metadata_path is None:
+        if self._metadata_path is None:
             metadata_path = pathlib.Path("/") / "tmp" / "flyte" / "metadata" / action.name
         else:
-            metadata_path = pathlib.Path(metadata_path) / action.name
+            metadata_path = pathlib.Path(self._metadata_path) / action.name
         output_path = metadata_path / "a0"
         if self._raw_data_path is None:
             path = pathlib.Path("/") / "tmp" / "flyte" / "raw_data" / action.name
@@ -1066,6 +1130,7 @@ class _Runner:
 
         ctx = internal_ctx()
         rd_base = raw_data_path.path
+        run_start_time = self._run_start_time or datetime.now(timezone.utc)
         tctx = TaskContext(
             action=action,
             checkpoint_paths=CheckpointPaths(
@@ -1082,7 +1147,7 @@ class _Runner:
             mode="local",
             custom_context=self._custom_context,
             disable_run_cache=self._disable_run_cache,
-            run_start_time=self._run_start_time or datetime.now(timezone.utc),
+            run_start_time=run_start_time,
         )
 
         if self._tracker is not None:
@@ -1097,12 +1162,60 @@ class _Runner:
         if persist:
             RunRecorder.initialize_persistence()
 
-        recorder = RunRecorder(tracker=self._tracker, persist=persist, run_name=run_name)
+        reporter = None
+        run_url = str(metadata_path)
+        if report_scope is not None:
+            from flyte._initialize import is_local_tracked_strict
+            from flyte._persistence._remote_reporter import start_tracked_run_reporting
+
+            org, project, domain = report_scope
+            init_config = get_init_config()
+            reporter = await start_tracked_run_reporting(
+                client=get_client(),
+                task=obj,
+                run_name=run_name,
+                org=org,
+                project=project,
+                domain=domain,
+                run_spec=self._apply_overrides(None, task=obj),
+                labels=self._labels,
+                run_start_time=run_start_time,
+                args=args,
+                kwargs=kwargs,
+                root_dir=init_config.root_dir,
+                strict=self._tracked_strict or is_local_tracked_strict(),
+            )
+            if reporter is not None:
+                run_url = get_client().console.tracked_run_url(project=project, domain=domain, run_name=run_name)
+                logger.info(f"Reporting tracked run to the control plane: {run_url}")
+
+        recorder = RunRecorder(tracker=self._tracker, persist=persist, run_name=run_name, reporter=reporter)
         controller.set_recorder(recorder)
 
         recorder.record_root_start(task_name=obj.name)
 
         new_args, new_kwargs, _ = await _unwrap_artifacts(args, kwargs)
+
+        # When reporting is active, catch SIGTERM for the duration of the run so an
+        # external termination reports ABORTED like Ctrl+C does. SIGINT is left to the
+        # interpreter's KeyboardInterrupt / asyncio cancellation flow.
+        interrupt_signal: List[str] = []
+        sigterm_installed = False
+        prev_sigterm: Any = None
+        if reporter is not None:
+            import signal
+            import threading
+
+            def _on_sigterm(signum: int, frame: Any) -> None:
+                interrupt_signal.append("SIGTERM")
+                raise KeyboardInterrupt
+
+            if threading.current_thread() is threading.main_thread():
+                try:
+                    prev_sigterm = signal.signal(signal.SIGTERM, _on_sigterm)
+                    sigterm_installed = True
+                except (ValueError, OSError):  # non-main interpreter contexts
+                    sigterm_installed = False
 
         try:
             with ctx.replace_task_context(tctx):
@@ -1113,19 +1226,55 @@ class _Runner:
                     outputs = await awaitable
                 else:
                     outputs = await controller.submit(obj, *new_args, **new_kwargs)
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            # Interrupted (Ctrl+C / SIGTERM / cancellation): report every in-flight
+            # action — the root included — as ABORTED with a short, bounded flush,
+            # then re-raise so conventional signal semantics are preserved.
+            if reporter is not None:
+                signal_name = interrupt_signal[0] if interrupt_signal else "SIGINT"
+                reporter.abort_all(reason=f"aborted by user ({signal_name})")
+                try:
+                    # Blocking is fine here — the process is exiting. A reporting
+                    # failure (even strict) must never replace the interrupt.
+                    reporter.close(timeout=5.0)
+                except Exception as flush_err:
+                    logger.warning(f"Tracked-run abort reporting incomplete: {flush_err}")
+            raise
         except Exception as e:
             recorder.record_root_failure(error=str(e))
+            if reporter is not None:
+                # Bounded flush so the terminal state lands before the process exits.
+                # Even in strict mode, a reporting failure must never mask the task's
+                # own error — log it instead of raising over `e`.
+                try:
+                    await reporter.aclose()
+                except Exception as flush_err:
+                    logger.warning(f"Tracked-run reporting failed during shutdown: {flush_err}")
             if self._notifications:
                 await self._send_local_notifications(
                     phase=ActionPhase.FAILED, task_name=obj.name, run_name=run_name, error=str(e)
                 )
             raise
         else:
-            recorder.record_root_complete()
+            try:
+                recorder.record_root_complete()
+            finally:
+                # Bounded flush barrier; in strict mode this re-raises the first
+                # captured reporting failure so the run exits loudly.
+                if reporter is not None:
+                    await reporter.aclose()
             if self._notifications:
                 await self._send_local_notifications(phase=ActionPhase.SUCCEEDED, task_name=obj.name, run_name=run_name)
+        finally:
+            if sigterm_installed:
+                import signal
 
-        return _wrap_inline_run(outputs, url=str(metadata_path))
+                try:
+                    signal.signal(signal.SIGTERM, prev_sigterm)
+                except (ValueError, OSError):
+                    pass
+
+        return _wrap_inline_run(outputs, url=run_url)
 
     @syncify  # type: ignore[arg-type]
     async def run(
@@ -1172,6 +1321,12 @@ class _Runner:
         # ignoring it in local/hybrid mode.
         if self._recover and self._mode != "remote":
             raise ValueError("recover is only supported in remote mode")
+
+        # report mirrors a locally-orchestrated run onto the control plane as a tracked run —
+        # local-only. Fail fast rather than silently ignoring it in remote/hybrid mode
+        # (remote runs are already reported).
+        if self._tracked and self._mode != "local":
+            raise ValueError("report is only supported in local mode (use --tracked)")
 
         # Set the run mode in the context variable so that offloaded types (files, directories, dataframes)
         # can check the mode for controlling auto-uploading behavior (only enabled in remote mode).
@@ -1399,6 +1554,8 @@ def with_runcontext(
     preserve_original_types: bool = False,
     debug: bool = False,
     recover: bool | str | None = False,
+    tracked: bool = False,
+    tracked_strict: bool = False,
     recover_force_rerun_actions: Sequence[str] | None = None,
     allow_missing_source_outputs: bool = False,
     _tracker: Any = None,
@@ -1498,6 +1655,14 @@ def with_runcontext(
             outputs were cleaned up from storage: proceed using the source inputs URI instead of
             failing. The client cannot verify the inputs still exist — if they were deleted too,
             the new run fails at runtime.
+        tracked: Local-only. If true, report tracked run state (actions, attempts, outputs, reports)
+            to the Flyte control plane via TrackedRunService so the run shows up in the console. Requires
+            an initialized client and a configured project/domain. Can also be enabled globally with the
+            `local.tracked` config key. Reporting is best-effort and never fails the local run.
+        tracked_strict: Local-only, for debugging reporting itself. When true (with `tracked`),
+            the first reporting failure — registration, an artifact upload, a rejected or undeliverable
+            ReportActions update, or a flush timeout — fails the run loudly instead of being logged and
+            swallowed. Can also be enabled globally with the `local.tracked_strict` config key.
         _tracker: This is an internal only parameter used by the CLI to render the TUI.
 
     Returns:
@@ -1549,6 +1714,8 @@ def with_runcontext(
         preserve_original_types=preserve_original_types,
         debug=debug,
         recover=recover,
+        tracked=tracked,
+        tracked_strict=tracked_strict,
         recover_force_rerun_actions=recover_force_rerun_actions,
         allow_missing_source_outputs=allow_missing_source_outputs,
         _tracker=_tracker,

--- a/src/flyte/cli/_create.py
+++ b/src/flyte/cli/_create.py
@@ -456,6 +456,13 @@ def secret(
     help="Enable SQLite persistence for local run metadata, allowing past runs to be browsed via 'flyte start tui'.",
     show_default=True,
 )
+@click.option(
+    "--local-tracked",
+    is_flag=True,
+    default=False,
+    help="Report local run state to the Flyte control plane so local runs show up in the console.",
+    show_default=True,
+)
 def config(
     output: str,
     endpoint: str | None = None,
@@ -468,6 +475,7 @@ def config(
     registry: str | None = None,
     auth_type: str | None = None,
     local_persistence: bool = False,
+    local_tracked: bool = False,
 ):
     """
     Creates a configuration file for Flyte CLI.
@@ -530,6 +538,8 @@ def config(
     local: Dict[str, Any] = {}
     if local_persistence:
         local["persistence"] = True
+    if local_tracked:
+        local["tracked"] = True
 
     if not admin and not task and not local:
         raise click.BadParameter("At least one of --endpoint, --org, or --local-persistence must be provided.")

--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -191,6 +191,31 @@ class RunArguments:
             )
         },
     )
+    tracked: bool = field(
+        default=False,
+        metadata={
+            "click.option": click.Option(
+                ["--tracked"],
+                is_flag=True,
+                default=False,
+                help="Run the task locally (implies --local) while reporting run state to the Flyte "
+                "control plane so the run shows up in the console. Requires a configured endpoint, "
+                "project and domain.",
+            )
+        },
+    )
+    tracked_strict: bool = field(
+        default=False,
+        metadata={
+            "click.option": click.Option(
+                ["--tracked-strict"],
+                is_flag=True,
+                default=False,
+                help="Strict tracked-run reporting for debugging (only valid with --tracked): "
+                "any reporting failure fails the run loudly instead of being logged and swallowed.",
+            )
+        },
+    )
     image: List[str] = field(
         default_factory=list,
         metadata={
@@ -450,6 +475,8 @@ Missing required parameter(s): {", ".join(f"--{p[0]} (type: {p[1]})" for p in mi
                 max_action_concurrency=self.run_args.max_action_concurrency,
                 labels=self.run_args.parsed_labels(),
                 queue=self.run_args.queue,
+                tracked=self.run_args.tracked,
+                tracked_strict=self.run_args.tracked_strict,
                 recover=self.run_args.recover_from,
                 recover_force_rerun_actions=self.run_args.force_rerun_action or None,
             )
@@ -521,6 +548,8 @@ Missing required parameter(s): {", ".join(f"--{p[0]} (type: {p[1]})" for p in mi
                 env_vars=self.run_args.parsed_env_vars(),
                 labels=self.run_args.parsed_labels(),
                 queue=self.run_args.queue,
+                tracked=self.run_args.tracked,
+                tracked_strict=self.run_args.tracked_strict,
                 _tracker=tracker,
             )
             return await execution_context.run.aio(self.obj, **ctx.params)
@@ -536,8 +565,14 @@ Missing required parameter(s): {", ".join(f"--{p[0]} (type: {p[1]})" for p in mi
             tuple(self.run_args.image) or None,
             not self.run_args.no_sync_local_sys_paths,
         )
+        if self.run_args.tracked:
+            # --tracked is --local plus control-plane reporting; normalize so every
+            # downstream local/remote branch sees a plain local run.
+            self.run_args.local = True
         if self.run_args.rerun_from and self.run_args.local:
-            raise click.UsageError("--rerun-from requires remote mode (it cannot be combined with --local)")
+            raise click.UsageError("--rerun-from requires remote mode (it cannot be combined with --local/--tracked)")
+        if self.run_args.tracked_strict and not self.run_args.tracked:
+            raise click.UsageError("--tracked-strict requires --tracked")
         if self.run_args.recover_from and self.run_args.local:
             raise click.UsageError("--recover-from requires remote mode (it cannot be combined with --local)")
         if self.run_args.force_rerun_action and not self.run_args.recover_from:
@@ -756,6 +791,8 @@ Missing required parameter(s): {", ".join(f"--{p[0]} (type: {p[1]})" for p in mi
             images=tuple(self.run_args.image) or None,
             sync_local_sys_paths=not self.run_args.no_sync_local_sys_paths,
         )
+        if self.run_args.tracked or self.run_args.tracked_strict:
+            raise click.UsageError("--tracked/--report-strict are not supported for deployed tasks")
         self._validate_required_params(ctx)
         # Main entry point remains very thin
         asyncio.run(self._execute_and_render(ctx, config))

--- a/src/flyte/config/_config.py
+++ b/src/flyte/config/_config.py
@@ -179,12 +179,19 @@ class LocalConfig(object):
     """Configuration for local execution settings."""
 
     persistence: bool = False
+    # Tracked runs: mirror a locally-orchestrated run onto the control plane via
+    # TrackedRunService. The `local.` section name is kept (these configure local
+    # execution, and renaming it would break existing config files).
+    tracked: bool = False
+    tracked_strict: bool = False
 
     @classmethod
     def auto(cls, config_file: typing.Optional[typing.Union[str, ConfigFile]] = None) -> "LocalConfig":
         config_file = get_config_file(config_file)
         kwargs: typing.Dict[str, typing.Any] = {}
         kwargs = set_if_exists(kwargs, "persistence", _internal.Local.PERSISTENCE.read(config_file))
+        kwargs = set_if_exists(kwargs, "tracked", _internal.Local.TRACKED.read(config_file))
+        kwargs = set_if_exists(kwargs, "tracked_strict", _internal.Local.TRACKED_STRICT.read(config_file))
         return LocalConfig(**kwargs)
 
 

--- a/src/flyte/config/_internal.py
+++ b/src/flyte/config/_internal.py
@@ -67,6 +67,10 @@ class Task(object):
 
 class Local(object):
     PERSISTENCE = ConfigEntry(YamlConfigEntry("local.persistence", bool))
+    # Tracked-run reporting (TrackedRunService). Section name stays `local.` — these are
+    # local-execution settings and the keys are user-facing.
+    TRACKED = ConfigEntry(YamlConfigEntry("local.tracked", bool))
+    TRACKED_STRICT = ConfigEntry(YamlConfigEntry("local.tracked_strict", bool))
 
 
 class Image(object):

--- a/src/flyte/remote/_client/_protocols.py
+++ b/src/flyte/remote/_client/_protocols.py
@@ -11,7 +11,7 @@ from flyteidl2.secret import payload_pb2
 from flyteidl2.settings import settings_service_pb2
 from flyteidl2.task import task_service_pb2
 from flyteidl2.trigger import trigger_service_pb2
-from flyteidl2.workflow import run_logs_service_pb2, run_service_pb2
+from flyteidl2.workflow import run_logs_service_pb2, run_service_pb2, tracked_run_service_pb2
 
 
 class ProjectDomainService(Protocol):
@@ -132,6 +132,37 @@ class RunService(Protocol):
     ) -> AsyncIterator[run_service_pb2.WatchActionsResponse]: ...
 
 
+class TrackedRunService(Protocol):
+    """Runs orchestrated outside the platform (e.g. on a user's machine) whose state is
+    reported to the control plane. The read surface mirrors RunService."""
+
+    async def create_run(
+        self, request: tracked_run_service_pb2.CreateTrackedRunRequest
+    ) -> run_service_pb2.CreateRunResponse: ...
+
+    async def report_actions(
+        self, request: tracked_run_service_pb2.ReportTrackedActionsRequest
+    ) -> tracked_run_service_pb2.ReportTrackedActionsResponse: ...
+
+    async def get_run_details(
+        self, request: run_service_pb2.GetRunDetailsRequest
+    ) -> run_service_pb2.GetRunDetailsResponse: ...
+
+    async def watch_run_details(
+        self, request: run_service_pb2.WatchRunDetailsRequest
+    ) -> AsyncIterator[run_service_pb2.WatchRunDetailsResponse]: ...
+
+    async def get_action_details(
+        self, request: run_service_pb2.GetActionDetailsRequest
+    ) -> run_service_pb2.GetActionDetailsResponse: ...
+
+    async def list_runs(self, request: run_service_pb2.ListRunsRequest) -> run_service_pb2.ListRunsResponse: ...
+
+    async def watch_actions(
+        self, request: run_service_pb2.WatchActionsRequest
+    ) -> AsyncIterator[run_service_pb2.WatchActionsResponse]: ...
+
+
 class DataProxyService(Protocol):
     async def create_upload_location(
         self, request: dataproxy_service_pb2.CreateUploadLocationRequest
@@ -152,6 +183,10 @@ class DataProxyService(Protocol):
     async def create_download_link(
         self, request: dataproxy_service_pb2.CreateDownloadLinkRequest
     ) -> dataproxy_service_pb2.CreateDownloadLinkResponse: ...
+
+    async def create_tracked_run_upload_location(
+        self, request: dataproxy_service_pb2.CreateUploadLocationRequest
+    ) -> tuple[dataproxy_service_pb2.CreateUploadLocationResponse, str]: ...
 
     def tail_logs(
         self, request: dataproxy_service_pb2.TailLogsRequest

--- a/src/flyte/remote/_client/controlplane.py
+++ b/src/flyte/remote/_client/controlplane.py
@@ -23,6 +23,7 @@ from flyteidl2.task.task_service_connect import TaskServiceClient
 from flyteidl2.trigger.trigger_service_connect import TriggerServiceClient
 from flyteidl2.workflow.run_logs_service_connect import RunLogsServiceClient
 from flyteidl2.workflow.run_service_connect import RunServiceClient
+from flyteidl2.workflow.tracked_run_service_connect import TrackedRunServiceClient
 
 from ._protocols import (
     AppService,
@@ -37,6 +38,7 @@ from ._protocols import (
     SecretService,
     SettingsService,
     TaskService,
+    TrackedRunService,
     TriggerService,
 )
 from .auth._session import SessionConfig, create_session_config
@@ -122,6 +124,21 @@ class Console:
             Console URL for the run
         """
         return self._resource_url(project, domain, "runs", run_name)
+
+    def tracked_run_url(self, project: str, domain: str, run_name: str) -> str:
+        """
+        Build console URL for a tracked run (a run orchestrated on the user's machine
+        whose state is reported to the control plane via TrackedRunService).
+
+        Args:
+            project: Project name
+            domain: Domain name
+            run_name: Run identifier
+
+        Returns:
+            Console URL for the tracked run
+        """
+        return self._resource_url(project, domain, "tracked-runs", run_name)
 
     def app_url(self, project: str, domain: str, app_name: str) -> str:
         """
@@ -235,6 +252,16 @@ class _ClusterAwareService:
         deduplicates concurrent callers and only caches successful results, so a
         transient failure won't poison the entry.
         """
+        client, _ = await self._select_and_build_with_cluster(req)
+        return client
+
+    async def _select_and_build_with_cluster(self, req: cluster_payload_pb2.SelectClusterRequest) -> tuple[Any, str]:
+        """SelectCluster + build the per-cluster client, returning `(client, cluster)`.
+
+        `cluster` is the SelectCluster response's cluster name, or `""` when the
+        call is served by the control plane (no endpoint returned, or the endpoint is
+        the session's own — the same-endpoint short-circuit).
+        """
         from flyte._logging import logger
 
         op_name = cluster_payload_pb2.SelectClusterRequest.Operation.Name(req.operation)
@@ -250,13 +277,13 @@ class _ClusterAwareService:
 
         endpoint = resp.cluster_endpoint
         if not endpoint or endpoint == self._session_config.endpoint:
-            return self._default_client
+            return self._default_client, ""
 
         # Forward the auth-related kwargs from the parent SessionConfig so the
-        # per-cluster session preserves the configured ``auth_type`` (Passthrough,
-        # ClientSecret, ExternalCommand, etc.). Without this ``create_session_config``
-        # falls back to the default ``auth_type="Pkce"`` and a Passthrough-only
-        # caller (e.g. a FastAPI app using ``init_passthrough``) trips the PKCE
+        # per-cluster session preserves the configured `auth_type` (Passthrough,
+        # ClientSecret, ExternalCommand, etc.). Without this `create_session_config`
+        # falls back to the default `auth_type="Pkce"` and a Passthrough-only
+        # caller (e.g. a FastAPI app using `init_passthrough`) trips the PKCE
         # browser flow as soon as the first cluster-routed call runs.
         auth_kwargs = dict(self._session_config.auth_kwargs or {})
         try:
@@ -272,7 +299,7 @@ class _ClusterAwareService:
             raise RuntimeError(f"Failed to create session for cluster endpoint '{endpoint}': {e}") from e
 
         logger.debug(f"Created {self._label} client for cluster endpoint: {endpoint}")
-        return self._new_client(**new_cfg.connect_kwargs())
+        return self._new_client(**new_cfg.connect_kwargs()), resp.cluster
 
 
 class ClusterAwareDataProxy(_ClusterAwareService):
@@ -392,6 +419,25 @@ class ClusterAwareDataProxy(_ClusterAwareService):
             client = self._default_client
         return await client.create_download_link(request)
 
+    async def create_tracked_run_upload_location(
+        self, request: dataproxy_service_pb2.CreateUploadLocationRequest
+    ) -> tuple[dataproxy_service_pb2.CreateUploadLocationResponse, str]:
+        """Signed upload URL for a tracked run's metadata artifact (inputs.pb / outputs.pb / report.html).
+
+        Routes via SelectCluster's `OPERATION_TRACKED_RUN_DATA` so backends can direct
+        tracked-run artifacts at a dataplane's storage. Returns `(response, cluster)`
+        where `cluster` is the routing cluster's name — `""` when the upload is
+        served by the control plane — so callers can stamp it on reported attempt
+        events and later reads route to the same cluster.
+        """
+        client, cluster = await self._resolve_with_cluster(
+            int(cluster_payload_pb2.SelectClusterRequest.Operation.OPERATION_TRACKED_RUN_DATA),
+            request.org,
+            request.project,
+            request.domain,
+        )
+        return await client.create_upload_location(request), cluster
+
     def tail_logs(
         self, request: dataproxy_service_pb2.TailLogsRequest
     ) -> AsyncIterator[dataproxy_service_pb2.TailLogsResponse]:
@@ -418,6 +464,16 @@ class ClusterAwareDataProxy(_ClusterAwareService):
         req = cluster_payload_pb2.SelectClusterRequest(operation=operation)
         req.project_id.CopyFrom(identifier_pb2.ProjectIdentifier(name=project, domain=domain, organization=org))
         return await self._select_and_build(req)
+
+    @alru_cache
+    async def _resolve_with_cluster(
+        self, operation: int, org: str, project: str, domain: str
+    ) -> tuple[DataProxyService, str]:
+        """Cached SelectCluster lookup, routed by ProjectIdentifier, that also returns
+        the selected cluster's name ("" when served by the control plane)."""
+        req = cluster_payload_pb2.SelectClusterRequest(operation=operation)
+        req.project_id.CopyFrom(identifier_pb2.ProjectIdentifier(name=project, domain=domain, organization=org))
+        return await self._select_and_build_with_cluster(req)
 
     @alru_cache
     async def _resolve_by_action(
@@ -561,6 +617,7 @@ class ClientSet:
         self._app_service = AppServiceClient(**shared)
         self._artifact_service = ArtifactServiceClient(**shared)
         self._run_service = RunServiceClient(**shared)
+        self._tracked_run_service = TrackedRunServiceClient(**shared)
         self._log_service = RunLogsServiceClient(**shared)
         self._identity_service = IdentityServiceClient(**shared)
         self._trigger_service = TriggerServiceClient(**shared)
@@ -621,6 +678,14 @@ class ClientSet:
     @property
     def run_service(self) -> RunService:
         return cast(RunService, self._run_service)
+
+    @property
+    def tracked_run_service(self) -> TrackedRunService:
+        """Client for runs orchestrated outside the platform (tracked runs).
+
+        Tracked-run RPCs are control-plane only and never route to a dataplane cluster.
+        """
+        return cast(TrackedRunService, self._tracked_run_service)
 
     @property
     def dataproxy_service(self) -> DataProxyService:

--- a/src/flyte/remote/_data.py
+++ b/src/flyte/remote/_data.py
@@ -112,6 +112,124 @@ def _redact_signed_url(url: str) -> str:
     return f"{base}?<redacted>" if sep else base
 
 
+async def _put_signed_url_with_retry(
+    source: typing.Union[Path, bytes],
+    signed_url: str,
+    extra_headers: dict,
+    verify: bool,
+    max_retries: int = 3,
+    min_backoff_sec: float = 0.5,
+    max_backoff_sec: float = 30.0,
+    retry_after_cap_sec: float = 60.0,
+):
+    """
+    PUT a file or in-memory bytes to a signed URL with exponential backoff retry.
+
+    Shared implementation behind `_upload_with_retry` (file uploads) and the
+    tracked-run metadata upload path (bytes). Retries on transient network errors and
+    5xx/429/408 HTTP errors; does not retry on 4xx client errors (except 408/429).
+
+    When the response is 429 or 503 and carries a `Retry-After` header in
+    integer-seconds form, the next backoff honors that value (clamped to
+    `retry_after_cap_sec`). HTTP-date form is not parsed; in that case we
+    fall back to exponential backoff.
+
+    Raises:
+        RuntimeSystemError: If upload fails after all retries
+    """
+    from flyte._logging import logger
+
+    is_bytes = isinstance(source, (bytes, bytearray))
+    # Kept in error/log messages: the full path is the diagnostic identity of a file
+    # upload; in-memory metadata artifacts have no path.
+    desc = "metadata artifact" if is_bytes else str(source)
+    short_desc = "metadata artifact" if is_bytes else typing.cast(Path, source).name
+
+    retry_attempt = 0
+    last_error: str | Exception | None = None
+    next_backoff_override: typing.Optional[float] = None
+
+    def _classify(put_resp: httpx.Response) -> bool:
+        """True on success; False when the attempt should be retried; raises otherwise."""
+        nonlocal last_error, next_backoff_override
+
+        if put_resp.status_code in [200, 201, 204]:
+            if retry_attempt > 0:
+                logger.info(f"Upload succeeded after {retry_attempt} retries for {short_desc}")
+            return True
+
+        last_error = f"status {put_resp.status_code}: {put_resp.text}"
+
+        # Check if retryable status code
+        if put_resp.status_code in [408, 429, 500, 502, 503, 504]:
+            if retry_attempt >= max_retries:
+                raise RuntimeSystemError(
+                    "UploadFailed",
+                    f"Failed to upload {desc} after {max_retries} retries: {last_error}",
+                )
+            # Honor Retry-After for rate-limit / overload signals.
+            if put_resp.status_code in (429, 503):
+                next_backoff_override = _parse_retry_after(put_resp.headers.get("Retry-After"), retry_after_cap_sec)
+        else:
+            # Non-retryable HTTP error
+            raise RuntimeSystemError(
+                "UploadFailed",
+                f"Failed to upload {desc} to {_redact_signed_url(signed_url)}, {last_error}",
+            )
+        return False
+
+    while retry_attempt <= max_retries:
+        next_backoff_override = None
+        try:
+            if isinstance(source, (bytes, bytearray)):
+                async with httpx.AsyncClient(verify=verify, timeout=_UPLOAD_TIMEOUT) as aclient:
+                    put_resp = await aclient.put(signed_url, headers=extra_headers, content=source)
+                    if _classify(put_resp):
+                        return put_resp
+            else:
+                async with aiofiles.open(str(source), "rb") as file:
+                    # Only wrap the body in the counting stream when someone is displaying
+                    # progress; otherwise hand httpx the file object exactly as before.
+                    content: typing.Any = file
+                    if _progress.current_handler() is not None:
+                        src_path = typing.cast(Path, source)
+                        content = _progress.stream_file(
+                            file,
+                            key=_progress.upload_key(src_path),
+                            name=src_path.name,
+                            total=_size_of(src_path),
+                        )
+                    async with httpx.AsyncClient(verify=verify, timeout=_UPLOAD_TIMEOUT) as aclient:
+                        put_resp = await aclient.put(signed_url, headers=extra_headers, content=content)
+                        if _classify(put_resp):
+                            return put_resp
+        except RuntimeSystemError:
+            raise
+        except (httpx.TimeoutException, httpx.NetworkError, OSError) as e:
+            # Some httpx/httpcore errors (e.g. ReadError) carry an empty str(e),
+            # so include the exception type to keep the message actionable.
+            last_error = f"{type(e).__name__}: {e}" if str(e) else type(e).__name__
+            if retry_attempt >= max_retries:
+                raise RuntimeSystemError(
+                    "UploadFailed",
+                    f"Failed to upload {desc} after {max_retries} retries: {last_error}",
+                ) from e
+
+        # Backoff and retry
+        retry_attempt += 1
+        if retry_attempt <= max_retries:
+            if next_backoff_override is not None:
+                backoff_delay = next_backoff_override
+            else:
+                backoff_delay = min(min_backoff_sec * (2 ** (retry_attempt - 1)), max_backoff_sec)
+            logger.warning(
+                f"Upload failed for {short_desc}, backing off for {backoff_delay:.2f}s "
+                f"[retry {retry_attempt}/{max_retries}]: {last_error}"
+            )
+            await asyncio.sleep(backoff_delay)
+    return None
+
+
 async def _upload_with_retry(
     fp: Path,
     signed_url: str,
@@ -125,13 +243,8 @@ async def _upload_with_retry(
     """
     Upload file to signed URL with exponential backoff retry.
 
-    Retries on transient network errors and 5xx/429/408 HTTP errors.
-    Does not retry on 4xx client errors (except 408/429).
-
-    When the response is 429 or 503 and carries a `Retry-After` header in
-    integer-seconds form, the next backoff honors that value (clamped to
-    `retry_after_cap_sec`). HTTP-date form is not parsed; in that case we
-    fall back to exponential backoff.
+    Thin wrapper over `_put_signed_url_with_retry`; see it for the retry /
+    Retry-After semantics.
 
     Args:
         fp: Path to file to upload
@@ -147,80 +260,16 @@ async def _upload_with_retry(
     Raises:
         RuntimeSystemError: If upload fails after all retries
     """
-    from flyte._logging import logger
-
-    retry_attempt = 0
-    last_error: str | Exception | None = None
-    next_backoff_override: typing.Optional[float] = None
-
-    while retry_attempt <= max_retries:
-        next_backoff_override = None
-        try:
-            async with aiofiles.open(str(fp), "rb") as file:
-                # Only wrap the body in the counting stream when someone is displaying
-                # progress; otherwise hand httpx the file object exactly as before.
-                content: typing.Any = file
-                if _progress.current_handler() is not None:
-                    content = _progress.stream_file(
-                        file,
-                        key=_progress.upload_key(fp),
-                        name=fp.name,
-                        total=_size_of(fp),
-                    )
-                async with httpx.AsyncClient(verify=verify, timeout=_UPLOAD_TIMEOUT) as aclient:
-                    put_resp = await aclient.put(signed_url, headers=extra_headers, content=content)
-
-                    # Success
-                    if put_resp.status_code in [200, 201, 204]:
-                        if retry_attempt > 0:
-                            logger.info(f"Upload succeeded after {retry_attempt} retries for {fp.name}")
-                        return put_resp
-
-                    last_error = f"status {put_resp.status_code}: {put_resp.text}"
-
-                    # Check if retryable status code
-                    if put_resp.status_code in [408, 429, 500, 502, 503, 504]:
-                        if retry_attempt >= max_retries:
-                            raise RuntimeSystemError(
-                                "UploadFailed",
-                                f"Failed to upload {fp} after {max_retries} retries: {last_error}",
-                            )
-                        # Honor Retry-After for rate-limit / overload signals.
-                        if put_resp.status_code in (429, 503):
-                            next_backoff_override = _parse_retry_after(
-                                put_resp.headers.get("Retry-After"), retry_after_cap_sec
-                            )
-                    else:
-                        # Non-retryable HTTP error
-                        raise RuntimeSystemError(
-                            "UploadFailed",
-                            f"Failed to upload {fp} to {_redact_signed_url(signed_url)}, {last_error}",
-                        )
-        except RuntimeSystemError:
-            raise
-        except (httpx.TimeoutException, httpx.NetworkError, OSError) as e:
-            # Some httpx/httpcore errors (e.g. ReadError) carry an empty str(e),
-            # so include the exception type to keep the message actionable.
-            last_error = f"{type(e).__name__}: {e}" if str(e) else type(e).__name__
-            if retry_attempt >= max_retries:
-                raise RuntimeSystemError(
-                    "UploadFailed",
-                    f"Failed to upload {fp} after {max_retries} retries: {last_error}",
-                ) from e
-
-        # Backoff and retry
-        retry_attempt += 1
-        if retry_attempt <= max_retries:
-            if next_backoff_override is not None:
-                backoff_delay = next_backoff_override
-            else:
-                backoff_delay = min(min_backoff_sec * (2 ** (retry_attempt - 1)), max_backoff_sec)
-            logger.warning(
-                f"Upload failed for {fp.name}, backing off for {backoff_delay:.2f}s "
-                f"[retry {retry_attempt}/{max_retries}]: {last_error}"
-            )
-            await asyncio.sleep(backoff_delay)
-    return None
+    return await _put_signed_url_with_retry(
+        fp,
+        signed_url,
+        extra_headers,
+        verify,
+        max_retries=max_retries,
+        min_backoff_sec=min_backoff_sec,
+        max_backoff_sec=max_backoff_sec,
+        retry_after_cap_sec=retry_after_cap_sec,
+    )
 
 
 @require_project_and_domain

--- a/src/flyte/report/_report.py
+++ b/src/flyte/report/_report.py
@@ -175,8 +175,19 @@ async def flush():
         "Content-Type": "text/html",  # For s3
         "content_type": "text/html",  # For gcs
     }
-    final_path = await storage.put_stream(report_html.encode("utf-8"), to_path=report_path, attributes=content_types)
+    report_bytes = report_html.encode("utf-8")
+    final_path = await storage.put_stream(report_bytes, to_path=report_path, attributes=content_types)
     logger.debug(f"Report flushed to {final_path}")
+
+    if task_context.mode == "local":
+        # Live write-through for tracked runs: mirror the flushed report — and
+        # only the report, never raw data — to the control plane so it is visible
+        # mid-run. No-op when tracked-run reporting is inactive.
+        from flyte._persistence._remote_reporter import get_active_reporter
+
+        reporter = get_active_reporter()
+        if reporter is not None:
+            reporter.report_flushed(task_context.action.name, report_bytes)
 
 
 @syncify

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -486,3 +486,25 @@ def test_create_config_non_interactive_skips_inference(runner: CliRunner, tmp_pa
     with open(outpath) as f:
         d = yaml.safe_load(f)
     assert "registry" not in d.get("image", {})
+
+
+def test_create_config_with_local_tracked(runner: CliRunner, tmp_path):
+    """Test that --local-tracked writes the local.tracked field to the config YAML."""
+    outpath = str(tmp_path / "config.yaml")
+    result = runner.invoke(
+        main,
+        [
+            "create",
+            "config",
+            "--endpoint",
+            "dns:///test.example.com",
+            "--local-tracked",
+            "-o",
+            outpath,
+            "--force",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    with open(outpath) as f:
+        d = yaml.safe_load(f)
+    assert d["local"]["tracked"] is True

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -1758,6 +1758,44 @@ def test_run_task_with_file_input_and_project(runner):
         Path(tmp_path).unlink(missing_ok=True)
 
 
+def test_run_command_has_tracked_option():
+    """--tracked is a visible option on `flyte run` (tracked run reported to the control plane)."""
+    opt_names = {decl for p in run.params for decl in p.opts}
+    assert "--tracked" in opt_names
+
+
+def test_run_tracked_rejects_rerun_from(runner):
+    """--tracked implies --local, so it cannot be combined with --rerun-from (remote-only)."""
+    cmd = ["--tracked", "--rerun-from", "someprevrun", str(HELLO_WORLD_PY), "say_hello"]
+    try:
+        result = runner.invoke(run, cmd)
+    except ValueError as ve:
+        if "I/O operation on closed file" in str(ve):
+            return
+        raise
+    assert result.exit_code != 0
+    assert "--rerun-from" in result.output
+
+
+def test_run_command_has_tracked_strict_option():
+    """--tracked-strict is a visible option on `flyte run`."""
+    opt_names = {decl for p in run.params for decl in p.opts}
+    assert "--tracked-strict" in opt_names
+
+
+def test_run_tracked_strict_requires_tracked(runner):
+    """--tracked-strict cannot be used without --tracked."""
+    cmd = ["--local", "--tracked-strict", str(HELLO_WORLD_PY), "say_hello"]
+    try:
+        result = runner.invoke(run, cmd)
+    except ValueError as ve:
+        if "I/O operation on closed file" in str(ve):
+            return
+        raise
+    assert result.exit_code != 0
+    assert "--tracked" in result.output
+
+
 def test_run_command_has_force_rerun_action_option():
     option_names = {decl for p in run.params for decl in p.opts}
     assert "--force-rerun-action" in option_names

--- a/tests/flyte/remote/test_tracked_run_client.py
+++ b/tests/flyte/remote/test_tracked_run_client.py
@@ -1,0 +1,144 @@
+"""Tests for the TrackedRunService client wiring and the routed tracked-run upload path."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from flyteidl2.cluster import payload_pb2 as cluster_payload_pb2
+from flyteidl2.dataproxy import dataproxy_service_pb2
+from flyteidl2.workflow.tracked_run_service_connect import TrackedRunServiceClient
+
+from flyte.remote._client._protocols import DataProxyService, TrackedRunService
+from flyte.remote._client.controlplane import ClusterAwareDataProxy, Console
+
+
+def _make_wrapper(select_cluster_response: cluster_payload_pb2.SelectClusterResponse | None = None):
+    cluster_service = MagicMock()
+    cluster_service.select_cluster = AsyncMock(
+        return_value=select_cluster_response or cluster_payload_pb2.SelectClusterResponse()
+    )
+    session_config = MagicMock()
+    session_config.endpoint = "dns:///localhost:8090"
+    session_config.insecure = True
+    session_config.insecure_skip_verify = False
+    session_config.auth_kwargs = {}
+    default_client = MagicMock()
+    default_client.create_upload_location = AsyncMock(
+        return_value=dataproxy_service_pb2.CreateUploadLocationResponse(signed_url="https://signed/")
+    )
+    return (
+        ClusterAwareDataProxy(
+            cluster_service=cluster_service,
+            session_config=session_config,
+            default_client=default_client,
+        ),
+        cluster_service,
+        default_client,
+    )
+
+
+@pytest.mark.asyncio
+async def test_tracked_run_upload_routes_via_tracked_run_data_operation():
+    """The routed upload resolves via SelectCluster's OPERATION_TRACKED_RUN_DATA keyed by
+    the request's org/project/domain; an empty response means the control plane serves
+    the upload — default client used, cluster ""."""
+    wrapper, cluster_service, default_client = _make_wrapper()
+    req = dataproxy_service_pb2.CreateUploadLocationRequest(
+        org="o",
+        project="p",
+        domain="d",
+        filename_root="tracked-runs/local-x/a0",
+        filename="inputs.pb",
+    )
+
+    resp, cluster = await wrapper.create_tracked_run_upload_location(req)
+
+    assert resp.signed_url == "https://signed/"
+    assert cluster == ""
+    sent = cluster_service.select_cluster.await_args[0][0]
+    assert sent.operation == cluster_payload_pb2.SelectClusterRequest.Operation.OPERATION_TRACKED_RUN_DATA
+    assert sent.WhichOneof("resource") == "project_id"
+    assert sent.project_id.name == "p"
+    assert sent.project_id.domain == "d"
+    assert sent.project_id.organization == "o"
+    default_client.create_upload_location.assert_awaited_once_with(req)
+
+
+@pytest.mark.asyncio
+async def test_tracked_run_upload_same_endpoint_short_circuits_to_default_client():
+    """SelectCluster returning the session's own endpoint short-circuits: default
+    client, cluster "" — even when the response names a cluster."""
+    wrapper, _cluster_service, default_client = _make_wrapper(
+        cluster_payload_pb2.SelectClusterResponse(cluster_endpoint="dns:///localhost:8090", cluster="c1")
+    )
+    req = dataproxy_service_pb2.CreateUploadLocationRequest(org="o", project="p", domain="d")
+
+    resp, cluster = await wrapper.create_tracked_run_upload_location(req)
+
+    assert resp.signed_url == "https://signed/"
+    assert cluster == ""
+    default_client.create_upload_location.assert_awaited_once_with(req)
+
+
+@pytest.mark.asyncio
+async def test_tracked_run_upload_routes_to_cluster_and_propagates_cluster_name():
+    """A different endpoint builds a per-cluster session/client (cached) and the
+    SelectCluster response's cluster name is propagated to the caller."""
+    wrapper, cluster_service, default_client = _make_wrapper(
+        cluster_payload_pb2.SelectClusterResponse(cluster_endpoint="dns:///other:8090", cluster="cluster-a")
+    )
+
+    new_client_inst = MagicMock()
+    new_client_inst.create_upload_location = AsyncMock(
+        return_value=dataproxy_service_pb2.CreateUploadLocationResponse(signed_url="https://remote/")
+    )
+    new_session_cfg = MagicMock()
+    new_session_cfg.connect_kwargs.return_value = {}
+
+    with (
+        patch(
+            "flyte.remote._client.controlplane.create_session_config",
+            new=AsyncMock(return_value=new_session_cfg),
+        ),
+        patch(
+            "flyte.remote._client.controlplane.DataProxyServiceClient",
+            return_value=new_client_inst,
+        ),
+    ):
+        req = dataproxy_service_pb2.CreateUploadLocationRequest(org="o", project="p", domain="d")
+        resp, cluster = await wrapper.create_tracked_run_upload_location(req)
+        # Cached for a subsequent call: one SelectCluster, one client build.
+        resp2, cluster2 = await wrapper.create_tracked_run_upload_location(req)
+
+    assert resp.signed_url == resp2.signed_url == "https://remote/"
+    assert cluster == cluster2 == "cluster-a"
+    assert cluster_service.select_cluster.await_count == 1
+    assert new_client_inst.create_upload_location.await_count == 2
+    default_client.create_upload_location.assert_not_awaited()
+
+
+def test_tracked_run_service_client_satisfies_protocol():
+    """The generated connect client provides every method the TrackedRunService protocol uses."""
+    for method in (
+        "create_run",
+        "report_actions",
+        "get_run_details",
+        "watch_run_details",
+        "list_runs",
+        "watch_actions",
+        "get_action_details",
+    ):
+        assert hasattr(TrackedRunService, method)
+        assert callable(getattr(TrackedRunServiceClient, method))
+
+
+def test_dataproxy_protocol_includes_tracked_run_upload():
+    assert hasattr(DataProxyService, "create_tracked_run_upload_location")
+    assert callable(ClusterAwareDataProxy.create_tracked_run_upload_location)
+
+
+def test_console_tracked_run_url():
+    console = Console("dns:///example.com", insecure=False)
+    assert (
+        console.tracked_run_url(project="proj", domain="dev", run_name="local-abc")
+        == "https://example.com/v2/domain/dev/project/proj/tracked-runs/local-abc"
+    )

--- a/tests/persistence/test_remote_reporter.py
+++ b/tests/persistence/test_remote_reporter.py
@@ -1,0 +1,1062 @@
+"""Tests for the tracked-run control-plane reporter (RemoteRunReporter).
+
+Runs tasks through the local controller with a fake ClientSet injected via
+``_init_for_testing`` (mirroring tests/flyte/local_controller/test_tracker_integration.py)
+and asserts on the CreateRun / ReportActions / routed CreateUploadLocation traffic.
+
+The fake backend is stateful and mirrors the real server contract: upload-location
+requests for outputs / reports fail with "missing entity" unless the target action was
+already created by an acked report (or CreateRun for a0), and the signed-PUT payloads
+are captured so tests assert on the actual serialized Inputs/Outputs proto bytes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from flyteidl2.common import identifier_pb2
+from flyteidl2.dataproxy import dataproxy_service_pb2
+from flyteidl2.task import common_pb2 as task_common_pb2
+from flyteidl2.workflow import run_service_pb2, tracked_run_service_pb2
+from google.rpc import status_pb2
+
+import flyte
+import flyte.errors
+from flyte._initialize import _init_for_testing
+from flyte._persistence._remote_reporter import (
+    ROOT_ACTION_NAME,
+    RemoteRunReporter,
+    TrackedRunReportingError,
+    generate_tracked_run_name,
+    validate_tracked_run_name,
+)
+from flyte.io import File
+from flyte.remote._client.controlplane import Console
+
+_PHASE_RUNNING = 4
+_PHASE_SUCCEEDED = 5
+_PHASE_FAILED = 6
+_PHASE_ABORTED = 7
+
+env = flyte.TaskEnvironment(name="remote_reporter_test")
+
+_flaky_attempts = {"count": 0}
+
+
+@env.task
+def add(a: int, b: int) -> int:
+    return a + b
+
+
+@env.task
+def failing_task(x: int) -> int:
+    raise ValueError("intentional failure")
+
+
+@env.task
+def parent_task(n: int) -> int:
+    return sum(add(a=i, b=i) for i in range(n))
+
+
+@env.task(retries=1)
+def flaky(x: int) -> int:
+    _flaky_attempts["count"] += 1
+    if _flaky_attempts["count"] < 2:
+        raise RuntimeError("transient error")
+    return x
+
+
+@env.task(report=True)
+async def report_task(x: int) -> int:
+    import flyte.report
+
+    flyte.report.get_tab("t").log("<p>report-marker</p>")
+    await flyte.report.flush.aio()
+    return x
+
+
+@flyte.trace
+def tracked_double(v: int) -> int:
+    return v * 2
+
+
+@env.task
+def task_with_trace(x: int) -> int:
+    return tracked_double(x)
+
+
+@env.task
+def empty_str_task() -> str:
+    return ""
+
+
+@env.task(report=True)
+async def multi_flush_report_task(x: int) -> int:
+    import asyncio as _asyncio
+
+    import flyte.report
+
+    flyte.report.get_tab("t").log("<p>flush-one</p>")
+    await flyte.report.flush.aio()
+    # Give the reporter worker time to drain the first snapshot as its own batch.
+    await _asyncio.sleep(0.3)
+    flyte.report.get_tab("t").log("<p>flush-two</p>")
+    await flyte.report.flush.aio()
+    return x
+
+
+# A real Ctrl+C under asyncio.run delivers KeyboardInterrupt to the main thread,
+# which cancels the running task — surfacing at _run_local's await as
+# CancelledError. Raising CancelledError from task code reproduces exactly that
+# boundary (raising KeyboardInterrupt inside a worker loop instead tears the loop
+# down before its future resolves, which is not what Ctrl+C does).
+@env.task
+async def interrupt_child(x: int) -> int:
+    raise asyncio.CancelledError
+
+
+@env.task
+async def interrupt_parent(n: int) -> int:
+    return await interrupt_child(x=n)
+
+
+@env.task
+async def file_roundtrip(f: "File") -> "File":
+    return f
+
+
+@env.task
+async def file_producer() -> "File":
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt") as tmp:
+        tmp.write("produced-locally")
+        path = tmp.name
+    return await File.from_local(path)
+
+
+def _make_fake_client():
+    """A stateful fake ClientSet mirroring the server's tracked-run upload contract.
+
+    - ``create_run`` creates the root action a0 (as the real server does).
+    - ``report_actions`` creates every reported action on first ack.
+    - ``create_tracked_run_upload_location`` for outputs / reports fails with "missing
+      entity" unless the target action already exists — so a regression that uploads
+      before the action's first report is acked fails these tests, not just the live
+      path. It returns ``(response, client.data_cluster)`` — set ``data_cluster`` to
+      simulate SelectCluster routing the run's data to a dataplane cluster.
+
+    Uploads are recorded as ``(kind, action, attempt, md5-hex)`` in ``client.uploads``
+    (kind is "inputs" / "outputs" / "report"; inputs record attempt 0); the fixture
+    pairs them with the actual PUT payload bytes in ``client.put_payloads`` keyed by
+    md5-hex.
+    """
+    client = MagicMock()
+    client.reported_actions = set()
+    client.uploads = []
+    client.put_payloads = {}
+    client.put_headers = {}
+    client.data_cluster = ""
+
+    client.tracked_run_service = MagicMock()
+
+    async def _create_run(req, **kwargs):
+        client.reported_actions.add(ROOT_ACTION_NAME)
+        return run_service_pb2.CreateRunResponse()
+
+    client.tracked_run_service.create_run = AsyncMock(side_effect=_create_run)
+
+    async def _report(req, **kwargs):
+        for u in req.updates:
+            client.reported_actions.add(u.event.id.name)
+        return tracked_run_service_pb2.ReportTrackedActionsResponse(
+            statuses=[status_pb2.Status(code=0) for _ in req.updates]
+        )
+
+    client.tracked_run_service.report_actions = AsyncMock(side_effect=_report)
+
+    client.dataproxy_service = MagicMock()
+
+    async def _create_upload_location(req, **kwargs):
+        # filename_root scheme: tracked-runs/<run>/<action>[/<attempt>].
+        parts = req.filename_root.split("/")
+        assert parts[0] == "tracked-runs"
+        action = parts[2]
+        attempt = int(parts[3]) if len(parts) > 3 else 0
+        kind = {"inputs.pb": "inputs", "outputs.pb": "outputs", "report.html": "report"}[req.filename]
+        if kind != "inputs":
+            # Server contract: outputs/reports are uploaded after the action was
+            # reported, so the action must already exist.
+            if action not in client.reported_actions:
+                raise RuntimeError(f"missing entity of type LocalAction with identifier {action}")
+        client.uploads.append((kind, action, attempt, req.content_md5.hex()))
+        return (
+            dataproxy_service_pb2.CreateUploadLocationResponse(
+                signed_url="https://signed.example/put",
+                native_url=f"s3://bucket/meta/{action}/{attempt}/{req.filename}",
+            ),
+            client.data_cluster,
+        )
+
+    client.dataproxy_service.create_tracked_run_upload_location = AsyncMock(side_effect=_create_upload_location)
+    client.console = Console("dns:///example.com", insecure=False)
+    return client
+
+
+def _uploaded_bytes(client, kind: str, action: str, attempt: int | None = None) -> bytes | None:
+    """The actual PUT payload for the recorded upload, or None when never uploaded."""
+    for t, a, att, md5_hex in client.uploads:
+        if t == kind and a == action and (attempt is None or att == attempt):
+            return client.put_payloads.get(md5_hex)
+    return None
+
+
+@pytest.fixture
+def fake_client():
+    import flyte._initialize as init_mod
+
+    prev = init_mod._init_config
+    client = _make_fake_client()
+    asyncio.run(_init_for_testing(project="testproj", domain="dev", org="testorg", client=client))
+
+    async def _capture_put(data, **kwargs):
+        md5_hex = hashlib.md5(data).hexdigest()
+        client.put_payloads[md5_hex] = bytes(data)
+        client.put_headers[md5_hex] = dict(kwargs.get("extra_headers") or {})
+
+    with patch("flyte._persistence._remote_upload._put_bytes_with_retry", new=AsyncMock(side_effect=_capture_put)):
+        yield client
+    init_mod._init_config = prev
+
+
+def _all_updates(client) -> list:
+    updates = []
+    for call in client.tracked_run_service.report_actions.await_args_list:
+        updates.extend(call[0][0].updates)
+    return updates
+
+
+def _events_for(updates, action_name):
+    return [u.event for u in updates if u.event.id.name == action_name]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end reporting through the local controller
+# ---------------------------------------------------------------------------
+
+
+def test_report_creates_run_and_reports_actions(fake_client):
+    """A single-task run: the driver action is mapped onto the root a0 (platform
+    semantics — the root action IS the driver execution, no duplicate)."""
+    run = flyte.with_runcontext(mode="local", tracked=True).run(add, a=2, b=3)
+
+    assert run.outputs()[0] == 5
+
+    # CreateRun called once with a fully-qualified run id and a valid generated name.
+    fake_client.tracked_run_service.create_run.assert_awaited_once()
+    create_req = fake_client.tracked_run_service.create_run.await_args[0][0]
+    assert create_req.run_id.org == "testorg"
+    assert create_req.run_id.project == "testproj"
+    assert create_req.run_id.domain == "dev"
+    run_name = create_req.run_id.name
+    assert len(run_name) <= 30
+    assert not run_name.startswith(("u", "r"))
+    assert create_req.WhichOneof("task") == "task_spec"
+    assert create_req.HasField("run_start_time")
+
+    # Root inputs were offloaded through a routed inputs upload targeting a0, and the
+    # uploaded payload is the actual serialized Inputs proto (a=2, b=3).
+    assert create_req.offloaded_input_data.uri == f"s3://bucket/meta/{ROOT_ACTION_NAME}/0/inputs.pb"
+    assert create_req.offloaded_input_data.inputs_hash != ""
+    root_inputs_bytes = _uploaded_bytes(fake_client, "inputs", ROOT_ACTION_NAME)
+    assert root_inputs_bytes is not None
+    root_inputs = task_common_pb2.Inputs.FromString(root_inputs_bytes)
+    assert {nl.name: nl.value.scalar.primitive.integer for nl in root_inputs.literals} == {"a": 2, "b": 3}
+
+    # Every reported update references the created run.
+    for call in fake_client.tracked_run_service.report_actions.await_args_list:
+        assert call[0][0].run_id == create_req.run_id
+
+    updates = _all_updates(fake_client)
+
+    # The driver is mapped onto a0 — no random-id duplicate action is ever reported.
+    assert {u.event.id.name for u in updates} == {ROOT_ACTION_NAME}
+
+    # a0's event stream merges root-start and driver events: RUNNING (root), RUNNING
+    # (driver start), SUCCEEDED (driver terminal) — attempt 1 with a single shared,
+    # monotonic version counter, and exactly one terminal event (root synthesis is
+    # deduped by the driver's own terminal).
+    root_events = _events_for(updates, ROOT_ACTION_NAME)
+    assert [e.phase for e in root_events] == [_PHASE_RUNNING, _PHASE_RUNNING, _PHASE_SUCCEEDED]
+    assert all(e.attempt == 1 for e in root_events)
+    assert [e.version for e in root_events] == [0, 1, 2]
+    root_first = next(u for u in updates if u.event.id.name == ROOT_ACTION_NAME)
+    assert root_first.parent_name == ""
+
+    # CreateRun's root task spec carries the typed interface (the console gates I/O
+    # rendering on it); mapped a0 updates don't need to re-send it.
+    root_iface = create_req.task_spec.task_template.interface
+    assert {e.key for e in root_iface.inputs.variables} == {"a", "b"}
+    assert {e.key for e in root_iface.outputs.variables} == {"o0"}
+
+    # Exactly one INPUTS upload (the bootstrap offload for a0) — the mapped driver
+    # does not re-upload under a random id.
+    inputs_uploads = [u for u in fake_client.uploads if u[0] == "inputs"]
+    assert [(a, att) for _, a, att, _ in inputs_uploads] == [(ROOT_ACTION_NAME, 0)]
+
+    # The succeeded attempt uploaded outputs.pb under a0 (real Outputs proto: o0 = 5)
+    # and the terminal event references it. The stateful fake rejects uploads for
+    # actions the server hasn't seen, so this also proves report-then-upload ordering.
+    outputs_uploads = [u for u in fake_client.uploads if u[0] == "outputs"]
+    assert [(a, att) for _, a, att, _ in outputs_uploads] == [(ROOT_ACTION_NAME, 1)]
+    root_outputs_bytes = _uploaded_bytes(fake_client, "outputs", ROOT_ACTION_NAME, 1)
+    assert root_outputs_bytes is not None
+    root_outputs = task_common_pb2.Outputs.FromString(root_outputs_bytes)
+    assert {nl.name: nl.value.scalar.primitive.integer for nl in root_outputs.literals} == {"o0": 5}
+    terminal = next(e for e in root_events if e.phase == _PHASE_SUCCEEDED)
+    assert terminal.outputs.output_uri == f"s3://bucket/meta/{ROOT_ACTION_NAME}/1/outputs.pb"
+
+    # The returned run points at the console tracked-runs page.
+    assert run.url == f"https://example.com/v2/domain/dev/project/testproj/tracked-runs/{run_name}"
+
+
+def test_report_nested_tasks_parent_chain(fake_client):
+    """Fanout lineage: the driver maps onto a0, children report parent == a0 —
+    never the driver's local random id (test_task_action_lineage-style guard)."""
+    flyte.with_runcontext(mode="local", tracked=True).run(parent_task, n=2)
+
+    updates = _all_updates(fake_client)
+    first_reports = {u.event.id.name: u for u in updates if u.WhichOneof("spec") == "task"}
+    # Spec-bearing first reports are the two children only (a0's spec came via CreateRun).
+    assert len(first_reports) == 2
+    assert all(u.parent_name == ROOT_ACTION_NAME for u in first_reports.values())
+
+    # The whole tree is a0 + the two children — no random-id driver action anywhere,
+    # and no update ever references a non-a0 parent.
+    assert {u.event.id.name for u in updates} == {ROOT_ACTION_NAME} | set(first_reports)
+    assert {u.parent_name for u in updates if u.parent_name} == {ROOT_ACTION_NAME}
+
+    # a0 (the driver) delivers exactly one terminal event.
+    root_terminals = [e for e in _events_for(updates, ROOT_ACTION_NAME) if e.phase == _PHASE_SUCCEEDED]
+    assert len(root_terminals) == 1
+
+    # Every child first-report spec carries a typed interface, and each child's
+    # inputs.pb was uploaded under its own id.
+    for name, update in first_reports.items():
+        iface = update.task.spec.task_template.interface
+        assert len(iface.inputs.variables) > 0
+        assert len(iface.outputs.variables) > 0
+        assert _uploaded_bytes(fake_client, "inputs", name) is not None
+
+
+def test_report_trace_action_spec_carries_interface(fake_client):
+    """@flyte.trace pseudo-actions report via the trace oneof: a TraceAction carrying
+    the function name and a TraceSpec with the typed interface (the backend persists
+    and serves trace specs)."""
+    run = flyte.with_runcontext(mode="local", tracked=True).run(task_with_trace, x=3)
+    assert run.outputs()[0] == 6
+
+    updates = _all_updates(fake_client)
+    trace_updates = [u for u in updates if u.WhichOneof("spec") == "trace"]
+    assert len(trace_updates) == 1
+    trace = trace_updates[0].trace
+    assert trace.name == "tracked_double"
+    iface = trace.spec.interface
+    assert {e.key for e in iface.inputs.variables} == {"v"}
+    assert len(iface.outputs.variables) > 0
+    # The trace nests under the driver, which is mapped onto a0.
+    assert trace_updates[0].parent_name == ROOT_ACTION_NAME
+
+
+def test_falsy_outputs_are_reported(fake_client):
+    """Falsy results (0 here) are real outputs: uploaded and referenced based on
+    presence, not truthiness — for both the trace and the task (driver) paths."""
+    run = flyte.with_runcontext(mode="local", tracked=True).run(task_with_trace, x=0)
+    assert run.outputs()[0] == 0
+
+    updates = _all_updates(fake_client)
+    (trace_name,) = {u.event.id.name for u in updates if u.WhichOneof("spec") == "trace"}
+
+    # The x=0 trace uploaded outputs.pb carrying o0 == 0 and referenced it.
+    trace_out = _uploaded_bytes(fake_client, "outputs", trace_name, 1)
+    assert trace_out is not None
+    outs = task_common_pb2.Outputs.FromString(trace_out)
+    assert outs.literals[0].name == "o0"
+    assert outs.literals[0].value.scalar.primitive.WhichOneof("value") == "integer"
+    assert outs.literals[0].value.scalar.primitive.integer == 0
+    terminal = next(e for e in _events_for(updates, trace_name) if e.phase == _PHASE_SUCCEEDED)
+    assert terminal.outputs.output_uri.endswith(f"{trace_name}/1/outputs.pb")
+
+    # The driver task (mapped onto a0) returning 0 uploads o0 == 0 as well.
+    root_out = _uploaded_bytes(fake_client, "outputs", ROOT_ACTION_NAME, 1)
+    assert root_out is not None
+    root_outs = task_common_pb2.Outputs.FromString(root_out)
+    assert root_outs.literals[0].value.scalar.primitive.integer == 0
+
+
+def test_empty_string_output_reported(fake_client):
+    """A task returning "" still uploads outputs.pb with the o0 literal present."""
+    run = flyte.with_runcontext(mode="local", tracked=True).run(empty_str_task)
+    assert run.outputs()[0] == ""
+
+    root_out = _uploaded_bytes(fake_client, "outputs", ROOT_ACTION_NAME, 1)
+    assert root_out is not None
+    outs = task_common_pb2.Outputs.FromString(root_out)
+    assert outs.literals[0].name == "o0"
+    assert outs.literals[0].value.scalar.primitive.WhichOneof("value") == "string_value"
+    assert outs.literals[0].value.scalar.primitive.string_value == ""
+
+
+def test_cache_hit_reports_outputs_and_cache_status(fake_client):
+    """Both the cache-miss and the cache-hit run report full trees with uploaded
+    outputs, and events/status carry core.CatalogCacheStatus (MISS -> POPULATED on
+    the storing run, HIT on the cached run)."""
+    import random
+
+    cache_env = flyte.TaskEnvironment(name="reporter_cache_test", cache=flyte.Cache("auto", version_override="v1"))
+
+    @cache_env.task
+    def cached_add(a: int, b: int) -> int:
+        return a + b
+
+    a = random.randint(10**6, 10**8)  # unique inputs so run 1 is always a miss
+    run1 = flyte.with_runcontext(mode="local", tracked=True).run(cached_add, a=a, b=3)
+    run2 = flyte.with_runcontext(mode="local", tracked=True).run(cached_add, a=a, b=3)
+    assert run1.outputs()[0] == run2.outputs()[0] == a + 3
+
+    per_run: dict[str, list] = {}
+    for call in fake_client.tracked_run_service.report_actions.await_args_list:
+        req = call[0][0]
+        per_run.setdefault(req.run_id.name, []).extend(req.updates)
+    assert len(per_run) == 2
+    r1_updates, r2_updates = list(per_run.values())
+
+    # Run 1 (miss): driver RUNNING carries CACHE_MISS; the storing terminal carries
+    # CACHE_POPULATED on both the event and the status rollup.
+    r1 = [u.event for u in r1_updates]
+    assert [e.phase for e in r1] == [_PHASE_RUNNING, _PHASE_RUNNING, _PHASE_SUCCEEDED]
+    assert r1[1].cache_status == 1  # CACHE_MISS
+    assert r1[2].cache_status == 3  # CACHE_POPULATED
+    assert r1_updates[2].status.cache_status == 3
+    assert r1[2].outputs.output_uri.endswith("a0/1/outputs.pb")
+
+    # Run 2 (hit): no attempt executed, but the tree is complete, outputs are
+    # uploaded, and CACHE_HIT is carried on the running + terminal events.
+    r2 = [u.event for u in r2_updates]
+    assert [e.phase for e in r2] == [_PHASE_RUNNING, _PHASE_RUNNING, _PHASE_SUCCEEDED]
+    assert r2[1].cache_status == 2  # CACHE_HIT
+    assert r2[2].cache_status == 2
+    assert r2_updates[2].status.cache_status == 2
+    assert r2[2].outputs.output_uri.endswith("a0/1/outputs.pb")
+
+    # Outputs were uploaded by BOTH runs (the hit run serves cache-sourced outputs).
+    outputs_uploads = [u for u in fake_client.uploads if u[0] == "outputs"]
+    assert [(a_, att) for _, a_, att, _ in outputs_uploads] == [(ROOT_ACTION_NAME, 1), (ROOT_ACTION_NAME, 1)]
+    payload = fake_client.put_payloads[outputs_uploads[1][3]]
+    outs = task_common_pb2.Outputs.FromString(payload)
+    assert outs.literals[0].value.scalar.primitive.integer == a + 3
+
+
+def test_file_output_keeps_local_uri(fake_client):
+    """A task RETURNING a File reports an outputs.pb whose blob literal keeps its
+    local URI — no rewrite, no raw-byte upload."""
+    run = flyte.with_runcontext(mode="local", tracked=True).run(file_producer)
+    out_path = str(run.outputs()[0].path)
+    assert not out_path.startswith(("s3://", "gs://", "abfs://"))
+
+    root_out = _uploaded_bytes(fake_client, "outputs", ROOT_ACTION_NAME, 1)
+    assert root_out is not None
+    outs = task_common_pb2.Outputs.FromString(root_out)
+    uri = outs.literals[0].value.scalar.blob.uri
+    assert not uri.startswith(("s3://", "gs://", "abfs://"))
+    assert out_path in uri or uri in out_path
+
+    # Only metadata artifact kinds ever uploaded; every PUT maps to an upload-location request.
+    kinds = {t for t, *_ in fake_client.uploads}
+    assert kinds <= {
+        "inputs",
+        "outputs",
+        "report",
+    }
+    assert set(fake_client.put_payloads) == {md5 for *_, md5 in fake_client.uploads}
+
+
+def test_report_upload_sets_html_content_type(fake_client):
+    """report.html PUTs carry Content-Type: text/html (object metadata, so the console
+    iframe renders instead of downloading); inputs/outputs stay default."""
+    flyte.with_runcontext(mode="local", tracked=True).run(report_task, x=2)
+
+    by_kind: dict[int, list[dict]] = {}
+    for t, _a, _att, md5_hex in fake_client.uploads:
+        by_kind.setdefault(t, []).append(fake_client.put_headers[md5_hex])
+
+    report_headers = by_kind.get("report", [])
+    assert report_headers
+    assert all(h.get("Content-Type") == "text/html" for h in report_headers)
+    for kind in ("inputs", "outputs"):
+        for h in by_kind.get(kind, []):
+            assert "Content-Type" not in h
+
+
+def test_report_failure_reports_failed(fake_client):
+    with pytest.raises(Exception):
+        flyte.with_runcontext(mode="local", tracked=True).run(failing_task, x=1)
+
+    updates = _all_updates(fake_client)
+    # The failing driver is mapped onto a0 — no duplicate action, and exactly one
+    # FAILED terminal (record_root_failure is deduped by the driver's own failure).
+    assert {u.event.id.name for u in updates} == {ROOT_ACTION_NAME}
+    root_events = _events_for(updates, ROOT_ACTION_NAME)
+    failed = [e for e in root_events if e.phase == _PHASE_FAILED]
+    assert len(failed) == 1
+    assert root_events[-1].phase == _PHASE_FAILED
+    assert "intentional failure" in failed[0].error_info.message
+    assert all(e.attempt == 1 for e in root_events)
+
+
+def test_report_retries_report_attempts(fake_client):
+    _flaky_attempts["count"] = 0
+    run = flyte.with_runcontext(mode="local", tracked=True).run(flaky, x=7)
+    assert run.outputs()[0] == 7
+
+    updates = _all_updates(fake_client)
+    # The retrying driver is mapped onto a0.
+    assert {u.event.id.name for u in updates} == {ROOT_ACTION_NAME}
+    task_events = _events_for(updates, ROOT_ACTION_NAME)
+
+    # Attempt 1 merges root-start and driver-start RUNNING events, then fails;
+    # attempt 2 runs and succeeds.
+    attempt1 = [e for e in task_events if e.attempt == 1]
+    attempt2 = [e for e in task_events if e.attempt == 2]
+    assert [e.phase for e in attempt1] == [_PHASE_RUNNING, _PHASE_RUNNING, _PHASE_FAILED]
+    assert [e.phase for e in attempt2] == [_PHASE_RUNNING, _PHASE_SUCCEEDED]
+    # Versions restart and stay monotonic per attempt (single shared a0 counter).
+    for events in (attempt1, attempt2):
+        versions = [e.version for e in events]
+        assert versions == sorted(versions)
+        assert len(set(versions)) == len(versions)
+
+    # The succeeded attempt (2) uploaded its outputs under a0 and referenced them.
+    outputs_bytes = _uploaded_bytes(fake_client, "outputs", ROOT_ACTION_NAME, 2)
+    assert outputs_bytes is not None
+    outputs = task_common_pb2.Outputs.FromString(outputs_bytes)
+    assert {nl.name: nl.value.scalar.primitive.integer for nl in outputs.literals} == {"o0": 7}
+    succeeded = next(e for e in attempt2 if e.phase == _PHASE_SUCCEEDED)
+    assert succeeded.outputs.output_uri == f"s3://bucket/meta/{ROOT_ACTION_NAME}/2/outputs.pb"
+
+
+def test_report_html_uploaded_and_referenced(fake_client):
+    run = flyte.with_runcontext(mode="local", tracked=True).run(report_task, x=9)
+    assert run.outputs()[0] == 9
+
+    updates = _all_updates(fake_client)
+    # The report-generating driver is mapped onto a0; its report uploads under a0.
+    assert {u.event.id.name for u in updates} == {ROOT_ACTION_NAME}
+
+    report_bytes = _uploaded_bytes(fake_client, "report", ROOT_ACTION_NAME, 1)
+    assert report_bytes is not None
+    assert b"report-marker" in report_bytes
+
+    terminal = next(e for e in _events_for(updates, ROOT_ACTION_NAME) if e.phase == _PHASE_SUCCEEDED)
+    assert terminal.outputs.report_uri == f"s3://bucket/meta/{ROOT_ACTION_NAME}/1/report.html"
+    assert terminal.outputs.output_uri == f"s3://bucket/meta/{ROOT_ACTION_NAME}/1/outputs.pb"
+
+
+def test_events_carry_routing_cluster(fake_client):
+    """When SelectCluster routes the run's data to a dataplane cluster, the reporter
+    stamps that cluster on reported events so later reads route to the same cluster.
+    The bootstrap inputs upload resolves the cluster before CreateRun, so every event
+    of a run with root inputs carries it from the start."""
+    fake_client.data_cluster = "cluster-a"
+
+    run = flyte.with_runcontext(mode="local", tracked=True).run(add, a=2, b=3)
+    assert run.outputs()[0] == 5
+
+    updates = _all_updates(fake_client)
+    assert updates
+    assert all(u.event.cluster == "cluster-a" for u in updates)
+
+
+def test_events_carry_empty_cluster_when_control_plane_serves_data(fake_client):
+    """Routed to the control plane (SelectCluster returned no cluster): events carry ""."""
+    run = flyte.with_runcontext(mode="local", tracked=True).run(add, a=2, b=3)
+    assert run.outputs()[0] == 5
+
+    updates = _all_updates(fake_client)
+    assert updates
+    assert all(u.event.cluster == "" for u in updates)
+
+
+def test_terminal_event_carries_cluster_stamped_after_first_upload(fake_client):
+    """A run without root inputs has no bootstrap upload, so the cluster is learned
+    from the first worker-side upload. Terminal artifacts upload before the terminal
+    event carrying their URIs is built, so that event is stamped correctly."""
+    fake_client.data_cluster = "cluster-b"
+
+    run = flyte.with_runcontext(mode="local", tracked=True).run(empty_str_task)
+    assert run.outputs()[0] == ""
+
+    updates = _all_updates(fake_client)
+    terminal = next(e for e in _events_for(updates, ROOT_ACTION_NAME) if e.phase == _PHASE_SUCCEEDED)
+    assert terminal.outputs.output_uri.endswith("outputs.pb")
+    assert terminal.cluster == "cluster-b"
+
+
+def test_reporting_failure_does_not_fail_run(fake_client):
+    fake_client.tracked_run_service.report_actions = AsyncMock(side_effect=RuntimeError("control plane down"))
+
+    with patch("flyte._persistence._remote_reporter._SEND_BACKOFF_SEC", 0.01):
+        run = flyte.with_runcontext(mode="local", tracked=True).run(add, a=1, b=1)
+
+    assert run.outputs()[0] == 2
+
+
+def test_upload_failure_does_not_fail_run(fake_client):
+    fake_client.dataproxy_service.create_tracked_run_upload_location = AsyncMock(side_effect=RuntimeError("no storage"))
+
+    run = flyte.with_runcontext(mode="local", tracked=True).run(add, a=1, b=2)
+
+    assert run.outputs()[0] == 3
+    # CreateRun proceeds without offloaded inputs? No — the inputs upload happens before
+    # CreateRun, so registration fails and the run silently continues unreported.
+    assert fake_client.tracked_run_service.report_actions.await_count == 0
+
+
+def test_create_run_failure_falls_back_to_unreported(fake_client):
+    fake_client.tracked_run_service.create_run = AsyncMock(side_effect=RuntimeError("nope"))
+
+    run = flyte.with_runcontext(mode="local", tracked=True).run(add, a=4, b=4)
+
+    assert run.outputs()[0] == 8
+    assert fake_client.tracked_run_service.report_actions.await_count == 0
+    # Falls back to the local metadata path URL.
+    assert not run.url.startswith("https://")
+
+
+def test_no_client_warns_and_skips():
+    import flyte._initialize as init_mod
+
+    prev = init_mod._init_config
+    try:
+        asyncio.run(_init_for_testing(project="testproj", domain="dev", client=None))
+        run = flyte.with_runcontext(mode="local", tracked=True).run(add, a=1, b=5)
+        assert run.outputs()[0] == 6
+        assert not run.url.startswith("https://")
+    finally:
+        init_mod._init_config = prev
+
+
+def test_missing_project_domain_raises():
+    import flyte._initialize as init_mod
+
+    prev = init_mod._init_config
+    try:
+        asyncio.run(_init_for_testing(client=_make_fake_client()))
+        with pytest.raises(flyte.errors.InitializationError):
+            flyte.with_runcontext(mode="local", tracked=True).run(add, a=1, b=1)
+    finally:
+        init_mod._init_config = prev
+
+
+def test_report_only_valid_in_local_mode(fake_client):
+    with pytest.raises(ValueError, match="only supported in local mode"):
+        flyte.with_runcontext(mode="remote", tracked=True).run(add, a=1, b=1)
+
+
+# ---------------------------------------------------------------------------
+# Live report write-through, aborts, and the raw-data-stays-local contract
+# ---------------------------------------------------------------------------
+
+
+def test_live_report_write_through(fake_client):
+    """Every mid-run flyte.report.flush() mirrors the current report to the control
+    plane; the completion upload remains the final authoritative write."""
+    run = flyte.with_runcontext(mode="local", tracked=True).run(multi_flush_report_task, x=1)
+    assert run.outputs()[0] == 1
+
+    report_uploads = [
+        (a, att, fake_client.put_payloads[md5]) for t, a, att, md5 in fake_client.uploads if t == "report"
+    ]
+    # At least a mid-run snapshot plus the authoritative completion write.
+    assert len(report_uploads) >= 2
+    # All report uploads target the driver's (a0's) running attempt.
+    assert all((a, att) == (ROOT_ACTION_NAME, 1) for a, att, _ in report_uploads)
+    # A mid-run snapshot has only the first flush; the final write has both.
+    assert any(b"flush-one" in p and b"flush-two" not in p for _, _, p in report_uploads)
+    assert b"flush-one" in report_uploads[-1][2]
+    assert b"flush-two" in report_uploads[-1][2]
+
+
+def test_interrupt_reports_aborted(fake_client):
+    """Ctrl+C (cancellation at the runner's await) mid-run reports every in-flight
+    action — a0 included — as ABORTED, with a bounded flush, then re-raises."""
+    import concurrent.futures
+
+    # The runner re-raises asyncio.CancelledError; the sync syncify bridge surfaces
+    # it as concurrent.futures.CancelledError (a distinct class on Python >= 3.14).
+    with pytest.raises((asyncio.CancelledError, concurrent.futures.CancelledError)):
+        flyte.with_runcontext(mode="local", tracked=True).run(interrupt_parent, n=1)
+
+    updates = _all_updates(fake_client)
+    aborted = {u.event.id.name: u.event for u in updates if u.event.phase == _PHASE_ABORTED}
+    # a0 (the mapped driver) and the in-flight child are both aborted.
+    assert ROOT_ACTION_NAME in aborted
+    assert len(aborted) >= 2
+    for event in aborted.values():
+        assert "aborted by user (SIGINT)" in event.error_info.message
+    # No SUCCEEDED/FAILED terminal was reported for the aborted actions.
+    for name in aborted:
+        phases = [e.phase for e in _events_for(updates, name)]
+        assert _PHASE_SUCCEEDED not in phases
+        assert _PHASE_FAILED not in phases
+
+
+def test_interrupt_reports_aborted_strict(fake_client):
+    """Strict mode preserves interrupt semantics: the interrupt propagates (never a
+    reporting error) and the aborts are still reported."""
+    import concurrent.futures
+
+    with pytest.raises((asyncio.CancelledError, concurrent.futures.CancelledError)):
+        flyte.with_runcontext(mode="local", tracked=True, tracked_strict=True).run(interrupt_parent, n=1)
+
+    updates = _all_updates(fake_client)
+    aborted = {u.event.id.name for u in updates if u.event.phase == _PHASE_ABORTED}
+    assert ROOT_ACTION_NAME in aborted
+
+
+def test_abort_all_skips_terminal_actions():
+    reporter = _make_reporter()
+    events = []
+    reporter._put = events.append
+
+    reporter.record_root_start(task_name="t")
+    reporter.record_start(action_id="c1", task_name="child1", parent_id=ROOT_ACTION_NAME)
+    reporter.record_complete(action_id="c1")
+    reporter.record_start(action_id="c2", task_name="child2", parent_id=ROOT_ACTION_NAME)
+
+    reporter.abort_all(reason="aborted by user (SIGTERM)")
+
+    aborted = [e for e in events if e.phase == _PHASE_ABORTED]
+    assert {e.action_name for e in aborted} == {"c2", ROOT_ACTION_NAME}
+    # The root's abort is the last transition observed.
+    assert aborted[-1].action_name == ROOT_ACTION_NAME
+    assert all(e.error == "aborted by user (SIGTERM)" for e in aborted)
+    reporter.close(timeout=1)
+
+
+def test_raw_file_data_never_uploads(fake_client, tmp_path):
+    """Locked semantic: only inputs.pb / outputs.pb / report.html ever reach the
+    dataproxy. File literals keep their local URIs — raw data stays local."""
+    src = tmp_path / "payload.txt"
+    src.write_text("raw-bytes-stay-local")
+
+    run = flyte.with_runcontext(mode="local", tracked=True).run(file_roundtrip, f=File(path=str(src)))
+    assert run.outputs()[0].path == str(src)
+
+    # (1) The only upload targets ever seen are the three metadata kinds.
+    kinds = {t for t, *_ in fake_client.uploads}
+    assert kinds <= {
+        "inputs",
+        "outputs",
+        "report",
+    }
+
+    # (3) Nothing else was PUT: every signed-PUT payload corresponds to a recorded
+    # upload-location request and vice versa.
+    assert set(fake_client.put_payloads) == {md5 for *_, md5 in fake_client.uploads}
+
+    # (2) The uploaded outputs.pb still contains the untouched local URI.
+    outputs_bytes = _uploaded_bytes(fake_client, "outputs", ROOT_ACTION_NAME, 1)
+    assert outputs_bytes is not None
+    outputs = task_common_pb2.Outputs.FromString(outputs_bytes)
+    out_uri = outputs.literals[0].value.scalar.blob.uri
+    assert str(src) in out_uri
+    assert not out_uri.startswith(("s3://", "gs://", "abfs://"))
+
+    # Same for the offloaded inputs.pb.
+    inputs_bytes = _uploaded_bytes(fake_client, "inputs", ROOT_ACTION_NAME)
+    assert inputs_bytes is not None
+    inputs = task_common_pb2.Inputs.FromString(inputs_bytes)
+    in_uri = inputs.literals[0].value.scalar.blob.uri
+    assert str(src) in in_uri
+    assert not in_uri.startswith(("s3://", "gs://", "abfs://"))
+
+
+# ---------------------------------------------------------------------------
+# Strict reporting mode (tracked_strict): every failure class fails the run loudly
+# ---------------------------------------------------------------------------
+
+
+def _fail_terminal_uploads(client):
+    """Make outputs/report uploads fail while inputs (and thus bootstrap) succeed."""
+    orig = client.dataproxy_service.create_tracked_run_upload_location.side_effect
+
+    async def _upload(req, **kwargs):
+        if req.filename != "inputs.pb":
+            raise RuntimeError("upload rejected")
+        return await orig(req, **kwargs)
+
+    client.dataproxy_service.create_tracked_run_upload_location = AsyncMock(side_effect=_upload)
+
+
+def test_strict_bootstrap_failure_fails_run(fake_client):
+    fake_client.tracked_run_service.create_run = AsyncMock(side_effect=RuntimeError("nope"))
+
+    with pytest.raises(TrackedRunReportingError, match="register tracked run"):
+        flyte.with_runcontext(mode="local", tracked=True, tracked_strict=True).run(add, a=1, b=1)
+
+
+def test_strict_upload_failure_fails_run(fake_client):
+    _fail_terminal_uploads(fake_client)
+
+    with pytest.raises(TrackedRunReportingError, match="outputs upload"):
+        flyte.with_runcontext(mode="local", tracked=True, tracked_strict=True).run(add, a=1, b=1)
+
+
+def test_default_mode_upload_failure_does_not_fail_run(fake_client):
+    """Counterpart: the same terminal-upload failure is swallowed under the default policy."""
+    _fail_terminal_uploads(fake_client)
+
+    run = flyte.with_runcontext(mode="local", tracked=True).run(add, a=1, b=1)
+    assert run.outputs()[0] == 2
+
+
+def test_strict_transport_failure_fails_run(fake_client):
+    fake_client.tracked_run_service.report_actions = AsyncMock(side_effect=RuntimeError("control plane down"))
+
+    with patch("flyte._persistence._remote_reporter._SEND_BACKOFF_SEC", 0.01):
+        with pytest.raises(TrackedRunReportingError, match="ReportActions"):
+            flyte.with_runcontext(mode="local", tracked=True, tracked_strict=True).run(add, a=1, b=1)
+
+
+def test_strict_rejected_update_fails_run(fake_client):
+    async def _reject(req, **kwargs):
+        return tracked_run_service_pb2.ReportTrackedActionsResponse(
+            statuses=[status_pb2.Status(code=3, message="validation failed") for _ in req.updates]
+        )
+
+    fake_client.tracked_run_service.report_actions = AsyncMock(side_effect=_reject)
+
+    with pytest.raises(TrackedRunReportingError, match="validation failed"):
+        flyte.with_runcontext(mode="local", tracked=True, tracked_strict=True).run(add, a=1, b=1)
+
+
+def test_default_mode_rejected_update_does_not_fail_run(fake_client):
+    async def _reject(req, **kwargs):
+        return tracked_run_service_pb2.ReportTrackedActionsResponse(
+            statuses=[status_pb2.Status(code=3, message="validation failed") for _ in req.updates]
+        )
+
+    fake_client.tracked_run_service.report_actions = AsyncMock(side_effect=_reject)
+
+    run = flyte.with_runcontext(mode="local", tracked=True).run(add, a=1, b=1)
+    assert run.outputs()[0] == 2
+
+
+def test_strict_flush_timeout_raises():
+    client = _make_fake_client()
+
+    async def _hang(req, **kwargs):
+        await asyncio.sleep(60)
+
+    client.tracked_run_service.report_actions = AsyncMock(side_effect=_hang)
+    reporter = _make_reporter(client, flush_timeout_sec=0.3, strict=True)
+    reporter.record_root_start(task_name="t")
+
+    start = time.monotonic()
+    with pytest.raises(TrackedRunReportingError, match="Timed out"):
+        reporter.close()
+    assert time.monotonic() - start < 5
+
+
+def test_strict_enqueue_reraises_first_failure():
+    reporter = _make_reporter(strict=True)
+    reporter._note_failure("outputs upload", "a1", "boom")
+
+    with pytest.raises(TrackedRunReportingError, match="outputs upload"):
+        reporter.record_start(action_id="a2", task_name="t")
+    # The failing path never fast-raises so it cannot mask the task's own error.
+    reporter.record_failure(action_id="a2", error="task error")
+    with pytest.raises(TrackedRunReportingError):
+        reporter.close(timeout=1)
+
+
+def test_strict_requires_report_enabled(fake_client):
+    with pytest.raises(ValueError, match="requires reporting to be enabled"):
+        flyte.with_runcontext(mode="local", tracked_strict=True).run(add, a=1, b=1)
+
+
+def test_strict_requires_client():
+    import flyte._initialize as init_mod
+
+    prev = init_mod._init_config
+    try:
+        asyncio.run(_init_for_testing(project="testproj", domain="dev", client=None))
+        with pytest.raises(flyte.errors.InitializationError):
+            flyte.with_runcontext(mode="local", tracked=True, tracked_strict=True).run(add, a=1, b=1)
+    finally:
+        init_mod._init_config = prev
+
+
+# ---------------------------------------------------------------------------
+# Run-name contract
+# ---------------------------------------------------------------------------
+
+
+def test_generated_run_name_is_compliant():
+    for _ in range(50):
+        name = generate_tracked_run_name()
+        assert len(name) <= 30
+        assert not name.startswith(("u", "r"))
+
+
+def test_validate_run_name_rejects_reserved_prefixes():
+    with pytest.raises(ValueError, match="reserved"):
+        validate_tracked_run_name("uplifting-run")
+    with pytest.raises(ValueError, match="reserved"):
+        validate_tracked_run_name("racy-run")
+    with pytest.raises(ValueError, match="too long"):
+        validate_tracked_run_name("x" * 31)
+    validate_tracked_run_name("my-local-run")
+
+
+def test_invalid_user_run_name_fails_fast(fake_client):
+    with pytest.raises(ValueError, match="reserved"):
+        flyte.with_runcontext(mode="local", tracked=True, name="urgent").run(add, a=1, b=1)
+    fake_client.tracked_run_service.create_run.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Reporter unit behavior (direct, no controller)
+# ---------------------------------------------------------------------------
+
+
+def _make_reporter(client=None, **kwargs) -> RemoteRunReporter:
+    run_id = identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="local-abc")
+    return RemoteRunReporter(client or _make_fake_client(), run_id, **kwargs)
+
+
+def test_flush_barrier_is_bounded():
+    client = _make_fake_client()
+
+    async def _hang(req, **kwargs):
+        await asyncio.sleep(60)
+
+    client.tracked_run_service.report_actions = AsyncMock(side_effect=_hang)
+    reporter = _make_reporter(client, flush_timeout_sec=0.5)
+    reporter.record_root_start(task_name="t")
+
+    start = time.monotonic()
+    reporter.close()
+    assert time.monotonic() - start < 5
+
+
+def test_terminal_dedupe_between_attempt_complete_and_complete():
+    reporter = _make_reporter()
+    events = []
+    reporter._put = events.append  # intercept before the worker consumes anything
+
+    reporter.record_start(action_id="a1", task_name="t")
+    reporter.record_attempt_start(action_id="a1", attempt_num=1)
+    reporter.record_attempt_complete(action_id="a1", attempt_num=1)
+    reporter.record_complete(action_id="a1")
+
+    phases = [e.phase for e in events]
+    assert phases == [_PHASE_RUNNING, _PHASE_SUCCEEDED]
+    versions = [e.version for e in events]
+    assert versions == [0, 1]
+    reporter.close(timeout=1)
+
+
+def test_root_terminal_synthesized_only_without_driver():
+    """record_root_* synthesis is fallback-only: it emits a0's terminal when no
+    driver action ever materialized, and dedupes when a mapped driver delivered it."""
+    reporter = _make_reporter()
+    events = []
+    reporter._put = events.append
+
+    # No driver ever reports (e.g. failure before dispatch): the root failure lands.
+    reporter.record_root_start(task_name="t")
+    reporter.record_root_failure(error="boom before dispatch")
+    assert [e.phase for e in events] == [_PHASE_RUNNING, _PHASE_FAILED]
+    assert events[-1].action_name == ROOT_ACTION_NAME
+    assert events[-1].error == "boom before dispatch"
+    reporter.close(timeout=1)
+
+    # Driver mapped onto a0 and already terminal: root synthesis is a no-op.
+    reporter2 = _make_reporter()
+    events2 = []
+    reporter2._put = events2.append
+    reporter2.record_root_start(task_name="t")
+    reporter2.record_start(action_id="driver-local-id", task_name="t", task=object())
+    reporter2.record_attempt_complete(action_id="driver-local-id", attempt_num=1)
+    reporter2.record_complete(action_id="driver-local-id")
+    reporter2.record_root_complete()
+    assert [(e.action_name, e.phase) for e in events2] == [
+        (ROOT_ACTION_NAME, _PHASE_RUNNING),
+        (ROOT_ACTION_NAME, _PHASE_RUNNING),
+        (ROOT_ACTION_NAME, _PHASE_SUCCEEDED),
+    ]
+    # Single shared per-attempt version counter across root + mapped driver events.
+    assert [e.version for e in events2] == [0, 1, 2]
+    reporter2.close(timeout=1)
+
+
+def test_enqueue_never_raises_after_close():
+    reporter = _make_reporter()
+    reporter.close(timeout=1)
+    # Late events are dropped silently.
+    reporter.record_start(action_id="a1", task_name="t")
+    reporter.record_complete(action_id="a1")
+
+
+def test_bounded_action_name_respects_the_api_cap():
+    """Local action ids concatenate the parent id, task name and a sequence number, so
+    anything nested exceeds ActionIdentifier.name's 30-character cap and the whole report
+    batch is rejected. Names must come back within the cap, stably, without colliding."""
+    from flyte._persistence._remote_reporter import (
+        _MAX_ACTION_NAME_LENGTH,
+        _bounded_action_name,
+    )
+
+    # Short ids are passed through untouched — no gratuitous rewriting of readable names.
+    assert _bounded_action_name("a0") == "a0"
+    assert _bounded_action_name("x" * _MAX_ACTION_NAME_LENGTH) == "x" * _MAX_ACTION_NAME_LENGTH
+
+    long_id = "conditions.basic_condition_task-1-cond-approval-0"
+    bounded = _bounded_action_name(long_id)
+    assert len(bounded) == _MAX_ACTION_NAME_LENGTH
+    # Deterministic: a parent reference and the action's own report are produced by
+    # different call sites, on different threads, that never coordinate.
+    assert bounded == _bounded_action_name(long_id)
+
+    # Siblings share a long common prefix (the parent id prefixes every child), so
+    # truncation alone would map them onto one action and silently merge the tree.
+    sibling = "conditions.basic_condition_task-1-cond-review-0"
+    assert _bounded_action_name(sibling) != bounded
+
+
+def test_deeply_nested_actions_are_reported_not_dropped(fake_client):
+    """End-to-end guard for the cap: every action the run produced must reach the
+    control plane. Before bounding, over-long ids failed protovalidate and the reporter
+    dropped the entire batch, so the console showed a run with only its root."""
+    from flyte._persistence._remote_reporter import _MAX_ACTION_NAME_LENGTH
+
+    flyte.with_runcontext(mode="local", tracked=True).run(parent_task, n=2)
+
+    updates = _all_updates(fake_client)
+    assert updates, "expected the run to report something"
+    for update in updates:
+        assert len(update.event.id.name) <= _MAX_ACTION_NAME_LENGTH, update.event.id.name
+        assert len(update.parent_name) <= _MAX_ACTION_NAME_LENGTH, update.parent_name
+
+    # Parent references must resolve to actions that were actually reported, otherwise the
+    # console renders orphans.
+    reported = {u.event.id.name for u in updates}
+    for update in updates:
+        if update.parent_name:
+            assert update.parent_name in reported

--- a/tests/persistence/test_remote_upload.py
+++ b/tests/persistence/test_remote_upload.py
@@ -1,0 +1,234 @@
+"""Tests for the tracked-run metadata signed-PUT upload helper."""
+
+from __future__ import annotations
+
+import hashlib
+from base64 import b64encode
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from connectrpc.code import Code
+from connectrpc.errors import ConnectError
+from flyteidl2.common import identifier_pb2
+from flyteidl2.dataproxy import dataproxy_service_pb2
+
+from flyte._persistence._remote_upload import _put_bytes_with_retry, upload_tracked_run_artifact
+from flyte.errors import RuntimeSystemError
+
+_RUN_ID = identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="local-x")
+
+
+def _make_dataproxy(headers: dict | None = None, cluster: str = ""):
+    dataproxy = MagicMock()
+    dataproxy.create_tracked_run_upload_location = AsyncMock(
+        return_value=(
+            dataproxy_service_pb2.CreateUploadLocationResponse(
+                signed_url="https://signed.example/put?sig=secret",
+                native_url="s3://bucket/tracked-runs/local-x/a0/inputs.pb",
+                headers=headers or {},
+            ),
+            cluster,
+        )
+    )
+    return dataproxy
+
+
+def _mock_http_client(put_results):
+    """Build a patched httpx.AsyncClient whose put() yields the given results in order."""
+    client = AsyncMock()
+    client.put.side_effect = put_results
+    ctx = AsyncMock()
+    ctx.__aenter__.return_value = client
+    ctx.__aexit__.return_value = False
+    return client, ctx
+
+
+@pytest.mark.asyncio
+async def test_upload_tracked_run_artifact_success():
+    data = b"serialized-proto-bytes"
+    dataproxy = _make_dataproxy(headers={"x-extra": "1"}, cluster="cluster-a")
+    client, ctx = _mock_http_client([httpx.Response(200)])
+
+    with patch("httpx.AsyncClient", return_value=ctx):
+        native_url, cluster = await upload_tracked_run_artifact(
+            dataproxy,
+            kind="inputs",
+            run_id=_RUN_ID,
+            action_name="a0",
+            attempt=None,
+            data=data,
+        )
+
+    assert native_url == "s3://bucket/tracked-runs/local-x/a0/inputs.pb"
+    assert cluster == "cluster-a"
+
+    req = dataproxy.create_tracked_run_upload_location.await_args[0][0]
+    assert req.org == "o"
+    assert req.project == "p"
+    assert req.domain == "d"
+    assert req.filename_root == "tracked-runs/local-x/a0"
+    assert req.filename == "inputs.pb"
+    assert req.content_md5 == hashlib.md5(data).digest()
+    assert req.content_length == len(data)
+    assert req.add_content_md5_metadata is True
+    assert req.expires_in.ToTimedelta().total_seconds() == 60
+
+    client.put.assert_awaited_once()
+    put_call = client.put.await_args
+    assert put_call[0][0] == "https://signed.example/put?sig=secret"
+    sent_headers = put_call[1]["headers"]
+    assert sent_headers["x-extra"] == "1"  # response headers are honored
+    assert sent_headers["Content-Length"] == str(len(data))
+    assert sent_headers["Content-MD5"] == b64encode(hashlib.md5(data).digest()).decode("utf-8")
+    assert put_call[1]["content"] == data
+
+
+@pytest.mark.asyncio
+async def test_upload_tracked_run_artifact_outputs_target_attempt():
+    dataproxy = _make_dataproxy()
+    _, ctx = _mock_http_client([httpx.Response(204)])
+
+    with patch("httpx.AsyncClient", return_value=ctx):
+        _, cluster = await upload_tracked_run_artifact(
+            dataproxy,
+            kind="outputs",
+            run_id=_RUN_ID,
+            action_name="a0",
+            attempt=2,
+            data=b"outputs",
+        )
+
+    # Control-plane-served uploads report no routing cluster.
+    assert cluster == ""
+    req = dataproxy.create_tracked_run_upload_location.await_args[0][0]
+    assert req.filename_root == "tracked-runs/local-x/a0/2"
+    assert req.filename == "outputs.pb"
+
+
+@pytest.mark.asyncio
+async def test_upload_tracked_run_artifact_report_filename():
+    dataproxy = _make_dataproxy()
+    _, ctx = _mock_http_client([httpx.Response(200)])
+
+    with patch("httpx.AsyncClient", return_value=ctx):
+        await upload_tracked_run_artifact(
+            dataproxy,
+            kind="report",
+            run_id=_RUN_ID,
+            action_name="a1",
+            attempt=1,
+            data=b"<html/>",
+            content_type="text/html",
+        )
+
+    req = dataproxy.create_tracked_run_upload_location.await_args[0][0]
+    assert req.filename_root == "tracked-runs/local-x/a1/1"
+    assert req.filename == "report.html"
+
+
+@pytest.mark.asyncio
+async def test_upload_tracked_run_artifact_validates_kind_and_attempt():
+    dataproxy = _make_dataproxy()
+    # Unknown kind.
+    with pytest.raises(ValueError, match="kind"):
+        await upload_tracked_run_artifact(
+            dataproxy, kind="code", run_id=_RUN_ID, action_name="a0", attempt=None, data=b"x"
+        )
+    # Inputs must not carry an attempt.
+    with pytest.raises(ValueError, match="attempt"):
+        await upload_tracked_run_artifact(
+            dataproxy, kind="inputs", run_id=_RUN_ID, action_name="a0", attempt=1, data=b"x"
+        )
+    # Outputs / reports must carry an attempt.
+    with pytest.raises(ValueError, match="attempt"):
+        await upload_tracked_run_artifact(
+            dataproxy, kind="outputs", run_id=_RUN_ID, action_name="a0", attempt=None, data=b"x"
+        )
+    dataproxy.create_tracked_run_upload_location.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_upload_tracked_run_artifact_maps_connect_errors():
+    dataproxy = MagicMock()
+    dataproxy.create_tracked_run_upload_location = AsyncMock(
+        side_effect=ConnectError(Code.PERMISSION_DENIED, "not yours")
+    )
+
+    with pytest.raises(RuntimeSystemError, match="not yours"):
+        await upload_tracked_run_artifact(
+            dataproxy,
+            kind="inputs",
+            run_id=_RUN_ID,
+            action_name="a0",
+            attempt=None,
+            data=b"x",
+        )
+
+
+@pytest.mark.asyncio
+async def test_put_bytes_retries_then_succeeds():
+    client, ctx = _mock_http_client([httpx.Response(503), httpx.Response(200)])
+
+    with patch("httpx.AsyncClient", return_value=ctx):
+        await _put_bytes_with_retry(
+            b"data",
+            signed_url="https://signed.example/put",
+            extra_headers={},
+            max_retries=2,
+            min_backoff_sec=0.01,
+        )
+
+    assert client.put.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_put_bytes_gives_up_after_max_retries():
+    client, ctx = _mock_http_client([httpx.Response(500)] * 3)
+
+    with patch("httpx.AsyncClient", return_value=ctx):
+        with pytest.raises(RuntimeSystemError, match="after 2 retries"):
+            await _put_bytes_with_retry(
+                b"data",
+                signed_url="https://signed.example/put",
+                extra_headers={},
+                max_retries=2,
+                min_backoff_sec=0.01,
+            )
+
+    assert client.put.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_put_bytes_does_not_retry_client_errors_and_redacts_url():
+    client, ctx = _mock_http_client([httpx.Response(403)])
+
+    with patch("httpx.AsyncClient", return_value=ctx):
+        with pytest.raises(RuntimeSystemError) as exc:
+            await _put_bytes_with_retry(
+                b"data",
+                signed_url="https://signed.example/put?X-Amz-Signature=secret",
+                extra_headers={},
+                max_retries=3,
+                min_backoff_sec=0.01,
+            )
+
+    assert client.put.await_count == 1
+    assert "X-Amz-Signature=secret" not in str(exc.value)
+    assert "<redacted>" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_put_bytes_retries_on_network_error():
+    client, ctx = _mock_http_client([httpx.ConnectError("refused"), httpx.Response(201)])
+
+    with patch("httpx.AsyncClient", return_value=ctx):
+        await _put_bytes_with_retry(
+            b"data",
+            signed_url="https://signed.example/put",
+            extra_headers={},
+            max_retries=1,
+            min_backoff_sec=0.01,
+        )
+
+    assert client.put.await_count == 2


### PR DESCRIPTION
## Overview

Tracked runs: the SDK keeps orchestrating everything locally while reporting run state — actions, attempts, inputs/outputs, HTML reports — to the control plane, so local runs appear live in the console. Builds on the IDL in flyteorg/flyte#7737 and the `TrackedRunService` rename (released as flyteidl2 2.0.40, which this PR pins).

### How it works

- **RemoteRunReporter** — a third `RunRecorder` sink alongside the TUI tracker and SQLite store. The recorder observer contract is synchronous and fires from async controller code *and* the threads that run sync tasks, so the sink is a sync enqueue facade over async I/O: `record_*` calls capture a fully-computed event under a lock (per-attempt monotonic versions; attempts start at 1 per the server contract) and a dedicated background event loop batches `TrackedRunService.ReportActions` calls and performs the signed-URL uploads (the same background-loop shape as `flyte.syncify`). Terminal events trigger a bounded flush barrier at run end. Reporting is best-effort and never fails or hangs the run (unless strict mode is on).
- **Data path routes like everything else**: artifacts upload via `DataProxyService.CreateUploadLocation` signed PUT URLs with the `tracked-runs/<run>/<action>[/<attempt>]` filename_root scheme, routed by `ClusterService.SelectCluster(OPERATION_TRACKED_RUN_DATA)` — an org with a directly-reachable data plane cluster uploads straight to that cluster's store; an org without one is served by the control plane's own store. The reporter stamps the routing cluster onto reported attempt events so reads later route to the same store. Inputs upload before CreateRun (deterministic path, no URI on the event); outputs/report URIs attach to the terminal event after their uploads complete. Reports also flush live mid-run so the report tab updates while the run executes.
- **Opt-in surface** (one naming family, anchored on the flag):
  - `flyte run --local --tracked [--tracked-strict]`
  - config: `local.tracked` / `local.tracked_strict` (section mirrors `local.persistence`)
  - `flyte.init(local_tracked=..., local_tracked_strict=...)`; `flyte create config --local-tracked`
  - runcontext: `flyte.with_runcontext(mode="local", tracked=True)`
- Requires project/domain; degrades gracefully with one warning when no client is initialized. `--tracked-strict` fails the run loudly on the first reporting failure (for debugging reporting itself). SIGINT/SIGTERM abort-flushes in-flight actions as ABORTED. `Run.url` points at the console tracked-runs page. Falsy outputs (`0`, `""`, `[]`, `False`) report correctly (presence, not truthiness). File/Dir raw data never uploads — only the three metadata artifacts (inputs.pb / outputs.pb / report.html) reach the dataproxy.

The deck feature (`@env.task(report=True)`, `flyte.report`) and the `@trace` decorator are unrelated and untouched.

## Test Plan

- 688 unit tests green on the released flyteidl2 pin (reporter lifecycle incl. retries/ordering/flush barrier/failure isolation/strict mode, upload helper, client protocol, CLI flags, config plumbing).
- Live E2E against three environments running a backend that implements `TrackedRunService`:
  - a single-process development stack: full lifecycle, watches, replay idempotency.
  - a hosted control plane with a directly-reachable data plane cluster: runs + inputs/outputs + reports render in the console; artifacts land in the cluster's metadata store, with the routing cluster recorded on attempts.
  - a hosted control plane where artifacts are served by the control plane's own store — the fallback leg of the routed data path, verified end to end on the released flyteidl2 pin.

## Rollout Plan

The feature is opt-in per run/config and requires a control plane that implements `TrackedRunService`; nothing changes for users who don't pass `--tracked`.

## Rollback Plan

Revert; the feature is client-side and opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
