### PR TITLE
fix: serialize concurrent code-bundle download/extract to prevent worker startup crashes in clustered tasks

### DIFF
--- a/src/flyte/_code_bundle/bundle.py
+++ b/src/flyte/_code_bundle/bundle.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import gzip
 import hashlib
 import logging
@@ -8,10 +9,16 @@ import os
 import pathlib
 import random
 import sqlite3
+import sys
 import tempfile
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar, Type
+from typing import TYPE_CHECKING, AsyncIterator, ClassVar, Type
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows local dev; task containers are POSIX
+    fcntl = None  # type: ignore[assignment]
 
 from async_lru import alru_cache
 
@@ -332,6 +339,112 @@ async def build_code_bundle_from_relative_paths(
         return CodeBundle(tgz=remote_path, destination=extract_dir, computed_version=hash_digest, files=files)
 
 
+@contextlib.asynccontextmanager
+async def _bundle_lock(lock_path: pathlib.Path) -> AsyncIterator[bool]:
+    """
+    Exclusive advisory flock on lock_path, yielding True if acquired.
+
+    Yields False when locking is unavailable (no fcntl, or lock file uncreatable, e.g. a read-only
+    destination) — callers then fall back to the historical unserialized behavior. flock is released
+    automatically by the kernel if the holder dies, so a crashed winner never deadlocks waiters.
+    The lock file is deliberately never unlinked: unlink+reopen would hand a late arrival a fresh
+    inode whose lock it "wins" while the old inode is still held.
+    """
+    if fcntl is None:
+        logger.debug("File locking unavailable on this platform, proceeding without serialization")
+        yield False
+        return
+    try:
+        fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o644)
+    except OSError as e:
+        logger.warning(f"Could not create bundle lock file {lock_path}: {e}, proceeding without serialization")
+        yield False
+        return
+    try:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            logger.info(f"Another process is downloading/extracting the code bundle, waiting on {lock_path}")
+            await asyncio.to_thread(fcntl.flock, fd, fcntl.LOCK_EX)
+        yield True
+    finally:
+        os.close(fd)
+
+
+async def _atomic_download(remote_path: str, target: pathlib.Path) -> None:
+    """Download remote_path into target's directory under a temp name, then os.replace into place."""
+    import flyte.storage as storage
+
+    fd, tmp = tempfile.mkstemp(dir=target.parent, prefix=f".{target.name}.", suffix=".part")
+    os.close(fd)
+    try:
+        logger.debug(f"Downloading code bundle from {remote_path} to {target.absolute()}")
+        await storage.get(remote_path, tmp)
+        os.replace(tmp, target)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+
+
+async def _extract_tar(archive: pathlib.Path, dest: pathlib.Path) -> None:
+    args = [
+        "-xvf",
+        str(archive),
+        "-C",
+        str(dest),
+    ]
+    if sys.platform != "darwin":
+        args.insert(0, "--overwrite")
+
+    process = await asyncio.create_subprocess_exec(
+        "tar",
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _stdout, stderr = await process.communicate()
+
+    if process.returncode != 0:
+        raise RuntimeError(stderr.decode())
+
+
+async def _locked_fetch(remote_path: str, dest: pathlib.Path, extract: bool) -> pathlib.Path:
+    """
+    Download (and optionally extract) remote_path into dest, serialized against concurrent callers.
+
+    Multiple worker processes may run this concurrently against the same destination (e.g. the
+    torchrun-spawned ranks of a clustered task each call download_bundle on startup). Exactly one
+    of them does the download/extract under an exclusive flock; the rest wait and then observe the
+    completion marker. The marker — not the archive's existence — is the "ready" signal, because
+    the archive appears on disk before extraction has finished.
+    """
+    downloaded = dest / os.path.basename(remote_path)
+    marker = dest / f".{downloaded.name}{'.extracted' if extract else '.done'}"
+
+    if marker.exists():
+        logger.debug(f"Code bundle {downloaded} already downloaded, skipping.")
+        return downloaded.absolute()
+
+    async with _bundle_lock(dest / f".{downloaded.name}.lock") as locked:
+        if locked and marker.exists():
+            # Another process completed the work while we waited on the lock.
+            return downloaded.absolute()
+        if not locked and downloaded.exists():
+            logger.debug(f"Code bundle {downloaded} already exists locally, skipping download.")
+            return downloaded.absolute()
+        # No marker means the archive (if present) may be a truncated leftover from a killed
+        # process — always re-download; os.replace over it is safe.
+        await _atomic_download(remote_path, downloaded)
+        if extract:
+            await _extract_tar(downloaded, dest)
+        if locked:
+            try:
+                marker.touch()
+            except OSError as e:
+                logger.warning(f"Could not write bundle marker {marker}: {e}")
+        return downloaded.absolute()
+
+
 @log(level=logging.INFO)
 async def download_bundle(bundle: CodeBundle) -> pathlib.Path:
     """
@@ -340,55 +453,15 @@ async def download_bundle(bundle: CodeBundle) -> pathlib.Path:
 
     :return: The path to the downloaded code bundle.
     """
-    import sys
-
-    import flyte.storage as storage
-
     dest = pathlib.Path(bundle.destination)
     if not dest.exists():
         dest.mkdir(parents=True, exist_ok=True)
     if not dest.is_dir():
         raise ValueError(f"Destination path should be a directory, found {dest}, {dest.stat()}")
 
-    # TODO make storage apis better to accept pathlib.Path
     if bundle.tgz:
-        downloaded_bundle = dest / os.path.basename(bundle.tgz)
-        if downloaded_bundle.exists():
-            logger.debug(f"Code bundle {downloaded_bundle} already exists locally, skipping download.")
-            return downloaded_bundle.absolute()
-        # Download the tgz file
-        logger.debug(f"Downloading code bundle from {bundle.tgz} to {downloaded_bundle.absolute()}")
-        await storage.get(bundle.tgz, str(downloaded_bundle.absolute()))
-        # NOTE the os.path.join(destination, ''). This is to ensure that the given path is in fact a directory and all
-        # downloaded data should be copied into this directory. We do this to account for a difference in behavior in
-        # fsspec, which requires a trailing slash in case of pre-existing directory.
-        args = [
-            "-xvf",
-            str(downloaded_bundle),
-            "-C",
-            str(dest),
-        ]
-        if sys.platform != "darwin":
-            args.insert(0, "--overwrite")
-
-        process = await asyncio.create_subprocess_exec(
-            "tar",
-            *args,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        _stdout, stderr = await process.communicate()
-
-        if process.returncode != 0:
-            raise RuntimeError(stderr.decode())
-        return downloaded_bundle.absolute()
-
+        return await _locked_fetch(bundle.tgz, dest, extract=True)
     elif bundle.pkl:
-        # Lets gunzip the pkl file
-
-        downloaded_bundle = dest / os.path.basename(bundle.pkl)
-        # Download the tgz file
-        await storage.get(bundle.pkl, str(downloaded_bundle.absolute()))
-        return downloaded_bundle.absolute()
+        return await _locked_fetch(bundle.pkl, dest, extract=False)
     else:
         raise ValueError("Code bundle should be either tgz or pkl, found neither.")

--- a/src/flyte/_code_bundle/bundle.py
+++ b/src/flyte/_code_bundle/bundle.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, AsyncIterator, ClassVar, Type
 try:
     import fcntl
 except ImportError:  # pragma: no cover - Windows local dev; task containers are POSIX
-    fcntl = None  # type: ignore[assignment]
+    fcntl = None  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
 
 from async_lru import alru_cache
 

--- a/tests/flyte/code_bundle/test_download_bundle.py
+++ b/tests/flyte/code_bundle/test_download_bundle.py
@@ -1,0 +1,264 @@
+"""Tests for download_bundle's concurrency-safe download + extract.
+
+Multiple worker processes (e.g. the torchrun-spawned ranks of a clustered task) call
+download_bundle concurrently against the same destination; these tests cover the flock + marker
+serialization that keeps them from racing on the tgz download and tar extraction.
+"""
+
+import asyncio
+import concurrent.futures
+import multiprocessing
+import os
+import pathlib
+import sys
+import tarfile
+
+import pytest
+
+import flyte.storage
+from flyte._code_bundle import bundle as bundle_module
+from flyte._code_bundle.bundle import download_bundle
+from flyte.models import CodeBundle
+
+BUNDLE_NAME = "fastdeadbeef.tar.gz"
+BUNDLE_FILES = {"pkg/mod_a.py": b"A = 1\n", "pkg/sub/mod_b.py": b"B = 2\n", "main.py": b"import pkg\n"}
+
+needs_flock = pytest.mark.skipif(sys.platform == "win32", reason="requires fcntl.flock")
+
+
+@pytest.fixture
+def tarball(tmp_path_factory) -> pathlib.Path:
+    src = tmp_path_factory.mktemp("bundle_src")
+    for rel, content in BUNDLE_FILES.items():
+        p = src / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(content)
+    archive = tmp_path_factory.mktemp("bundle_tgz") / BUNDLE_NAME
+    with tarfile.open(archive, "w:gz") as tar:
+        for rel in BUNDLE_FILES:
+            tar.add(src / rel, arcname=rel)
+    return archive
+
+
+def make_bundle(dest: pathlib.Path, name: str = BUNDLE_NAME, pkl: bool = False) -> CodeBundle:
+    kwargs = {"pkl" if pkl else "tgz": f"s3://bucket/{name}"}
+    return CodeBundle(computed_version="v1", destination=str(dest), **kwargs)
+
+
+class CopyingGet:
+    """Stand-in for flyte.storage.get that copies a local fixture and counts invocations."""
+
+    def __init__(self, source: pathlib.Path, delay: float = 0.0):
+        self.source = source
+        self.delay = delay
+        self.calls = 0
+
+    async def __call__(self, remote: str, local: str, **kwargs):
+        self.calls += 1
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        pathlib.Path(local).write_bytes(self.source.read_bytes())
+
+
+def assert_extracted(dest: pathlib.Path):
+    for rel, content in BUNDLE_FILES.items():
+        assert (dest / rel).read_bytes() == content
+
+
+@pytest.mark.asyncio
+async def test_happy_path_tgz(tmp_path, tarball, monkeypatch):
+    fake = CopyingGet(tarball)
+    monkeypatch.setattr(flyte.storage, "get", fake)
+
+    result = await download_bundle(make_bundle(tmp_path))
+
+    assert result == (tmp_path / BUNDLE_NAME).absolute()
+    assert fake.calls == 1
+    assert_extracted(tmp_path)
+    assert (tmp_path / f".{BUNDLE_NAME}.extracted").exists()
+    assert not list(tmp_path.glob("*.part"))
+
+
+@pytest.mark.asyncio
+async def test_marker_fast_path_skips_download(tmp_path, tarball, monkeypatch):
+    fake = CopyingGet(tarball)
+    monkeypatch.setattr(flyte.storage, "get", fake)
+    (tmp_path / BUNDLE_NAME).touch()
+    (tmp_path / f".{BUNDLE_NAME}.extracted").touch()
+
+    result = await download_bundle(make_bundle(tmp_path))
+
+    assert result == (tmp_path / BUNDLE_NAME).absolute()
+    assert fake.calls == 0
+
+
+@needs_flock
+@pytest.mark.asyncio
+async def test_waiter_sees_marker_written_by_lock_holder(tmp_path, tarball, monkeypatch):
+    import fcntl
+
+    fake = CopyingGet(tarball)
+    monkeypatch.setattr(flyte.storage, "get", fake)
+
+    fd = os.open(tmp_path / f".{BUNDLE_NAME}.lock", os.O_RDWR | os.O_CREAT)
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    try:
+        task = asyncio.create_task(download_bundle(make_bundle(tmp_path)))
+        await asyncio.sleep(0.3)
+        assert not task.done()
+        (tmp_path / BUNDLE_NAME).touch()
+        (tmp_path / f".{BUNDLE_NAME}.extracted").touch()
+    finally:
+        os.close(fd)
+
+    result = await asyncio.wait_for(task, timeout=5)
+    assert result == (tmp_path / BUNDLE_NAME).absolute()
+    assert fake.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_stale_tgz_without_marker_is_redownloaded(tmp_path, tarball, monkeypatch):
+    fake = CopyingGet(tarball)
+    monkeypatch.setattr(flyte.storage, "get", fake)
+    (tmp_path / BUNDLE_NAME).write_bytes(tarball.read_bytes()[: tarball.stat().st_size // 2])
+
+    await download_bundle(make_bundle(tmp_path))
+
+    assert fake.calls == 1
+    assert_extracted(tmp_path)
+    assert (tmp_path / f".{BUNDLE_NAME}.extracted").exists()
+
+
+@pytest.mark.asyncio
+async def test_corrupt_bundle_leaves_no_marker_and_retry_succeeds(tmp_path, tarball, monkeypatch):
+    class GarbageGet(CopyingGet):
+        async def __call__(self, remote: str, local: str, **kwargs):
+            self.calls += 1
+            pathlib.Path(local).write_bytes(b"not a tarball")
+
+    monkeypatch.setattr(flyte.storage, "get", GarbageGet(tarball))
+    with pytest.raises(RuntimeError):
+        await download_bundle(make_bundle(tmp_path))
+    assert not (tmp_path / f".{BUNDLE_NAME}.extracted").exists()
+
+    monkeypatch.setattr(flyte.storage, "get", CopyingGet(tarball))
+    await download_bundle(make_bundle(tmp_path))
+    assert_extracted(tmp_path)
+
+
+@needs_flock
+@pytest.mark.asyncio
+async def test_same_process_concurrency_downloads_once(tmp_path, tarball, monkeypatch):
+    fake = CopyingGet(tarball, delay=0.2)
+    monkeypatch.setattr(flyte.storage, "get", fake)
+
+    results = await asyncio.gather(*[download_bundle(make_bundle(tmp_path)) for _ in range(8)])
+
+    assert all(r == (tmp_path / BUNDLE_NAME).absolute() for r in results)
+    assert fake.calls == 1
+    assert_extracted(tmp_path)
+
+
+def _worker(dest: str, archive: str, sentinel_dir: str, idx: int) -> str:
+    """Child-process entrypoint: patch storage.get with a slow copy that drops a sentinel."""
+    import flyte.storage as storage
+    from flyte._code_bundle.bundle import download_bundle as dl
+
+    async def slow_get(remote: str, local: str, **kwargs):
+        pathlib.Path(sentinel_dir, f"downloaded-by-{idx}").touch()
+        await asyncio.sleep(0.3)
+        pathlib.Path(local).write_bytes(pathlib.Path(archive).read_bytes())
+
+    storage.get = slow_get
+    result = asyncio.run(dl(CodeBundle(computed_version="v1", destination=dest, tgz=f"s3://bucket/{BUNDLE_NAME}")))
+    return str(result)
+
+
+@needs_flock
+def test_multi_process_concurrency(tmp_path, tarball):
+    """The production repro: N processes download+extract the same bundle into one directory."""
+    sentinels = tmp_path / "sentinels"
+    sentinels.mkdir()
+    dest = tmp_path / "dest"
+    dest.mkdir()
+
+    ctx = multiprocessing.get_context("spawn")
+    with concurrent.futures.ProcessPoolExecutor(max_workers=4, mp_context=ctx) as pool:
+        futures = [pool.submit(_worker, str(dest), str(tarball), str(sentinels), i) for i in range(4)]
+        results = [f.result(timeout=120) for f in futures]
+
+    assert all(r == str((dest / BUNDLE_NAME).absolute()) for r in results)
+    assert len(list(sentinels.iterdir())) == 1
+    assert_extracted(dest)
+    assert (dest / f".{BUNDLE_NAME}.extracted").exists()
+
+
+@pytest.mark.asyncio
+async def test_degraded_mode_without_fcntl(tmp_path, tarball, monkeypatch):
+    monkeypatch.setattr(bundle_module, "fcntl", None)
+    fake = CopyingGet(tarball)
+    monkeypatch.setattr(flyte.storage, "get", fake)
+
+    # Legacy semantics: a pre-existing tgz short-circuits, marker not required.
+    (tmp_path / BUNDLE_NAME).touch()
+    result = await download_bundle(make_bundle(tmp_path))
+    assert result == (tmp_path / BUNDLE_NAME).absolute()
+    assert fake.calls == 0
+
+    # And a fresh dest still downloads + extracts.
+    fresh = tmp_path / "fresh"
+    fresh.mkdir()
+    await download_bundle(make_bundle(fresh))
+    assert fake.calls == 1
+    assert_extracted(fresh)
+
+
+@pytest.mark.asyncio
+async def test_marker_write_failure_is_non_fatal(tmp_path, tarball, monkeypatch):
+    monkeypatch.setattr(flyte.storage, "get", CopyingGet(tarball))
+
+    def failing_touch(self, *args, **kwargs):
+        if self.name.endswith(".extracted"):
+            raise OSError("disk full")
+        return original_touch(self, *args, **kwargs)
+
+    original_touch = pathlib.Path.touch
+    monkeypatch.setattr(pathlib.Path, "touch", failing_touch)
+
+    result = await download_bundle(make_bundle(tmp_path))
+    assert result == (tmp_path / BUNDLE_NAME).absolute()
+    assert_extracted(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_pkl_branch(tmp_path, tarball, monkeypatch):
+    name = "fastcafe.pkl.gz"
+    fake = CopyingGet(tarball, delay=0.1)
+    monkeypatch.setattr(flyte.storage, "get", fake)
+
+    results = await asyncio.gather(*[download_bundle(make_bundle(tmp_path, name=name, pkl=True)) for _ in range(4)])
+
+    assert all(r == (tmp_path / name).absolute() for r in results)
+    assert fake.calls == 1
+    assert (tmp_path / f".{name}.done").exists()
+    assert not list(tmp_path.glob("*.part"))
+
+    # Fast path on a subsequent call.
+    await download_bundle(make_bundle(tmp_path, name=name, pkl=True))
+    assert fake.calls == 1
+
+
+@needs_flock
+@pytest.mark.asyncio
+async def test_different_bundles_do_not_contend(tmp_path, tarball, monkeypatch):
+    fake = CopyingGet(tarball, delay=0.2)
+    monkeypatch.setattr(flyte.storage, "get", fake)
+    other = "fastfeedface.tar.gz"
+
+    results = await asyncio.wait_for(
+        asyncio.gather(download_bundle(make_bundle(tmp_path)), download_bundle(make_bundle(tmp_path, name=other))),
+        timeout=10,
+    )
+
+    assert fake.calls == 2
+    assert {r.name for r in results} == {BUNDLE_NAME, other}


### PR DESCRIPTION
## Issue
Tracks the following Issue on Linear: [ENG26-1039](https://linear.app/unionai/issue/ENG26-1039/clustered-task-environments-integration-test-failing)

## Motivation

  Clustered (JobSet) tasks launch nproc_per_node separate a0 processes per pod via torchrun, and each one independently runs download_bundle into the same destination directory. The concurrent downloads and tar --overwrite extractions race with each other, intermittently crashing workers at startup (tar: <file>: Cannot open: No
  such file or directory); each crash burns a JobSet restart, which is what has been failing test_clustered_failure_cascade in the scheduled integration tests ("jobset failed due to reaching max number of restarts").

  ## Summary

  - download_bundle now serializes download+extract per bundle behind an exclusive flock (dest/.<basename>.lock), with a completion marker (.extracted / .done) as the "ready" signal — the archive's existence alone is not trusted, since it appears on disk before extraction finishes.
  - Downloads land atomically via mkstemp + os.replace, fixing the non-atomic fsspec fallback that could expose a half-written tgz/pkl to a peer process.
  - The lock waits without a timeout and is never unlinked; the kernel releases it if the holder dies, and the next waiter redoes the work (no marker → re-download).
  Where locking is unavailable (no fcntl, read-only destination) behavior degrades to the previous semantics.
  - The pkl branch gets the same protection (previously a peer could gzip.open a half-written pkl). No new dependencies; public signature unchanged.

 ## Test Plan

  - New tests/flyte/code_bundle/test_download_bundle.py (11 tests): happy path, marker fast-path, lock-wait, stale partial archive, corrupt bundle retry, same-process and multi-process concurrency, degraded mode, marker-write failure, pkl branch, cross-bundle non-contention.
  - The multi-process test reproduces the production race against the pre-fix code (fails 3/3 with the same tar collision) and passes with the fix: git stash && uv  run python -m pytest tests/flyte/code_bundle/test_download_bundle.py::test_multi_process_concurrency vs. unstashed.
  - Full unit suite passes (make unit_test); only pre-existing unrelated failure (test_keyring_store).
  - End-to-end: 5/5 consecutive examples/clustered/failure_cascade.py runs succeeded on playground canary with the fixed wheel baked into the image and a CI-sized bundle (1863 files, 38 MB, --copy-style all), each exercising crash → JobSet restart → completion with no tar errors.