### PR TITLE
Revert #1312

### DIFF
--- a/examples/plugins/dask_example.py
+++ b/examples/plugins/dask_example.py
@@ -9,24 +9,8 @@ import flyte.remote
 import flyte.storage
 from flyte import Resources
 
-# The scheduler and worker pods inherit this image (Scheduler()/WorkerGroup() below leave
-# image unset), and the Dask K8s operator launches them via the standalone `dask-scheduler`
-# and `dask-worker` commands. Those console scripts were removed from `distributed` in
-# 2026.6.0 (replaced by the `dask scheduler` / `dask worker` subcommands), so a newer
-# dask[distributed] makes the cluster pods crash-loop with
-# "dask-scheduler: executable file not found in $PATH". Pin below 2026.6.0 to keep them.
-# (flyteplugins-dask caps this itself as of the next release; the explicit pin here keeps
-# the example working against the currently-published, un-capped plugin.)
-#
-# connectrpc<0.11 keeps the runtime from hitting "'Headers' object is not callable":
-# connectrpc 0.11 turned RequestContext.request_headers into a property, which the flyte
-# auth interceptor (method-call style) can't use. flyte>=2.5.10 caps this too, but pinning
-# here guarantees a clean rebuild picks up a compatible connectrpc.
 image = flyte.Image.from_debian_base(python_version=(3, 12)).with_pip_packages(
     "flyteplugins-dask",
-    "dask[distributed]<2026.6.0",
-    "connectrpc<0.11",
-    "bokeh",
 )
 
 dask_config = Dask(

--- a/plugins/dask/pyproject.toml
+++ b/plugins/dask/pyproject.toml
@@ -6,12 +6,7 @@ readme = "README.md"
 authors = [{ name = "Kevin Su", email = "pingsutw@users.noreply.github.com" }]
 requires-python = ">=3.10"
 dependencies = [
-    # Cap below 2026.6.0: distributed removed the standalone `dask-scheduler` /
-    # `dask-worker` console scripts in that release (deprecated back in 2022.10.0 in
-    # favor of the `dask scheduler` / `dask worker` subcommands). The Dask K8s operator
-    # still launches cluster pods via the old commands, so a newer distributed makes the
-    # scheduler/worker pods crash-loop with "dask-scheduler: executable file not found".
-    "dask[distributed]>=2022.10.2,<2026.6.0",
+    "dask[distributed]>=2022.10.2",
     "flyte",
     "bokeh"
 ]

--- a/plugins/dask/uv.lock
+++ b/plugins/dask/uv.lock
@@ -717,7 +717,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "bokeh" },
-    { name = "dask", extras = ["distributed"], specifier = ">=2022.10.2,<2026.6.0" },
+    { name = "dask", extras = ["distributed"], specifier = ">=2022.10.2" },
     { name = "flyte", editable = "../../" },
 ]
 


### PR DESCRIPTION
Revert #1312 because the backend plugin has been updated to use the latest Dask script to start the workers and scheduler, making this change no longer necessary.

https://github.com/flyteorg/flyte/pull/7707