### PR TITLE
chore(deps): bump flyteidl2 to 2.0.37 for the settings desc renumber

### DIFF
--- a/plugins/ray/pyproject.toml
+++ b/plugins/ray/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.10,<3.13"
 dependencies = [
     "ray[default]",
     "flyte",
-    "flyteidl2==2.0.31",
+    "flyteidl2==2.0.37",
 ]
 
 [dependency-groups]

--- a/plugins/ray/uv.lock
+++ b/plugins/ray/uv.lock
@@ -536,7 +536,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.31" },
+    { name = "flyteidl2", specifier = "==2.0.37" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -604,7 +604,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.31"
+version = "2.0.37"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -613,7 +613,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/9b/dec92c854bbb968e3e429eb6d06fa6e8ac433707796c64d9b61f886a2904/flyteidl2-2.0.31-py3-none-any.whl", hash = "sha256:c1df8819c413912377d9336447df04865ca48b2913349ec7e75eb2d3bd1f34c8", size = 353273, upload-time = "2026-07-30T18:30:11.423Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/63/2f28d0e42724d3612d0ae10071e9ce5be2e3db9a4f99eaa6b6087e1af2c7/flyteidl2-2.0.37-py3-none-any.whl", hash = "sha256:0d85f68832e244e667f94e909748bb789754e224e66838b9ecc7e1575d2cb554", size = 374991, upload-time = "2026-08-05T01:25:03.521Z" },
 ]
 
 [[package]]
@@ -635,7 +635,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "flyte", editable = "../../" },
-    { name = "flyteidl2", specifier = "==2.0.31" },
+    { name = "flyteidl2", specifier = "==2.0.37" },
     { name = "ray", extras = ["default"] },
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "async-lru>=2.0.5",
     "mashumaro",
     "aiolimiter>=1.2.1",
-    "flyteidl2==2.0.31",
+    "flyteidl2==2.0.37",
     "packaging",
     "sentry-sdk>=2.0",
     "pyOpenSSL>=24.0.0",

--- a/rs_controller/Cargo.lock
+++ b/rs_controller/Cargo.lock
@@ -269,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.31"
+version = "2.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a04a42c9d33f396196a0976b2109cd0cec810551d49b6117c323096399dd85de"
+checksum = "44a6906b406f1740a5e329f7dfbd0c6c5da241e896546f754880a12ce1493b12"
 dependencies = [
  "async-trait",
  "futures",

--- a/rs_controller/Cargo.toml
+++ b/rs_controller/Cargo.toml
@@ -34,7 +34,7 @@ async-trait = "0.1"
 thiserror = "1.0"
 # Uncomment this if you need to use local flyteidl2
 #flyteidl2 = { path = "/Users/ytong/go/src/github.com/flyteorg/flyte/gen/rust" }
-flyteidl2 = "=2.0.31"
+flyteidl2 = "=2.0.37"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/rs_controller/pyproject.toml
+++ b/rs_controller/pyproject.toml
@@ -9,7 +9,7 @@ description = "Rust controller for Union"
 requires-python = ">=3.10"
 classifiers = ["Programming Language :: Python", "Programming Language :: Rust"]
 dependencies = [
-    "flyteidl2==2.0.31",
+    "flyteidl2==2.0.37",
 ]
 [tool.maturin]
 module-name = "flyte_controller_base"

--- a/rs_controller/uv.lock
+++ b/rs_controller/uv.lock
@@ -10,14 +10,14 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-25T18:54:10.612679Z"
+exclude-newer = "2026-07-31T01:42:18.232227Z"
 exclude-newer-span = "P5D"
 
 [options.exclude-newer-package]
-flyteidl2 = { timestamp = "2026-07-30T18:54:10.612919Z", span = "PT0S" }
-flyte-controller-base = { timestamp = "2026-07-30T18:54:10.613137Z", span = "PT0S" }
-ty = { timestamp = "2026-07-30T18:54:10.613138Z", span = "PT0S" }
-flyteplugins-union = { timestamp = "2026-07-30T18:54:10.613138Z", span = "PT0S" }
+flyteidl2 = { timestamp = "2026-08-05T01:42:18.232236Z", span = "PT0S" }
+flyte-controller-base = { timestamp = "2026-08-05T01:42:18.232242Z", span = "PT0S" }
+ty = { timestamp = "2026-08-05T01:42:18.232244Z", span = "PT0S" }
+flyteplugins-union = { timestamp = "2026-08-05T01:42:18.232243Z", span = "PT0S" }
 
 [[package]]
 name = "cel-python"
@@ -45,11 +45,11 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "flyteidl2", specifier = "==2.0.31" }]
+requires-dist = [{ name = "flyteidl2", specifier = "==2.0.37" }]
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.31"
+version = "2.0.37"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -58,7 +58,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/9b/dec92c854bbb968e3e429eb6d06fa6e8ac433707796c64d9b61f886a2904/flyteidl2-2.0.31-py3-none-any.whl", hash = "sha256:c1df8819c413912377d9336447df04865ca48b2913349ec7e75eb2d3bd1f34c8", size = 353273, upload-time = "2026-07-30T18:30:11.423Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/63/2f28d0e42724d3612d0ae10071e9ce5be2e3db9a4f99eaa6b6087e1af2c7/flyteidl2-2.0.37-py3-none-any.whl", hash = "sha256:0d85f68832e244e667f94e909748bb789754e224e66838b9ecc7e1575d2cb554", size = 374991, upload-time = "2026-08-05T01:25:03.521Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -21,14 +21,14 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-25T18:51:46.989114Z"
+exclude-newer = "2026-07-31T01:42:07.89647Z"
 exclude-newer-span = "P5D"
 
 [options.exclude-newer-package]
