### PR TITLE
fix(ray): reject RayJob TTL/shutdown options when a reuse policy is set

### DIFF
--- a/plugins/ray/src/flyteplugins/ray/task.py
+++ b/plugins/ray/src/flyteplugins/ray/task.py
@@ -149,6 +149,19 @@ class RayFunctionTask(AsyncFunctionTaskTemplate):
                 f"Reusable Ray tasks currently doesn't support setting concurrency;"
                 f" got concurrency={self.reusable.concurrency}.",
             )
+        if self.reusable is not None and self.plugin_config.shutdown_after_job_finishes:
+            raise flyte.errors.RuntimeUserError(
+                "BadConfiguration",
+                "shutdown_after_job_finishes cannot be used with a reuse policy: the shared "
+                "RayCluster must outlive individual jobs. Remove shutdown_after_job_finishes; "
+                "the cluster is shut down after ReusePolicy(idle_ttl=...) of inactivity.",
+            )
+        if self.reusable is not None and self.plugin_config.ttl_seconds_after_finished is not None:
+            raise flyte.errors.RuntimeUserError(
+                "BadConfiguration",
+                "ttl_seconds_after_finished is ignored when a reuse policy is set; use "
+                "ReusePolicy(idle_ttl=...) to control when the shared RayCluster is shut down.",
+            )
 
     async def pre(self, *args, **kwargs) -> Dict[str, Any]:
         init_params = {"address": self.plugin_config.address}

--- a/plugins/ray/tests/test_task.py
+++ b/plugins/ray/tests/test_task.py
@@ -239,3 +239,32 @@ def test_custom_config_rejects_multiple_reuse_replicas(sctx):
             plugin_config=RayJobConfig(worker_node_config=[]),
             reusable=flyte.ReusePolicy(replicas=(1, 3)),
         )
+
+
+def test_reuse_policy_rejects_shutdown_after_job_finishes(sctx):
+    import flyte.errors
+
+    # In reuse mode the shared cluster must outlive individual jobs; the backend forces
+    # shutdown_after_job_finishes off, so setting it is a configuration error.
+    with pytest.raises(flyte.errors.RuntimeUserError, match="shutdown_after_job_finishes"):
+        RayFunctionTask(
+            name="t",
+            interface=None,
+            func=lambda: None,
+            plugin_config=RayJobConfig(worker_node_config=[], shutdown_after_job_finishes=True),
+            reusable=flyte.ReusePolicy(replicas=1, idle_ttl=600),
+        )
+
+
+def test_reuse_policy_rejects_ttl_seconds_after_finished(sctx):
+    import flyte.errors
+
+    # ReusePolicy(idle_ttl=...) is the sole TTL knob in reuse mode; the RayJob-level TTL is ignored.
+    with pytest.raises(flyte.errors.RuntimeUserError, match="ttl_seconds_after_finished"):
+        RayFunctionTask(
+            name="t",
+            interface=None,
+            func=lambda: None,
+            plugin_config=RayJobConfig(worker_node_config=[], ttl_seconds_after_finished=300),
+            reusable=flyte.ReusePolicy(replicas=1, idle_ttl=600),
+        )


### PR DESCRIPTION
## Why

With `reusable=ReusePolicy(...)` on a Ray `TaskEnvironment`, two `RayJobConfig` fields are silently overridden by the shared-cluster backend:

- `shutdown_after_job_finishes` — forced off, since a finishing job must not tear down the shared RayCluster other tasks are using.
- `ttl_seconds_after_finished` — ignored; cluster lifetime is governed by `ReusePolicy(idle_ttl=...)` (the backend only falls back to the RayJob TTL when no reuse-policy TTL exists, and the SDK always sets one).

Silently ignoring explicit user configuration is confusing, so fail fast at task construction with a `RuntimeUserError` explaining the right knob — consistent with the existing `replicas`/`concurrency` validations in `RayFunctionTask.__post_init__`.

## Changes

- `RayFunctionTask.__post_init__`: raise `BadConfiguration` when a reuse policy is combined with `shutdown_after_job_finishes=True` or `ttl_seconds_after_finished`.
- Tests for both rejections (`plugins/ray/tests/test_task.py`); full ray plugin suite passes (11 passed).