### PR TITLE
fix setting config image registry

### DIFF
--- a/src/flyte/_internal/imagebuild/image_builder.py
+++ b/src/flyte/_internal/imagebuild/image_builder.py
@@ -291,6 +291,17 @@ class ImageBuildEngine:
         :return: An ImageBuild object with the image URI and remote run (if applicable).
         """
         from flyte._build import ImageBuild
+        from flyte._image import _get_push_registry
+
+        # Images are commonly declared at module import time, before flyte.init_from_config()
+        # records image.registry. Re-resolve the push registry at build time so local builds
+        # honor config-loaded registries without requiring users to pass registry= on every Image.
+        cfg = _get_init_config()
+        if cfg and cfg.image_builder:
+            builder = builder or cfg.image_builder
+        if str(builder or "local") == "local" and image._is_cloned and not image.registry:
+            if registry := _get_push_registry():
+                image = image.clone(registry=registry)
 
         # Skip the existence check when force or dry_run is set.
         image_uri: str | None
@@ -308,9 +319,6 @@ class ImageBuildEngine:
         image.validate()
 
         # If a builder is not specified, use the first registered builder
-        cfg = _get_init_config()
-        if cfg and cfg.image_builder:
-            builder = builder or cfg.image_builder
         img_builder = ImageBuildEngine._get_builder(builder)
         logger.debug(f"Using `{img_builder}` image builder to build image.")
 

--- a/tests/flyte/imagebuild/test_image_build_engine.py
+++ b/tests/flyte/imagebuild/test_image_build_engine.py
@@ -112,6 +112,34 @@ async def test_build_skips_when_image_exists(mock_image_exists, mock_get_builder
     mock_builder.build_image.assert_not_called()
 
 
+@mock.patch("flyte._internal.imagebuild.image_builder._write_image_cache")
+@mock.patch("flyte._image._get_push_registry", return_value="ghcr.io/test-owner")
+@mock.patch("flyte._internal.imagebuild.image_builder.ImageBuildEngine._get_builder")
+@mock.patch("flyte._internal.imagebuild.image_builder.ImageBuildEngine.image_exists", new_callable=mock.AsyncMock)
+@pytest.mark.asyncio
+async def test_build_applies_configured_push_registry_to_preinit_image(
+    mock_image_exists, mock_get_builder, mock_get_push_registry, mock_write_cache
+):
+    """Images declared before init have no registry, but local build should honor
+    image.registry once init_from_config has loaded it."""
+    ImageBuildEngine.build.cache_clear()
+    mock_image_exists.return_value = None
+    mock_builder = mock.AsyncMock()
+    mock_builder.build_image.return_value = ImageBuild(uri="ghcr.io/test-owner/my-app:tag", remote_run=None)
+    mock_get_builder.return_value = mock_builder
+
+    img = Image.from_base("ghcr.io/example/base:latest").clone(name="my-app", extendable=True)
+    assert img.registry is None
+
+    result = await ImageBuildEngine.build(image=img)
+
+    assert result.uri == "ghcr.io/test-owner/my-app:tag"
+    checked_image = mock_image_exists.call_args.args[0]
+    built_image = mock_builder.build_image.call_args.args[0]
+    assert checked_image.registry == "ghcr.io/test-owner"
+    assert built_image.registry == "ghcr.io/test-owner"
+
+
 @mock.patch("flyte._internal.imagebuild.image_builder.ImageBuildEngine._get_builder")
 @mock.patch("flyte._internal.imagebuild.image_builder.ImageBuildEngine.image_exists", new_callable=mock.AsyncMock)
 @pytest.mark.asyncio


### PR DESCRIPTION
- Follow-up to https://github.com/flyteorg/flyte-sdk/pull/1304

Fixes local image builds for images declared before flyte.init_from_config().

Image.from_debian_base() can run at module import time before config is loaded, leaving the image without a registry. The local builder then failed with “no container registry is configured” even when image.registry was set in the config file.

  Changes:
  - Re-resolve the push registry at build time for local, registry-less cloned images.
  - Clone the image with the configured push registry before existence checks/building.
  - Add a regression test for pre-init image declarations.
  
  
  **Before:**
  
  ``` python
  # hello.py

import flyte

env = flyte.TaskEnvironment(
    name="my_map_workflow",
    image=flyte.Image.from_debian_base().with_pip_packages("pandas"),
)


# use TaskEnvironments to define tasks, which are regular Python functions.
@env.task
def fn(x: int) -> int:  # type annotations are recommended.
    slope, intercept = 2, 5
    print(slope * x + intercept)
    return slope * x + intercept


# tasks can also call other tasks, which will be manifested in different containers.
@env.task(entrypoint=True)
def main(x_list: list[int] = list(range(10))) -> float:
    x_len = len(x_list)
    if x_len < 10:
        raise ValueError(
            f"x_list doesn't have a larger enough sample size, found: {x_len}"
        )

    y_list = list(
        flyte.map(fn, x_list)
    )  # flyte.map is like Python map, but runs in parallel.
    y_mean = sum(y_list) / len(y_list)
    return y_mean


if __name__ == "__main__":
    flyte.init_from_config("jan-playground.yaml")
    run = flyte.run(main)
    print(run.url)
```
with `jan-playground.yaml`:
``` yaml
admin:
  endpoint: dns:///jan-playground.sh-us-east-2.union.ai
image:
  builder: local
  registry: ghcr.io/fiedlernr9
task:
  domain: development
  org: jan-playground
  project: flytesnacks
```
resulted in
``` bash
ImageBuildError: Cannot build image 'flyte': no container registry is configured to push to. The default base registry (ghcr.io/flyteorg) is read-only for pulls and cannot be pushed to. Set a push registry via any of:
  - add `registry: <your-registry>` under the `image:` section of your config.yaml
  - re-run `flyte create config` and add `--registry <your-registry>`
  - set the FLYTE_IMAGE_REGISTRY environment variable to <your-registry>
  - flyte.Image(...): pass registry='<your-registry>' (e.g. registry='docker.io/<user>')
 ```
 **After**:
 - builds image and runs as expected