-flyteidl2 = { timestamp = "2026-07-30T18:51:46.989353Z", span = "PT0S" }
-flyte-controller-base = { timestamp = "2026-07-30T18:51:46.989563Z", span = "PT0S" }
-ty = { timestamp = "2026-07-30T18:51:46.989565Z", span = "PT0S" }
-flyteplugins-union = { timestamp = "2026-07-30T18:51:46.989564Z", span = "PT0S" }
+flyteidl2 = { timestamp = "2026-08-05T01:42:07.896727Z", span = "PT0S" }
+flyte-controller-base = { timestamp = "2026-08-05T01:42:07.897051Z", span = "PT0S" }
+ty = { timestamp = "2026-08-05T01:42:07.897052Z", span = "PT0S" }
+flyteplugins-union = { timestamp = "2026-08-05T01:42:07.897052Z", span = "PT0S" }
 
 [[package]]
 name = "aiofiles"
@@ -1223,7 +1223,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.31" },
+    { name = "flyteidl2", specifier = "==2.0.37" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -1298,11 +1298,11 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "flyteidl2", specifier = "==2.0.31" }]
+requires-dist = [{ name = "flyteidl2", specifier = "==2.0.37" }]
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.31"
+version = "2.0.37"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -1311,7 +1311,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/9b/dec92c854bbb968e3e429eb6d06fa6e8ac433707796c64d9b61f886a2904/flyteidl2-2.0.31-py3-none-any.whl", hash = "sha256:c1df8819c413912377d9336447df04865ca48b2913349ec7e75eb2d3bd1f34c8", size = 353273, upload-time = "2026-07-30T18:30:11.423Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/63/2f28d0e42724d3612d0ae10071e9ce5be2e3db9a4f99eaa6b6087e1af2c7/flyteidl2-2.0.37-py3-none-any.whl", hash = "sha256:0d85f68832e244e667f94e909748bb789754e224e66838b9ecc7e1575d2cb554", size = 374991, upload-time = "2026-08-05T01:25:03.521Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Bumps `flyteidl2` `2.0.31` → `2.0.37` across all four pinned sites (`pyproject.toml`, `rs_controller/pyproject.toml`, `rs_controller/Cargo.toml`, `plugins/ray/pyproject.toml`) and regenerates the four lockfiles.

## Why

[flyteorg/flyte#7776](https://github.com/flyteorg/flyte/pull/7776) moved the `desc` field option in `flyteidl2/settings/settings_definition.proto` off extension number **50000** to **1364**, from the block the protobuf global extension registry assigns to Flyte.

50000 sits in the range protobuf reserves for use within a single organization — only safe for schemas that never share a descriptor pool with third-party protos. `flyteidl2` is published to buf.build, PyPI and npm, and `desc` collided there with another published extension claiming the same tag. That collision fails extension registration **at import time** for anyone importing both schemas.

The SDK reads this annotation in `_resolve_description` (`src/flyte/remote/_settings.py`) to render the per-setting `##` documentation lines in `flyte get settings` output.

## No source change needed

`_resolve_description` goes through the generated `settings_definition_pb2.desc` symbol, never the literal number, and the annotation lives in `FieldOptions` so it is never serialized into an RPC payload. The renumber is descriptor-level only — the pin is the whole change.

The existing `test_every_leaf_has_a_description` is the regression guard: it fails loudly if the annotation ever stops resolving.

## Verification

- `desc.number` is `1364` on 2.0.37, and all 18 leaves still resolve a description (none blank).
- `pytest tests/flyte/remote/test_settings.py tests/flyte/cli/test_edit_settings.py` → 110 passed.
- Full suite → 4711 passed, 9 skipped. Two failures (`test_retrieve_degrades_when_keyring_not_installed`, `test_real_build`) are local-environment ones that reproduce identically on 2.0.31.
- `cargo check` in `rs_controller/` clean against the 2.0.37 crate.
- The `check-flyteidl2-versions` lint condition holds across all four pins.

The jump spans six releases, so it also picks up unrelated proto changes to `app`, `artifact`, `core/literals`, `core/tasks`, `task/common` and `workflow/run_definition`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)