### PR TITLE
Update links in README for Flyte 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,11 +306,9 @@ features = ["extension-module"]
 
 ## Learn More
 
-- **[Live Demo](https://flyte2intro.apps.demo.hosted.unionai.cloud/)** — Try Flyte 2 in your browser
-- **[Documentation](https://www.union.ai/docs/v2/flyte/user-guide/running-locally/)** — Get started running locally
+- **[Try DevBox](https://www.union.ai/docs/v2/flyte/user-guide/get-started/run-modes/running-devbox/)** - Get started
 - **[SDK Reference](https://www.union.ai/docs/v2/union/api-reference/flyte-sdk/)** — API reference docs
 - **[CLI Reference](https://www.union.ai/docs/v2/union/api-reference/flyte-cli/)** — CLI docs
-- **[Join the Flyte 2 Production Preview](https://www.union.ai/try-flyte-2)** — Get early access
 - **[Features](FEATURES.md)** — Async parallelism, app serving, tracing, and more
 - **[Examples](examples/)** — Ready-to-run examples for every feature
 - **[Contributing](CONTRIBUTING.md)** — Set up a dev environment and contribute


### PR DESCRIPTION
Removed outdated links and added a link to DevBox.