### PR TITLE
fix(map): await local-mode map results instead of yielding bare coroutines

### DIFF
--- a/src/flyte/_map.py
+++ b/src/flyte/_map.py
@@ -1,5 +1,6 @@
 import asyncio
 import functools
+import inspect
 import logging
 from typing import Any, AsyncGenerator, AsyncIterator, Generic, Iterable, Iterator, List, Union, cast, overload
 
@@ -203,6 +204,24 @@ class MapAsyncIterator(Generic[P, R]):
         return f"MapAsyncIterator(group_name='{self.name}', concurrency={self.concurrency})"
 
 
+async def _invoke_local(func: AsyncFunctionTaskTemplate[P, R, F] | functools.partial[R], arg_tuple: tuple) -> R:
+    """
+    Await a single mapped call in local mode, handling functools.partial and the
+    no-task-context case (where ``.aio`` returns the bare coroutine from ``forward``).
+    """
+    if isinstance(func, functools.partial):
+        base_func = cast(AsyncFunctionTaskTemplate, func.func)
+        result = await base_func.aio(*(func.args + arg_tuple), **(func.keywords or {}))
+    else:
+        result = await func.aio(*arg_tuple)  # type: ignore[call-overload]  # ty: ignore[no-matching-overload]
+    if inspect.iscoroutine(result):
+        result = await result
+    return cast(R, result)
+
+
+_invoke_local_sync = syncify(_invoke_local)
+
+
 class _Mapper(Generic[P, R]):
     """
     Internal mapper class to handle the mapping logic
@@ -312,7 +331,7 @@ class _Mapper(Generic[P, R]):
                 logger.warning("Running map in local mode, which will run every task sequentially.")
                 for v in zip(*args):
                     try:
-                        yield func(*v)  # type: ignore
+                        yield cast(R, _invoke_local_sync(func, v))
                     except Exception as e:
                         if return_exceptions:
                             yield e
@@ -361,7 +380,7 @@ class _Mapper(Generic[P, R]):
                 logger.warning("Running map in local mode, which will run every task sequentially.")
                 for v in zip(*args):
                     try:
-                        yield func(*v)  # type: ignore
+                        yield cast(R, await _invoke_local(func, v))
                     except Exception as e:
                         if return_exceptions:
                             yield e

--- a/tests/flyte/test_map_local.py
+++ b/tests/flyte/test_map_local.py
@@ -1,0 +1,101 @@
+"""Tests for flyte.map / flyte.map.aio in local mode.
+
+Regression tests for https://github.com/flyteorg/flyte-sdk/issues/1359:
+in local mode the map local branch yielded bare, un-awaited coroutines
+instead of resolved task results.
+"""
+
+import inspect
+
+import pytest
+
+import flyte
+
+env = flyte.TaskEnvironment(name="map_local_test")
+
+
+@env.task
+async def echo(x: str) -> str:
+    return f"echo:{x}"
+
+
+@env.task
+def echo_sync(x: str) -> str:
+    return f"echo:{x}"
+
+
+@env.task
+async def aio_parent() -> list[str]:
+    out = []
+    async for r in flyte.map.aio(echo, ["a", "b", "c"], concurrency=0, return_exceptions=False):
+        assert not inspect.iscoroutine(r), f"map.aio yielded an un-awaited coroutine: {r!r}"
+        out.append(r)
+    return out
+
+
+@env.task
+def sync_parent() -> list[str]:
+    out = []
+    for r in flyte.map(echo_sync, ["a", "b", "c"], return_exceptions=False):
+        assert not inspect.iscoroutine(r), f"map yielded an un-awaited coroutine: {r!r}"
+        out.append(r)
+    return out
+
+
+@pytest.mark.asyncio
+async def test_map_aio_local_yields_results():
+    """flyte.map.aio inside a local-mode parent task must yield awaited results."""
+    await flyte.init.aio()
+    result = await flyte.with_runcontext(mode="local").run.aio(aio_parent)
+    assert result.outputs()[0] == ["echo:a", "echo:b", "echo:c"]
+
+
+def test_map_sync_local_yields_results():
+    """flyte.map inside a local-mode parent task must yield awaited results."""
+    flyte.init()
+    result = flyte.with_runcontext(mode="local").run(sync_parent)
+    assert result.outputs()[0] == ["echo:a", "echo:b", "echo:c"]
+
+
+@env.task
+def sync_parent_async_child() -> list[str]:
+    out = []
+    for r in flyte.map(echo, ["a", "b", "c"], return_exceptions=False):
+        assert not inspect.iscoroutine(r), f"map yielded an un-awaited coroutine: {r!r}"
+        out.append(r)
+    return out
+
+
+def test_map_sync_local_async_child_yields_results():
+    """Blocking flyte.map over an async task in local mode must yield awaited results."""
+    flyte.init()
+    result = flyte.with_runcontext(mode="local").run(sync_parent_async_child)
+    assert result.outputs()[0] == ["echo:a", "echo:b", "echo:c"]
+
+
+@env.task
+async def fail_on_b(x: str) -> str:
+    if x == "b":
+        raise ValueError(f"boom:{x}")
+    return f"echo:{x}"
+
+
+@env.task
+async def aio_parent_return_exceptions() -> list[str]:
+    out = []
+    async for r in flyte.map.aio(fail_on_b, ["a", "b", "c"], return_exceptions=True):
+        assert not inspect.iscoroutine(r), f"map.aio yielded an un-awaited coroutine: {r!r}"
+        out.append(f"error:{r}" if isinstance(r, Exception) else r)
+    return out
+
+
+@pytest.mark.asyncio
+async def test_map_aio_local_return_exceptions():
+    """With return_exceptions=True, local-mode map.aio must yield the exception, not a coroutine."""
+    await flyte.init.aio()
+    result = await flyte.with_runcontext(mode="local").run.aio(aio_parent_return_exceptions)
+    outputs = result.outputs()[0]
+    assert outputs[0] == "echo:a"
+    assert outputs[1].startswith("error:")
+    assert "boom:b" in outputs[1]
+    assert outputs[2] == "echo:c"


### PR DESCRIPTION
## Summary

Fixes #1359 — in local mode, `flyte.map(...)` and `flyte.map.aio(...)` yielded bare, un-awaited coroutines instead of task results.

Both local branches in `_Mapper.__call__` / `_Mapper.aio` did `yield func(*v)`. For an async task inside a run context, `func(*v)` returns the un-awaited `LocalController.submit(...)` coroutine, so callers got coroutine objects (with `RuntimeWarning: coroutine 'LocalController.submit' was never awaited`) and task exceptions never surfaced, silently breaking `return_exceptions` semantics too.

## Fix

- New `_invoke_local(func, arg_tuple)` helper in `src/flyte/_map.py`: partial-aware (mirrors `MapAsyncIterator._invoke`), awaits `func.aio(...)`, and additionally awaits the `forward()` coroutine for the no-task-context case (async task mapped outside any run).
- `_Mapper.aio` local branch: `yield await _invoke_local(func, v)` — stays on the caller's loop.
- `_Mapper.__call__` local branch: `yield _invoke_local_sync(func, v)` (syncified) — bridges into the syncify background loop, the same mechanism the remote branch already uses via `_map(...)`; contextvars propagate through `run_coroutine_threadsafe`, so the child still submits through the `LocalController` (tracking/cache preserved).

## Tests

`tests/flyte/test_map_local.py` (all previously red on main except the sync-task case, which only worked because a sync function returns its value directly):

- `flyte.map.aio` over an async task in a local run yields awaited results
- blocking `flyte.map` over an async task in a local run yields awaited results
- blocking `flyte.map` over a sync task (regression guard for the one path that already worked)
- `return_exceptions=True` yields the exception instance, not a coroutine

Each test asserts `not inspect.iscoroutine(r)` per item plus final output values.

Verified: repro from #1359 now prints `['echo:a', 'echo:b', 'echo:c']`; `ruff` + `mypy` clean on changed files; broad `tests/flyte` sweep passes (2548 passed; only pre-existing environment-dependent failures in `keyring`/`test_int_image_builder`, which fail identically on clean main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)