### PR TITLE
fix: retry GetActionData NOT_FOUND for actions already observed as terminal

### DIFF
--- a/src/flyte/remote/_action.py
+++ b/src/flyte/remote/_action.py
@@ -48,6 +48,12 @@ WaitFor = Literal["terminal", "running", "logs-ready"]
 # is stable) — never crash on an enum value the local bindings don't know.
 _ACTION_PHASE_RECOVERED: int = getattr(phase_pb2, "ACTION_PHASE_RECOVERED", 10)
 
+# GetActionData can transiently 404 for a handful of seconds right after a done action is
+# observed via watch/poll -- see _fetch_action_data. Bounded retry with backoff for that window.
+_ACTION_DATA_NOT_FOUND_MAX_RETRIES = 5
+_ACTION_DATA_NOT_FOUND_INITIAL_BACKOFF = 1.0
+_ACTION_DATA_NOT_FOUND_MAX_BACKOFF = 8.0
+
 # ActionMetadata.relation is not available until the flyteidl2 pin is bumped past the release
 # that ships common.Relation; gate all access on the descriptor so both versions work.
 # DESCRIPTOR internals are opaque to checkers; `relation`/`Relation`/`RelationType` are absent from
@@ -1050,10 +1056,26 @@ class ActionDetails(ToJSONMixin):
         :meth:`output_literals` / :meth:`typed_outputs`.
         """
         if self._action_data is None:
-            self._action_data = await get_client().dataproxy_service.get_action_data(
-                request=dataproxy_service_pb2.GetActionDataRequest(action_id=self.pb2.id)
-            )
-        return self._action_data
+            backoff = _ACTION_DATA_NOT_FOUND_INITIAL_BACKOFF
+            for attempt in range(_ACTION_DATA_NOT_FOUND_MAX_RETRIES + 1):
+                try:
+                    resp = await get_client().dataproxy_service.get_action_data(
+                        request=dataproxy_service_pb2.GetActionDataRequest(action_id=self.pb2.id)
+                    )
+                    self._action_data = resp
+                    return resp
+                except ConnectError as e:
+                    # The watch/poll stream can observe a terminal phase (e.g. SUCCEEDED) slightly
+                    # before the action's attempt/output record is queryable via GetActionData, which
+                    # is served by a different backend path. In that window GetActionData transiently
+                    # 404s even though the action really did complete, so retry with backoff instead
+                    # of surfacing a spurious "outputs not available" error. A NOT_FOUND for an action
+                    # that isn't done yet (or a truly unknown action) is not retried.
+                    if e.code != Code.NOT_FOUND or not self.done() or attempt == _ACTION_DATA_NOT_FOUND_MAX_RETRIES:
+                        raise
+                    await asyncio.sleep(backoff)
+                    backoff = min(backoff * 2, _ACTION_DATA_NOT_FOUND_MAX_BACKOFF)
+        return cast(dataproxy_service_pb2.GetActionDataResponse, self._action_data)
 
     @syncify
     async def _cache_data(self) -> bool:

--- a/tests/flyte/remote/test_action_io.py
+++ b/tests/flyte/remote/test_action_io.py
@@ -1,10 +1,13 @@
 import asyncio
 import base64
 import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import msgpack
 import pytest
-from flyteidl2.common import phase_pb2
+from connectrpc.code import Code
+from connectrpc.errors import ConnectError
+from flyteidl2.common import identifier_pb2, phase_pb2
 from flyteidl2.core import literals_pb2
 from flyteidl2.dataproxy import dataproxy_service_pb2
 from flyteidl2.task import common_pb2
@@ -874,3 +877,110 @@ class TestRunTypedAccess:
         run = _run_with_outputs(common_pb2.Outputs(literals=[_named_sync("o0", 7, int)]))
         raw = run.output_literals()
         assert set(raw) == {"o0"} and isinstance(raw["o0"], literals_pb2.Literal)
+
+
+def _succeeded_action_details() -> ActionDetails:
+    """A terminal (SUCCEEDED) ActionDetails with no data-proxy response cached, so
+    ``outputs()``/``_fetch_action_data`` will actually hit the (mocked) client."""
+    action_id = identifier_pb2.ActionIdentifier(
+        run=identifier_pb2.RunIdentifier(org="test-org", project="p", domain="d", name="test-run"),
+        name="test-action",
+    )
+    pb2 = run_definition_pb2.ActionDetails(id=action_id)
+    pb2.status.phase = phase_pb2.ACTION_PHASE_SUCCEEDED
+    return ActionDetails(pb2=pb2)
+
+
+class TestFetchActionDataNotFoundRace:
+    """Regression coverage for a race where GetActionData transiently 404s right after the
+    watch/poll stream reports a terminal (SUCCEEDED) phase, because the action's attempt/output
+    record isn't queryable via the data proxy yet. See customer reports where `run.outputs()`
+    called immediately after ActionPhase.SUCCEEDED raised NOT_FOUND "outputs not available"."""
+
+    @pytest.mark.asyncio
+    async def test_retries_not_found_and_succeeds_for_done_action(self):
+        outs = common_pb2.Outputs(literals=[await _named("o0", 42, int)])
+        resp = dataproxy_service_pb2.GetActionDataResponse(outputs=outs)
+
+        mock_client = MagicMock()
+        mock_client.dataproxy_service.get_action_data = AsyncMock(
+            side_effect=[
+                ConnectError(Code.NOT_FOUND, "outputs not available"),
+                ConnectError(Code.NOT_FOUND, "outputs not available, no attempts for action"),
+                resp,
+            ]
+        )
+
+        ad = _succeeded_action_details()
+        with (
+            patch("flyte.remote._action.get_client", return_value=mock_client),
+            patch("flyte.remote._action.asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        ):
+            raw = await ad.output_literals()
+
+        assert raw["o0"].scalar.primitive.integer == 42
+        assert mock_client.dataproxy_service.get_action_data.await_count == 3
+        assert mock_sleep.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_gives_up_after_max_retries(self):
+        mock_client = MagicMock()
+        mock_client.dataproxy_service.get_action_data = AsyncMock(
+            side_effect=ConnectError(Code.NOT_FOUND, "outputs not available, no attempts for action"),
+        )
+
+        ad = _succeeded_action_details()
+        with (
+            patch("flyte.remote._action.get_client", return_value=mock_client),
+            patch("flyte.remote._action.asyncio.sleep", new=AsyncMock()),
+        ):
+            with pytest.raises(ConnectError):
+                await ad.outputs()
+
+        # 1 initial attempt + 5 retries.
+        assert mock_client.dataproxy_service.get_action_data.await_count == 6
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_not_found_when_action_not_done(self):
+        """A NOT_FOUND for an action that isn't terminal yet is a real error, not a race -- don't
+        retry it (and don't wait on retries that would never resolve)."""
+        action_id = identifier_pb2.ActionIdentifier(
+            run=identifier_pb2.RunIdentifier(org="test-org", project="p", domain="d", name="test-run"),
+            name="test-action",
+        )
+        pb2 = run_definition_pb2.ActionDetails(id=action_id)
+        pb2.status.phase = phase_pb2.ACTION_PHASE_RUNNING
+        ad = ActionDetails(pb2=pb2)
+
+        mock_client = MagicMock()
+        mock_client.dataproxy_service.get_action_data = AsyncMock(
+            side_effect=ConnectError(Code.NOT_FOUND, "outputs not available"),
+        )
+
+        with (
+            patch("flyte.remote._action.get_client", return_value=mock_client),
+            patch("flyte.remote._action.asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        ):
+            with pytest.raises(ConnectError):
+                await ad._fetch_action_data()
+
+        assert mock_client.dataproxy_service.get_action_data.await_count == 1
+        mock_sleep.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_non_not_found_errors(self):
+        mock_client = MagicMock()
+        mock_client.dataproxy_service.get_action_data = AsyncMock(
+            side_effect=ConnectError(Code.INTERNAL, "server error"),
+        )
+
+        ad = _succeeded_action_details()
+        with (
+            patch("flyte.remote._action.get_client", return_value=mock_client),
+            patch("flyte.remote._action.asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        ):
+            with pytest.raises(ConnectError):
+                await ad._fetch_action_data()
+
+        assert mock_client.dataproxy_service.get_action_data.await_count == 1
+        mock_sleep.assert_not_awaited()


### PR DESCRIPTION
## Summary

Fixes two customer reports of `GetActionData` returning `NOT_FOUND: outputs not available` (and `"...no attempts for action"`) immediately after an action/run reports `ActionPhase.SUCCEEDED`, even though the action genuinely succeeded and outputs exist in object storage.

**Root cause:** the watch/poll stream can observe a terminal phase (e.g. `SUCCEEDED`) slightly before the action's attempt/output record is queryable via `GetActionData`, which is served by a different backend path than the phase stream. `ActionDetails.outputs()` / `output_literals()` / `input_literals()` call `GetActionData` the instant the client sees `done()`, with no grace period. The SDK's generic RPC retry interceptor (`RetryUnaryInterceptor`) deliberately excludes `NOT_FOUND` from its retryable codes (correct in general — a bad action ID shouldn't be retried), so this transient race surfaced straight to the caller as a hard error.

- Customer 1: `run.outputs()` called right after the action reached `SUCCEEDED` raised `AioRpcError NOT_FOUND: outputs not available`.
- Customer 2: server confirmed 1 attempt and outputs present in object storage, but `GetActionData` reported `"outputs not available, no attempts for action"`.

**Fix:** `ActionDetails._fetch_action_data` (`src/flyte/remote/_action.py`) now retries `GetActionData` with exponential backoff (up to 5 retries, 1s → 8s cap) specifically when the error is `NOT_FOUND` *and* the action is already known `done()` — that combination is the known-transient case. A `NOT_FOUND` for an action that isn't done yet, or any other error code, still fails immediately (unchanged behavior).

## Test plan

- [x] Added `TestFetchActionDataNotFoundRace` in `tests/flyte/remote/test_action_io.py`:
  - retries `NOT_FOUND` and succeeds once the record becomes available
  - gives up and re-raises after the retry budget is exhausted
  - does **not** retry `NOT_FOUND` when the action isn't terminal yet
  - does **not** retry non-`NOT_FOUND` errors
- [x] `uv run pytest tests/flyte/remote/` — 489 passed
- [x] `uv run pytest tests/` (full suite) — 1999 passed, 3 skipped; only failure is `test_dir_walk_s3`, which requires a local S3/localstack stack (`localhost:4566`) not available in this environment — unrelated to this change
- [x] `make mypy` / `make ty` / `make fmt` — clean (pre-commit hooks passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)