### PR TITLE
Add 1-based TaskContext.attempt, deprecate 0-based attempt_number

### DIFF
--- a/src/flyte/models.py
+++ b/src/flyte/models.py
@@ -311,10 +311,33 @@ class TaskContext:
     @property
     def attempt_number(self) -> int:
         """
-        Get the attempt number for the current task.
-        :return: The attempt number.
+        Get the 0-based retry index for the current task: 0 on the first attempt,
+        1 on the first retry, and so on.
+
+        .. deprecated::
+            Prefer :py:attr:`attempt`, which is 1-based and matches the attempt
+            numbering shown in the console, the TUI, and action events.
+
+        :return: The 0-based retry index.
         """
         return int(os.environ.get("FLYTE_ATTEMPT_NUMBER", "0"))
+
+    @property
+    def attempt(self) -> int:
+        """
+        Get the 1-based attempt number for the current task: 1 on the first
+        attempt, 2 on the first retry, and so on. Matches the attempt numbering
+        shown in the console, the TUI, and action events.
+
+        Reads FLYTE_ATTEMPT when the backend provides it, falling back to
+        FLYTE_ATTEMPT_NUMBER + 1 on older backends.
+
+        :return: The 1-based attempt number.
+        """
+        v = os.environ.get("FLYTE_ATTEMPT")
+        if v is not None:
+            return int(v)
+        return int(os.environ.get("FLYTE_ATTEMPT_NUMBER", "0")) + 1
 
     # ------------------------------------------------------------------
     # Distributed / clustered fields — all None on non-clustered tasks.


### PR DESCRIPTION
## Why

`ctx.attempt_number` is a 0-based retry index (from `FLYTE_ATTEMPT_NUMBER`), while the console, TUI, and action events number attempts from 1 — so a task printing its attempt disagrees with every dashboard showing the same execution.

## What

New `TaskContext.attempt` property: 1-based, reads the new `FLYTE_ATTEMPT` env var (stamped by flyteorg/flyte#7792), and falls back to `FLYTE_ATTEMPT_NUMBER + 1` on backends that don't stamp it yet — correct across every backend/SDK version combination, including local runs (defaults to 1). `attempt_number` is unchanged and documented as deprecated.

## Testing

Verified all three env combinations (neither var set → 1/0; only `FLYTE_ATTEMPT_NUMBER=2` → 3/2; both stamped → values read from their own vars independently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199AnC2fWkbhANzJtAKEV61