### PR TITLE
fix(io): preserve zero-byte files in Dir/File downloads

### DIFF
--- a/src/flyte/storage/_parallel_reader.py
+++ b/src/flyte/storage/_parallel_reader.py
@@ -183,17 +183,23 @@ class ObstoreParallelReader:
                     file_offset = task.chunk.offset + task.source.offset
                     try:
                         buf = active[task.source.id]
-                        data_to_write = await obstore.get_range_async(
-                            self._store,
-                            str(task.source.path),
-                            start=file_offset,
-                            end=file_offset + task.chunk.length,
-                        )
-                        await buf.write(
-                            task.chunk.offset,
-                            task.chunk.length,
-                            data_to_write,
-                        )
+                        # A zero-length chunk (0-byte file) has nothing to fetch or write: the
+                        # buffer is already complete (pending == 0) and _FileBuffer.new touched
+                        # the file on creation. Skip the fetch — obstore rejects a zero-length
+                        # range request (start == end) with an error — and fall through to
+                        # completion so the empty file is still finalized.
+                        if task.chunk.length != 0:
+                            data_to_write = await obstore.get_range_async(
+                                self._store,
+                                str(task.source.path),
+                                start=file_offset,
+                                end=file_offset + task.chunk.length,
+                            )
+                            await buf.write(
+                                task.chunk.offset,
+                                task.chunk.length,
+                                data_to_write,
+                            )
                         if not buf.complete:
                             continue
                         if transformer is not None:
@@ -327,7 +333,13 @@ class ObstoreParallelReader:
                 source = Source(id=path, path=path, length=size)
                 # Strip src_prefix from path for destination
                 rel_path = path.relative_to(src_prefix)  # doesn't work on windows
-                for offset, length in self._chunks(size):
+                # Emit a single empty chunk for zero-byte objects so the file is still
+                # materialized locally; self._chunks(0) yields nothing (range(0, 0) is empty),
+                # which would otherwise silently drop the file from the download. Handled here
+                # rather than in _chunks so the other _chunks caller (the model loader, which
+                # skips zero-size tensors) is unaffected.
+                chunk_ranges = self._chunks(size) if size else [(0, 0)]
+                for offset, length in chunk_ranges:
                     yield DownloadTask(
                         source=source,
                         target=tmp_dir / rel_path,  # doesn't work on windows

--- a/src/flyte/storage/_parallel_reader.py
+++ b/src/flyte/storage/_parallel_reader.py
@@ -183,11 +183,7 @@ class ObstoreParallelReader:
                     file_offset = task.chunk.offset + task.source.offset
                     try:
                         buf = active[task.source.id]
-                        # A zero-length chunk (0-byte file) has nothing to fetch or write: the
-                        # buffer is already complete (pending == 0) and _FileBuffer.new touched
-                        # the file on creation. Skip the fetch — obstore rejects a zero-length
-                        # range request (start == end) with an error — and fall through to
-                        # completion so the empty file is still finalized.
+                        # Handle a zero-length chunk so that empty files still write
                         if task.chunk.length != 0:
                             data_to_write = await obstore.get_range_async(
                                 self._store,
@@ -333,11 +329,7 @@ class ObstoreParallelReader:
                 source = Source(id=path, path=path, length=size)
                 # Strip src_prefix from path for destination
                 rel_path = path.relative_to(src_prefix)  # doesn't work on windows
-                # Emit a single empty chunk for zero-byte objects so the file is still
-                # materialized locally; self._chunks(0) yields nothing (range(0, 0) is empty),
-                # which would otherwise silently drop the file from the download. Handled here
-                # rather than in _chunks so the other _chunks caller (the model loader, which
-                # skips zero-size tensors) is unaffected.
+                # Emit a single empty chunk for zero-byte objects so the file is still materialized locally
                 chunk_ranges = self._chunks(size) if size else [(0, 0)]
                 for offset, length in chunk_ranges:
                     yield DownloadTask(

--- a/tests/flyte/storage/test_parallel_reader.py
+++ b/tests/flyte/storage/test_parallel_reader.py
@@ -178,6 +178,37 @@ async def test_as_completed_pre311_surfaces_worker_exception_without_hanging():
             await asyncio.wait_for(_consume(), timeout=0.5)
 
 
+@pytest.mark.asyncio
+async def test_download_preserves_zero_byte_files(tmp_path):
+    """Regression: a 0-byte object must still be materialized locally. Previously
+    _chunks(0) yielded no chunks, so no DownloadTask was generated and the file was
+    silently dropped from the download."""
+
+    store = mock.MagicMock()
+    reader = ObstoreParallelReader(store, max_concurrency=2)
+
+    async def _mock_list(*args, **kwargs):
+        yield [
+            {"path": "prefix/one.bin", "size": 1},
+            {"path": "prefix/empty.bin", "size": 0},
+        ]
+
+    async def _mock_get_range(store, path, start=0, end=0):
+        return b"x" * (end - start)
+
+    with mock.patch("flyte.storage._parallel_reader.obstore") as mock_obstore:
+        mock_obstore.list = _mock_list
+        mock_obstore.get_range_async = _mock_get_range
+
+        target = tmp_path / "out"
+        await reader.download_files(Path("prefix"), target)
+
+    downloaded = sorted(p.name for p in target.rglob("*") if p.is_file())
+    assert downloaded == ["empty.bin", "one.bin"]
+    assert (target / "empty.bin").stat().st_size == 0
+    assert (target / "one.bin").read_bytes() == b"x"
+
+
 @pytest.mark.skip
 @pytest.mark.asyncio
 async def test_access_large_file():


### PR DESCRIPTION
## Problem

A task that returns a `flyte.io.Dir` **silently drops every zero-byte file** in that directory (reported on SDK 2.5.16). The round trip reports success and the directory looks complete — file count and total size are plausible — so there is no signal that anything was dropped.

Repro:
```python
@env.task
async def t() -> Dir:
    os.makedirs("/tmp/d", exist_ok=True)
    open("/tmp/d/empty.bin", "w").close()       # 0 bytes -> missing afterwards
    open("/tmp/d/one.bin", "w").write("x")      # 1 byte  -> survives
    return await Dir.from_local("/tmp/d")
```
Downloading the `Dir` in a second task: `empty.bin` is absent.

## Root cause

The loss is on the **download** side, in `ObstoreParallelReader` (`src/flyte/storage/_parallel_reader.py`). `_chunks(size)` iterates `range(0, size, cs)`, which is empty for a 0-byte object. So `download_files._gen` emitted **no** `DownloadTask` for an empty file, no buffer was ever created, and the local file was never touched/written.

Upload is unaffected — the object is written to the store and even returned by `obstore.list` — which is why round trips looked complete with no error. (This only affects obstore-backed stores: S3/GCS/Azure.)

## Fix

Scoped to the download path so the *other* `_chunks` caller — the model loader, which intentionally skips zero-size tensors — is unchanged:

- `download_files._gen` emits a single `(0, 0)` chunk for zero-byte objects, so the file is created via `_FileBuffer.new` (which `touch()`es it).
- `_worker` skips the `obstore.get_range_async` fetch/write when the chunk length is 0 — obstore rejects a zero-length `start == end` range request — and falls through to completion so the empty file is finalized.

## Testing

- New regression test `test_download_preserves_zero_byte_files` covering a mixed 0-byte / non-empty directory download (asserts `empty.bin` exists with size 0 and `one.bin` is byte-exact).
- Full `test_parallel_reader.py` suite passes (the two `*sandbox*`/`*with_storage*` tests require a live LocalStack S3 and fail identically on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)