### PR TITLE
fix: retry App update on revision conflict with a fresh refetch

### DIFF
--- a/src/flyte/remote/_app.py
+++ b/src/flyte/remote/_app.py
@@ -41,6 +41,21 @@ _DEPLOYMENT_STATUS_PREFIX = "DEPLOYMENT_STATUS_"
 # not the integer enum value.
 _STATUS_FILTER_FIELD = "status_phase"
 
+# App is the only entity in this SDK with optimistic-concurrency (revision) semantics: an update
+# is rejected if the App's stored revision was bumped (by another deploy, the console, or a
+# server-side reconciler) between our read and our write. Retrying with a fresh fetch closes that
+# window instead of surfacing a transient conflict as a hard failure.
+_REVISION_CONFLICT_MAX_ATTEMPTS = 3
+_REVISION_CONFLICT_BACKOFF_SECONDS = 0.5
+_REVISION_CONFLICT_CODES = (Code.ABORTED, Code.ALREADY_EXISTS, Code.FAILED_PRECONDITION)
+
+
+def _is_revision_conflict(e: ConnectError) -> bool:
+    if e.code in _REVISION_CONFLICT_CODES:
+        return True
+    message = str(e).lower()
+    return "revision" in message and ("match" in message or "already been applied" in message)
+
 
 def _status_filter(in_status: str | Tuple[str, ...]) -> list_pb2.Filter:
     statuses = (in_status,) if isinstance(in_status, str) else in_status
