### PR TITLE
Publish the prefetched model as an artifact and use in Apps

### DIFF
--- a/src/flyte/app/__init__.py
+++ b/src/flyte/app/__init__.py
@@ -2,12 +2,13 @@ from flyte.app._app_environment import AppEnvironment
 from flyte.app._connector_environment import ConnectorEnvironment
 from flyte.app._context import ctx
 from flyte.app._deploy import DeployedAppEnvironment
-from flyte.app._parameter import AppEndpoint, Parameter, RunOutput, get_parameter
+from flyte.app._parameter import AppEndpoint, ArtifactValue, Parameter, RunOutput, get_parameter
 from flyte.app._types import Domain, Link, Port, Scaling, Timeouts
 
 __all__ = [
     "AppEndpoint",
     "AppEnvironment",
+    "ArtifactValue",
     "ConnectorEnvironment",
     "DeployedAppEnvironment",
     "Domain",

--- a/src/flyte/app/_app_environment.py
+++ b/src/flyte/app/_app_environment.py
@@ -122,8 +122,9 @@ class AppEnvironment(Environment):
     :param domain: `Domain` object for custom domain configuration.
     :param links: List of `Link` objects for connecting to other environments.
     :param parameters: List of `Parameter` objects for app inputs. Use `RunOutput`
-        to connect app parameters to task outputs, or `AppEndpoint` to reference
-        other app endpoints.
+        to connect app parameters to task outputs, `ArtifactValue` to resolve a
+        published artifact (e.g. a prefetched model), or `AppEndpoint` to
+        reference other app endpoints.
     :param cluster_pool: Cluster pool for scheduling. Default `"default"`.
     :param timeouts: `Timeouts` object for startup/health check timeouts.
     :param name: Name of the app (required). Must be lowercase alphanumeric with hyphens.

--- a/src/flyte/app/_parameter.py
+++ b/src/flyte/app/_parameter.py
@@ -159,6 +159,66 @@ class RunOutput(_DelayedValue):
         return typing.cast(ParameterTypes, output)
 
 
+class ArtifactValue(_DelayedValue):
+    """
+    Use a published artifact as an app parameter value.
+
+    The artifact is resolved from the artifact service at deployment time and
+    materializes to the File or Dir it stores (declare which via `type`), so an
+    app can mount e.g. a prefetched model directly:
+
+    ```python
+    Parameter(
+        name="model",
+        value=ArtifactValue(type="directory", name="bert-small"),
+        mount="/models/bert-small",
+    )
+    ```
+
+    :param name: The artifact name.
+    :param version: The artifact version; None resolves the latest version at deploy time.
+    :param project: Project to look in; defaults to the init configuration.
+    :param domain: Domain to look in; defaults to the init configuration.
+    """
+
+    name: str
+    version: str | None = None
+    project: str | None = None
+    domain: str | None = None
+
+    @requires_initialization
+    async def materialize(self) -> ParameterTypes:
+        import flyte.errors
+        from flyte.remote import Artifact
+
+        if self.type not in ("file", "directory"):
+            raise ValueError(f"ArtifactValue supports 'file' and 'directory' parameters, got {self.type!r}")
+        try:
+            artifact = await Artifact.get.aio(
+                self.name,
+                version=self.version or "latest",
+                project=self.project,
+                domain=self.domain,
+            )
+            value = await artifact.to_python()
+        except Exception as e:
+            raise flyte.errors.ParameterMaterializationError(
+                f"Failed to materialize artifact {self.name}@{self.version or 'latest'}"
+            ) from e
+        materialized: flyte.io.File | flyte.io.Dir
+        if self.type == "file" and isinstance(value, flyte.io.File):
+            materialized = value
+        elif self.type == "directory" and isinstance(value, flyte.io.Dir):
+            materialized = value
+        else:
+            raise flyte.errors.ParameterMaterializationError(
+                f"Artifact {self.name}@{artifact.version} stores a {type(value).__name__}, "
+                f"but the parameter is declared as {self.type!r}"
+            )
+        logger.debug("Materialized artifact %s@%s -> %s", self.name, artifact.version, materialized.path)
+        return materialized
+
+
 class AppEndpoint(_DelayedValue):
     """
     Embed an upstream app's endpoint as an app parameter.
@@ -240,10 +300,11 @@ class Parameter:
             raise ValueError(f"env_var ({self.env_var}) is not a valid environment name for shells")
 
         if self.value is not None and not isinstance(
-            self.value, (str, flyte.io.File, flyte.io.Dir, RunOutput, AppEndpoint)
+            self.value, (str, flyte.io.File, flyte.io.Dir, RunOutput, ArtifactValue, AppEndpoint)
         ):
             raise TypeError(
-                f"Expected value to be of type str, file, dir, RunOutput or AppEndpoint, got {type(self.value)}"
+                f"Expected value to be of type str, file, dir, RunOutput, ArtifactValue or AppEndpoint, "
+                f"got {type(self.value)}"
             )
 
         if self.name is None:
@@ -286,7 +347,7 @@ class SerializableParameter(BaseModel):
             value = param.value.path
             tpe = "directory"
             download = True if param.mount is not None else param.download
-        elif isinstance(param.value, RunOutput):
+        elif isinstance(param.value, (RunOutput, ArtifactValue)):
             value = param.value.model_dump_json()
             tpe = param.value.type
             download = True if param.mount is not None else param.download

--- a/src/flyte/app/_parameter.py
+++ b/src/flyte/app/_parameter.py
@@ -164,13 +164,13 @@ class ArtifactValue(_DelayedValue):
     Use a published artifact as an app parameter value.
 
     The artifact is resolved from the artifact service at deployment time and
-    materializes to the File or Dir it stores (declare which via `type`), so an
-    app can mount e.g. a prefetched model directly:
+    materializes to the File or Dir it stores — the type is inferred from the
+    artifact itself — so an app can mount e.g. a prefetched model directly:
 
     ```python
     Parameter(
         name="model",
-        value=ArtifactValue(type="directory", name="bert-small"),
+        value=ArtifactValue(name="bert-small"),
         mount="/models/bert-small",
     )
     ```
@@ -179,19 +179,22 @@ class ArtifactValue(_DelayedValue):
     :param version: The artifact version; None resolves the latest version at deploy time.
     :param project: Project to look in; defaults to the init configuration.
     :param domain: Domain to look in; defaults to the init configuration.
+    :param type: Optional declared type ('file' or 'directory'). When set, materialization
+        fails if the artifact stores something else; when omitted, the type is inferred.
     """
 
     name: str
     version: str | None = None
     project: str | None = None
     domain: str | None = None
+    type: _SerializedParameterType | None = None  # type: ignore[assignment]
 
     @requires_initialization
     async def materialize(self) -> ParameterTypes:
         import flyte.errors
         from flyte.remote import Artifact
 
-        if self.type not in ("file", "directory"):
+        if self.type is not None and self.type not in ("file", "directory"):
             raise ValueError(f"ArtifactValue supports 'file' and 'directory' parameters, got {self.type!r}")
         try:
             artifact = await Artifact.get.aio(
@@ -205,18 +208,19 @@ class ArtifactValue(_DelayedValue):
             raise flyte.errors.ParameterMaterializationError(
                 f"Failed to materialize artifact {self.name}@{self.version or 'latest'}"
             ) from e
-        materialized: flyte.io.File | flyte.io.Dir
-        if self.type == "file" and isinstance(value, flyte.io.File):
-            materialized = value
-        elif self.type == "directory" and isinstance(value, flyte.io.Dir):
-            materialized = value
-        else:
+        if not isinstance(value, (flyte.io.File, flyte.io.Dir)):
+            raise flyte.errors.ParameterMaterializationError(
+                f"Artifact {self.name}@{artifact.version} stores a {type(value).__name__}; "
+                "only File and Dir artifacts can be app parameters"
+            )
+        inferred: _SerializedParameterType = "file" if isinstance(value, flyte.io.File) else "directory"
+        if self.type is not None and self.type != inferred:
             raise flyte.errors.ParameterMaterializationError(
                 f"Artifact {self.name}@{artifact.version} stores a {type(value).__name__}, "
                 f"but the parameter is declared as {self.type!r}"
             )
-        logger.debug("Materialized artifact %s@%s -> %s", self.name, artifact.version, materialized.path)
-        return materialized
+        logger.debug("Materialized artifact %s@%s -> %s", self.name, artifact.version, value.path)
+        return value
 
 
 class AppEndpoint(_DelayedValue):
@@ -348,6 +352,12 @@ class SerializableParameter(BaseModel):
             tpe = "directory"
             download = True if param.mount is not None else param.download
         elif isinstance(param.value, (RunOutput, ArtifactValue)):
+            if param.value.type is None:
+                # Deploy materializes delayed values before serialization, so this
+                # only triggers when serializing an unmaterialized parameter directly.
+                raise ValueError(
+                    f"Parameter '{param.name}' must be materialized (or declare type=) before serialization"
+                )
             value = param.value.model_dump_json()
             tpe = param.value.type
             download = True if param.mount is not None else param.download

--- a/src/flyte/artifacts/_metadata.py
+++ b/src/flyte/artifacts/_metadata.py
@@ -33,22 +33,28 @@ class Metadata:
         task: Optional[str] = None,
         modality: Tuple[str, ...] = ("text",),
         serial_format: str = "safetensors",
+        data: Optional[typing.Mapping[str, str]] = None,
     ) -> Metadata:
         """
         Helper method to create ModelMetadata. This method sets the data keys specific to models.
+        Extra key/values passed via `data` are merged in; the model-specific keys win on conflict.
         """
-        return cls(
-            name=name,
-            version=version,
-            description=description,
-            data={
+        merged: dict[str, str] = dict(data) if data else {}
+        merged.update(
+            {
                 "framework": framework or "",
                 "model_type": model_type or "",
                 "architecture": architecture or "",
                 "task": task or "",
                 "modality": ",".join(modality) if modality else "",
                 "serial_format": serial_format or "",
-            },
+            }
+        )
+        return cls(
+            name=name,
+            version=version,
+            description=description,
+            data=merged,
             card=card,
         )
 

--- a/src/flyte/prefetch/_hf_model.py
+++ b/src/flyte/prefetch/_hf_model.py
@@ -29,12 +29,23 @@ DEFAULT_SHARD_PATTERN = "model-rank-{rank}-part-{part}.safetensors"
 
 # Minimal readable wrapper for HTML model cards rendered from the repo README.
 _CARD_HTML_PREFIX = (
-    "<!DOCTYPE html><html><head><meta charset='utf-8'><style>"
-    "body{font-family:-apple-system,'Segoe UI',Roboto,sans-serif;line-height:1.6;"
-    "max-width:860px;margin:0 auto;padding:32px;color:#1a1a2e;background:#fff}"
-    "pre,code{background:#f4f2fa;border-radius:6px;padding:2px 6px;overflow-x:auto}"
-    "pre{padding:12px}img{max-width:100%}h1,h2,h3{letter-spacing:-0.3px}"
-    "table{border-collapse:collapse}td,th{border:1px solid #ddd;padding:6px 10px}"
+    "<!DOCTYPE html><html><head><meta charset='utf-8'>"
+    "<meta name='viewport' content='width=device-width, initial-scale=1'><style>"
+    "body{font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;"
+    "font-size:15px;line-height:1.65;max-width:860px;margin:0 auto;padding:40px 32px;"
+    "color:#24292f;background:#fff}"
+    "a{color:#7652a2}"
+    "h1,h2{border-bottom:1px solid #eaecef;padding-bottom:.3em;letter-spacing:-0.3px}"
+    "h1,h2,h3{margin-top:1.4em;margin-bottom:.6em}"
+    "code{background:#f4f2fa;border-radius:6px;padding:2px 6px;font-size:85%;"
+    "font-family:ui-monospace,'SF Mono',Menlo,Consolas,monospace}"
+    "pre{background:#f6f8fa;border-radius:8px;padding:16px;overflow-x:auto;line-height:1.45}"
+    "pre code{background:transparent;padding:0;font-size:13px}"
+    "blockquote{border-left:4px solid #d8dee4;margin-left:0;padding-left:16px;color:#57606a}"
+    "img{max-width:100%}ul,ol{padding-left:1.6em}li{margin:.2em 0}"
+    "table{border-collapse:collapse;display:block;overflow-x:auto}"
+    "td,th{border:1px solid #d8dee4;padding:6px 12px}th{background:#f6f8fa}"
+    "hr{border:none;border-top:1px solid #eaecef;margin:24px 0}"
     "</style></head><body>"
 )
 _CARD_HTML_SUFFIX = "</body></html>"
@@ -367,7 +378,9 @@ def _wrap_as_model_artifact(
         try:
             import markdown
 
-            content = _CARD_HTML_PREFIX + markdown.markdown(content) + _CARD_HTML_SUFFIX
+            # "extra" bundles fenced code blocks and tables, which HF READMEs
+            # use heavily (bibtex blocks, benchmark tables).
+            content = _CARD_HTML_PREFIX + markdown.markdown(content, extensions=["extra"]) + _CARD_HTML_SUFFIX
             fmt = "html"
         except Exception as e:
             logger.warning(f"Markdown-to-HTML conversion unavailable, uploading markdown card: {e}")
@@ -483,7 +496,7 @@ def store_hf_model_task(info: str, raw_data_path: str | None = None) -> Dir:
             # Try to import markdown if available (don't add import; just use if exists)
             import markdown
 
-            report = markdown.markdown(card)
+            report = markdown.markdown(card, extensions=["extra"])
         except Exception:
             report = card  # fallback to plain markdown content
         flyte.report.log(report)

--- a/src/flyte/prefetch/_hf_model.py
+++ b/src/flyte/prefetch/_hf_model.py
@@ -27,6 +27,18 @@ if TYPE_CHECKING:
 
 DEFAULT_SHARD_PATTERN = "model-rank-{rank}-part-{part}.safetensors"
 
+# Minimal readable wrapper for HTML model cards rendered from the repo README.
+_CARD_HTML_PREFIX = (
+    "<!DOCTYPE html><html><head><meta charset='utf-8'><style>"
+    "body{font-family:-apple-system,'Segoe UI',Roboto,sans-serif;line-height:1.6;"
+    "max-width:860px;margin:0 auto;padding:32px;color:#1a1a2e;background:#fff}"
+    "pre,code{background:#f4f2fa;border-radius:6px;padding:2px 6px;overflow-x:auto}"
+    "pre{padding:12px}img{max-width:100%}h1,h2,h3{letter-spacing:-0.3px}"
+    "table{border-collapse:collapse}td,th{border:1px solid #ddd;padding:6px 10px}"
+    "</style></head><body>"
+)
+_CARD_HTML_SUFFIX = "</body></html>"
+
 
 class VLLMShardArgs(BaseModel):
     """
@@ -347,9 +359,20 @@ def _wrap_as_model_artifact(
     if card_md:
         # HuggingFace READMEs open with a YAML frontmatter block (tags, license,
         # ...) that renders as literal text in a markdown card — drop it.
-        stripped = re.sub(r"\A\s*---\n.*?\n---\n", "", card_md, count=1, flags=re.DOTALL)
+        content = re.sub(r"\A\s*---\n.*?\n---\n", "", card_md, count=1, flags=re.DOTALL) or card_md
+        # Prefer an HTML card: the UI renders HTML cards in an iframe, which
+        # works against any object store; markdown cards need a browser fetch
+        # of the presigned URL and thus CORS on the bucket.
+        fmt: str = "md"
         try:
-            card = artifacts.Card.create_from(content=stripped or card_md, format="md", card_type="model")
+            import markdown
+
+            content = _CARD_HTML_PREFIX + markdown.markdown(content) + _CARD_HTML_SUFFIX
+            fmt = "html"
+        except Exception as e:
+            logger.warning(f"Markdown-to-HTML conversion unavailable, uploading markdown card: {e}")
+        try:
+            card = artifacts.Card.create_from(content=content, format=fmt, card_type="model")  # type: ignore[arg-type]
         except Exception as e:
             logger.warning(f"Could not upload model card: {e}")
 

--- a/src/flyte/prefetch/_hf_model.py
+++ b/src/flyte/prefetch/_hf_model.py
@@ -291,7 +291,7 @@ def _shard_model(
     repo: str,
     commit: str,
     shard_config: ShardConfig,
-    token: str,
+    token: str | None,
     model_path: str,
     output_dir: str,
 ) -> tuple[str, str | None]:

--- a/src/flyte/prefetch/_hf_model.py
+++ b/src/flyte/prefetch/_hf_model.py
@@ -345,8 +345,11 @@ def _wrap_as_model_artifact(
 
     card = None
     if card_md:
+        # HuggingFace READMEs open with a YAML frontmatter block (tags, license,
+        # ...) that renders as literal text in a markdown card — drop it.
+        stripped = re.sub(r"\A\s*---\n.*?\n---\n", "", card_md, count=1, flags=re.DOTALL)
         try:
-            card = artifacts.Card.create_from(content=card_md, format="md", card_type="model")
+            card = artifacts.Card.create_from(content=stripped or card_md, format="md", card_type="model")
         except Exception as e:
             logger.warning(f"Could not upload model card: {e}")
 

--- a/src/flyte/prefetch/_hf_model.py
+++ b/src/flyte/prefetch/_hf_model.py
@@ -328,6 +328,48 @@ def _shard_model(
     return output_dir, card
 
 
+def _wrap_as_model_artifact(
+    result_dir: Dir,
+    info: HuggingFaceModelInfo,
+    artifact_name: str,
+    commit: str,
+    card_md: str | None,
+) -> Dir:
+    """
+    Wrap the stored model Dir with artifact metadata so the platform records a
+    model artifact when the task succeeds: name is the artifact name, version is
+    the HuggingFace commit (re-prefetching the same commit republishes the same
+    version), and the repo README becomes the model card.
+    """
+    import flyte.artifacts as artifacts
+
+    card = None
+    if card_md:
+        try:
+            card = artifacts.Card.create_from(content=card_md, format="md", card_type="model")
+        except Exception as e:
+            logger.warning(f"Could not upload model card: {e}")
+
+    data = {"source_repo": info.repo, "source_commit": commit}
+    if info.shard_config is not None:
+        data["sharding"] = f"{info.shard_config.engine}-tp{info.shard_config.args.tensor_parallel_size}"
+
+    metadata = artifacts.Metadata.create_model_metadata(
+        name=artifact_name,
+        version=commit,
+        description=info.short_description or f"HuggingFace model {info.repo}",
+        card=card,
+        framework="huggingface",
+        model_type=info.model_type,
+        architecture=info.architecture,
+        task=info.task,
+        modality=info.modality,
+        serial_format=info.serial_format or "safetensors",
+        data=data,
+    )
+    return artifacts.new(result_dir, metadata)
+
+
 # NOTE: the info argument is a json string instead of a HuggingFaceModelInfo
 # object because the type engine cannot handle nested pydantic or dataclass
 # objects when run in interactive mode.
@@ -423,7 +465,7 @@ def store_hf_model_task(info: str, raw_data_path: str | None = None) -> Dir:
         flyte.report.flush()
 
     logger.info(f"Model stored successfully at {result_dir.path}")
-    return result_dir
+    return _wrap_as_model_artifact(result_dir, _info, artifact_name, commit, card)
 
 
 def hf_model(
@@ -452,6 +494,13 @@ def hf_model(
     1. If the model isn't being sharded, stream files directly to remote storage.
     2. If streaming fails, fall back to downloading a snapshot and uploading.
     3. If sharding is configured, download locally, shard with vLLM, then upload.
+
+    On success the platform records a **model artifact** for the stored Dir:
+    the artifact name is `artifact_name` (default: the repo name), the version
+    is the HuggingFace commit id, the searchable metadata carries the model
+    facts (framework/architecture/task/modality/serial_format plus the source
+    repo and commit), and the repo's README is attached as the model card.
+    Retrieve it later with `flyte.remote.Artifact.get(artifact_name)`.
 
     Example usage:
 
@@ -556,7 +605,7 @@ def hf_model(
         resources=resources,
         secrets=[Secret(key=hf_token_key, as_env_var="HF_TOKEN")],
     )
-    prefetch_task = env.task(report=True)(store_hf_model_task)
+    prefetch_task = env.task(report=True, produces_artifacts=True)(store_hf_model_task)
     run = flyte.with_runcontext(interactive_mode=True, disable_run_cache=disable_run_cache).run(
         prefetch_task, info.model_dump_json(), raw_data_path
     )

--- a/src/flyte/prefetch/_hf_model.py
+++ b/src/flyte/prefetch/_hf_model.py
@@ -645,7 +645,11 @@ def hf_model(
         secrets=[Secret(key=hf_token_key, as_env_var="HF_TOKEN")] if hf_token_key else None,
     )
     prefetch_task = env.task(report=True, produces_artifacts=True)(store_hf_model_task)
-    run = flyte.with_runcontext(interactive_mode=True, disable_run_cache=disable_run_cache).run(
-        prefetch_task, info.model_dump_json(), raw_data_path
-    )
+    # Label the run with the model being prefetched so runs are searchable by model.
+    model_label = artifact_name or repo.rsplit("/", maxsplit=1)[-1].replace(".", "-")
+    run = flyte.with_runcontext(
+        interactive_mode=True,
+        disable_run_cache=disable_run_cache,
+        labels={"model": model_label},
+    ).run(prefetch_task, info.model_dump_json(), raw_data_path)
     return typing.cast(Run, run)

--- a/src/flyte/prefetch/_hf_model.py
+++ b/src/flyte/prefetch/_hf_model.py
@@ -380,9 +380,8 @@ def store_hf_model_task(info: str, raw_data_path: str | None = None) -> Dir:
 
     import flyte.report
 
-    # Get HF token from secrets
-    token = os.environ.get("HF_TOKEN")
-    assert token is not None, "HF_TOKEN environment variable is not set"
+    # Get HF token from secrets; absent means anonymous access (public models).
+    token = os.environ.get("HF_TOKEN") or None
 
     # Validate repo exists and get latest commit
     _info: HuggingFaceModelInfo = HuggingFaceModelInfo.model_validate_json(info)
@@ -480,7 +479,7 @@ def hf_model(
     model_type: str | None = None,
     short_description: str | None = None,
     shard_config: ShardConfig | None = None,
-    hf_token_key: str = "HF_TOKEN",
+    hf_token_key: str | None = "HF_TOKEN",
     resources: Resources = Resources(cpu="2", memory="8Gi", disk="50Gi"),
     force: int = 0,
 ) -> Run:
@@ -542,6 +541,7 @@ def hf_model(
     :param short_description: Short description of the model.
     :param shard_config: Optional configuration for model sharding with vLLM.
     :param hf_token_key: Name of the secret containing the HuggingFace token. Default: 'HF_TOKEN'.
+        Pass None to prefetch public models anonymously (no secret required).
     :param cpu: CPU request for the prefetch task (e.g., '2').
     :param mem: Memory request for the prefetch task (e.g., '16Gi').
     :param disk: Disk storage request (e.g., '100Gi').
@@ -603,7 +603,7 @@ def hf_model(
         name="prefetch-hf-model",
         image=image,
         resources=resources,
-        secrets=[Secret(key=hf_token_key, as_env_var="HF_TOKEN")],
+        secrets=[Secret(key=hf_token_key, as_env_var="HF_TOKEN")] if hf_token_key else None,
     )
     prefetch_task = env.task(report=True, produces_artifacts=True)(store_hf_model_task)
     run = flyte.with_runcontext(interactive_mode=True, disable_run_cache=disable_run_cache).run(

--- a/tests/flyte/prefetch/test_hf_model.py
+++ b/tests/flyte/prefetch/test_hf_model.py
@@ -495,6 +495,88 @@ def test_prefetch_hf_model_task_nonexistent_repo_raises():
 
 
 # =============================================================================
+# _wrap_as_model_artifact Tests
+# =============================================================================
+
+
+def test_wrap_as_model_artifact_metadata():
+    """The stored Dir is wrapped with model artifact metadata: name, HF commit
+    as version, model facts + source repo/commit as data, README as card."""
+    from flyte.io import Dir
+    from flyte.prefetch._hf_model import _wrap_as_model_artifact
+
+    info = HuggingFaceModelInfo(
+        repo="meta-llama/Llama-2-7b-hf",
+        architecture="LlamaForCausalLM",
+        model_type="llama",
+        task="generate",
+        short_description="Llama 2 7B",
+    )
+    result_dir = Dir(path="s3://bucket/models/llama")
+
+    import flyte.artifacts as artifacts
+
+    fake_card = artifacts.Card(uri="s3://b/model.md", format="md", card_type="model")
+    with patch("flyte.artifacts.Card.create_from", return_value=fake_card) as mock_card:
+        wrapped = _wrap_as_model_artifact(result_dir, info, "Llama-2-7b-hf", "abc123", "# Llama 2")
+
+    mock_card.assert_called_once_with(content="# Llama 2", format="md", card_type="model")
+    md = wrapped.get_flyte_metadata()
+    assert md.name == "Llama-2-7b-hf"
+    assert md.version == "abc123"
+    assert md.description == "Llama 2 7B"
+    assert md.card == fake_card
+    assert md.data["architecture"] == "LlamaForCausalLM"
+    assert md.data["model_type"] == "llama"
+    assert md.data["task"] == "generate"
+    assert md.data["framework"] == "huggingface"
+    assert md.data["serial_format"] == "safetensors"
+    assert md.data["source_repo"] == "meta-llama/Llama-2-7b-hf"
+    assert md.data["source_commit"] == "abc123"
+    assert "sharding" not in md.data
+    # The wrapper preserves the Dir interface.
+    assert wrapped.path == "s3://bucket/models/llama"
+
+
+def test_wrap_as_model_artifact_no_readme_no_card():
+    """No README -> no card, and the description falls back to the repo."""
+    from flyte.io import Dir
+    from flyte.prefetch._hf_model import _wrap_as_model_artifact
+
+    info = HuggingFaceModelInfo(repo="org/model")
+    wrapped = _wrap_as_model_artifact(Dir(path="s3://b/m"), info, "model", "deadbeef", None)
+
+    md = wrapped.get_flyte_metadata()
+    assert md.card is None
+    assert md.description == "HuggingFace model org/model"
+
+
+def test_wrap_as_model_artifact_sharded_records_sharding():
+    """Sharded prefetch records the sharding engine and parallelism."""
+    from flyte.io import Dir
+    from flyte.prefetch._hf_model import _wrap_as_model_artifact
+
+    info = HuggingFaceModelInfo(
+        repo="org/model",
+        shard_config=ShardConfig(args=VLLMShardArgs(tensor_parallel_size=8)),
+    )
+    wrapped = _wrap_as_model_artifact(Dir(path="s3://b/m"), info, "model", "c1", None)
+    assert wrapped.get_flyte_metadata().data["sharding"] == "vllm-tp8"
+
+
+def test_wrap_as_model_artifact_card_upload_failure_is_nonfatal():
+    """A card upload failure must not fail the prefetch."""
+    from flyte.io import Dir
+    from flyte.prefetch._hf_model import _wrap_as_model_artifact
+
+    info = HuggingFaceModelInfo(repo="org/model")
+    with patch("flyte.artifacts.Card.create_from", side_effect=RuntimeError("no storage")):
+        wrapped = _wrap_as_model_artifact(Dir(path="s3://b/m"), info, "model", "c1", "# README")
+
+    assert wrapped.get_flyte_metadata().card is None
+
+
+# =============================================================================
 # _shard_model Tests
 # =============================================================================
 

--- a/tests/flyte/prefetch/test_hf_model.py
+++ b/tests/flyte/prefetch/test_hf_model.py
@@ -574,7 +574,25 @@ def test_wrap_as_model_artifact_strips_readme_frontmatter():
     with patch("flyte.artifacts.Card.create_from") as mock_card:
         _wrap_as_model_artifact(Dir(path="s3://b/m"), info, "model", "c1", readme)
 
-    assert mock_card.call_args.kwargs["content"] == "# Model\nBody text."
+    content = mock_card.call_args.kwargs["content"]
+    assert "license: mit" not in content
+    assert "Body text." in content
+
+
+def test_wrap_as_model_artifact_card_is_html_when_markdown_available():
+    """With the markdown package present the card uploads as a rendered HTML page."""
+    from flyte.io import Dir
+    from flyte.prefetch._hf_model import _wrap_as_model_artifact
+
+    pytest.importorskip("markdown")
+    info = HuggingFaceModelInfo(repo="org/model")
+    with patch("flyte.artifacts.Card.create_from") as mock_card:
+        _wrap_as_model_artifact(Dir(path="s3://b/m"), info, "model", "c1", "# Title\nBody")
+
+    assert mock_card.call_args.kwargs["format"] == "html"
+    content = mock_card.call_args.kwargs["content"]
+    assert content.startswith("<!DOCTYPE html>")
+    assert "<h1>Title</h1>" in content
 
 
 def test_wrap_as_model_artifact_card_upload_failure_is_nonfatal():

--- a/tests/flyte/prefetch/test_hf_model.py
+++ b/tests/flyte/prefetch/test_hf_model.py
@@ -564,6 +564,19 @@ def test_wrap_as_model_artifact_sharded_records_sharding():
     assert wrapped.get_flyte_metadata().data["sharding"] == "vllm-tp8"
 
 
+def test_wrap_as_model_artifact_strips_readme_frontmatter():
+    """HF README YAML frontmatter is dropped from the uploaded card."""
+    from flyte.io import Dir
+    from flyte.prefetch._hf_model import _wrap_as_model_artifact
+
+    readme = "---\nlanguage:\n  - en\nlicense: mit\n---\n# Model\nBody text."
+    info = HuggingFaceModelInfo(repo="org/model")
+    with patch("flyte.artifacts.Card.create_from") as mock_card:
+        _wrap_as_model_artifact(Dir(path="s3://b/m"), info, "model", "c1", readme)
+
+    assert mock_card.call_args.kwargs["content"] == "# Model\nBody text."
+
+
 def test_wrap_as_model_artifact_card_upload_failure_is_nonfatal():
     """A card upload failure must not fail the prefetch."""
     from flyte.io import Dir

--- a/tests/flyte/prefetch/test_hf_model.py
+++ b/tests/flyte/prefetch/test_hf_model.py
@@ -520,7 +520,11 @@ def test_wrap_as_model_artifact_metadata():
     with patch("flyte.artifacts.Card.create_from", return_value=fake_card) as mock_card:
         wrapped = _wrap_as_model_artifact(result_dir, info, "Llama-2-7b-hf", "abc123", "# Llama 2")
 
-    mock_card.assert_called_once_with(content="# Llama 2", format="md", card_type="model")
+    kwargs = mock_card.call_args.kwargs
+    assert kwargs["card_type"] == "model"
+    # html when the markdown package is importable, md otherwise.
+    assert kwargs["format"] in ("md", "html")
+    assert "Llama 2" in kwargs["content"]
     md = wrapped.get_flyte_metadata()
     assert md.name == "Llama-2-7b-hf"
     assert md.version == "abc123"

--- a/tests/flyte/test_produces_artifacts.py
+++ b/tests/flyte/test_produces_artifacts.py
@@ -124,6 +124,16 @@ class TestMetadataCompactJson:
         md = Metadata(name="n", data={"b": "2", "a": "1"})
         assert to_compact_json(md) == to_compact_json(Metadata(name="n", data={"a": "1", "b": "2"}))
 
+    def test_model_metadata_merges_extra_data(self):
+        md = Metadata.create_model_metadata(
+            name="m",
+            framework="torch",
+            data={"source_repo": "org/model", "framework": "should-lose"},
+        )
+        assert md.data["source_repo"] == "org/model"
+        # Model-specific keys win on conflict.
+        assert md.data["framework"] == "torch"
+
 
 class TestOutputStamping:
     @pytest.mark.asyncio

--- a/tests/user_api_apps/test_artifact_value.py
+++ b/tests/user_api_apps/test_artifact_value.py
@@ -11,15 +11,16 @@ from flyte.io import Dir, File
 
 
 def test_artifact_value_minimal():
-    av = ArtifactValue(type="directory", name="bert-small")
+    av = ArtifactValue(name="bert-small")
     assert av.name == "bert-small"
     assert av.version is None
     assert av.project is None
     assert av.domain is None
+    assert av.type is None  # inferred from the artifact at materialization
 
 
 def test_artifact_value_pinned_version():
-    av = ArtifactValue(type="file", name="weights", version="abc123", project="p", domain="d")
+    av = ArtifactValue(name="weights", version="abc123", project="p", domain="d")
     assert av.version == "abc123"
     assert av.project == "p"
     assert av.domain == "d"
@@ -31,22 +32,28 @@ def test_artifact_value_python_type_mapping():
 
 
 def test_artifact_value_json_roundtrip():
-    av = ArtifactValue(type="directory", name="bert-small", version="v1")
+    av = ArtifactValue(name="bert-small", version="v1")
     restored = ArtifactValue.model_validate_json(av.model_dump_json())
     assert restored == av
 
 
 def test_parameter_accepts_artifact_value():
-    p = Parameter(name="model", value=ArtifactValue(type="directory", name="bert-small"), mount="/models")
+    p = Parameter(name="model", value=ArtifactValue(name="bert-small"), mount="/models")
     assert isinstance(p.value, ArtifactValue)
 
 
-def test_serializable_parameter_from_unmaterialized_artifact_value():
+def test_serializable_parameter_from_unmaterialized_declared_type():
     p = Parameter(name="model", value=ArtifactValue(type="directory", name="bert-small"), mount="/models")
     sp = SerializableParameter.from_parameter(p)
     assert sp.type == "directory"
     assert sp.download is True
     assert '"name":"bert-small"' in sp.value
+
+
+def test_serializable_parameter_from_unmaterialized_inferred_type_raises():
+    p = Parameter(name="model", value=ArtifactValue(name="bert-small"), mount="/models")
+    with pytest.raises(ValueError, match="materialized"):
+        SerializableParameter.from_parameter(p)
 
 
 def _patched_remote_artifact(value):
@@ -60,14 +67,23 @@ def _patched_remote_artifact(value):
 
 
 @pytest.mark.asyncio
-async def test_materialize_directory_artifact():
+async def test_materialize_infers_directory():
     mock_cls, get = _patched_remote_artifact(Dir(path="s3://bucket/models/bert"))
     with patch("flyte._initialize.is_initialized", return_value=True), patch("flyte.remote.Artifact", mock_cls):
-        value = await ArtifactValue(type="directory", name="bert-small").materialize()
+        value = await ArtifactValue(name="bert-small").materialize()
 
     assert isinstance(value, Dir)
     assert value.path == "s3://bucket/models/bert"
     get.assert_awaited_once_with("bert-small", version="latest", project=None, domain=None)
+
+
+@pytest.mark.asyncio
+async def test_materialize_infers_file():
+    mock_cls, _ = _patched_remote_artifact(File(path="s3://bucket/weights.pt"))
+    with patch("flyte._initialize.is_initialized", return_value=True), patch("flyte.remote.Artifact", mock_cls):
+        value = await ArtifactValue(name="weights").materialize()
+
+    assert isinstance(value, File)
 
 
 @pytest.mark.asyncio
@@ -81,7 +97,7 @@ async def test_materialize_pinned_version_and_scope():
 
 
 @pytest.mark.asyncio
-async def test_materialize_type_mismatch_raises():
+async def test_materialize_declared_type_mismatch_raises():
     mock_cls, _ = _patched_remote_artifact(File(path="s3://bucket/weights.pt"))
     with (
         patch("flyte._initialize.is_initialized", return_value=True),
@@ -89,6 +105,17 @@ async def test_materialize_type_mismatch_raises():
         pytest.raises(flyte.errors.ParameterMaterializationError, match="declared as 'directory'"),
     ):
         await ArtifactValue(type="directory", name="weights").materialize()
+
+
+@pytest.mark.asyncio
+async def test_materialize_non_asset_artifact_raises():
+    mock_cls, _ = _patched_remote_artifact("a string value")
+    with (
+        patch("flyte._initialize.is_initialized", return_value=True),
+        patch("flyte.remote.Artifact", mock_cls),
+        pytest.raises(flyte.errors.ParameterMaterializationError, match="only File and Dir"),
+    ):
+        await ArtifactValue(name="weights").materialize()
 
 
 @pytest.mark.asyncio

--- a/tests/user_api_apps/test_artifact_value.py
+++ b/tests/user_api_apps/test_artifact_value.py
@@ -1,0 +1,109 @@
+"""Tests for flyte.app.ArtifactValue: artifacts as app parameter values."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import flyte.errors
+from flyte.app import ArtifactValue, Parameter
+from flyte.app._parameter import SerializableParameter
+from flyte.io import Dir, File
+
+
+def test_artifact_value_minimal():
+    av = ArtifactValue(type="directory", name="bert-small")
+    assert av.name == "bert-small"
+    assert av.version is None
+    assert av.project is None
+    assert av.domain is None
+
+
+def test_artifact_value_pinned_version():
+    av = ArtifactValue(type="file", name="weights", version="abc123", project="p", domain="d")
+    assert av.version == "abc123"
+    assert av.project == "p"
+    assert av.domain == "d"
+
+
+def test_artifact_value_python_type_mapping():
+    assert ArtifactValue(type=File, name="a").type == "file"
+    assert ArtifactValue(type=Dir, name="a").type == "directory"
+
+
+def test_artifact_value_json_roundtrip():
+    av = ArtifactValue(type="directory", name="bert-small", version="v1")
+    restored = ArtifactValue.model_validate_json(av.model_dump_json())
+    assert restored == av
+
+
+def test_parameter_accepts_artifact_value():
+    p = Parameter(name="model", value=ArtifactValue(type="directory", name="bert-small"), mount="/models")
+    assert isinstance(p.value, ArtifactValue)
+
+
+def test_serializable_parameter_from_unmaterialized_artifact_value():
+    p = Parameter(name="model", value=ArtifactValue(type="directory", name="bert-small"), mount="/models")
+    sp = SerializableParameter.from_parameter(p)
+    assert sp.type == "directory"
+    assert sp.download is True
+    assert '"name":"bert-small"' in sp.value
+
+
+def _patched_remote_artifact(value):
+    artifact = MagicMock()
+    artifact.version = "v1"
+    artifact.to_python = AsyncMock(return_value=value)
+    get = AsyncMock(return_value=artifact)
+    mock_artifact_cls = MagicMock()
+    mock_artifact_cls.get.aio = get
+    return mock_artifact_cls, get
+
+
+@pytest.mark.asyncio
+async def test_materialize_directory_artifact():
+    mock_cls, get = _patched_remote_artifact(Dir(path="s3://bucket/models/bert"))
+    with patch("flyte._initialize.is_initialized", return_value=True), patch("flyte.remote.Artifact", mock_cls):
+        value = await ArtifactValue(type="directory", name="bert-small").materialize()
+
+    assert isinstance(value, Dir)
+    assert value.path == "s3://bucket/models/bert"
+    get.assert_awaited_once_with("bert-small", version="latest", project=None, domain=None)
+
+
+@pytest.mark.asyncio
+async def test_materialize_pinned_version_and_scope():
+    mock_cls, get = _patched_remote_artifact(File(path="s3://bucket/weights.pt"))
+    with patch("flyte._initialize.is_initialized", return_value=True), patch("flyte.remote.Artifact", mock_cls):
+        value = await ArtifactValue(type="file", name="weights", version="abc", project="p", domain="d").materialize()
+
+    assert isinstance(value, File)
+    get.assert_awaited_once_with("weights", version="abc", project="p", domain="d")
+
+
+@pytest.mark.asyncio
+async def test_materialize_type_mismatch_raises():
+    mock_cls, _ = _patched_remote_artifact(File(path="s3://bucket/weights.pt"))
+    with (
+        patch("flyte._initialize.is_initialized", return_value=True),
+        patch("flyte.remote.Artifact", mock_cls),
+        pytest.raises(flyte.errors.ParameterMaterializationError, match="declared as 'directory'"),
+    ):
+        await ArtifactValue(type="directory", name="weights").materialize()
+
+
+@pytest.mark.asyncio
+async def test_materialize_string_type_rejected():
+    with patch("flyte._initialize.is_initialized", return_value=True), pytest.raises(ValueError, match="file"):
+        await ArtifactValue(type="string", name="weights").materialize()
+
+
+@pytest.mark.asyncio
+async def test_materialize_lookup_failure_wrapped():
+    mock_cls = MagicMock()
+    mock_cls.get.aio = AsyncMock(side_effect=RuntimeError("not found"))
+    with (
+        patch("flyte._initialize.is_initialized", return_value=True),
+        patch("flyte.remote.Artifact", mock_cls),
+        pytest.raises(flyte.errors.ParameterMaterializationError, match="weights@latest"),
+    ):
+        await ArtifactValue(type="file", name="weights").materialize()


### PR DESCRIPTION
`flyte.prefetch.hf_model` now publishes a model artifact for the prefetched model.

- The store task runs with `produces_artifacts=True` and wraps the stored `Dir`: artifact name = `artifact_name` (default: repo name), **version = the HuggingFace commit id**.
- Searchable metadata carries the model facts (framework/architecture/task/modality/serial_format) plus `source_repo`/`source_commit`, and `sharding` when vLLM sharding is used. `create_model_metadata` gains an extra-data merge parameter for this.
- The repo README becomes the model card, converted to styled HTML (fenced code/tables supported, YAML frontmatter stripped); HTML cards render in the UI iframe with no bucket CORS requirement. Missing README is tolerated.
- `hf_token_key=None` skips the secret mount for anonymous prefetch of public models.
- Runs are labeled `model=<artifact_name>` so prefetches are filterable by model.
- **Apps**: new `flyte.app.ArtifactValue(name, version=...)` delayed parameter (parallel to `RunOutput`) resolves a published artifact at deployment time and materializes its stored File/Dir (type inferred from the artifact; optional `type=` asserts it) — so an app can mount a prefetched model by artifact name.

Devbox-e2e-verified: `tiny-random-gpt2` (no README), `bert-mini`, `bert-small` (README → HTML card, presign verified), `tiny-random-bert` (run label verified). `ArtifactValue` materialization verified live against the devbox artifact service (bert-small -> stored model Dir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
