### PR TITLE
feat(recovery): make action names stable across code changes

### DIFF
--- a/src/flyte/_internal/controllers/__init__.py
+++ b/src/flyte/_internal/controllers/__init__.py
@@ -1,7 +1,7 @@
 import concurrent.futures
 import threading
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Callable, DefaultDict, Literal, Optional, Protocol, Tuple, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Callable, DefaultDict, Literal, Optional, Protocol, Tuple, TypeVar
 
 from flyte._task import TaskTemplate
 from flyte.models import ActionID, NativeInterface
@@ -15,28 +15,27 @@ __all__ = ["Controller", "ControllerType", "TaskCallSequencer", "TraceInfo", "cr
 
 
 class TaskCallSequencer:
-    """Track per-(parent-action, task-name) call sequence numbers.
+    """Track per-(parent-action, call-identity) call sequence numbers.
 
     Used by both LocalController and RemoteController to generate
     deterministic, unique sub-action IDs when the same task is invoked
     multiple times within a single parent action.
+
+    ``call_key`` should combine the task identity with the inputs hash so that
+    concurrent calls with different inputs never share a counter — sequence
+    assignment (and therefore action names) then stays independent of
+    event-loop scheduling order. Calls that do share a counter are
+    byte-identical and interchangeable.
     """
 
     def __init__(self) -> None:
-        self._counters: DefaultDict[str, DefaultDict[int | str, int]] = defaultdict(lambda: defaultdict(int))
+        self._counters: DefaultDict[str, DefaultDict[str, int]] = defaultdict(lambda: defaultdict(int))
 
-    def next_seq(self, task_obj: object, action_key: str) -> int:
-        """Return the next sequence number for *task_obj* under *action_key*."""
-        name = ""
-        if hasattr(task_obj, "__name__"):
-            name = task_obj.__name__
-        elif hasattr(task_obj, "name"):
-            name = task_obj.name
-
+    def next_seq(self, call_key: str, action_key: str) -> int:
+        """Return the next sequence number for *call_key* under *action_key*."""
         sequencer = self._counters[action_key]
-        task_id: int | str = cast("int | str", name or id(task_obj))
-        seq = sequencer[task_id] + 1
-        sequencer[task_id] = seq
+        seq = sequencer[call_key] + 1
+        sequencer[call_key] = seq
         return seq
 
     def clear(self, action_key: str) -> None:

--- a/src/flyte/_internal/controllers/_local_controller.py
+++ b/src/flyte/_internal/controllers/_local_controller.py
@@ -499,7 +499,7 @@ class LocalController(ControllerProtocol):
         logger.info(f"Waiting for condition: {condition.name}")
 
         parent_action_id = self._get_current_action_id()
-        condition_seq = self._sequencer.next_seq(condition, parent_action_id)
+        condition_seq = self._sequencer.next_seq(condition.name, parent_action_id)
         condition_action_id = f"{parent_action_id}-cond-{condition.name}-{condition_seq}"
 
         # Record the condition as a sub-action of the waiting task. Only set the parent

--- a/src/flyte/_internal/controllers/_local_controller.py
+++ b/src/flyte/_internal/controllers/_local_controller.py
@@ -139,7 +139,7 @@ class LocalController(ControllerProtocol):
         inputs_hash = convert.generate_inputs_hash_from_proto(inputs.proto_inputs)
         task_interface = cast(interface_pb2.TypedInterface, transform_native_to_typed_interface(_task.interface))
 
-        task_call_seq = self._sequencer.next_seq(_task, tctx.action.name)
+        task_call_seq = self._sequencer.next_seq(f"{_task.name}:{inputs_hash}", tctx.action.name)
         sub_action_id, sub_action_output_path = convert.generate_sub_action_id_and_output_path(
             tctx, _task.name, inputs_hash, task_call_seq
         )
@@ -351,7 +351,7 @@ class LocalController(ControllerProtocol):
 
         func_name = cast(FunctionType, _func).__name__
         inputs_hash = convert.generate_inputs_hash_from_proto(converted_inputs.proto_inputs)
-        invoke_seq_num = self._sequencer.next_seq(_func, tctx.action.name)
+        invoke_seq_num = self._sequencer.next_seq(f"{func_name}:{inputs_hash}", tctx.action.name)
         action_id, action_output_path = convert.generate_sub_action_id_and_output_path(
             tctx,
             func_name,

--- a/src/flyte/_internal/controllers/remote/_controller.py
+++ b/src/flyte/_internal/controllers/remote/_controller.py
@@ -154,17 +154,19 @@ class RemoteController(Controller):
         self._submit_init_lock = threading.Lock()
         self._pending_conditions: dict[str, Action] = {}
 
-    def generate_task_call_sequence(self, task_obj: object, action_id: ActionID) -> int:
+    def generate_task_call_sequence(self, call_key: str, action_id: ActionID) -> int:
         """
-        Generate a task call sequence for the given task object and action ID.
-        This is used to track the number of times a task is called within an action.
+        Generate a task call sequence for the given call identity (task identity + inputs hash)
+        and action ID. This is used to track the number of times an identical call is made
+        within an action; keying by inputs keeps sequence assignment independent of async
+        scheduling order across calls with different inputs.
         """
         action_key = unique_action_name(action_id)
-        seq = self._sequencer.next_seq(task_obj, action_key)
+        seq = self._sequencer.next_seq(call_key, action_key)
         logger.info(f"For action {action_key}, task call sequence is {seq}")
         return seq
 
-    async def _submit(self, _task_call_seq: int, _task: TaskTemplate, *args, **kwargs) -> Any:
+    async def _submit(self, _task: TaskTemplate, *args, **kwargs) -> Any:
         ctx = internal_ctx()
         tctx = ctx.data.task_context
         if tctx is None:
@@ -208,8 +210,23 @@ class RemoteController(Controller):
 
         task_spec = translate_task_to_wire(_task, new_serialization_context, task_context=tctx)
         inputs_hash = convert.generate_inputs_hash_from_proto(inputs.proto_inputs)
+
+        md = task_spec.task_template.metadata
+        ignored_input_vars = []
+        if len(md.cache_ignore_input_vars) > 0:
+            ignored_input_vars = list(md.cache_ignore_input_vars)
+        # The action name folds in only position, inputs, and per-task code identity (not the
+        # full spec), so names stay stable across code-bundle changes and recovery can match
+        # completed actions from a previous run.
+        task_identity = convert.generate_task_identity_hash(task_spec.task_template)
+        name_inputs_hash = (
+            convert.generate_filtered_inputs_hash(inputs.proto_inputs, ignored_input_vars)
+            if ignored_input_vars
+            else inputs_hash
+        )
+        task_call_seq = self.generate_task_call_sequence(f"{task_identity}:{name_inputs_hash}", current_action_id)
         sub_action_id, sub_action_output_path = convert.generate_sub_action_id_and_output_path(
-            tctx, task_spec, inputs_hash, _task_call_seq
+            tctx, task_identity, name_inputs_hash, task_call_seq
         )
         logger.info(f"Sub action {sub_action_id} output path {sub_action_output_path}")
 
@@ -217,10 +234,6 @@ class RemoteController(Controller):
         inputs_uri = io.inputs_path(sub_action_output_path)
         await upload_inputs_with_retry(serialized_inputs, inputs_uri, max_bytes=_task.max_inline_io_bytes)
 
-        md = task_spec.task_template.metadata
-        ignored_input_vars = []
-        if len(md.cache_ignore_input_vars) > 0:
-            ignored_input_vars = list(md.cache_ignore_input_vars)
         cache_key = None
         if task_spec.task_template.metadata and task_spec.task_template.metadata.discoverable:
             discovery_version = task_spec.task_template.metadata.discovery_version
@@ -314,16 +327,15 @@ class RemoteController(Controller):
             raise flyte.errors.RuntimeSystemError("BadContext", "Task context not initialized")
         if tctx.task_action is None:
             raise flyte.errors.RuntimeSystemError("BadContext", "Task action not initialized")
-        current_action_id = tctx.action
         # Concurrency is gated per real running task (task_action), consistent with the trace path and
-        # finalize_parent_action. The call sequence stays keyed on `action` to keep sub-action names
-        # unique-per-scope and deterministic for replay.
+        # finalize_parent_action. The call sequence is generated inside _submit (keyed on `action` and
+        # the call identity) once the inputs hash is known, keeping sub-action names unique-per-scope
+        # and deterministic for replay regardless of async scheduling order.
         task_action = tctx.task_action
-        task_call_seq = self.generate_task_call_sequence(_task, current_action_id)
         async with self._parent_action_semaphore[unique_action_name(task_action)]:
             sw = Stopwatch(f"controller-submit-{unique_action_name(task_action)}")
             sw.start()
-            result = await self._submit(task_call_seq, _task, *args, **kwargs)
+            result = await self._submit(_task, *args, **kwargs)
             sw.stop()
             return result
 
@@ -409,16 +421,19 @@ class RemoteController(Controller):
         current_action_id = tctx.action
 
         func_name = cast(FunctionType, _func).__name__
-        invoke_seq_num = self.generate_task_call_sequence(_func, current_action_id)
+        # Trace identity folds in the function body hash so an edited trace function re-executes
+        # on recovery instead of replaying a stale recorded result.
+        trace_identity = convert.generate_trace_action_identity(_func)
 
         _ctx = ctx.new_in_driver_literal_conversion(True) if ctx.is_task_context() else nullcontext()
         with _ctx:
             inputs = await convert.convert_from_native_to_inputs(_interface, *args, **kwargs)
         serialized_inputs = inputs.proto_inputs.SerializeToString(deterministic=True)
         inputs_hash = convert.generate_inputs_hash_from_proto(inputs.proto_inputs)
+        invoke_seq_num = self.generate_task_call_sequence(f"{trace_identity}:{inputs_hash}", current_action_id)
 
         sub_action_id, sub_action_output_path = convert.generate_sub_action_id_and_output_path(
-            tctx, func_name, inputs_hash, invoke_seq_num
+            tctx, trace_identity, inputs_hash, invoke_seq_num
         )
 
         inputs_uri = io.inputs_path(sub_action_output_path)
@@ -548,7 +563,7 @@ class RemoteController(Controller):
                 # If the action is cancelled, we need to cancel the action on the server as well
                 raise
 
-    async def _submit_task_ref(self, invoke_seq_num: int, _task: TaskDetails, *args, **kwargs) -> Any:
+    async def _submit_task_ref(self, _task: TaskDetails, *args, **kwargs) -> Any:
         ctx = internal_ctx()
         tctx = ctx.data.task_context
         if tctx is None:
@@ -567,8 +582,20 @@ class RemoteController(Controller):
         with _ctx:
             inputs = await convert.convert_from_native_to_inputs(native_interface, *args, **kwargs)
         inputs_hash = convert.generate_inputs_hash_from_proto(inputs.proto_inputs)
+
+        md = _task.pb2.spec.task_template.metadata
+        ignored_input_vars = []
+        if len(md.cache_ignore_input_vars) > 0:
+            ignored_input_vars = list(md.cache_ignore_input_vars)
+        task_identity = convert.generate_task_identity_hash(_task.pb2.spec.task_template)
+        name_inputs_hash = (
+            convert.generate_filtered_inputs_hash(inputs.proto_inputs, ignored_input_vars)
+            if ignored_input_vars
+            else inputs_hash
+        )
+        invoke_seq_num = self.generate_task_call_sequence(f"{task_identity}:{name_inputs_hash}", current_action_id)
         sub_action_id, sub_action_output_path = convert.generate_sub_action_id_and_output_path(
-            tctx, task_name, inputs_hash, invoke_seq_num
+            tctx, task_identity, name_inputs_hash, invoke_seq_num
         )
 
         serialized_inputs = inputs.proto_inputs.SerializeToString(deterministic=True)
@@ -576,10 +603,6 @@ class RemoteController(Controller):
         await upload_inputs_with_retry(serialized_inputs, inputs_uri, _task.max_inline_io_bytes)
         # cache key - task name, task signature, inputs, cache version
         cache_key = None
-        md = _task.pb2.spec.task_template.metadata
-        ignored_input_vars = []
-        if len(md.cache_ignore_input_vars) > 0:
-            ignored_input_vars = list(md.cache_ignore_input_vars)
         if md and md.discoverable:
             discovery_version = md.discovery_version
             cache_key = convert.generate_cache_key_hash(
@@ -648,11 +671,9 @@ class RemoteController(Controller):
             raise flyte.errors.RuntimeSystemError("BadContext", "Task context not initialized")
         if tctx.task_action is None:
             raise flyte.errors.RuntimeSystemError("BadContext", "Task action not initialized")
-        current_action_id = tctx.action
         task_action = tctx.task_action
-        task_call_seq = self.generate_task_call_sequence(_task, current_action_id)
         async with self._parent_action_semaphore[unique_action_name(task_action)]:
-            return await self._submit_task_ref(task_call_seq, _task, *args, **kwargs)
+            return await self._submit_task_ref(_task, *args, **kwargs)
 
     async def register_condition(self, condition: Any):
         """
@@ -677,7 +698,7 @@ class RemoteController(Controller):
         # Condition actions nest under the real running task (task_action), so conditions fired inside a
         # @trace still parent to the task rather than the trace pseudo-action.
         task_action = tctx.task_action
-        invoke_seq = self.generate_task_call_sequence(condition, current_action_id)
+        invoke_seq = self.generate_task_call_sequence(condition.name, current_action_id)
 
         # Generate a deterministic action name from condition name + sequence
         sub_action_id, sub_action_output_path = convert.generate_sub_action_id_and_output_path(

--- a/src/flyte/_internal/controllers/remote/_r_controller.py
+++ b/src/flyte/_internal/controllers/remote/_r_controller.py
@@ -157,17 +157,19 @@ class RemoteController(BaseController):
         self._submit_loop: asyncio.AbstractEventLoop | None = None
         self._submit_thread: threading.Thread | None = None
 
-    def generate_task_call_sequence(self, task_obj: object, action_id: ActionID) -> int:
+    def generate_task_call_sequence(self, call_key: str, action_id: ActionID) -> int:
         """
-        Generate a task call sequence for the given task object and action ID.
-        This is used to track the number of times a task is called within an action.
+        Generate a task call sequence for the given call identity (task identity + inputs hash)
+        and action ID. This is used to track the number of times an identical call is made
+        within an action; keying by inputs keeps sequence assignment independent of async
+        scheduling order across calls with different inputs.
         """
         action_key = unique_action_name(action_id)
-        seq = self._sequencer.next_seq(task_obj, action_key)
+        seq = self._sequencer.next_seq(call_key, action_key)
         logger.info(f"For action {action_key}, task call sequence is {seq}")
         return seq
 
-    async def _submit(self, _task_call_seq: int, _task: TaskTemplate, *args, **kwargs) -> Any:
+    async def _submit(self, _task: TaskTemplate, *args, **kwargs) -> Any:
         ctx = internal_ctx()
         tctx = ctx.data.task_context
         if tctx is None:
@@ -204,8 +206,23 @@ class RemoteController(BaseController):
 
         task_spec = translate_task_to_wire(_task, new_serialization_context, task_context=tctx)
         inputs_hash = convert.generate_inputs_hash_from_proto(inputs.proto_inputs)
+
+        md = task_spec.task_template.metadata
+        ignored_input_vars = []
+        if len(md.cache_ignore_input_vars) > 0:
+            ignored_input_vars = list(md.cache_ignore_input_vars)
+        # The action name folds in only position, inputs, and per-task code identity (not the
+        # full spec), so names stay stable across code-bundle changes and recovery can match
+        # completed actions from a previous run.
+        task_identity = convert.generate_task_identity_hash(task_spec.task_template)
+        name_inputs_hash = (
+            convert.generate_filtered_inputs_hash(inputs.proto_inputs, ignored_input_vars)
+            if ignored_input_vars
+            else inputs_hash
+        )
+        task_call_seq = self.generate_task_call_sequence(f"{task_identity}:{name_inputs_hash}", current_action_id)
         sub_action_id, sub_action_output_path = convert.generate_sub_action_id_and_output_path(
-            tctx, task_spec, inputs_hash, _task_call_seq
+            tctx, task_identity, name_inputs_hash, task_call_seq
         )
         logger.info(f"Sub action {sub_action_id} output path {sub_action_output_path}")
 
@@ -213,10 +230,6 @@ class RemoteController(BaseController):
         inputs_uri = io.inputs_path(sub_action_output_path)
         await upload_inputs_with_retry(serialized_inputs, inputs_uri, max_bytes=_task.max_inline_io_bytes)
 
-        md = task_spec.task_template.metadata
-        ignored_input_vars = []
-        if len(md.cache_ignore_input_vars) > 0:
-            ignored_input_vars = list(md.cache_ignore_input_vars)
         cache_key = None
         if task_spec.task_template.metadata and task_spec.task_template.metadata.discoverable:
             discovery_version = task_spec.task_template.metadata.discovery_version
@@ -317,9 +330,11 @@ class RemoteController(BaseController):
         if tctx is None:
             raise flyte.errors.RuntimeSystemError("BadContext", "Task context not initialized")
         current_action_id = tctx.action
-        task_call_seq = self.generate_task_call_sequence(_task, current_action_id)
+        # The call sequence is generated inside _submit (keyed on the call identity) once the
+        # inputs hash is known, keeping sub-action names deterministic regardless of async
+        # scheduling order.
         async with self._parent_action_semaphore[unique_action_name(current_action_id)]:
-            return await self._submit(task_call_seq, _task, *args, **kwargs)
+            return await self._submit(_task, *args, **kwargs)
 
     def _sync_thread_loop_runner(self) -> None:
         """This method runs the event loop and should be invoked in a separate thread."""
@@ -418,13 +433,16 @@ class RemoteController(BaseController):
         current_action_id = tctx.action
 
         func_name = cast(FunctionType, _func).__name__
-        invoke_seq_num = self.generate_task_call_sequence(_func, current_action_id)
+        # Trace identity folds in the function body hash so an edited trace function re-executes
+        # on recovery instead of replaying a stale recorded result.
+        trace_identity = convert.generate_trace_action_identity(_func)
         inputs = await convert.convert_from_native_to_inputs(_interface, *args, **kwargs)
         serialized_inputs = inputs.proto_inputs.SerializeToString(deterministic=True)
         inputs_hash = convert.generate_inputs_hash_from_proto(inputs.proto_inputs)
+        invoke_seq_num = self.generate_task_call_sequence(f"{trace_identity}:{inputs_hash}", current_action_id)
 
         sub_action_id, sub_action_output_path = convert.generate_sub_action_id_and_output_path(
-            tctx, func_name, inputs_hash, invoke_seq_num
+            tctx, trace_identity, inputs_hash, invoke_seq_num
         )
 
         inputs_uri = io.inputs_path(sub_action_output_path)
@@ -548,7 +566,7 @@ class RemoteController(BaseController):
                 # If the action is cancelled, we need to cancel the action on the server as well
                 raise
 
-    async def _submit_task_ref(self, invoke_seq_num: int, _task: TaskDetails, *args, **kwargs) -> Any:
+    async def _submit_task_ref(self, _task: TaskDetails, *args, **kwargs) -> Any:
         ctx = internal_ctx()
         tctx = ctx.data.task_context
         if tctx is None:
@@ -561,8 +579,20 @@ class RemoteController(BaseController):
 
         inputs = await convert.convert_from_native_to_inputs(native_interface, *args, **kwargs)
         inputs_hash = convert.generate_inputs_hash_from_proto(inputs.proto_inputs)
+
+        md = _task.pb2.spec.task_template.metadata
+        ignored_input_vars = []
+        if len(md.cache_ignore_input_vars) > 0:
+            ignored_input_vars = list(md.cache_ignore_input_vars)
+        task_identity = convert.generate_task_identity_hash(_task.pb2.spec.task_template)
+        name_inputs_hash = (
+            convert.generate_filtered_inputs_hash(inputs.proto_inputs, ignored_input_vars)
+            if ignored_input_vars
+            else inputs_hash
+        )
+        invoke_seq_num = self.generate_task_call_sequence(f"{task_identity}:{name_inputs_hash}", current_action_id)
         sub_action_id, sub_action_output_path = convert.generate_sub_action_id_and_output_path(
-            tctx, task_name, inputs_hash, invoke_seq_num
+            tctx, task_identity, name_inputs_hash, invoke_seq_num
         )
 
         serialized_inputs = inputs.proto_inputs.SerializeToString(deterministic=True)
@@ -570,10 +600,6 @@ class RemoteController(BaseController):
         await upload_inputs_with_retry(serialized_inputs, inputs_uri, _task.max_inline_io_bytes)
         # cache key - task name, task signature, inputs, cache version
         cache_key = None
-        md = _task.pb2.spec.task_template.metadata
-        ignored_input_vars = []
-        if len(md.cache_ignore_input_vars) > 0:
-            ignored_input_vars = list(md.cache_ignore_input_vars)
         if md and md.discoverable:
             discovery_version = md.discovery_version
             cache_key = convert.generate_cache_key_hash(
@@ -647,6 +673,5 @@ class RemoteController(BaseController):
         if tctx is None:
             raise flyte.errors.RuntimeSystemError("BadContext", "Task context not initialized")
         current_action_id = tctx.action
-        task_call_seq = self.generate_task_call_sequence(_task, current_action_id)
         async with self._parent_action_semaphore[unique_action_name(current_action_id)]:
-            return await self._submit_task_ref(task_call_seq, _task, *args, **kwargs)
+            return await self._submit_task_ref(_task, *args, **kwargs)

--- a/src/flyte/_internal/runtime/convert.py
+++ b/src/flyte/_internal/runtime/convert.py
@@ -9,8 +9,8 @@ from dataclasses import dataclass
 from types import NoneType
 from typing import Any, Dict, List, Optional, Tuple, Union, cast, get_args
 
-from flyteidl2.core import execution_pb2, interface_pb2, literals_pb2
-from flyteidl2.task import common_pb2, task_definition_pb2
+from flyteidl2.core import execution_pb2, interface_pb2, literals_pb2, tasks_pb2
+from flyteidl2.task import common_pb2
 
 import flyte.errors
 import flyte.storage as storage
@@ -558,9 +558,7 @@ def generate_cache_key_hash(
     :return: A hexadecimal string representation of the cache key hash.
     """
     if ignored_input_vars:
-        filtered = [named_lit for named_lit in proto_inputs.literals if named_lit.name not in ignored_input_vars]
-        final = common_pb2.Inputs(literals=filtered)
-        final_inputs = generate_inputs_hash_from_proto(final)
+        final_inputs = generate_filtered_inputs_hash(proto_inputs, ignored_input_vars)
     else:
         final_inputs = inputs_hash
 
@@ -570,31 +568,82 @@ def generate_cache_key_hash(
     return hash_data(data)
 
 
+def generate_filtered_inputs_hash(proto_inputs: common_pb2.Inputs, ignored_input_vars: List[str]) -> str:
+    """
+    Generate an inputs hash excluding the given input variable names.
+
+    :param proto_inputs: The proto inputs for the task.
+    :param ignored_input_vars: Input variable names to exclude from the hash.
+    :return: A hexadecimal string representation of the hash.
+    """
+    filtered = [named_lit for named_lit in proto_inputs.literals if named_lit.name not in ignored_input_vars]
+    return generate_inputs_hash_from_proto(common_pb2.Inputs(literals=filtered))
+
+
+def generate_task_identity_hash(task_template: tasks_pb2.TaskTemplate) -> str:
+    """
+    Hash of the task's run-independent identity: fully-qualified name, interface, and per-task
+    code version (``metadata.discovery_version``, always populated by task_serde — the function
+    body AST hash unless overridden).
+
+    Deliberately excludes the container image, code-bundle version, resources, env vars, and
+    plugin config, so that action names stay stable across code-only changes and recovery can
+    match completed actions from a previous run. Editing a task's own function body changes its
+    discovery_version and therefore its action name, so that task re-runs.
+
+    :param task_template: The serialized task template.
+    :return: A hexadecimal string representation of the hash.
+    """
+    interface_hash = generate_interface_hash(task_template.interface)
+    version = task_template.metadata.discovery_version if task_template.HasField("metadata") else ""
+    return hash_data(f"{task_template.id.name}-{interface_hash}-{version}")
+
+
+def generate_trace_action_identity(func: Any) -> str:
+    """
+    Identity for a trace action: the function name plus a hash of the function body (AST), so an
+    edited trace function re-executes on recovery instead of replaying a stale recorded result.
+    Falls back to the bare name when the source is unavailable (e.g. REPL-defined functions).
+
+    :param func: The traced function.
+    :return: A stable identity string for the trace action.
+    """
+    name = getattr(func, "__name__", str(func))
+    try:
+        from flyte._cache.cache import VersionParameters
+        from flyte._cache.policy_function_body import FunctionBodyPolicy
+
+        version = FunctionBodyPolicy().get_version(salt="", params=VersionParameters(func=func))
+    except Exception:
+        return name
+    return f"{name}-{version}"
+
+
 def generate_sub_action_id_and_output_path(
     tctx: TaskContext,
-    task_spec_or_name: task_definition_pb2.TaskSpec | str,
+    task_identity: str,
     inputs_hash: str,
     invoke_seq: int,
 ) -> Tuple[ActionID, str]:
     """
-    Generate a sub-action ID and output path based on the current task context, task name, and inputs.
+    Generate a sub-action ID and output path based on the current task context, task identity, and inputs.
 
-    action name = current action name + task name + input hash + group name (if available)
+    action name = hash(parent action name + inputs hash + task identity + invocation sequence [+ group])
+
+    ``task_identity`` must be stable across runs for recovery to match completed actions: use
+    :func:`generate_task_identity_hash` for tasks and :func:`generate_trace_action_identity` for
+    trace actions. In particular it must not depend on the code-bundle version or container image.
+
     :param tctx:
-    :param task_spec_or_name: task specification or task name. Task name is only used in case of trace actions.
-    :param inputs_hash: Consistent hash string of the inputs
+    :param task_identity: Stable identity string for the task being invoked.
+    :param inputs_hash: Consistent hash string of the inputs (filtered of cache-ignored vars if any).
     :param invoke_seq: The sequence number of the invocation, used to differentiate between multiple invocations.
     :return:
     """
     current_action_id = tctx.action
     current_output_path = tctx.run_base_dir
-    if isinstance(task_spec_or_name, task_definition_pb2.TaskSpec):
-        task_spec_or_name.task_template.interface
-        task_hash = hash_data(task_spec_or_name.SerializeToString(deterministic=True))
-    else:
-        task_hash = task_spec_or_name
     sub_action_id = current_action_id.new_sub_action_from(
-        task_hash=task_hash,
+        task_hash=task_identity,
         input_hash=inputs_hash,
         group=tctx.group_data.name if tctx.group_data else None,
         task_call_seq=invoke_seq,

--- a/src/flyte/_internal/runtime/task_serde.py
+++ b/src/flyte/_internal/runtime/task_serde.py
@@ -216,22 +216,24 @@ def get_proto_task(
     # -------------- CACHE HANDLING ----------------------
     task_cache = cache_from_request(task.cache)
     cache_enabled = task_cache.is_enabled()
-    cache_version = None
 
-    if task_cache.is_enabled():
-        logger.debug(f"Cache enabled for task {task.name}")
-        if serialize_context.code_bundle and serialize_context.code_bundle.pkl:
-            logger.debug(f"Detected pkl bundle for task {task.name}, using computed version as cache version")
-            cache_version = serialize_context.code_bundle.computed_version
-        else:
-            if isinstance(task, AsyncFunctionTaskTemplate):
-                version_parameters = VersionParameters(func=cast(typing.Callable, task.func), image=task.image)
-            else:
-                version_parameters = VersionParameters(func=None, image=task.image)
-            cache_version = task_cache.get_version(version_parameters)
-            logger.debug(f"Cache version for task {task.name} is {cache_version}")
+    # The version is computed even when caching is disabled (falling back to the auto policy):
+    # it feeds metadata.discovery_version, which identifies the task's code in deterministic
+    # action names so recovery can tell "same task code" apart from "changed code"
+    # (see convert.generate_task_identity_hash).
+    if serialize_context.code_bundle and serialize_context.code_bundle.pkl:
+        logger.debug(f"Detected pkl bundle for task {task.name}, using computed version as cache version")
+        cache_version = serialize_context.code_bundle.computed_version
     else:
-        logger.debug(f"Cache disabled for task {task.name}")
+        if isinstance(task, AsyncFunctionTaskTemplate):
+            version_parameters = VersionParameters(func=cast(typing.Callable, task.func), image=task.image)
+        else:
+            version_parameters = VersionParameters(func=None, image=task.image)
+        version_cache = task_cache if cache_enabled else cache_from_request("auto")
+        cache_version = version_cache.get_version(version_parameters)
+        logger.debug(
+            f"Cache {'enabled' if cache_enabled else 'disabled'} for task {task.name}, version {cache_version}"
+        )
 
     image_build_run = None
     if serialize_context.image_cache and task.parent_env_name in serialize_context.image_cache.build_run_ids:

--- a/src/flyte/models.py
+++ b/src/flyte/models.py
@@ -69,7 +69,13 @@ class ActionID:
         return replace(self, name=name)
 
     def new_sub_action_from(self, task_call_seq: int, task_hash: str, input_hash: str, group: str | None) -> ActionID:
-        """Make a deterministic name"""
+        """
+        Make a deterministic name from the parent action name, the task identity, the inputs
+        hash, the call sequence, and the group (if any). All components must be stable across
+        runs — recovery matches completed actions from a previous run by this name — so
+        ``task_hash`` must not depend on the code-bundle version or container image (see
+        convert.generate_task_identity_hash).
+        """
         import hashlib
 
         from flyte._utils.helpers import base36_encode

--- a/tests/cli/test_tui_tracker.py
+++ b/tests/cli/test_tui_tracker.py
@@ -427,54 +427,43 @@ class TestTaskCallSequencer:
         from flyte._internal.controllers import TaskCallSequencer
 
         s = TaskCallSequencer()
-        assert s.next_seq(type("T", (), {"name": "my_task"})(), "parent") == 1
-        assert s.next_seq(type("T", (), {"name": "my_task"})(), "parent") == 2
-        assert s.next_seq(type("T", (), {"name": "my_task"})(), "parent") == 3
+        assert s.next_seq("my_task:h1", "parent") == 1
+        assert s.next_seq("my_task:h1", "parent") == 2
+        assert s.next_seq("my_task:h1", "parent") == 3
 
-    def test_different_tasks_independent(self):
+    def test_different_call_keys_independent(self):
         from flyte._internal.controllers import TaskCallSequencer
 
         s = TaskCallSequencer()
-        assert s.next_seq(type("A", (), {"name": "task_a"})(), "p") == 1
-        assert s.next_seq(type("B", (), {"name": "task_b"})(), "p") == 1
-        assert s.next_seq(type("A", (), {"name": "task_a"})(), "p") == 2
+        assert s.next_seq("task_a:h1", "p") == 1
+        assert s.next_seq("task_b:h1", "p") == 1
+        assert s.next_seq("task_a:h1", "p") == 2
+
+    def test_same_task_different_inputs_independent(self):
+        # Calls of the same task with different inputs never share a counter, so
+        # sequence assignment is independent of the order the calls are made in.
+        from flyte._internal.controllers import TaskCallSequencer
+
+        s = TaskCallSequencer()
+        assert s.next_seq("task_a:h1", "p") == 1
+        assert s.next_seq("task_a:h2", "p") == 1
+        assert s.next_seq("task_a:h1", "p") == 2
 
     def test_different_parents_independent(self):
         from flyte._internal.controllers import TaskCallSequencer
 
         s = TaskCallSequencer()
-        task = type("T", (), {"name": "t"})()
-        assert s.next_seq(task, "parent1") == 1
-        assert s.next_seq(task, "parent2") == 1
+        assert s.next_seq("t:h1", "parent1") == 1
+        assert s.next_seq("t:h1", "parent2") == 1
 
     def test_clear(self):
         from flyte._internal.controllers import TaskCallSequencer
 
         s = TaskCallSequencer()
-        task = type("T", (), {"name": "t"})()
-        s.next_seq(task, "p1")
-        s.next_seq(task, "p1")
+        s.next_seq("t:h1", "p1")
+        s.next_seq("t:h1", "p1")
         s.clear("p1")
-        assert s.next_seq(task, "p1") == 1
-
-    def test_function_uses_dunder_name(self):
-        from flyte._internal.controllers import TaskCallSequencer
-
-        s = TaskCallSequencer()
-
-        def my_func():
-            pass
-
-        assert s.next_seq(my_func, "p") == 1
-        assert s.next_seq(my_func, "p") == 2
-
-    def test_object_without_name_uses_id(self):
-        from flyte._internal.controllers import TaskCallSequencer
-
-        s = TaskCallSequencer()
-        obj = object()
-        assert s.next_seq(obj, "p") == 1
-        assert s.next_seq(obj, "p") == 2
+        assert s.next_seq("t:h1", "p1") == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/flyte/internal/runtime/test_action_name_stability.py
+++ b/tests/flyte/internal/runtime/test_action_name_stability.py
@@ -1,0 +1,182 @@
+"""
+Action-name stability across runs (ENG26-1042).
+
+Recovery matches completed actions from a previous run by action name, so the name must fold
+in only the task's position, inputs, and per-task code identity — never the code-bundle
+version, container image, or other spec fields that change on every code edit or deploy.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+from flyteidl2.core import identifier_pb2, interface_pb2, literals_pb2, tasks_pb2, types_pb2
+from flyteidl2.task import common_pb2
+
+import flyte
+from flyte._internal.runtime import convert
+from flyte._internal.runtime.task_serde import translate_task_to_wire
+from flyte.models import ActionID, RawDataPath, SerializationContext, TaskContext
+from flyte.report import Report
+
+
+def _make_template(
+    name: str = "env.my_task",
+    image: str = "img:v1",
+    args: tuple[str, ...] = ("--version", "v1"),
+    discovery_version: str = "body-hash-1",
+    input_type: int = types_pb2.INTEGER,
+) -> tasks_pb2.TaskTemplate:
+    return tasks_pb2.TaskTemplate(
+        id=identifier_pb2.Identifier(name=name, version="run-version"),
+        type="python",
+        metadata=tasks_pb2.TaskMetadata(discovery_version=discovery_version),
+        interface=interface_pb2.TypedInterface(
+            inputs=interface_pb2.VariableMap(
+                variables=[
+                    interface_pb2.VariableEntry(
+                        key="x",
+                        value=interface_pb2.Variable(type=types_pb2.LiteralType(simple=input_type)),
+                    )
+                ]
+            )
+        ),
+        container=tasks_pb2.Container(image=image, args=list(args)),
+    )
+
+
+def _make_tctx() -> TaskContext:
+    return TaskContext(
+        action=ActionID(name="parent", run_name="run1", project="p", domain="d"),
+        run_base_dir="s3://bucket/metadata/p/d/run1",
+        version="v1",
+        raw_data_path=RawDataPath(path="s3://bucket/raw/p/d/run1"),
+        output_path="s3://bucket/output/p/d/run1",
+        report=Report(name="test"),
+    )
+
+
+def _named_literal(name: str, value: int) -> common_pb2.NamedLiteral:
+    return common_pb2.NamedLiteral(
+        name=name,
+        value=literals_pb2.Literal(scalar=literals_pb2.Scalar(primitive=literals_pb2.Primitive(integer=value))),
+    )
+
+
+class TestTaskIdentityHash:
+    def test_stable_across_code_bundle_and_image_changes(self):
+        """A new code bundle / image (any code edit or redeploy) must not change the identity."""
+        t1 = _make_template(image="img:v1", args=("--version", "v1"))
+        t2 = _make_template(image="img:v2", args=("--version", "v2"))
+        assert convert.generate_task_identity_hash(t1) == convert.generate_task_identity_hash(t2)
+
+    def test_stable_across_resource_and_env_changes(self):
+        t1 = _make_template()
+        t2 = _make_template()
+        t2.container.resources.requests.add(name=tasks_pb2.Resources.CPU, value="2")
+        t2.container.env.add(key="FOO", value="bar")
+        assert convert.generate_task_identity_hash(t1) == convert.generate_task_identity_hash(t2)
+
+    def test_changes_with_discovery_version(self):
+        """Editing the task's own function body changes discovery_version → new identity."""
+        t1 = _make_template(discovery_version="body-hash-1")
+        t2 = _make_template(discovery_version="body-hash-2")
+        assert convert.generate_task_identity_hash(t1) != convert.generate_task_identity_hash(t2)
+
+    def test_changes_with_task_name(self):
+        t1 = _make_template(name="env.task_a")
+        t2 = _make_template(name="env.task_b")
+        assert convert.generate_task_identity_hash(t1) != convert.generate_task_identity_hash(t2)
+
+    def test_changes_with_interface(self):
+        t1 = _make_template(input_type=types_pb2.INTEGER)
+        t2 = _make_template(input_type=types_pb2.STRING)
+        assert convert.generate_task_identity_hash(t1) != convert.generate_task_identity_hash(t2)
+
+    def test_action_name_stable_across_code_bundle_changes(self):
+        """End to end: same position + inputs + code identity → same action name."""
+        tctx = _make_tctx()
+        inputs_hash = "abc123"
+        id1, _ = convert.generate_sub_action_id_and_output_path(
+            tctx, convert.generate_task_identity_hash(_make_template(image="img:v1")), inputs_hash, 1
+        )
+        id2, _ = convert.generate_sub_action_id_and_output_path(
+            tctx, convert.generate_task_identity_hash(_make_template(image="img:v2")), inputs_hash, 1
+        )
+        assert id1.name == id2.name
+
+
+class TestFilteredInputsHash:
+    def test_ignored_vars_excluded(self):
+        """Two input sets differing only in an ignored var must hash identically."""
+        inputs_a = common_pb2.Inputs(literals=[_named_literal("x", 1), _named_literal("ts", 100)])
+        inputs_b = common_pb2.Inputs(literals=[_named_literal("x", 1), _named_literal("ts", 200)])
+        assert convert.generate_filtered_inputs_hash(inputs_a, ["ts"]) == convert.generate_filtered_inputs_hash(
+            inputs_b, ["ts"]
+        )
+
+    def test_non_ignored_vars_still_distinguish(self):
+        inputs_a = common_pb2.Inputs(literals=[_named_literal("x", 1), _named_literal("ts", 100)])
+        inputs_b = common_pb2.Inputs(literals=[_named_literal("x", 2), _named_literal("ts", 100)])
+        assert convert.generate_filtered_inputs_hash(inputs_a, ["ts"]) != convert.generate_filtered_inputs_hash(
+            inputs_b, ["ts"]
+        )
+
+
+class TestTraceActionIdentity:
+    def test_deterministic(self):
+        def my_trace(x: int) -> int:
+            return x + 1
+
+        assert convert.generate_trace_action_identity(my_trace) == convert.generate_trace_action_identity(my_trace)
+
+    def test_changes_with_function_body(self):
+        def my_trace(x: int) -> int:
+            return x + 1
+
+        def my_trace_edited(x: int) -> int:
+            return x + 2
+
+        id_orig = convert.generate_trace_action_identity(my_trace)
+        id_edited = convert.generate_trace_action_identity(my_trace_edited)
+        assert id_orig != id_edited
+
+    def test_falls_back_to_name_without_source(self):
+        ns: dict = {}
+        exec("def no_source(x):\n    return x\n", ns)
+        assert convert.generate_trace_action_identity(ns["no_source"]) == "no_source"
+
+
+class TestDiscoveryVersionAlwaysPopulated:
+    def test_cache_disabled_still_gets_version(self):
+        """The spec must carry a per-task code version even with caching disabled, since
+        deterministic action names depend on it."""
+        env = flyte.TaskEnvironment(name="stability_env")
+
+        @env.task(cache="disable")
+        async def t_disabled(a: int) -> int:
+            return a
+
+        @env.task(cache=flyte.Cache(behavior="auto"))
+        async def t_auto(a: int) -> int:
+            return a
+
+        sctx = SerializationContext(
+            project="p",
+            domain="d",
+            version="v-test",
+            org="o",
+            input_path="/tmp/inputs",
+            output_path="/tmp/outputs",
+            image_cache=None,
+            code_bundle=None,
+            root_dir=pathlib.Path.cwd(),
+        )
+
+        spec_disabled = translate_task_to_wire(t_disabled, sctx)
+        spec_auto = translate_task_to_wire(t_auto, sctx)
+
+        assert spec_disabled.task_template.metadata.discoverable is False
+        assert spec_disabled.task_template.metadata.discovery_version != ""
+        assert spec_auto.task_template.metadata.discoverable is True
+        assert spec_auto.task_template.metadata.discovery_version != ""

--- a/tests/flyte/internal/runtime/test_convert.py
+++ b/tests/flyte/internal/runtime/test_convert.py
@@ -71,7 +71,7 @@ async def test_generate_sub_action_id_and_output_path_consistency_task_name(gene
     inputs_hash = convert.generate_inputs_hash(serialized_inputs)
     sub_action_id, path = generate_sub_action_id_and_output_path(
         tctx=tctx,
-        task_spec_or_name="test_task",
+        task_identity="test_task",
         inputs_hash=inputs_hash,
         invoke_seq=1,
     )
@@ -101,7 +101,7 @@ def test_1M_action_name_with_min_diff():
     for i in range(1000000):
         sub_action_id, _path = generate_sub_action_id_and_output_path(
             tctx=tctx,
-            task_spec_or_name="t1",
+            task_identity="t1",
             inputs_hash=inputs_hash,
             invoke_seq=i,
         )


### PR DESCRIPTION
Action names previously folded in a hash of the full serialized TaskSpec (code-bundle URI, image, resources), so any code edit renamed every action and recovery re-ran the whole workflow. Names now fold in only position, inputs, and per-task code identity (task name + interface hash + discovery_version, computed with the auto cache policy even when caching is disabled), so recovery can reuse completed actions across code changes while an edited task's own function body still triggers a re-run. Trace actions hash the traced function body so edited traces re-execute instead of replaying, and call-sequence counters are keyed by (task identity + inputs hash) so sequence assignment is independent of async scheduling order.

https://linear.app/unionai/issue/ENG26-1042