@@ -336,24 +351,38 @@ class App(ToJSONMixin):
         :return: A new app
         """
         ensure_client()
-        app = await cls.get.aio(name=name, project=project, domain=domain)
 
-        updated_app_spec.creator.CopyFrom(app.pb2.spec.creator)
+        for attempt in range(1, _REVISION_CONFLICT_MAX_ATTEMPTS + 1):
+            app = await cls.get.aio(name=name, project=project, domain=domain)
 
-        if await cls._app_specs_are_equal(app.pb2.spec, updated_app_spec):
-            logger.warning(f"No changes in the App spec for '{name}', skipping update")
-            return app
+            updated_app_spec.creator.CopyFrom(app.pb2.spec.creator)
 
-        new_app = app_definition_pb2.App(
-            metadata=app_definition_pb2.Meta(
-                id=app.pb2.metadata.id,
-                revision=app.revision,
-                labels=labels or app.pb2.metadata.labels,
-            ),
-            spec=updated_app_spec,
-            status=app.pb2.status,
-        )
-        return await cls.update.aio(new_app, reason=reason)
+            if await cls._app_specs_are_equal(app.pb2.spec, updated_app_spec):
+                logger.warning(f"No changes in the App spec for '{name}', skipping update")
+                return app
+
+            new_app = app_definition_pb2.App(
+                metadata=app_definition_pb2.Meta(
+                    id=app.pb2.metadata.id,
+                    revision=app.revision,
+                    labels=labels or app.pb2.metadata.labels,
+                ),
+                spec=updated_app_spec,
+                status=app.pb2.status,
+            )
+            try:
+                return await cls.update.aio(new_app, reason=reason)
+            except ConnectError as e:
+                if attempt < _REVISION_CONFLICT_MAX_ATTEMPTS and _is_revision_conflict(e):
+                    logger.warning(
+                        f"App '{name}' update conflicted with revision {app.revision} (attempt "
+                        f"{attempt}/{_REVISION_CONFLICT_MAX_ATTEMPTS}); refetching latest revision and retrying."
+                    )
+                    await asyncio.sleep(_REVISION_CONFLICT_BACKOFF_SECONDS * attempt)
+                    continue
+                raise
+
+        raise AssertionError("unreachable")  # pragma: no cover
 
     @syncify
     @classmethod

--- a/tests/flyte/remote/test_connectrpc_error_handling.py
+++ b/tests/flyte/remote/test_connectrpc_error_handling.py
@@ -160,6 +160,120 @@ class TestAppCreateErrors:
             mock_replace.aio.assert_called_once()
 
 
+# --- App.replace (revision-conflict retry) ---
+
+
+class TestAppReplaceRevisionConflict:
+    def _make_get_response(self, name="test-app", project="p", domain="d", revision=1, image="img:v1"):
+        app_pb2 = app_definition_pb2.App()
+        app_pb2.metadata.id.name = name
+        app_pb2.metadata.id.project = project
+        app_pb2.metadata.id.domain = domain
+        app_pb2.metadata.revision = revision
+        app_pb2.spec.ingress.SetInParent()
+        app_pb2.spec.container.image = image
+        return MagicMock(app=app_pb2)
+
+    def _make_updated_spec(self, image="img:v2"):
+        spec = app_definition_pb2.Spec()
+        spec.container.image = image
+        return spec
+
+    @pytest.mark.asyncio
+    async def test_retries_on_aborted_and_succeeds(self):
+        """A single ABORTED conflict is retried with a fresh get+revision and then succeeds."""
+        from flyte.remote._app import App
+
+        mock_client = MagicMock()
+        mock_client.app_service.get = AsyncMock(
+            side_effect=[
+                self._make_get_response(revision=1),
+                self._make_get_response(revision=2),
+            ]
+        )
+        success_resp = MagicMock(app=self._make_get_response(revision=2).app)
+        mock_client.app_service.update = AsyncMock(
+            side_effect=[
+                ConnectError(Code.ABORTED, "revision doesn't match the latest"),
+                success_resp,
+            ]
+        )
+        mock_cfg = MagicMock(org="o", project="p", domain="d")
+        with (
+            patch("flyte.remote._app.ensure_client"),
+            patch("flyte.remote._app.get_client", return_value=mock_client),
+            patch("flyte.remote._app.get_init_config", return_value=mock_cfg),
+            patch("flyte.remote._app.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await App.replace.aio(
+                name="test-app",
+                updated_app_spec=self._make_updated_spec(),
+                reason="test",
+                project="p",
+                domain="d",
+            )
+        assert isinstance(result, App)
+        assert mock_client.app_service.get.call_count == 2
+        assert mock_client.app_service.update.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_gives_up_after_max_attempts(self):
+        """A persistent conflict is retried up to the max, then propagates."""
+        from flyte.remote._app import App
+
+        mock_client = MagicMock()
+        mock_client.app_service.get = AsyncMock(
+            side_effect=[self._make_get_response(revision=i, image=f"img:old-{i}") for i in range(1, 5)]
+        )
+        mock_client.app_service.update = AsyncMock(
+            side_effect=ConnectError(Code.ABORTED, "revision doesn't match the latest")
+        )
+        mock_cfg = MagicMock(org="o", project="p", domain="d")
+        with (
+            patch("flyte.remote._app.ensure_client"),
+            patch("flyte.remote._app.get_client", return_value=mock_client),
+            patch("flyte.remote._app.get_init_config", return_value=mock_cfg),
+            patch("flyte.remote._app.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            with pytest.raises(ConnectError):
+                await App.replace.aio(
+                    name="test-app",
+                    updated_app_spec=self._make_updated_spec(),
+                    reason="test",
+                    project="p",
+                    domain="d",
+                )
+        from flyte.remote._app import _REVISION_CONFLICT_MAX_ATTEMPTS
+
+        assert mock_client.app_service.update.call_count == _REVISION_CONFLICT_MAX_ATTEMPTS
+
+    @pytest.mark.asyncio
+    async def test_non_conflict_error_is_not_retried(self):
+        """A non-conflict error (e.g. INTERNAL) propagates immediately without retrying."""
+        from flyte.remote._app import App
+
+        mock_client = MagicMock()
+        mock_client.app_service.get = AsyncMock(return_value=self._make_get_response(revision=1))
+        mock_client.app_service.update = AsyncMock(side_effect=ConnectError(Code.INTERNAL, "server error"))
+        mock_cfg = MagicMock(org="o", project="p", domain="d")
+        with (
+            patch("flyte.remote._app.ensure_client"),
+            patch("flyte.remote._app.get_client", return_value=mock_client),
+            patch("flyte.remote._app.get_init_config", return_value=mock_cfg),
+            patch("flyte.remote._app.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            with pytest.raises(ConnectError):
+                await App.replace.aio(
+                    name="test-app",
+                    updated_app_spec=self._make_updated_spec(),
+                    reason="test",
+                    project="p",
+                    domain="d",
+                )
+        assert mock_client.app_service.get.call_count == 1
+        assert mock_client.app_service.update.call_count == 1
+
+
 # --- TaskDetails.get -> LazyEntity -> deferred_get ---
 
 


### PR DESCRIPTION
## Summary
- Customer report: repeated `flyte deploy` of an existing App fails immediately with "update failed on entity of type [App]. Either the change has already been applied or the revision doesn't match the latest." — even on a clean, isolated re-run with a brand-new image and nothing else deploying concurrently.
- `App.replace()` already does a fresh `App.get()` immediately before building the update, so there's no client-side stale-cache bug. But between that `get` and the `update` call, the App's stored revision can be bumped by something else (another deploy, the console, a server-side reconciler) — a classic optimistic-concurrency TOCTOU race. Root cause of *why* the revision keeps moving looks backend-side, but the SDK had no way to recover from a transient conflict.
- This adds a bounded retry (3 attempts, small backoff) in `App.replace()`: on a revision-conflict error (`ABORTED`/`ALREADY_EXISTS`/`FAILED_PRECONDITION`, or a message match as a defensive fallback since the exact backend code for this path isn't pinned down anywhere in the repo/flyteidl2), refetch the App and retry the update with the new revision before giving up.
- This is a stop-gap: if a backend process is *continuously* winning the race on every single attempt, retries won't help. But it closes the race for intermittent conflicts, which is the common case, without adding any new user-facing flags or behavior changes for the success path.

## Test plan
- [x] `uv run pytest tests/flyte/remote/test_connectrpc_error_handling.py tests/flyte/remote/test_app.py` — 49 passed, including 3 new tests covering: retry-then-succeed, retry-exhausted-then-raise, and non-conflict errors are not retried.
- [x] `make fmt` / `mypy` / `ty` pre-commit hooks passed.