### PR TITLE
docs: convert Sphinx roles in docstrings to Markdown code spans

### DIFF
--- a/plugins/agento11y/src/flyteplugins/agento11y/_binding.py
+++ b/plugins/agento11y/src/flyteplugins/agento11y/_binding.py
@@ -13,7 +13,7 @@ produced them. Flyte knows all three, and nobody should have to restate them by 
 Binding them means a Flyte run shows up in Grafana as one conversation, and a redeploy shows
 up as a new agent version, so the before-and-after of a prompt change is directly comparable.
 
-This is a :class:`flyte._observe.Observer` which is what makes it work at all: the values
+This is a `flyte._observe.Observer` which is what makes it work at all: the values
 have to be set for the duration of the task body, before any generation starts, and that is
 exactly the window a task span covers.
 """

--- a/plugins/agento11y/src/flyteplugins/agento11y/_frameworks.py
+++ b/plugins/agento11y/src/flyteplugins/agento11y/_frameworks.py
@@ -99,7 +99,7 @@ def _load(integration: _Integration) -> typing.Any | None:
 def _with_conversation_metadata(config: typing.Any) -> typing.Any:
     """Put the Flyte run name into a runnable config's metadata as the conversation id.
 
-    :class:`~flyteplugins.agento11y.FlyteIdentityBinding` sets a conversation contextvar, and
+    `flyteplugins.agento11y.FlyteIdentityBinding` sets a conversation contextvar, and
     the client honours it for generations recorded directly. Framework handlers do not: they
     resolve a conversation id from the callback payload themselves, so the contextvar is never
     consulted and the run's generations end up ungrouped. Metadata is the payload key the
@@ -214,7 +214,7 @@ def _make_call_wrapper(wrapped_query: typing.Any, client: typing.Any) -> typing.
 def register_all(client: typing.Any) -> tuple[str, ...]:
     """Register an instrumentor for every framework whose integration is installed.
 
-    Returns the frameworks that were registered, which is what :func:`init` reports back so
+    Returns the frameworks that were registered, which is what `init` reports back so
     a caller can tell instrumentation is actually in place.
     """
     from flyteplugins.agents.core import register_call_wrapper, register_instrumentor

--- a/plugins/agento11y/src/flyteplugins/agento11y/_setup.py
+++ b/plugins/agento11y/src/flyteplugins/agento11y/_setup.py
@@ -53,7 +53,7 @@ def init(
         endpoint: agento11y generation export endpoint. Falls back to the AGENTO11Y_ env
             vars, which is how the Grafana docs configure it.
         client: Use a client you built yourself. Its tracer and exporters are left alone,
-            and it is not shut down by :func:`shutdown`.
+            and it is not shut down by `shutdown`.
         client_options: Extra ``ClientConfig`` fields, for anything this signature does not
             surface: auth mode and token, protocol, content capture, a custom
             ``generation_exporter``. Ignored when ``client`` is supplied.
@@ -97,7 +97,7 @@ def _init_locked(
     trace: bool,
     otel_kwargs: dict[str, typing.Any],
 ) -> Client:
-    """The body of :func:`init`, run with the lock already held."""
+    """The body of `init`, run with the lock already held."""
     if _state["client"] is not None:
         logger.debug("flyteplugins-agento11y already initialized; returning the existing client")
         return _state["client"]
@@ -165,7 +165,7 @@ def _flush_at_exit() -> None:
 
 
 def get_client() -> Client | None:
-    """The client :func:`init` built, for recording generations by hand."""
+    """The client `init` built, for recording generations by hand."""
     return _state["client"]
 
 

--- a/plugins/agento11y/src/flyteplugins/agento11y/links.py
+++ b/plugins/agento11y/src/flyteplugins/agento11y/links.py
@@ -2,7 +2,7 @@
 
 This lives here rather than in ``flyteplugins-otel`` because it is only correct when this
 package is in use: it addresses a run by conversation id, and it is
-:class:`~flyteplugins.agento11y.FlyteIdentityBinding` that makes the run name the conversation
+`flyteplugins.agento11y.FlyteIdentityBinding` that makes the run name the conversation
 id in the first place. Shipping it alongside the generic tracing plugin would mean a link that
 silently points at nothing for anyone not running the bridge.
 

--- a/plugins/agents/claude/src/flyteplugins/agents/claude/__init__.py
+++ b/plugins/agents/claude/src/flyteplugins/agents/claude/__init__.py
@@ -5,8 +5,8 @@ expose are Flyte tasks (so each tool call is a durable child action with its own
 container/resources, retries and caching); the agent loop itself runs in the
 Claude Code runtime, and its timeline is rendered into the Flyte task report.
 
-- :func:`tool` — turn an ``@env.task`` into a Claude in-process MCP tool.
-- :func:`run_agent` — run the agent loop inside your task and return the answer.
+- `tool` — turn an ``@env.task`` into a Claude in-process MCP tool.
+- `run_agent` — run the agent loop inside your task and return the answer.
 
 The ``claude-agent-sdk`` wheel bundles the native ``claude`` CLI (no separate Node.js
 install needed); set an Anthropic API key in the environment.

--- a/plugins/agents/claude/src/flyteplugins/agents/claude/_durable.py
+++ b/plugins/agents/claude/src/flyteplugins/agents/claude/_durable.py
@@ -6,7 +6,7 @@ Instead we use the SDK's own session mirror + resume: the CLI mirrors the runnin
 transcript to a ``SessionStore`` we provide, and on a retry it resumes from that store
 rather than starting over.
 
-We back that store with :class:`flyte.Checkpoint` — the native, retry-surviving
+We back that store with `flyte.Checkpoint` — the native, retry-surviving
 durable prefix the runtime hands each task (``save`` writes this attempt's blob,
 ``load`` restores the previous attempt's). So a crashed attempt's conversation is
 restored on the next attempt instead of replayed from scratch, without us owning
@@ -71,7 +71,7 @@ def _read_payload(local: typing.Any) -> dict | None:
 
 
 class CheckpointSessionStore:
-    """A duck-typed Claude ``SessionStore`` persisted via :class:`flyte.Checkpoint`.
+    """A duck-typed Claude ``SessionStore`` persisted via `flyte.Checkpoint`.
 
     The SDK requires only ``append`` and ``load`` and probes for the optional methods
     (``list_sessions``/``delete``/...), so we deliberately omit them. The whole store —

--- a/plugins/agents/claude/src/flyteplugins/agents/claude/_memory.py
+++ b/plugins/agents/claude/src/flyteplugins/agents/claude/_memory.py
@@ -1,7 +1,7 @@
 """Cross-run Claude memory — a ``SessionStore`` backed by a keyed ``MemoryStore``.
 
 Claude's session resume materializes a ``SessionStore``'s transcript into the
-CLI. The per-run crash-resume store (see :mod:`._durable`) is keyed by the action
+CLI. The per-run crash-resume store (see `._durable`) is keyed by the action
 and backed by a ``flyte.Checkpoint`` (ephemeral, per-run). This store is keyed by a
 stable ``memory_key`` (a user/thread id) and backed by a durable, cross-run
 ``MemoryStore`` — so a later run with the same key resumes the prior

--- a/plugins/agents/claude/src/flyteplugins/agents/claude/_run.py
+++ b/plugins/agents/claude/src/flyteplugins/agents/claude/_run.py
@@ -6,11 +6,11 @@ in-process MCP server from the tools, points the SDK at it, streams the run, and
 renders the timeline into the Flyte report.
 
 Durability: tool calls are durable Flyte child actions (see
-:func:`flyteplugins.agents.claude.tool`). Per-turn model replay is not
+`flyteplugins.agents.claude.tool`). Per-turn model replay is not
 available here — the model loop runs in the Claude Code runtime (a subprocess
 Flyte doesn't intercept), so a model turn can't be a ``flyte.trace`` leaf the way
 it is for client-side SDKs. Instead, ``durable=True`` wires the SDK's own session
-mirror + resume onto a :class:`flyte.Checkpoint` (see :mod:`._durable`), so a
+mirror + resume onto a `flyte.Checkpoint` (see `._durable`), so a
 crashed attempt's conversation is restored on retry rather than restarted. Tool
 durability, retries and caching apply regardless.
 
@@ -74,7 +74,7 @@ async def run_agent(
     """Run a Claude agent with the given tools and prompt; return the final text.
 
     Await this from an async task as ``await run_agent(...)``; from a sync task
-    use :func:`run_agent_sync` instead.
+    use `run_agent_sync` instead.
 
     Call this from inside an ``@env.task`` — that task is the durable parent,
     and each tool the agent calls runs as a durable Flyte child action. Pass a

--- a/plugins/agents/claude/src/flyteplugins/agents/claude/_tools.py
+++ b/plugins/agents/claude/src/flyteplugins/agents/claude/_tools.py
@@ -1,7 +1,7 @@
 """Turn Flyte tasks into Claude Agent SDK tools that execute as durable actions.
 
 The Claude Agent SDK exposes custom tools as in-process MCP tools (``@tool`` /
-``SdkMcpTool``). :func:`tool` wraps a Flyte ``@env.task`` as one whose
+``SdkMcpTool``). `tool` wraps a Flyte ``@env.task`` as one whose
 handler dispatches to the task via ``task.aio()`` — so when Claude calls the
 tool, it runs as a durable Flyte child action (its own container/resources, with
 retries and caching) rather than inline in the agent process.
@@ -32,7 +32,7 @@ def tool(
     - For an ``@env.task``: returns an ``SdkMcpTool`` whose handler runs the task
       as a durable Flyte child action when Claude calls it. The input schema is
       derived from the task via the Flyte type engine. The backing task is wired
-      to :class:`~flyteplugins.agents.core.ToolTaskResolver` and exposed via
+      to `flyteplugins.agents.core.ToolTaskResolver` and exposed via
       ``__wrapped_task__`` so it resolves to itself on the worker (no recursion).
     - For a plain (async) callable: returns an ``SdkMcpTool`` that runs it inline.
 

--- a/plugins/agents/core/src/flyteplugins/agents/core/__init__.py
+++ b/plugins/agents/core/src/flyteplugins/agents/core/__init__.py
@@ -4,13 +4,13 @@ This package holds the SDK-agnostic machinery that makes Flyte the durable
 runtime under any agent framework, so each ``flyteplugins-agents-<sdk>`` adapter
 stays thin and consistent:
 
-- :func:`durable_step` — record a call as a durable, replayable ``flyte.trace``
+- `durable_step` — record a call as a durable, replayable ``flyte.trace``
   leaf (the model-turn durability mechanism), keyed by a fingerprint.
-- :func:`fingerprint` — a deterministic memo key from a request payload.
-- :class:`ToolTaskResolver` / :func:`attach_tool_resolver` — make a tool-backing
+- `fingerprint` — a deterministic memo key from a request payload.
+- `ToolTaskResolver` / `attach_tool_resolver` — make a tool-backing
   task resolve to itself on the worker.
-- :class:`ReportTimeline` — render agent events into the Flyte task report.
-- :mod:`flyteplugins.agents.core.testing` — :func:`assert_adapter_conforms`, the
+- `ReportTimeline` — render agent events into the Flyte task report.
+- `flyteplugins.agents.core.testing` — `assert_adapter_conforms`, the
   CI-enforced conformance check every adapter runs.
 
 The division of labor every adapter follows: the agent run is a Flyte

--- a/plugins/agents/core/src/flyteplugins/agents/core/_durable.py
+++ b/plugins/agents/core/src/flyteplugins/agents/core/_durable.py
@@ -4,7 +4,7 @@ A model turn (or any expensive, replay-worthy call) is recorded as a
 ``flyte.trace`` leaf so that, inside a Flyte task, a crash/retry replays the
 recorded result instead of re-running it. The real call is usually
 non-serializable (closures, SDK objects), but ``flyte.trace`` keys its memo on
-the decorated function's serializable arguments. :func:`durable_step` resolves
+the decorated function's serializable arguments. `durable_step` resolves
 that by capturing the real call in a closure and feeding the trace only a
 deterministic ``request_key``.
 """

--- a/plugins/agents/core/src/flyteplugins/agents/core/_instrumentation.py
+++ b/plugins/agents/core/src/flyteplugins/agents/core/_instrumentation.py
@@ -11,7 +11,7 @@ gets a chance to return a modified one. ``flyteplugins-agento11y`` is the first 
 This module deliberately knows nothing about any observability vendor: it moves an opaque
 object through a function and keeps the agents plugin free of those dependencies.
 
-Adapters call :func:`apply_instrumentation` at the invocation site:
+Adapters call `apply_instrumentation` at the invocation site:
 
     config = apply_instrumentation("langgraph", config)
     result = await agent.ainvoke(state, config=config)

--- a/plugins/agents/core/src/flyteplugins/agents/core/_observability.py
+++ b/plugins/agents/core/src/flyteplugins/agents/core/_observability.py
@@ -1,8 +1,8 @@
 """Shared report timeline — render agent events into the Flyte task report.
 
-Each adapter maps its own SDK's trace/span/event shape onto :class:`ReportTimeline`
+Each adapter maps its own SDK's trace/span/event shape onto `ReportTimeline`
 rows; the row formatting, abbreviation, and best-effort error handling now live in
-``flyte.report`` (:class:`flyte.report.Timeline`), so the native ``flyte.ai.agents``
+``flyte.report`` (`flyte.report.Timeline`), so the native ``flyte.ai.agents``
 loop and every adapter render through one implementation. This module keeps the
 adapter-facing names (``ReportTimeline`` defaulting to the ``Agent`` tab, plus the
 ``abbrev``/``duration_ms``/``flush_report`` helpers) stable.
@@ -18,7 +18,7 @@ __all__ = ["ReportTimeline", "abbrev", "duration_ms", "flush_report"]
 
 
 class ReportTimeline(Timeline):
-    """A :class:`flyte.report.Timeline` that defaults to the ``Agent`` report tab."""
+    """A `flyte.report.Timeline` that defaults to the ``Agent`` report tab."""
 
     def __init__(self, tab_name: str = "Agent"):
         super().__init__(tab_name)

--- a/plugins/agents/core/src/flyteplugins/agents/core/_sync.py
+++ b/plugins/agents/core/src/flyteplugins/agents/core/_sync.py
@@ -53,7 +53,7 @@ def sync_variant(afunc: typing.Callable[..., typing.Coroutine[typing.Any, typing
         run_agent_sync = sync_variant(run_agent)
 
     The wrapper keeps run_agent's signature and docstring for introspection and
-    dispatches through :func:`run_coro_sync`.
+    dispatches through `run_coro_sync`.
     """
 
     @functools.wraps(afunc)

--- a/plugins/agents/core/src/flyteplugins/agents/core/_tools.py
+++ b/plugins/agents/core/src/flyteplugins/agents/core/_tools.py
@@ -5,10 +5,10 @@ the module attribute to the tool and shadows the task. Without a guard, the
 worker's default resolver loads the tool, the task runner calls the tool's
 ``execute``, and the task re-dispatches itself — recursing without end.
 
-:class:`ToolTaskResolver` recovers the real task via the tool's
-``__wrapped_task__`` hook; :func:`attach_tool_resolver` wires it onto the task.
+`ToolTaskResolver` recovers the real task via the tool's
+``__wrapped_task__`` hook; `attach_tool_resolver` wires it onto the task.
 Each adapter's tool object only has to expose ``__wrapped_task__`` returning its
-backing :class:`~flyte._task.TaskTemplate`.
+backing `flyte._task.TaskTemplate`.
 """
 
 from __future__ import annotations
@@ -43,7 +43,7 @@ class ToolTaskResolver(DefaultTaskResolver):
 
 
 def attach_tool_resolver(task: typing.Any) -> None:
-    """Point a tool-backing ``@env.task`` at :class:`ToolTaskResolver`.
+    """Point a tool-backing ``@env.task`` at `ToolTaskResolver`.
 
     No-op for anything that isn't an async-function task or that already declares
     a custom resolver, so the default resolver is left untouched elsewhere.
@@ -85,7 +85,7 @@ def tool(
     signature + docstring), this is the whole adapter ``tool``: the returned
     function carries the task's signature (``functools.wraps``), dispatches to
     ``task.aio()`` (so each call is a durable Flyte child action), exposes
-    ``__wrapped_task__``, and wires the backing task to :class:`ToolTaskResolver`.
+    ``__wrapped_task__``, and wires the backing task to `ToolTaskResolver`.
     Adapters whose SDK needs a native tool type (e.g. OpenAI's
     ``FunctionTool``, Claude's MCP ``SdkMcpTool``) provide their own instead.
 

--- a/plugins/agents/core/src/flyteplugins/agents/core/testing.py
+++ b/plugins/agents/core/src/flyteplugins/agents/core/testing.py
@@ -27,7 +27,7 @@ def assert_adapter_conforms(adapter: typing.Any) -> None:
     The contract:
 
     1. exports a callable ``tool`` that turns an ``@env.task`` into the
-       SDK's tool type, attaching :class:`~flyteplugins.agents.core.ToolTaskResolver`
+       SDK's tool type, attaching `flyteplugins.agents.core.ToolTaskResolver`
        and exposing ``__wrapped_task__`` (so the task does not self-recurse on the
        worker);
     2. exports an async ``run_agent`` (awaited from async tasks) and a plain

--- a/plugins/agents/crewai/src/flyteplugins/agents/crewai/__init__.py
+++ b/plugins/agents/crewai/src/flyteplugins/agents/crewai/__init__.py
@@ -3,9 +3,9 @@
 Bring your own CrewAI ``Agent`` and run it durably on Flyte. The adapter
 provides:
 
-- :func:`tool` — turn a Flyte ``@env.task`` into a CrewAI tool that executes as
+- `tool` — turn a Flyte ``@env.task`` into a CrewAI tool that executes as
   a durable child action (own container/GPU, retries, caching).
-- :func:`run_agent` — run the CrewAI agent loop inside your task and return the
+- `run_agent` — run the CrewAI agent loop inside your task and return the
   final answer.
 
 Each tool call runs as a durable Flyte child action, and the run timeline is

--- a/plugins/agents/crewai/src/flyteplugins/agents/crewai/_durable.py
+++ b/plugins/agents/crewai/src/flyteplugins/agents/crewai/_durable.py
@@ -3,10 +3,10 @@
 CrewAI owns the agent loop and drives the model itself: during
 ``Agent.kickoff_async`` it calls its ``crewai.LLM`` once per turn. To make that
 loop durable we swap in a durable ``LLM``: it records each turn through the
-shared :func:`~flyteplugins.agents.core.durable_step` (a ``flyte.trace`` leaf),
+shared `flyteplugins.agents.core.durable_step` (a ``flyte.trace`` leaf),
 so inside a Flyte task a crashed/retried run replays completed turns from their
 recorded completions instead of re-calling (and re-billing) the model. Tool
-calls run as durable child actions (see :func:`flyteplugins.agents.crewai.tool`),
+calls run as durable child actions (see `flyteplugins.agents.crewai.tool`),
 so the whole run becomes crash-resilient when the enclosing task carries
 ``retries=...``.
 

--- a/plugins/agents/crewai/src/flyteplugins/agents/crewai/_run.py
+++ b/plugins/agents/crewai/src/flyteplugins/agents/crewai/_run.py
@@ -55,7 +55,7 @@ async def run_agent(
     """Run a CrewAI agent with the given tools and prompt; return the final text.
 
     Await this from an async task as ``await run_agent(...)``; from a sync task
-    use :func:`run_agent_sync` instead.
+    use `run_agent_sync` instead.
 
     Call this from inside an ``@env.task`` — that task is the durable parent.
     Within it, each tool call runs as a durable Flyte child action. Give the

--- a/plugins/agents/crewai/src/flyteplugins/agents/crewai/_tools.py
+++ b/plugins/agents/crewai/src/flyteplugins/agents/crewai/_tools.py
@@ -2,7 +2,7 @@
 
 CrewAI requires tools attached to an ``Agent(tools=[...])`` to be
 ``crewai.tools.BaseTool`` instances — plain callables are rejected by pydantic
-validation. :func:`tool` therefore wraps a Flyte ``@env.task`` as a ``BaseTool``
+validation. `tool` therefore wraps a Flyte ``@env.task`` as a ``BaseTool``
 subclass whose execution dispatches to the task via ``task.aio()`` — so when the
 agent calls the tool, it runs as a durable Flyte child action (its own
 container/resources, with retries and caching) rather than inline in the agent's
@@ -13,7 +13,7 @@ Sync/async bridge: CrewAI invokes tools synchronously (``BaseTool.run`` ->
 ``self.func`` — our ``_run`` — and, if it returns a coroutine, ``asyncio.run``s it).
 ``asyncio.run`` explodes inside the already-running loop of a Flyte task, so we make
 ``_run`` a *synchronous* method that bridges to ``task.aio()`` via
-:func:`flyte._utils.asyn.run_sync`, which drives the coroutine on a dedicated
+`flyte._utils.asyn.run_sync`, which drives the coroutine on a dedicated
 background-thread loop and works from within a running loop. ``_arun`` awaits the
 task directly for CrewAI's native async path.
 """
@@ -43,7 +43,7 @@ def tool(
     - For an ``@env.task``: returns a ``BaseTool`` whose execution runs the task as
       a durable Flyte child action when the agent invokes it. The input schema is
       derived from the task via the Flyte type engine. The backing task is wired
-      to :class:`~flyteplugins.agents.core.ToolTaskResolver` and exposed via
+      to `flyteplugins.agents.core.ToolTaskResolver` and exposed via
       ``__wrapped_task__`` so it resolves to itself on the worker (no recursion).
     - For a plain (async) callable: returns a ``BaseTool`` that runs it inline.
 
@@ -105,7 +105,7 @@ def _make_base_tool_class() -> type:
         ``_run`` is synchronous by design: CrewAI's structured-tool path calls it
         and ``asyncio.run``s any returned coroutine, which would fail inside a
         Flyte task's running loop. We instead bridge to the async dispatcher via
-        :func:`run_sync` (a background-thread loop) and return a plain string.
+        `run_sync` (a background-thread loop) and return a plain string.
         """
 
         # Pydantic model config: allow the non-field private attributes below.

--- a/plugins/agents/deepagents/src/flyteplugins/agents/deepagents/__init__.py
+++ b/plugins/agents/deepagents/src/flyteplugins/agents/deepagents/__init__.py
@@ -4,14 +4,14 @@ Bring your own `Deep Agent <https://docs.langchain.com/oss/python/deepagents/ove
 — LangChain's agent harness with built-in planning, a virtual filesystem, and
 subagents — and run it durably on Flyte. The adapter provides:
 
-- :func:`tool` — turn a Flyte ``@env.task`` into a LangChain ``StructuredTool``
+- `tool` — turn a Flyte ``@env.task`` into a LangChain ``StructuredTool``
   (a ``BaseTool``) that executes as a durable child action (own container/GPU,
   retries, caching). Attach it to the main agent or to a subagent.
-- :func:`run_agent` — run the deep agent (a compiled ``create_deep_agent``
+- `run_agent` — run the deep agent (a compiled ``create_deep_agent``
   graph) inside your task and return the final answer. Either pass a pre-built
   ``agent`` or let it build one from ``tools`` + ``model`` + ``instructions``
   (Deep-Agents options like ``subagents=`` pass through).
-- :class:`DurableChatModel` — wrap any LangChain chat model so each model turn
+- `DurableChatModel` — wrap any LangChain chat model so each model turn
   is recorded/replayed via ``flyte.trace``; use it when building your own agent
   with ``create_deep_agent(model=DurableChatModel(inner=...))``.
 

--- a/plugins/agents/deepagents/src/flyteplugins/agents/deepagents/_durable.py
+++ b/plugins/agents/deepagents/src/flyteplugins/agents/deepagents/_durable.py
@@ -2,12 +2,12 @@
 
 A deep agent (``create_deep_agent``) is a compiled LangGraph graph whose loop
 calls the chat model once per iteration (a "model turn").
-:class:`DurableChatModel` wraps any LangChain ``BaseChatModel`` so every turn is
-recorded through the shared :func:`~flyteplugins.agents.core.durable_step` (a
+`DurableChatModel` wraps any LangChain ``BaseChatModel`` so every turn is
+recorded through the shared `flyteplugins.agents.core.durable_step` (a
 ``flyte.trace`` leaf). Inside a Flyte task this means a crashed/retried run
 replays completed turns from their recorded outputs instead of re-calling (and
 re-billing) the model. Tool calls run as durable child actions (see
-:func:`flyteplugins.agents.deepagents.tool`), so the whole agent run becomes
+`flyteplugins.agents.deepagents.tool`), so the whole agent run becomes
 crash-resilient when the enclosing task carries ``retries=...``.
 
 The turn is recorded as JSON: the generated messages of the model's
@@ -15,7 +15,7 @@ The turn is recorded as JSON: the generated messages of the model's
 ``messages_from_dict``, which keeps the recorded turn human-readable in the
 Flyte UI.
 
-Tool-calling still works because :meth:`DurableChatModel.bind_tools` delegates to
+Tool-calling still works because `DurableChatModel.bind_tools` delegates to
 the inner model to format the tools, then re-binds the resulting kwargs to *this*
 wrapper — so the deep agent's bound runnable still routes generation through the
 durable override. This also covers subagents: pass the wrapped model as a
@@ -44,7 +44,7 @@ def _dumps_result(result: "ChatResult") -> str:
 
 
 def _loads_result(payload: str) -> "ChatResult":
-    """Rebuild a ``ChatResult`` from the JSON written by :func:`_dumps_result`."""
+    """Rebuild a ``ChatResult`` from the JSON written by `_dumps_result`."""
     from langchain_core.messages import messages_from_dict
     from langchain_core.outputs import ChatGeneration, ChatResult
 

--- a/plugins/agents/deepagents/src/flyteplugins/agents/deepagents/_memory.py
+++ b/plugins/agents/deepagents/src/flyteplugins/agents/deepagents/_memory.py
@@ -3,7 +3,7 @@
 A deep agent is driven with a messages state (``graph.ainvoke({"messages":
 [...]})``) and also carries a virtual filesystem (the ``files`` state its
 built-in filesystem tools read and write). By default neither survives the run.
-This module bridges both: it resolves a keyed :class:`MemoryStore`, loads the
+This module bridges both: it resolves a keyed `MemoryStore`, loads the
 prior conversation and files from path-addressed JSON slots, and writes them
 back after the run — so a later run with the same ``memory_key`` continues the
 conversation *and* sees the same virtual filesystem.

--- a/plugins/agents/deepagents/src/flyteplugins/agents/deepagents/_run.py
+++ b/plugins/agents/deepagents/src/flyteplugins/agents/deepagents/_run.py
@@ -53,7 +53,7 @@ def _resolve_chat_model(model: typing.Any) -> typing.Any:
 
 
 def _wrap_durable(model: typing.Any) -> typing.Any:
-    """Wrap a chat model in :class:`DurableChatModel` when possible.
+    """Wrap a chat model in `DurableChatModel` when possible.
 
     Best-effort: only ``BaseChatModel`` instances are wrappable; anything else
     (or any failure) is returned unchanged so durability never breaks a run.
@@ -109,7 +109,7 @@ async def run_agent(
     """Run a Deep Agent with the given tools and prompt; return the final text.
 
     Await this from an async task as ``await run_agent(...)``; from a sync task
-    use :func:`run_agent_sync` instead.
+    use `run_agent_sync` instead.
 
     Call this from inside an ``@env.task`` — that task is the durable parent.
     Within it, each tool call runs as a durable Flyte child action. Give the
@@ -134,7 +134,7 @@ async def run_agent(
         name: Agent name (for debugging/observability).
         durable: Record/replay each model turn via ``flyte.trace``. Applies when
             the agent is being built — the resolved model is wrapped in
-            :class:`DurableChatModel`. A fully pre-built compiled ``agent`` cannot
+            `DurableChatModel`. A fully pre-built compiled ``agent`` cannot
             be rewrapped (wrap its model yourself, see above); its tool calls
             remain durable regardless.
         observability: Render the run timeline into the Flyte task report.

--- a/plugins/agents/deepagents/src/flyteplugins/agents/deepagents/_tools.py
+++ b/plugins/agents/deepagents/src/flyteplugins/agents/deepagents/_tools.py
@@ -2,7 +2,7 @@
 
 Deep Agents (LangChain's agent harness) accepts LangChain ``BaseTool`` instances
 as tools — both on the main agent (``create_deep_agent(tools=[...])``) and on
-subagents (``SubAgent(tools=[...])``). :func:`tool` wraps a Flyte ``@env.task``
+subagents (``SubAgent(tools=[...])``). `tool` wraps a Flyte ``@env.task``
 as a LangChain ``StructuredTool`` whose async coroutine dispatches to the task
 via ``task.aio()`` — so when the agent calls the tool, it runs as a durable
 Flyte child action (its own container/resources, with retries and caching)
@@ -12,7 +12,7 @@ The returned object is a real ``StructuredTool`` (a ``BaseTool``), so it drops
 straight into ``create_deep_agent(tools=[...])`` or a subagent's tool list. It
 additionally exposes ``__wrapped_task__`` and ``task`` (via direct attribute
 assignment, which ``StructuredTool`` permits) and wires the backing task to
-:class:`~flyteplugins.agents.core.ToolTaskResolver` so it resolves to itself on
+`flyteplugins.agents.core.ToolTaskResolver` so it resolves to itself on
 the worker (no recursion).
 """
 
@@ -38,7 +38,7 @@ def tool(
     - For an ``@env.task``: returns a ``StructuredTool`` whose async coroutine runs
       the task as a durable Flyte child action when the agent invokes it. The input
       schema is derived from the task's typed signature. The backing task is wired to
-      :class:`~flyteplugins.agents.core.ToolTaskResolver` and exposed via
+      `flyteplugins.agents.core.ToolTaskResolver` and exposed via
       ``__wrapped_task__`` so it resolves to itself on the worker (no recursion).
     - For a plain (async) callable: returns a ``StructuredTool`` that runs it inline.
 

--- a/plugins/agents/google/src/flyteplugins/agents/google/__init__.py
+++ b/plugins/agents/google/src/flyteplugins/agents/google/__init__.py
@@ -6,9 +6,9 @@ owns the loop; Flyte is the runtime underneath: the tools you expose are Flyte t
 the run timeline renders into the task report, and ``memory_key`` gives cross-run
 conversation memory.
 
-- :func:`tool` — turn an ``@env.task`` into a Google ADK tool.
-- :func:`run_agent` — run the ADK agent loop inside your task and return the answer.
-- :func:`durable_model` — wrap a model so its turns are durable, for hand-built agent
+- `tool` — turn an ``@env.task`` into a Google ADK tool.
+- `run_agent` — run the ADK agent loop inside your task and return the answer.
+- `durable_model` — wrap a model so its turns are durable, for hand-built agent
   trees (e.g. sub-agent transfers) passed to ``run_agent`` via ``agent=``.
 
 Set the model provider's API key in the environment (e.g. ``GOOGLE_API_KEY`` for

--- a/plugins/agents/google/src/flyteplugins/agents/google/_durable.py
+++ b/plugins/agents/google/src/flyteplugins/agents/google/_durable.py
@@ -1,7 +1,7 @@
 """Durable model turns for Google ADK — trace the seam below the loop.
 
 ADK's ``Runner`` owns the loop, but every model turn flows through the agent's
-``BaseLlm.generate_content_async``. :class:`FlyteLlm` wraps that method so each
+``BaseLlm.generate_content_async``. `FlyteLlm` wraps that method so each
 (non-streaming) turn is recorded as a ``durable_step`` (a ``flyte.trace`` leaf):
 on a crash/retry the completed turns replay from their recorded ``LlmResponse``
 instead of re-calling (and re-billing) the model — while ADK still drives the loop.
@@ -26,7 +26,7 @@ class FlyteLlm(BaseLlm):
 
     Wraps an inner ``BaseLlm`` (resolved from the agent's ``model``); ``model`` is set
     to the inner model name so ADK behaves identically. Construct via
-    :func:`durable_model`.
+    `durable_model`.
     """
 
     inner: typing.Any = None
@@ -64,7 +64,7 @@ def _request_key(llm_request: typing.Any) -> typing.Any:
 def durable_model(model: typing.Any) -> typing.Any:
     """Wrap ``model`` (a name string or ``BaseLlm``) so its turns are durable.
 
-    Returns a :class:`FlyteLlm` over the resolved inner model, or ``model`` unchanged
+    Returns a `FlyteLlm` over the resolved inner model, or ``model`` unchanged
     when it can't be wrapped (durability is best-effort, never fatal).
     """
     try:

--- a/plugins/agents/google/src/flyteplugins/agents/google/_run.py
+++ b/plugins/agents/google/src/flyteplugins/agents/google/_run.py
@@ -6,7 +6,7 @@ ADK's ``Runner`` owns the agent loop (it drives the model + tools and yields
 into the Flyte report, and returns the final answer.
 
 Durability via the seam below the loop: with ``durable=True`` the agent's model is
-wrapped (:class:`FlyteLlm`) so each turn is recorded for replay. Cross-run memory
+wrapped (`FlyteLlm`) so each turn is recorded for replay. Cross-run memory
 via ``memory_key``: the session transcript is persisted to a keyed ``MemoryStore``
 and restored on the next run.
 
@@ -133,7 +133,7 @@ async def run_agent(
     """Run a Google ADK agent with the given tools and prompt; return the final text.
 
     Await this from an async task as ``await run_agent(...)``; from a sync task
-    use :func:`run_agent_sync` instead.
+    use `run_agent_sync` instead.
 
     Call this from inside an ``@env.task`` — that task is the durable parent, and each
     tool the agent calls runs as a durable Flyte child action. Provide either a

--- a/plugins/agents/hermes/src/flyteplugins/agents/hermes/__init__.py
+++ b/plugins/agents/hermes/src/flyteplugins/agents/hermes/__init__.py
@@ -3,10 +3,10 @@
 Bring your own Hermes agent (the ``hermes-agent`` package's ``AIAgent``) and
 run it durably on Flyte. The adapter provides:
 
-- :func:`tool` — turn a Flyte ``@env.task`` into a Hermes tool that executes as
+- `tool` — turn a Flyte ``@env.task`` into a Hermes tool that executes as
   a durable child action (own container/GPU, retries, caching), registered in
-  the Hermes tool registry under the :data:`FLYTE_TOOLSET` toolset.
-- :func:`run_agent` — run the Hermes agent loop inside your task and return the
+  the Hermes tool registry under the `FLYTE_TOOLSET` toolset.
+- `run_agent` — run the Hermes agent loop inside your task and return the
   final answer.
 
 Each tool call runs as a durable Flyte child action, and the run timeline is

--- a/plugins/agents/hermes/src/flyteplugins/agents/hermes/_memory.py
+++ b/plugins/agents/hermes/src/flyteplugins/agents/hermes/_memory.py
@@ -1,7 +1,7 @@
 """Cross-run Hermes memory — a thin bridge over Flyte's keyed ``MemoryStore``.
 
 Hermes keeps conversation state in-memory. This module persists the conversation
-transcript to a durable, keyed :class:`~flyte.ai.agents.memory.MemoryStore` (an
+transcript to a durable, keyed `flyte.ai.agents.memory.MemoryStore` (an
 object-store slot addressed by ``memory_key``) so a later run with the same key
 continues the conversation — across workers and restarts.
 

--- a/plugins/agents/hermes/src/flyteplugins/agents/hermes/_run.py
+++ b/plugins/agents/hermes/src/flyteplugins/agents/hermes/_run.py
@@ -13,7 +13,7 @@ Observability: the run timeline is rendered into the Flyte task report.
 
 The adapter minimizes delta between native Hermes code and Flyte integration:
 bring your own pre-configured ``AIAgent`` (with ``enabled_toolsets`` including
-:data:`~flyteplugins.agents.hermes.FLYTE_TOOLSET`) or let ``run_agent`` build
+`flyteplugins.agents.hermes.FLYTE_TOOLSET`) or let ``run_agent`` build
 one from ``tools`` + ``model``.
 """
 
@@ -39,7 +39,7 @@ _OPENAI_BASE_URL = "https://api.openai.com/v1"
 
 
 def _coerce_tool(t: typing.Any) -> typing.Any:
-    """Route anything not already Hermes-registered through :func:`tool`."""
+    """Route anything not already Hermes-registered through `tool`."""
     if getattr(t, "__hermes_registered__", False):
         return t
     return tool(t)
@@ -48,7 +48,7 @@ def _coerce_tool(t: typing.Any) -> typing.Any:
 def _scoped_toolset(agent_name: str, registered: typing.Sequence[typing.Any]) -> str:
     """Create (or refresh) a Hermes toolset holding exactly this agent's tools.
 
-    :func:`tool` registers every tool under the shared ``FLYTE_TOOLSET``; scoping
+    `tool` registers every tool under the shared ``FLYTE_TOOLSET``; scoping
     each built agent to a named subset keeps two agents in one process from
     seeing each other's tools.
     """
@@ -76,7 +76,7 @@ async def run_agent(
     """Run a Hermes agent with the given tools and prompt; return the final text.
 
     Await this from an async task as ``await run_agent(...)``; from a sync task
-    use :func:`run_agent_sync` instead.
+    use `run_agent_sync` instead.
 
     Call this from inside an ``@env.task`` — that task is the durable parent.
     Within it, each tool call runs as a durable Flyte child action. Give the

--- a/plugins/agents/hermes/src/flyteplugins/agents/hermes/_tools.py
+++ b/plugins/agents/hermes/src/flyteplugins/agents/hermes/_tools.py
@@ -3,15 +3,15 @@
 Hermes (the ``hermes-agent`` package) does not accept tool callables on the
 agent object. Tools live in a process-global registry (``tools.registry``),
 keyed by name and grouped into *toolsets*; an ``AIAgent`` exposes whatever its
-``enabled_toolsets`` resolve to. :func:`tool` therefore does two things:
+``enabled_toolsets`` resolve to. `tool` therefore does two things:
 
 1. wraps the Flyte ``@env.task`` with the shared core wrapper
-   (:func:`flyteplugins.agents.core.tool`) so a call dispatches to
+   (`flyteplugins.agents.core.tool`) so a call dispatches to
    ``task.aio()`` — a durable Flyte child action (its own container/resources,
    with retries and caching) — and the backing task resolves to itself on the
    worker;
 2. registers that wrapper in the Hermes tool registry under the
-   :data:`FLYTE_TOOLSET` toolset, with an OpenAI-format schema derived from the
+   `FLYTE_TOOLSET` toolset, with an OpenAI-format schema derived from the
    task via the Flyte type engine.
 
 ``run_agent`` then scopes each built agent to exactly the requested tools via a
@@ -46,7 +46,7 @@ def tool(
     - For an ``@env.task``: returns the shared core tool wrapper (a plain async
       function dispatching to the task as a durable Flyte child action, with
       ``__wrapped_task__`` and the resolver wired), *and* registers it in the
-      Hermes tool registry under :data:`FLYTE_TOOLSET` so an ``AIAgent`` can
+      Hermes tool registry under `FLYTE_TOOLSET` so an ``AIAgent`` can
       call it by name. The input schema is derived from the task via the Flyte
       type engine.
     - For a plain (sync or async) callable: registers it as an inline Hermes
@@ -85,7 +85,7 @@ def _register_hermes_tool(
     parameters: dict[str, typing.Any],
     wrapper: typing.Callable,
 ) -> None:
-    """Register ``wrapper`` in the Hermes tool registry under :data:`FLYTE_TOOLSET`.
+    """Register ``wrapper`` in the Hermes tool registry under `FLYTE_TOOLSET`.
 
     The handler receives the model's arguments as a dict (Hermes dispatches
     ``handler(args, **context)``) and returns a string for the model. Re-registering

--- a/plugins/agents/langchain/src/flyteplugins/agents/langchain/__init__.py
+++ b/plugins/agents/langchain/src/flyteplugins/agents/langchain/__init__.py
@@ -2,10 +2,10 @@
 
 Bring your own LangChain agent and run it durably on Flyte. The adapter provides:
 
-- :func:`tool` — turn a Flyte ``@env.task`` into a LangChain ``StructuredTool``
+- `tool` — turn a Flyte ``@env.task`` into a LangChain ``StructuredTool``
   (a ``BaseTool``) that executes as a durable child action (own container/GPU,
   retries, caching).
-- :func:`run_agent` — run the LangChain agent (a compiled ``create_agent`` graph)
+- `run_agent` — run the LangChain agent (a compiled ``create_agent`` graph)
   inside your task and return the final answer. Either pass a pre-built ``agent``
   or let it build one from ``tools`` + ``model`` + ``instructions``.
 

--- a/plugins/agents/langchain/src/flyteplugins/agents/langchain/_durable.py
+++ b/plugins/agents/langchain/src/flyteplugins/agents/langchain/_durable.py
@@ -1,12 +1,12 @@
 """Durable, replayable model turns for LangChain chat models.
 
 LangChain's ``create_agent`` graph owns the agent loop; each iteration calls the
-chat model once (a "model turn"). :class:`DurableChatModel` wraps any
+chat model once (a "model turn"). `DurableChatModel` wraps any
 ``BaseChatModel`` so every turn is recorded through the shared
-:func:`~flyteplugins.agents.core.durable_step` (a ``flyte.trace`` leaf). Inside a
+`flyteplugins.agents.core.durable_step` (a ``flyte.trace`` leaf). Inside a
 Flyte task this means a crashed/retried run replays completed turns from their
 recorded outputs instead of re-calling (and re-billing) the model. Tool calls run
-as durable child actions (see :func:`flyteplugins.agents.langchain.tool`), so the
+as durable child actions (see `flyteplugins.agents.langchain.tool`), so the
 whole agent run becomes crash-resilient when the enclosing task carries
 ``retries=...``.
 
@@ -15,7 +15,7 @@ The turn is recorded as JSON: the generated messages of the model's
 ``messages_from_dict`` (the same round-trip the langgraph adapter uses), which
 keeps the recorded turn human-readable in the Flyte UI.
 
-Tool-calling still works because :meth:`DurableChatModel.bind_tools` delegates to
+Tool-calling still works because `DurableChatModel.bind_tools` delegates to
 the inner model to format the tools, then re-binds the resulting kwargs to *this*
 wrapper — so ``create_agent``'s bound runnable still routes generation through the
 durable override.
@@ -43,7 +43,7 @@ def _dumps_result(result: "ChatResult") -> str:
 
 
 def _loads_result(payload: str) -> "ChatResult":
-    """Rebuild a ``ChatResult`` from the JSON written by :func:`_dumps_result`."""
+    """Rebuild a ``ChatResult`` from the JSON written by `_dumps_result`."""
     from langchain_core.messages import messages_from_dict
     from langchain_core.outputs import ChatGeneration, ChatResult
 

--- a/plugins/agents/langchain/src/flyteplugins/agents/langchain/_memory.py
+++ b/plugins/agents/langchain/src/flyteplugins/agents/langchain/_memory.py
@@ -2,7 +2,7 @@
 
 LangChain's ``create_agent`` graph is driven with a messages state
 (``graph.ainvoke({"messages": [...]})``) and, by default, keeps no state across
-runs. This module bridges that: it resolves a keyed :class:`MemoryStore`, loads a
+runs. This module bridges that: it resolves a keyed `MemoryStore`, loads a
 prior conversation from a path-addressed JSON slot, and writes the full
 transcript back after the run — so a later run with the same ``memory_key``
 continues the conversation.

--- a/plugins/agents/langchain/src/flyteplugins/agents/langchain/_run.py
+++ b/plugins/agents/langchain/src/flyteplugins/agents/langchain/_run.py
@@ -66,7 +66,7 @@ async def run_agent(
     """Run a LangChain agent with the given tools and prompt; return the final text.
 
     Await this from an async task as ``await run_agent(...)``; from a sync task
-    use :func:`run_agent_sync` instead.
+    use `run_agent_sync` instead.
 
     Call this from inside an ``@env.task`` — that task is the durable parent.
     Within it, each tool call runs as a durable Flyte child action. Give the
@@ -88,7 +88,7 @@ async def run_agent(
         name: Agent name (for debugging/observability).
         durable: Record/replay each model turn via ``flyte.trace``. Applies when
             a model is being built (``tools`` + ``model``, or a caller-passed
-            ``BaseChatModel``) — the model is wrapped in :class:`DurableChatModel`.
+            ``BaseChatModel``) — the model is wrapped in `DurableChatModel`.
             A fully pre-built compiled ``agent`` cannot be rewrapped, so its model
             turns are not made durable (its tool calls remain durable regardless).
         observability: Render the run timeline into the Flyte task report.
@@ -158,7 +158,7 @@ async def run_agent(
 
 
 def _wrap_durable(model: typing.Any) -> typing.Any:
-    """Wrap a chat model in :class:`DurableChatModel` when possible.
+    """Wrap a chat model in `DurableChatModel` when possible.
 
     Best-effort: only ``BaseChatModel`` instances are wrappable; anything else
     (or any failure) is returned unchanged so durability never breaks a run.

--- a/plugins/agents/langchain/src/flyteplugins/agents/langchain/_tools.py
+++ b/plugins/agents/langchain/src/flyteplugins/agents/langchain/_tools.py
@@ -1,6 +1,6 @@
 """Turn Flyte tasks into LangChain tools that execute as durable actions.
 
-LangChain accepts ``BaseTool`` instances as tools. :func:`tool` wraps a Flyte
+LangChain accepts ``BaseTool`` instances as tools. `tool` wraps a Flyte
 ``@env.task`` as a LangChain ``StructuredTool`` whose async coroutine dispatches
 to the task via ``task.aio()`` — so when the agent calls the tool, it runs as a
 durable Flyte child action (its own container/resources, with retries and
@@ -10,7 +10,7 @@ The returned object is a real ``StructuredTool`` (a ``BaseTool``), so it drops
 straight into ``create_agent(model, tools=[...])``. It additionally exposes
 ``__wrapped_task__`` and ``task`` (via direct attribute assignment, which
 ``StructuredTool`` permits) and wires the backing task to
-:class:`~flyteplugins.agents.core.ToolTaskResolver` so it resolves to itself on
+`flyteplugins.agents.core.ToolTaskResolver` so it resolves to itself on
 the worker (no recursion).
 """
 
@@ -36,7 +36,7 @@ def tool(
     - For an ``@env.task``: returns a ``StructuredTool`` whose async coroutine runs
       the task as a durable Flyte child action when the agent invokes it. The input
       schema is derived from the task's typed signature. The backing task is wired to
-      :class:`~flyteplugins.agents.core.ToolTaskResolver` and exposed via
+      `flyteplugins.agents.core.ToolTaskResolver` and exposed via
       ``__wrapped_task__`` so it resolves to itself on the worker (no recursion).
     - For a plain (async) callable: returns a ``StructuredTool`` that runs it inline.
 

--- a/plugins/agents/langgraph/src/flyteplugins/agents/langgraph/__init__.py
+++ b/plugins/agents/langgraph/src/flyteplugins/agents/langgraph/__init__.py
@@ -3,14 +3,14 @@
 Bring your own LangGraph ``StateGraph`` and run it durably on Flyte. You build the
 graph; the adapter provides the durable, observable building blocks:
 
-- :func:`tool` — turn a Flyte ``@env.task`` into a LangChain ``StructuredTool``
+- `tool` — turn a Flyte ``@env.task`` into a LangChain ``StructuredTool``
   (a first-class LangGraph tool) that executes as a durable child action (own
   container/GPU, retries, caching).
-- :func:`ai_node` — the model-calling node: binds the tools to your chat model
+- `ai_node` — the model-calling node: binds the tools to your chat model
   and records each model turn durably (replayed on retry).
-- :func:`tool_node` — the tool-executing node: runs the model's tool calls as
+- `tool_node` — the tool-executing node: runs the model's tool calls as
   durable Flyte child actions.
-- :func:`run_agent` — drive a compiled graph (or build a default one from tools)
+- `run_agent` — drive a compiled graph (or build a default one from tools)
   inside your task and return the final answer.
 
 Each tool call runs as a durable Flyte child action, and the run timeline is

--- a/plugins/agents/langgraph/src/flyteplugins/agents/langgraph/_memory.py
+++ b/plugins/agents/langgraph/src/flyteplugins/agents/langgraph/_memory.py
@@ -1,7 +1,7 @@
 """Cross-run LangGraph memory — a thin bridge over Flyte's keyed ``MemoryStore``.
 
 LangGraph keeps conversation state in-memory. This module persists the message
-transcript to a durable, keyed :class:`~flyte.ai.agents.memory.MemoryStore` (an
+transcript to a durable, keyed `flyte.ai.agents.memory.MemoryStore` (an
 object-store slot addressed by ``memory_key``) so a later run with the same key
 continues the conversation — across workers and restarts.
 

--- a/plugins/agents/langgraph/src/flyteplugins/agents/langgraph/_nodes.py
+++ b/plugins/agents/langgraph/src/flyteplugins/agents/langgraph/_nodes.py
@@ -3,12 +3,12 @@
 The intended devex: you build the ``StateGraph`` yourself, and these two factories
 provide the nodes that Flyte makes durable and observable.
 
-- :func:`ai_node` — the model-calling node. It binds your ``@tool``-wrapped tasks
+- `ai_node` — the model-calling node. It binds your ``@tool``-wrapped tasks
   to the chat model and runs one model turn. Each turn is recorded as a durable
-  ``flyte.trace`` leaf (via :func:`~flyteplugins.agents.core.durable_step`), so a
+  ``flyte.trace`` leaf (via `flyteplugins.agents.core.durable_step`), so a
   crash/retry replays the recorded response instead of re-calling (and re-billing)
   the model.
-- :func:`tool_node` — the tool-executing node. It runs the tool calls the model
+- `tool_node` — the tool-executing node. It runs the tool calls the model
   emitted; each ``@tool``-wrapped task runs as a durable Flyte child action (its
   own container/resources, retries, caching).
 

--- a/plugins/agents/langgraph/src/flyteplugins/agents/langgraph/_run.py
+++ b/plugins/agents/langgraph/src/flyteplugins/agents/langgraph/_run.py
@@ -1,8 +1,8 @@
 """``run_agent`` — drive a LangGraph graph on Flyte.
 
 The intended devex is that *you* build the ``StateGraph`` (with
-:func:`~flyteplugins.agents.langgraph.ai_node` /
-:func:`~flyteplugins.agents.langgraph.tool_node`), compile it, and hand the
+`flyteplugins.agents.langgraph.ai_node` /
+`flyteplugins.agents.langgraph.tool_node`), compile it, and hand the
 compiled graph to ``run_agent(agent=...)``. ``run_agent`` runs that graph inside
 your ``@env.task``: each model turn is durable (replayed on retry) and each tool
 call runs as a durable Flyte child action.
@@ -110,7 +110,7 @@ async def run_agent(
     """Run a LangGraph graph and return the final text.
 
     Await this from an async task as ``await run_agent(...)``; from a sync task
-    use :func:`run_agent_sync` instead.
+    use `run_agent_sync` instead.
 
     Call this from inside an ``@env.task`` — that task is the durable parent.
     Within it, each model turn is recorded via ``flyte.trace`` (replayed on
@@ -119,7 +119,7 @@ async def run_agent(
     the agent timeline.
 
     Provide either a pre-built ``agent`` (a compiled ``StateGraph`` you built
-    with :func:`ai_node` / :func:`tool_node`) or ``tools`` to have a default
+    with `ai_node` / `tool_node`) or ``tools`` to have a default
     tool-calling graph built for you. The two are mutually exclusive.
 
     Args:

--- a/plugins/agents/langgraph/src/flyteplugins/agents/langgraph/_tools.py
+++ b/plugins/agents/langgraph/src/flyteplugins/agents/langgraph/_tools.py
@@ -2,14 +2,14 @@
 
 LangGraph (via LangChain) drives tools that are ``BaseTool`` instances: it binds
 them to the model (``model.bind_tools([...])``) so the LLM can call them, and it
-executes them from a tool node. :func:`tool` wraps a Flyte ``@env.task`` as a
+executes them from a tool node. `tool` wraps a Flyte ``@env.task`` as a
 LangChain ``StructuredTool`` whose async body dispatches to the task via
 ``task.aio()`` — so when the graph executes the tool, it runs as a durable Flyte
 child action (its own container/resources, with retries and caching) rather than
 inline in the graph's process.
 
 The returned tool is a first-class ``StructuredTool``: pass it straight to
-``model.bind_tools(...)``, to :func:`~flyteplugins.agents.langgraph.tool_node`,
+``model.bind_tools(...)``, to `flyteplugins.agents.langgraph.tool_node`,
 or to LangGraph's ``ToolNode``. It additionally exposes ``__wrapped_task__`` /
 ``task`` (so the backing task resolves to itself on the worker, no recursion) and
 ``__name__`` for convenience.
@@ -66,13 +66,13 @@ def tool(
     - For an ``@env.task``: returns a ``StructuredTool`` whose async body runs the
       task as a durable Flyte child action when the graph invokes it. The input
       schema is inferred from the task's typed signature. The backing task is
-      wired to :class:`~flyteplugins.agents.core.ToolTaskResolver` and exposed via
+      wired to `flyteplugins.agents.core.ToolTaskResolver` and exposed via
       ``__wrapped_task__`` so it resolves to itself on the worker (no recursion).
     - For a plain (async) callable: returns a ``StructuredTool`` that runs it inline.
 
     The result is a first-class LangGraph tool — bind it to a model or hand it to
-    :func:`~flyteplugins.agents.langgraph.tool_node` /
-    :func:`~flyteplugins.agents.langgraph.ai_node`.
+    `flyteplugins.agents.langgraph.tool_node` /
+    `flyteplugins.agents.langgraph.ai_node`.
 
     Usable bare, parametrized, or as a direct call::
 

--- a/plugins/agents/mistral/src/flyteplugins/agents/mistral/__init__.py
+++ b/plugins/agents/mistral/src/flyteplugins/agents/mistral/__init__.py
@@ -5,8 +5,8 @@ expose are Flyte tasks (each call a durable child action), and each model turn i
 recorded via ``flyte.trace`` (the turns are in-process HTTP calls, so we can trace
 the seam below the SDK's loop) for per-turn replay on retry.
 
-- :func:`tool` — turn an ``@env.task`` into a Mistral run-framework tool.
-- :func:`run_agent` — run the SDK's agent loop inside your task; return the answer.
+- `tool` — turn an ``@env.task`` into a Mistral run-framework tool.
+- `run_agent` — run the SDK's agent loop inside your task; return the answer.
 """
 
 from flyteplugins.agents.core import tool

--- a/plugins/agents/mistral/src/flyteplugins/agents/mistral/_run.py
+++ b/plugins/agents/mistral/src/flyteplugins/agents/mistral/_run.py
@@ -187,7 +187,7 @@ async def run_agent(
     """Run a Mistral agent with the given tools and prompt; return the final text.
 
     Await this from an async task as ``await run_agent(...)``; from a sync task
-    use :func:`run_agent_sync` instead.
+    use `run_agent_sync` instead.
 
     Call this from inside an ``@env.task`` — that task is the durable parent.
     The Mistral SDK runs the agent loop; each tool the agent calls runs as a

--- a/plugins/agents/openai/src/flyteplugins/agents/openai/__init__.py
+++ b/plugins/agents/openai/src/flyteplugins/agents/openai/__init__.py
@@ -4,16 +4,16 @@ Bring your own ``openai-agents`` ``Agent`` (tools, handoffs, guardrails) and run
 it durably on Flyte. The adapter provides three things, each independently
 usable:
 
-- :func:`tool` — turn a Flyte ``@env.task`` into an OpenAI Agents tool
+- `tool` — turn a Flyte ``@env.task`` into an OpenAI Agents tool
   that executes as a durable child action (own container/GPU, retries,
   caching) when the agent calls it.
-- :class:`FlyteModelProvider` — a ``ModelProvider`` wrapper that records each
+- `FlyteModelProvider` — a ``ModelProvider`` wrapper that records each
   model turn through ``flyte.trace`` so a crashed/retried run replays
   completed turns instead of re-calling (and re-billing) the LLM.
-- :class:`FlyteTracingProcessor` — forwards the OpenAI Agents trace (turns, tool
+- `FlyteTracingProcessor` — forwards the OpenAI Agents trace (turns, tool
   calls, handoffs, token usage) into the Flyte task report for observability.
 
-:func:`run_agent` wires all three together for the common case. For full control,
+`run_agent` wires all three together for the common case. For full control,
 use them directly with ``Runner.run`` and a ``RunConfig``.
 """
 

--- a/plugins/agents/openai/src/flyteplugins/agents/openai/_durable.py
+++ b/plugins/agents/openai/src/flyteplugins/agents/openai/_durable.py
@@ -1,12 +1,12 @@
 """Durable, replayable model turns for the OpenAI Agents SDK.
 
 The OpenAI Agents ``Runner`` owns the agent loop. To make that loop durable we
-swap in a :class:`FlyteModelProvider`: it wraps the real model so every
+swap in a `FlyteModelProvider`: it wraps the real model so every
 ``get_response`` (one model turn) is recorded through the shared
-:func:`~flyteplugins.agents.core.durable_step` (a ``flyte.trace`` leaf). Inside a
+`flyteplugins.agents.core.durable_step` (a ``flyte.trace`` leaf). Inside a
 Flyte task this means a crashed/retried run replays completed turns from
 their recorded outputs instead of re-calling (and re-billing) the model. Tool
-calls run as durable child actions (see :func:`flyteplugins.agents.openai.tool`),
+calls run as durable child actions (see `flyteplugins.agents.openai.tool`),
 so the whole agent run becomes crash-resilient and self-healing when the enclosing task
 carries ``retries=...``.
 
@@ -67,7 +67,7 @@ def _request_fingerprint(args: tuple[typing.Any, ...], kwargs: dict[str, typing.
 
 
 class FlyteModel(Model):
-    """Wrap a :class:`~agents.models.interface.Model` so each turn is durable.
+    """Wrap a `agents.models.interface.Model` so each turn is durable.
 
     ``get_response`` is recorded/replayed via ``durable_step``. ``stream_response``
     is delegated unchanged: streamed turns are not memoized in this version (tool

--- a/plugins/agents/openai/src/flyteplugins/agents/openai/_memory.py
+++ b/plugins/agents/openai/src/flyteplugins/agents/openai/_memory.py
@@ -2,8 +2,8 @@
 
 The OpenAI Agents SDK reads and writes conversation history through a ``Session``
 (``get_items`` / ``add_items`` / ``pop_item`` / ``clear_session``).
-:class:`FlyteSession` implements that protocol over a durable, cross-run
-:class:`~flyte.ai.agents.memory.MemoryStore` (keyed by a ``memory_key``), so
+`FlyteSession` implements that protocol over a durable, cross-run
+`flyte.ai.agents.memory.MemoryStore` (keyed by a ``memory_key``), so
 passing ``session=FlyteSession(store)`` to ``Runner.run`` gives the agent memory
 that survives across runs and workers — backed by object storage rather than the
 SDK's default local SQLite (which doesn't persist on a distributed backend).

--- a/plugins/agents/openai/src/flyteplugins/agents/openai/_observability.py
+++ b/plugins/agents/openai/src/flyteplugins/agents/openai/_observability.py
@@ -2,8 +2,8 @@
 
 The OpenAI Agents SDK emits a structured trace of every run (agent spans, model
 ``generation``/``response`` turns, ``function`` tool calls, ``handoff`` and
-``guardrail`` spans). :class:`FlyteTracingProcessor` is a ``TracingProcessor``
-that maps those spans onto the shared :class:`~flyteplugins.agents.core.ReportTimeline`,
+``guardrail`` spans). `FlyteTracingProcessor` is a ``TracingProcessor``
+that maps those spans onto the shared `flyteplugins.agents.core.ReportTimeline`,
 rendering an in-run timeline (timings, token usage, tool inputs/outputs) into a tab of
 the enclosing task's Flyte report, alongside the tool tasks that already show up as
 Flyte actions.
@@ -48,7 +48,7 @@ def _summarize(kind: str, export: dict[str, typing.Any]) -> str:
 
 
 class FlyteTracingProcessor(TracingProcessor):
-    """Map OpenAI Agents spans onto the shared :class:`ReportTimeline`."""
+    """Map OpenAI Agents spans onto the shared `ReportTimeline`."""
 
     def __init__(self, tab_name: str = "Agent"):
         self._timeline = ReportTimeline(tab_name)
@@ -91,7 +91,7 @@ class FlyteTracingProcessor(TracingProcessor):
 
 
 def install_flyte_tracing(*, exclusive: bool = True, tab_name: str = "Agent") -> FlyteTracingProcessor:
-    """Install a :class:`FlyteTracingProcessor` as a global trace processor.
+    """Install a `FlyteTracingProcessor` as a global trace processor.
 
     With ``exclusive=True`` (default) it replaces all processors, so traces are
     rendered only into the Flyte report and nothing is uploaded to OpenAI's

--- a/plugins/agents/openai/src/flyteplugins/agents/openai/_run.py
+++ b/plugins/agents/openai/src/flyteplugins/agents/openai/_run.py
@@ -40,7 +40,7 @@ async def run_agent(
     """Run an OpenAI Agents SDK agent with Flyte providing the runtime.
 
     Await this from an async task as ``await run_agent(...)``; from a sync task
-    use :func:`run_agent_sync` instead.
+    use `run_agent_sync` instead.
 
     Call this from inside an ``@env.task`` — that task is the durable parent.
     Within it, each model turn is recorded via ``flyte.trace`` (replayed on
@@ -50,7 +50,7 @@ async def run_agent(
 
     Provide either a fully-built ``agent`` (keeping its handoffs/guardrails), or
     ``tools`` + ``instructions`` + ``model`` to have one built for you. ``tools``
-    may be :func:`tool`-wrapped tools or bare ``@env.task`` templates
+    may be `tool`-wrapped tools or bare ``@env.task`` templates
     (wrapped automatically).
 
     Args:

--- a/plugins/agents/openai/src/flyteplugins/agents/openai/_tools.py
+++ b/plugins/agents/openai/src/flyteplugins/agents/openai/_tools.py
@@ -39,7 +39,7 @@ class FunctionTool(OpenAIFunctionTool):
 
     @property
     def __wrapped_task__(self) -> typing.Any:
-        """The backing :class:`TaskTemplate` so :class:`ToolTaskResolver` can recover it.
+        """The backing `TaskTemplate` so `ToolTaskResolver` can recover it.
 
         Stacking ``@tool`` on ``@env.task`` rebinds the module attribute
         to this tool, hiding the task from the default resolver;
@@ -57,7 +57,7 @@ def tool(
     """Flyte-aware replacement for ``agents.function_tool`` — named ``tool`` for consistency.
 
     - For an ``@env.task`` (an ``AsyncFunctionTaskTemplate``): returns a
-      :class:`FunctionTool` whose invocation runs the task as a durable Flyte
+      `FunctionTool` whose invocation runs the task as a durable Flyte
       action. The tool's JSON schema, name and description are derived by the
       OpenAI Agents SDK from the task's function signature, so strict-mode tool
       calling works unchanged.
@@ -87,7 +87,7 @@ def tool(
 
 
 def _task_to_tool(task: AsyncFunctionTaskTemplate, **kwargs: typing.Any) -> FunctionTool:
-    """Build a :class:`FunctionTool` from a Flyte task.
+    """Build a `FunctionTool` from a Flyte task.
 
     Only the stable, public fields of ``agents.FunctionTool`` are copied from a
     base tool built by ``agents.function_tool`` — we deliberately do not reflect

--- a/plugins/agents/pydantic_ai/src/flyteplugins/agents/pydantic_ai/__init__.py
+++ b/plugins/agents/pydantic_ai/src/flyteplugins/agents/pydantic_ai/__init__.py
@@ -3,12 +3,12 @@
 Bring your own Pydantic AI ``Agent`` and run it durably on Flyte. The adapter
 provides:
 
-- :func:`tool` — turn a Flyte ``@env.task`` into a Pydantic AI tool that
+- `tool` — turn a Flyte ``@env.task`` into a Pydantic AI tool that
   executes as a durable child action (own container/GPU, retries, caching).
-  This is the shared :func:`flyteplugins.agents.core.tool`: Pydantic AI accepts
+  This is the shared `flyteplugins.agents.core.tool`: Pydantic AI accepts
   plain (async) callables in ``Agent(tools=[...])`` and infers each tool's
   schema from the callable's signature, which the core wrapper preserves.
-- :func:`run_agent` — run the Pydantic AI agent loop inside your task and return
+- `run_agent` — run the Pydantic AI agent loop inside your task and return
   the final answer.
 
 Each tool call runs as a durable Flyte child action, and the run timeline is

--- a/plugins/agents/pydantic_ai/src/flyteplugins/agents/pydantic_ai/_durable.py
+++ b/plugins/agents/pydantic_ai/src/flyteplugins/agents/pydantic_ai/_durable.py
@@ -1,13 +1,13 @@
 """Durable, replayable model turns for Pydantic AI.
 
-Pydantic AI owns the agent loop and drives a :class:`~pydantic_ai.models.Model`
+Pydantic AI owns the agent loop and drives a `pydantic_ai.models.Model`
 one turn at a time via ``await model.request(messages, settings, params)``. To make
-that loop durable we wrap the real model in a :class:`FlyteModel`: every
+that loop durable we wrap the real model in a `FlyteModel`: every
 ``request`` (one model turn) is recorded through the shared
-:func:`~flyteplugins.agents.core.durable_step` (a ``flyte.trace`` leaf). Inside a
+`flyteplugins.agents.core.durable_step` (a ``flyte.trace`` leaf). Inside a
 Flyte task this means a crashed/retried run replays completed turns from their
 recorded outputs instead of re-calling (and re-billing) the model. Tool calls run
-as durable child actions (see :func:`flyteplugins.agents.pydantic_ai.tool`), so the
+as durable child actions (see `flyteplugins.agents.pydantic_ai.tool`), so the
 whole agent run becomes crash-resilient when the enclosing task carries
 ``retries=...``.
 
@@ -72,7 +72,7 @@ def _request_fingerprint(
 
 
 class FlyteModel(Model):
-    """Wrap a :class:`~pydantic_ai.models.Model` so each model turn is durable.
+    """Wrap a `pydantic_ai.models.Model` so each model turn is durable.
 
     ``request`` is recorded/replayed via ``durable_step``. ``request_stream`` is
     delegated unchanged: streamed turns are not memoized in this version (tool

--- a/plugins/agents/pydantic_ai/src/flyteplugins/agents/pydantic_ai/_memory.py
+++ b/plugins/agents/pydantic_ai/src/flyteplugins/agents/pydantic_ai/_memory.py
@@ -3,7 +3,7 @@
 Pydantic AI keeps conversation state in-memory: each ``Agent.run`` returns a
 result whose ``all_messages()`` is the full message history, and a follow-up run
 continues the conversation by passing that history as ``message_history=``. This
-module bridges that onto a durable, keyed :class:`~flyte.ai.agents.memory.MemoryStore`
+module bridges that onto a durable, keyed `flyte.ai.agents.memory.MemoryStore`
 so a later run with the same ``memory_key`` resumes where the last one left off —
 even on a different worker.
 

--- a/plugins/agents/pydantic_ai/src/flyteplugins/agents/pydantic_ai/_run.py
+++ b/plugins/agents/pydantic_ai/src/flyteplugins/agents/pydantic_ai/_run.py
@@ -37,7 +37,7 @@ Agent = _AgentType
 def _coerce_tool(t: typing.Any) -> typing.Any:
     """Coerce a tool to a Pydantic AI-compatible callable.
 
-    A bare ``@env.task`` is wrapped via the shared core :func:`tool` (Pydantic AI
+    A bare ``@env.task`` is wrapped via the shared core `tool` (Pydantic AI
     accepts plain async callables and infers the schema from the preserved
     signature); anything else — an already ``tool``-wrapped callable, or a native
     Pydantic AI ``Tool`` — passes through unchanged.
@@ -75,7 +75,7 @@ async def run_agent(
     """Run a Pydantic AI agent with the given tools and prompt; return the final text.
 
     Await this from an async task as ``await run_agent(...)``; from a sync task
-    use :func:`run_agent_sync` instead.
+    use `run_agent_sync` instead.
 
     Call this from inside an ``@env.task`` — that task is the durable parent.
     Within it, each tool call runs as a durable Flyte child action. Give the
@@ -172,7 +172,7 @@ async def run_agent(
 
 
 def _durable_override(agent: typing.Any) -> typing.Any:
-    """Return a context manager that swaps the agent's model for a durable :class:`FlyteModel`.
+    """Return a context manager that swaps the agent's model for a durable `FlyteModel`.
 
     Uses ``Agent.override(model=...)`` so the swap is scoped to the run. Best-effort:
     if the agent's model can't be obtained/wrapped (e.g. a stub agent in tests, or a
@@ -205,7 +205,7 @@ def _build_agent(
 
     ``model`` is required (the caller validates it). When ``durable`` (and using
     the real ``pydantic_ai.Agent``) the model is resolved via ``infer_model`` and
-    wrapped in :class:`FlyteModel` so each model turn records/replays via
+    wrapped in `FlyteModel` so each model turn records/replays via
     ``flyte.trace``. Best-effort: if the model can't be inferred/wrapped, falls
     back to the model as given.
     """
@@ -232,7 +232,7 @@ def _build_agent(
 
 
 def _durable_model(model: typing.Any) -> typing.Any:
-    """Wrap an inferred model in :class:`FlyteModel` for durable turns; fall back to the input.
+    """Wrap an inferred model in `FlyteModel` for durable turns; fall back to the input.
 
     Accepts a model name string or an already-constructed ``Model`` instance
     (``infer_model`` passes instances through unchanged). Best-effort:

--- a/plugins/otel/src/flyteplugins/otel/_observer.py
+++ b/plugins/otel/src/flyteplugins/otel/_observer.py
@@ -141,7 +141,7 @@ def _finish(span: Span, recorder: "Recorder") -> None:
 
 
 class OtelObserver:
-    """A :class:`flyte._observe.Observer` that records spans.
+    """A `flyte._observe.Observer` that records spans.
 
     Task spans are roots pinned to the run's derived trace id. Every attempt of a task
     therefore starts its own subtree and because the trace id is shared those subtrees all

--- a/plugins/otel/src/flyteplugins/otel/_setup.py
+++ b/plugins/otel/src/flyteplugins/otel/_setup.py
@@ -207,7 +207,7 @@ def init(
             it. Not used when adopting a provider, which is assumed to be installed already.
 
     Returns:
-        The registered observer, which can be passed to :func:`shutdown`.
+        The registered observer, which can be passed to `shutdown`.
 
     Raises:
         ValueError: If tracer_provider is combined with the exporter building arguments.
@@ -242,7 +242,7 @@ def _init_locked(
     disable_batch: bool,
     set_global: bool,
 ) -> OtelObserver:
-    """The body of :func:`init` run with the lock already held."""
+    """The body of `init` run with the lock already held."""
     _warn_if_task_already_started()
 
     if tracer_provider is not None:
@@ -312,7 +312,7 @@ def _attach(provider: trace_api.TracerProvider, *, owns_provider: bool) -> OtelO
 
 
 def get_tracer() -> Optional[trace_api.Tracer]:
-    """The tracer :func:`init` built for handing to another instrumentation library.
+    """The tracer `init` built for handing to another instrumentation library.
 
     Libraries that create their own provider still nest correctly since parenting comes from
     the active context rather than the provider. Sharing the tracer just keeps everything on

--- a/src/flyte/_bin/mcp.py
+++ b/src/flyte/_bin/mcp.py
@@ -140,7 +140,7 @@ def _prepare_search_corpus(
 ) -> tuple[str | None, str | None, str | None]:
     """Populate (or reuse) the on-disk search corpus cache under ``cache_dir``.
 
-    Mirrors the layout baked into :data:`flyte.ai.mcp._flyte_mcp_app.DEFAULT_IMAGE`
+    Mirrors the layout baked into `flyte.ai.mcp._flyte_mcp_app.DEFAULT_IMAGE`
     so a locally-run MCP server has the same content available as the remote
     deployment. Each asset is cloned/downloaded only if it isn't already cached;
     pass ``refresh=True`` to evict the existing entries before fetching.

--- a/src/flyte/_code_bundle/__init__.py
+++ b/src/flyte/_code_bundle/__init__.py
@@ -5,14 +5,14 @@ download and run.
 When a task runs on a remote cluster, its Python files need to get from the
 developer's machine into the container. This module does that packaging.
 It takes a source directory plus a few knobs, produces a versioned,
-content-addressed archive, uploads it, and hands back a :class:`CodeBundle`
+content-addressed archive, uploads it, and hands back a `CodeBundle`
 handle that the backend attaches to the task spec.
 
 --------------------------------------------------------------------------
 The bundle
 --------------------------------------------------------------------------
 
-A :class:`flyte.models.CodeBundle` is exactly one of:
+A `flyte.models.CodeBundle` is exactly one of:
 
 * **tgz** — a gzipped tarball of source files. The common case.
 
@@ -69,15 +69,15 @@ across environments, and must live under ``from_dir``.
 Public API
 --------------------------------------------------------------------------
 
-* :func:`build_code_bundle` — walk ``from_dir`` using ``copy_style``,
-  tar+gzip, upload, return a tgz :class:`CodeBundle`. The main entry
+* `build_code_bundle` — walk ``from_dir`` using ``copy_style``,
+  tar+gzip, upload, return a tgz `CodeBundle`. The main entry
   point.
-* :func:`build_code_bundle_from_relative_paths` — bundle an explicit list
+* `build_code_bundle_from_relative_paths` — bundle an explicit list
   of relative paths (no discovery). Used for the includes-only case and
   for ``copy_style="custom"``.
-* :func:`build_pkl_bundle` — cloudpickle the task/app in memory and
-  upload. Returns a pkl :class:`CodeBundle`.
-* :func:`download_bundle` — the counterpart that runs on the worker:
+* `build_pkl_bundle` — cloudpickle the task/app in memory and
+  upload. Returns a pkl `CodeBundle`.
+* `download_bundle` — the counterpart that runs on the worker:
   fetch the tgz/pkl and extract it into the task's working directory.
 """
 

--- a/src/flyte/_context.py
+++ b/src/flyte/_context.py
@@ -111,9 +111,9 @@ class Context:
 
     def new_in_driver_literal_conversion(self, in_driver_literal_conversion: bool) -> Context:
         """
-        Return a context with :attr:`flyte.models.TaskContext.in_driver_literal_conversion` set on the active task.
+        Return a context with `flyte.models.TaskContext.in_driver_literal_conversion` set on the active task.
 
-        Requires :meth:`is_task_context`. Use ``nullcontext()`` at call sites when there is no task context.
+        Requires `is_task_context`. Use ``nullcontext()`` at call sites when there is no task context.
         """
         d = self.data
         if d.task_context is None:
@@ -192,7 +192,7 @@ def ctx() -> TaskContext:
 
     Note: Only use this in task code and not module level.
 
-    Use :attr:`flyte.models.TaskContext.checkpoint` for durable task checkpointing
+    Use `flyte.models.TaskContext.checkpoint` for durable task checkpointing
     (object-store prefixes from the runtime).
     """
     from flyte.models import NULL_TASK_CONTEXT

--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -680,7 +680,7 @@ def _get_init_config() -> Optional[_InitConfig]:
     """
     Get the current initialization configuration. Thread-safe implementation.
 
-    A context-scoped override installed by :func:`init_config_context` wins over the
+    A context-scoped override installed by `init_config_context` wins over the
     module-global config; otherwise the global is returned.
 
     :return: The current InitData if initialized, None otherwise

--- a/src/flyte/_internal/controllers/_local_controller.py
+++ b/src/flyte/_internal/controllers/_local_controller.py
@@ -40,7 +40,7 @@ _BACKOFF_MULTIPLIER = 2.0
 def _stage_prev_checkpoint_for_local_retry(checkpoint_paths: CheckpointPaths | None) -> None:
     """
     Before a local retry, copy the last attempt's checkpoint object into ``prev_checkpoint`` so
-    :class:`~flyte.Checkpoint` can load it (mirrors remote behavior where the platform stages prior output).
+    `flyte.Checkpoint` can load it (mirrors remote behavior where the platform stages prior output).
     """
     if checkpoint_paths is None:
         return

--- a/src/flyte/_internal/runtime/convert.py
+++ b/src/flyte/_internal/runtime/convert.py
@@ -37,7 +37,7 @@ _output_name_var: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar
 
 def current_output_name() -> Optional[str]:
     """The output slot name being converted right now (e.g. ``"o0"``), or
-    ``None`` when not inside output conversion. See :data:`_output_name_var`.
+    ``None`` when not inside output conversion. See `_output_name_var`.
     """
     return _output_name_var.get()
 
@@ -775,7 +775,7 @@ def generate_sub_action_id_and_output_path(
     action name = hash(parent action name + inputs hash + task identity + invocation sequence [+ group])
 
     ``task_identity`` must be stable across runs for recovery to match completed actions: use
-    :func:`generate_task_identity_hash` for tasks and :func:`generate_trace_action_identity` for
+    `generate_task_identity_hash` for tasks and `generate_trace_action_identity` for
     trace actions. In particular it must not depend on the code-bundle version or container image.
 
     :param tctx:

--- a/src/flyte/_internal/runtime/task_serde.py
+++ b/src/flyte/_internal/runtime/task_serde.py
@@ -107,7 +107,7 @@ def _to_duration(value: timedelta | int | None) -> Optional[Duration]:
 
 
 def _to_timeout_duration(value: timedelta | int | None) -> Optional[Duration]:
-    """Like :func:`_to_duration`, but for timeout/deadline fields where ``0``
+    """Like `_to_duration`, but for timeout/deadline fields where ``0``
     means "unlimited" (same as ``None``) and is omitted on the wire."""
     if value is None:
         return None

--- a/src/flyte/_observe.py
+++ b/src/flyte/_observe.py
@@ -176,10 +176,10 @@ def _fan_out(method: str, info: object) -> Generator[Recorder, None, None]:
 
 
 def observe_task(info: TaskInfo) -> contextlib.AbstractContextManager[Recorder]:
-    """Observe a task's execution. Yields a :class:`Recorder`."""
+    """Observe a task's execution. Yields a `Recorder`."""
     return _fan_out("task_span", info)
 
 
 def observe_step(info: StepInfo) -> contextlib.AbstractContextManager[Recorder]:
-    """Observe one ``flyte.trace`` step, executed or replayed. Yields a :class:`Recorder`."""
+    """Observe one ``flyte.trace`` step, executed or replayed. Yields a `Recorder`."""
     return _fan_out("step_span", info)

--- a/src/flyte/_pod.py
+++ b/src/flyte/_pod.py
@@ -61,7 +61,7 @@ class PodTemplate(object):
         annotations: Optional[Dict[str, str]] = None,
     ) -> PodTemplate:
         """
-        Create a :class:`PodTemplate` from an existing ``V1PodSpec``.
+        Create a `PodTemplate` from an existing ``V1PodSpec``.
 
         The spec is deep-copied, so later mutations of the input (or of the
         returned template) don't leak into each other.
@@ -337,7 +337,7 @@ def _set_apparmor_unconfined(pt: PodTemplate, caller: str) -> None:
 
 
 def _apply_fuse(pod_template: PodTemplate, *, privileged: bool = False) -> PodTemplate:
-    """Augmentor behind :meth:`PodTemplate.allow_fuse`. Dispatches to one of two
+    """Augmentor behind `PodTemplate.allow_fuse`. Dispatches to one of two
     clearly separate strategies; both grant CAP_SYS_ADMIN and stamp the fuse
     capability annotation."""
     pt = _clone_with_primary(pod_template)
@@ -410,7 +410,7 @@ def _apply_fuse_privileged(pt: PodTemplate, primary: "V1Container") -> None:
 
 
 def _apply_sandboxing(pod_template: PodTemplate) -> PodTemplate:
-    """Augmentor behind :meth:`PodTemplate.allow_nested_sandboxing`."""
+    """Augmentor behind `PodTemplate.allow_nested_sandboxing`."""
     pt = _clone_with_primary(pod_template)
     primary = _get_primary_container(pt)
 

--- a/src/flyte/_retry.py
+++ b/src/flyte/_retry.py
@@ -5,12 +5,12 @@ A retry is a fresh attempt at executing a failed action. ``RetryStrategy.count``
 is the number of *user* retries; system retries (network, container, k8s) are
 governed by the platform and are not subject to this policy.
 
-User retries can be paced by an optional :class:`Backoff` policy. Without a
+User retries can be paced by an optional `Backoff` policy. Without a
 backoff, retries fire back-to-back. With a backoff, the n-th retry (0-indexed)
 is delayed by ``min(base * factor**n, cap)``.
 
 Retries are *not* triggered when user code raises
-:class:`flyte.errors.NonRecoverableError` — that exception is the explicit
+`flyte.errors.NonRecoverableError` — that exception is the explicit
 opt-out: "this failure is terminal, do not retry, even if attempts remain."
 """
 
@@ -74,7 +74,7 @@ class RetryStrategy:
     Retry strategy for a task.
 
     :param count: Number of user retries. ``count=0`` disables retries.
-    :param backoff: Optional :class:`Backoff` policy applied between retries.
+    :param backoff: Optional `Backoff` policy applied between retries.
                     When unset, retries fire immediately back-to-back.
 
     Examples::

--- a/src/flyte/_timeout.py
+++ b/src/flyte/_timeout.py
@@ -60,7 +60,7 @@ TimeoutType = Timeout | int | timedelta
 
 def timeout_from_request(timeout: TimeoutType) -> Timeout:
     """
-    Normalize a user-supplied timeout into a :class:`Timeout`.
+    Normalize a user-supplied timeout into a `Timeout`.
 
     A bare ``int`` (seconds) or ``timedelta`` is interpreted as
     ``max_runtime`` for backward compatibility with the original single-bound

--- a/src/flyte/ai/agents/_code.py
+++ b/src/flyte/ai/agents/_code.py
@@ -1,4 +1,4 @@
-"""Code-mode helpers for :class:`flyte.ai.agents.Agent`.
+"""Code-mode helpers for `flyte.ai.agents.Agent`.
 
 In *code mode* the agent does not emit JSON tool calls. Instead, on each turn the
 LLM writes a short Python program that is executed in the Monty sandbox
@@ -11,7 +11,7 @@ traced, and ``flyte_map(...)`` fans out in parallel — all the usual Flyte
 features, driven by generated code.
 
 This module is internal: the public surface is the ``code_mode`` flag on
-:class:`~flyte.ai.agents.Agent`.
+`flyte.ai.agents.Agent`.
 """
 
 from __future__ import annotations
@@ -115,7 +115,7 @@ def build_sandbox_tools(
     ``LazyEntity`` / plain-callable tools without a handler are passed through as
     their underlying object so they keep native dispatch (durable tasks
     run on-cluster). Tools without such a target (e.g. MCP or hand-built
-    :class:`AgentTool`) are wrapped in a named async shim over ``execute``.
+    `AgentTool`) are wrapped in a named async shim over ``execute``.
 
     Raises:
         ValueError: if two tools resolve to the same sandbox function name. The

--- a/src/flyte/ai/agents/_llm.py
+++ b/src/flyte/ai/agents/_llm.py
@@ -1,7 +1,7 @@
-"""LLM callback abstraction used by :class:`flyte.ai.agents.Agent`.
+"""LLM callback abstraction used by `flyte.ai.agents.Agent`.
 
-This module is internal: import :class:`LLMMessage` from
-:mod:`flyte.ai.agents` instead. The agent module re-exports the default
+This module is internal: import `LLMMessage` from
+`flyte.ai.agents` instead. The agent module re-exports the default
 litellm-backed callback for back-compat.
 """
 
@@ -15,7 +15,7 @@ from typing import Any, Awaitable, Callable
 
 @dataclass
 class LLMMessage:
-    """Provider-agnostic shape returned by :data:`LLMCallable`.
+    """Provider-agnostic shape returned by `LLMCallable`.
 
     ``tool_calls`` follows the OpenAI tool-calling convention; provider-specific
     callers should normalize to this shape.

--- a/src/flyte/ai/agents/_mcp.py
+++ b/src/flyte/ai/agents/_mcp.py
@@ -1,7 +1,7 @@
-"""MCP (Model Context Protocol) tool loading for :class:`flyte.ai.agents.Agent`.
+"""MCP (Model Context Protocol) tool loading for `flyte.ai.agents.Agent`.
 
-This module is internal: import :class:`MCPServerSpec` from
-:mod:`flyte.ai.agents` instead. The agent module re-exports the loader for
+This module is internal: import `MCPServerSpec` from
+`flyte.ai.agents` instead. The agent module re-exports the loader for
 back-compat with callers that historically imported from
 ``flyte.ai.agents.agent``.
 """
@@ -64,9 +64,9 @@ class MCPServerSpec:
 
 
 class _MCPToolLoader:
-    """Discovers tools from an MCP server and surfaces them as :class:`AgentTool`.
+    """Discovers tools from an MCP server and surfaces them as `AgentTool`.
 
-    Stays inactive until :meth:`load` is called. We delay all MCP imports here
+    Stays inactive until `load` is called. We delay all MCP imports here
     so that ``Agent`` itself has no required dependency on the ``mcp``
     package.
     """

--- a/src/flyte/ai/agents/_report.py
+++ b/src/flyte/ai/agents/_report.py
@@ -1,8 +1,8 @@
 """Render the agent loop's progress events into a Flyte report tab.
 
-The loop already emits normalized :class:`~flyte.ai.agents.agent.AgentEvent`s through
-:data:`~flyte.ai.agents.agent.agent_progress_cb`; this module turns those into rows on a
-:class:`flyte.report.Timeline` — the same widget the ``flyteplugins.agents.*`` adapters
+The loop already emits normalized `flyte.ai.agents.agent.AgentEvent`s through
+`flyte.ai.agents.agent.agent_progress_cb`; this module turns those into rows on a
+`flyte.report.Timeline` — the same widget the ``flyteplugins.agents.*`` adapters
 render through, so a native agent and an adapter-wrapped agent produce a consistent
 report. It is a plain subscriber: it chains onto any callback the caller already
 installed, and it is best-effort (a no-op when there is no active report, and it never
@@ -21,7 +21,7 @@ if typing.TYPE_CHECKING:
 
 
 def render_event(timeline: Timeline, event: "AgentEvent") -> None:
-    """Map one :class:`AgentEvent` onto a heading or row of ``timeline``."""
+    """Map one `AgentEvent` onto a heading or row of ``timeline``."""
     data = event.data
     kind = event.type
     if kind == "agent_start":

--- a/src/flyte/ai/agents/_tools.py
+++ b/src/flyte/ai/agents/_tools.py
@@ -1,7 +1,7 @@
-"""Tool resolution and serialization helpers for :class:`flyte.ai.agents.Agent`.
+"""Tool resolution and serialization helpers for `flyte.ai.agents.Agent`.
 
 This module is internal: import the public symbols (``AgentTool``) from
-:mod:`flyte.ai.agents` instead. The agent module re-exports the ``_``-prefixed
+`flyte.ai.agents` instead. The agent module re-exports the ``_``-prefixed
 helpers below for callers that historically imported from
 ``flyte.ai.agents.agent``.
 """
@@ -32,7 +32,7 @@ _ToolExecutor = Callable[[dict[str, Any]], Awaitable[Any]]
 #         ...
 #
 # where ``call_llm`` is the owning agent's LLM callback, ``tool_fn`` is the
-# :class:`ToolFn` for the tool being invoked (call it to run the default
+# `ToolFn` for the tool being invoked (call it to run the default
 # behavior, or reach into ``tool_fn.target`` to customize), and ``**kwargs`` are
 # the arguments the model produced for the call. Whatever the handler returns is
 # used as the tool result.
@@ -43,11 +43,11 @@ _DEFAULT_TOOL_MODEL = "claude-haiku-4-5"
 
 @dataclass
 class AgentTool:
-    """A normalized tool descriptor used by :class:`Agent`.
+    """A normalized tool descriptor used by `Agent`.
 
-    Most users do not construct :class:`AgentTool` directly — pass plain
+    Most users do not construct `AgentTool` directly — pass plain
     callables, ``@flyte.trace`` helpers, or ``@env.task`` templates to
-    :class:`Agent` and they will be wrapped automatically. Build one
+    `Agent` and they will be wrapped automatically. Build one
     explicitly when you need to:
 
     - rename a tool for the LLM,
@@ -68,10 +68,10 @@ class AgentTool:
     # leave this ``None``. Exposed to ``call_handler`` via ``ToolFn.target``.
     target: Any = None
     # Optional interceptor that customizes how the tool is invoked. See
-    # :data:`ToolCallHandler`.
+    # `ToolCallHandler`.
     call_handler: ToolCallHandler | None = None
-    # When set (typically by :class:`Agent` during construction), used as the
-    # default ``call_llm`` / ``model`` for :meth:`aio` and direct calls that
+    # When set (typically by `Agent` during construction), used as the
+    # default ``call_llm`` / ``model`` for `aio` and direct calls that
     # route through ``call_handler``.
     call_llm: LLMCallable | None = None
     model: str | None = None
@@ -79,11 +79,11 @@ class AgentTool:
     async def aio(self, *args: Any, **kwargs: Any) -> Any:
         """Invoke the tool, routing through ``call_handler`` when one is registered.
 
-        Mirrors :meth:`~flyte._task.TaskTemplate.aio` enough for ``flyte.map`` and
+        Mirrors `flyte._task.TaskTemplate.aio` enough for ``flyte.map`` and
         in-task calls on ``@tool``-wrapped tasks. When a ``call_handler`` is set,
-        it runs with :attr:`call_llm` and :attr:`model` (or their defaults).
+        it runs with `call_llm` and `model` (or their defaults).
         Otherwise, durable ``@env.task`` / remote-task targets delegate to their
-        underlying ``.aio``; everything else goes through :meth:`execute`.
+        underlying ``.aio``; everything else goes through `execute`.
         """
         if self.call_handler is not None:
             return await invoke_agent_tool_from_call(
@@ -125,7 +125,7 @@ class AgentTool:
         """The underlying ``TaskTemplate`` when this tool wraps one, else ``None``.
 
         When ``@tool`` is stacked on ``@env.task`` the module attribute becomes
-        this :class:`AgentTool`, shadowing the task. Flyte's task resolver looks
+        this `AgentTool`, shadowing the task. Flyte's task resolver looks
         for this attribute to recover the real task for remote execution.
         """
         from flyte._task import TaskTemplate
@@ -135,7 +135,7 @@ class AgentTool:
 
 @dataclass
 class ToolFn:
-    """The tool under invocation, handed to a :data:`ToolCallHandler`.
+    """The tool under invocation, handed to a `ToolCallHandler`.
 
     Awaiting the instance runs the tool's *default* behavior::
 
@@ -144,12 +144,12 @@ class ToolFn:
     The attributes give a custom handler everything it needs to change that
     behavior without re-deriving it. The most useful are:
 
-    - :attr:`target` — the underlying ``@env.task`` template, plain callable, or
+    - `target` — the underlying ``@env.task`` template, plain callable, or
       ``LazyEntity`` (``None`` for custom / MCP tools). Reach into it to, e.g.,
       ``tool_fn.target.override(resources=...).aio(**kwargs)``.
-    - :attr:`model` — the owning agent's model id, to pass to ``call_llm`` when
+    - `model` — the owning agent's model id, to pass to ``call_llm`` when
       the handler wants to consult the LLM.
-    - :attr:`name` / :attr:`description` / :attr:`parameters` — the tool's
+    - `name` / `description` / `parameters` — the tool's
       LLM-facing metadata.
     """
 
@@ -200,7 +200,7 @@ def _callable_short_doc(fn: Callable[..., Any]) -> str:
 
 
 def _native_interface_for_target(target: Any) -> Any | None:
-    """Return a :class:`~flyte.models.NativeInterface` for *target*, if derivable."""
+    """Return a `flyte.models.NativeInterface` for *target*, if derivable."""
     if target is None:
         return None
     from flyte._task import TaskTemplate
@@ -293,7 +293,7 @@ async def invoke_agent_tool_from_call(
     model: str | None = None,
     **kwargs: Any,
 ) -> Any:
-    """Like :func:`invoke_agent_tool` but accepts a Monty-style ``*args, **kwargs`` call."""
+    """Like `invoke_agent_tool` but accepts a Monty-style ``*args, **kwargs`` call."""
     call_args = _kwargs_from_call(tool.target, args, kwargs)
     return await invoke_agent_tool(tool, call_args, call_llm=call_llm, model=model)
 
@@ -381,12 +381,12 @@ def _make_lazy_entity_tool(lazy: "LazyEntity", *, name: str | None = None) -> Ag
 
 
 def _to_agent_tool(obj: Any, *, name: str | None = None) -> AgentTool:
-    """Normalize a single tool-like object into an :class:`AgentTool`.
+    """Normalize a single tool-like object into an `AgentTool`.
 
-    Accepts already-constructed :class:`AgentTool` instances, plain Python
+    Accepts already-constructed `AgentTool` instances, plain Python
     callables (sync or async), ``@flyte.trace`` helpers, ``@env.task``
-    :class:`~flyte.TaskTemplate` instances, and
-    :class:`~flyte.remote._task.LazyEntity` remote-task references.
+    `flyte.TaskTemplate` instances, and
+    `flyte.remote._task.LazyEntity` remote-task references.
     """
     if isinstance(obj, AgentTool):
         if name and name != obj.name:
@@ -411,11 +411,11 @@ def _resolve_tools(
     """Normalize the user-provided ``tools`` argument into ``{name: AgentTool}``.
 
     Accepts:
-    - already-constructed :class:`AgentTool` instances
+    - already-constructed `AgentTool` instances
     - plain Python callables (sync or async)
     - ``@flyte.trace`` helpers
-    - ``@env.task`` :class:`~flyte.TaskTemplate` instances
-    - :class:`~flyte.remote._task.LazyEntity` remote-task references
+    - ``@env.task`` `flyte.TaskTemplate` instances
+    - `flyte.remote._task.LazyEntity` remote-task references
     """
     items: list[tuple[str | None, Any]]
     if isinstance(tools, Mapping):
@@ -455,9 +455,9 @@ def tool(
     requires_approval: bool = False,
     call_handler: ToolCallHandler | None = None,
 ) -> AgentTool | Callable[[Any], AgentTool]:
-    """Wrap a task, ``@flyte.trace`` helper, plain callable, or ``LazyEntity`` as an :class:`AgentTool`.
+    """Wrap a task, ``@flyte.trace`` helper, plain callable, or ``LazyEntity`` as an `AgentTool`.
 
-    This removes the boilerplate of building an :class:`AgentTool` by hand
+    This removes the boilerplate of building an `AgentTool` by hand
     (manually pulling the docstring, JSON schema, and writing a dict-args
     execution bridge) when you only need to tweak how a tool is presented to
     the model or gate it behind human approval.
@@ -476,12 +476,12 @@ def tool(
         @tool
         def search(query: str) -> str: ...
 
-    The wrapped task is still registered with its :class:`~flyte.TaskEnvironment`
+    The wrapped task is still registered with its `flyte.TaskEnvironment`
     and executes on-cluster via ``task.aio`` when the agent calls it.
 
     Pass ``call_handler`` to intercept *how* the tool is invoked. The handler is
     an async callback ``(call_llm, tool_fn, **kwargs) -> result`` that runs in
-    place of the default execution. ``tool_fn`` is a :class:`ToolFn`: await it to
+    place of the default execution. ``tool_fn`` is a `ToolFn`: await it to
     run the default behavior, or use ``tool_fn.target`` (the underlying task /
     callable) and ``call_llm`` to do something custom — e.g. ask the LLM how to
     size compute, then run the task with overridden resources and retry on OOM::
@@ -504,11 +504,11 @@ def tool(
         requires_approval: Gate execution behind the agent's HITL approval
             callback.
         call_handler: Optional async interceptor ``(call_llm, tool_fn, **kwargs)``
-            that customizes how the tool is invoked. See :data:`ToolCallHandler`
-            and :class:`ToolFn`.
+            that customizes how the tool is invoked. See `ToolCallHandler`
+            and `ToolFn`.
 
     Returns:
-        An :class:`AgentTool` (direct call) or a decorator returning one.
+        An `AgentTool` (direct call) or a decorator returning one.
     """
 
     def _wrap(target: Any) -> AgentTool:
@@ -542,14 +542,14 @@ class ToolTaskResolver(DefaultTaskResolver):
     """Resolver for a task shadowed at module scope by an ``@tool`` wrapper.
 
     Stacking ``@tool`` on ``@env.task`` rebinds the module attribute to the
-    resulting :class:`AgentTool`, so the default resolver's ``getattr`` returns
-    the tool rather than the :class:`~flyte._task.TaskTemplate`. This resolver
+    resulting `AgentTool`, so the default resolver's ``getattr`` returns
+    the tool rather than the `flyte._task.TaskTemplate`. This resolver
     recovers the underlying task via the wrapper's ``__wrapped_task__`` hook.
 
     ``@tool`` attaches an instance of this to the wrapped task's
-    ``task_resolver`` (see :func:`_attach_tool_task_resolver`), so the default
+    ``task_resolver`` (see `_attach_tool_task_resolver`), so the default
     resolver is left completely untouched. Loader-arg generation is inherited
-    unchanged from :class:`DefaultTaskResolver`.
+    unchanged from `DefaultTaskResolver`.
     """
 
     @property
@@ -569,7 +569,7 @@ class ToolTaskResolver(DefaultTaskResolver):
 
 
 def _attach_tool_task_resolver(target: Any) -> None:
-    """Point a wrapped task at :class:`ToolTaskResolver` so it resolves remotely.
+    """Point a wrapped task at `ToolTaskResolver` so it resolves remotely.
 
     Only applies to ``@env.task`` async-function templates that don't already
     declare a custom resolver; everything else (plain callables, ``LazyEntity``,

--- a/src/flyte/ai/agents/agent.py
+++ b/src/flyte/ai/agents/agent.py
@@ -13,21 +13,21 @@ Design goals
 
 - **Minimal core**: a single agent loop with clear extension points.
 - **Tools = anything callable**: plain functions, ``@flyte.trace`` helpers,
-  ``@env.task`` :class:`~flyte.TaskTemplate` instances (durable, on-cluster
+  ``@env.task`` `flyte.TaskTemplate` instances (durable, on-cluster
   execution), ``LazyEntity`` references to remote tasks, or pre-built
-  :class:`AgentTool` instances.
+  `AgentTool` instances.
 - **MCP integration**: connect to external MCP servers (Slack, GitHub, Linear,
   filesystem, etc.) and surface their tools to the agent transparently.
-- **Memory**: optional :class:`MemoryStore` that serializes conversation
-  history plus path-addressed artifacts to / from :class:`flyte.io.Dir`,
+- **Memory**: optional `MemoryStore` that serializes conversation
+  history plus path-addressed artifacts to / from `flyte.io.Dir`,
   letting the agent persist state across runs (e.g. across scheduled wake-ups
   or webhook invocations). Includes opt-in audit log, read-only prefixes, and
   optimistic concurrency for multi-agent / sleep-wake patterns.
 - **HITL**: opt-in per-tool human approval that pauses the loop on a
-  flyte-native condition (:func:`flyte.new_condition`) and waits for a human
+  flyte-native condition (`flyte.new_condition`) and waits for a human
   to signal it before executing the tool.
-- **Flyte-native**: implements the :class:`AgentProtocol` so it works
-  seamlessly with :class:`~flyte.ai.chat.AgentChatAppEnvironment` and is happy
+- **Flyte-native**: implements the `AgentProtocol` so it works
+  seamlessly with `flyte.ai.chat.AgentChatAppEnvironment` and is happy
   to be wrapped in ``@env.task(triggers=...)`` for scheduled or webhook-driven
   wake-ups.
 
@@ -36,7 +36,7 @@ agent harness — in particular its event model and the separation of the loop
 from message conversion / tool invocation.
 
 Implementation note: the tool/MCP/LLM building blocks live in sibling modules
-(:mod:`._tools`, :mod:`._mcp`, :mod:`._llm`); this module focuses on the
+(`._tools`, `._mcp`, `._llm`); this module focuses on the
 ``Agent`` class and the loop.
 """
 
@@ -100,9 +100,9 @@ agent_progress_cb: contextvars.ContextVar[AgentProgressCallback | None] = contex
 class _RunIdentity:
     """Identifies the agent run that is emitting events in the current context.
 
-    Set by :meth:`Agent._run_loop` for the duration of a run so that
-    :func:`_emit` can stamp ``agent`` and ``run_id`` onto every event. Stored
-    in a :class:`~contextvars.ContextVar` so concurrent runs in the same
+    Set by `Agent._run_loop` for the duration of a run so that
+    `_emit` can stamp ``agent`` and ``run_id`` onto every event. Stored
+    in a `contextvars.ContextVar` so concurrent runs in the same
     process (fan-out via ``asyncio.gather``, sub-agents invoked as tools) each
     stamp their own identity instead of conflating.
     """
@@ -157,7 +157,7 @@ class AgentEvent:
     """Lightweight event emitted by the agent loop.
 
     The agent stays decoupled from any specific UI: subscribe via
-    :data:`agent_progress_cb` to forward these to logs, NDJSON streams, websockets,
+    `agent_progress_cb` to forward these to logs, NDJSON streams, websockets,
     Flyte reports, etc.
 
     ``agent`` and ``run_id`` are stamped automatically on every event so that
@@ -179,8 +179,8 @@ class AgentEvent:
 # start/end events, timing, message setup, the call-LLM-per-turn cadence, the
 # max-turns guard, and memory finalization). They differ only in what happens
 # *after* the LLM responds each turn. That per-turn behavior is supplied as a
-# ``step`` callback returning a :class:`_TurnResult`; :meth:`Agent._run_loop`
-# owns everything else and returns a :class:`_RunOutcome`.
+# ``step`` callback returning a `_TurnResult`; `Agent._run_loop`
+# owns everything else and returns a `_RunOutcome`.
 # ----------------------------------------------------------------------------
 
 
@@ -194,7 +194,7 @@ class _TurnResult:
 
 @dataclass
 class _RunOutcome:
-    """Terminal state of the agent loop, used to build an :class:`AgentResult`."""
+    """Terminal state of the agent loop, used to build an `AgentResult`."""
 
     attempts: int
     last_text: str
@@ -233,7 +233,7 @@ ApprovalCallback = Callable[[AgentTool, dict[str, Any]], Awaitable[bool]]
 async def _condition_approval(tool: AgentTool, args: dict[str, Any]) -> bool:
     """Default HITL approval: pause the run on a flyte-native condition.
 
-    Registers a condition via :func:`flyte.new_condition` and blocks until a
+    Registers a condition via `flyte.new_condition` and blocks until a
     human signals it — from the UI, ``flyte signal condition``, or
     ``flyte.remote.Condition.signal``. Returns ``True`` if the user approves
     the tool call. When the agent is running outside a Flyte task context
@@ -282,24 +282,24 @@ class Agent:
     tools:
         Sequence (or ``{name: tool}`` mapping) of tools the agent may call.
         Each entry can be a plain callable, a ``@flyte.trace`` helper, an
-        ``@env.task`` :class:`~flyte.TaskTemplate`, a
-        :class:`~flyte.remote._task.LazyEntity`, or a pre-built
-        :class:`AgentTool`.
+        ``@env.task`` `flyte.TaskTemplate`, a
+        `flyte.remote._task.LazyEntity`, or a pre-built
+        `AgentTool`.
     mcp_servers:
         Optional remote / stdio MCP servers whose tools should be loaded into
-        the agent's tool registry on first use. See :class:`MCPServerSpec`.
+        the agent's tool registry on first use. See `MCPServerSpec`.
     skills:
         Extra context appended to the system prompt. Each entry is either a
-        string or a :class:`pathlib.Path` pointing to a local text file.
+        string or a `pathlib.Path` pointing to a local text file.
     max_turns:
         Maximum number of LLM ↔ tool turns before the loop gives up.
     call_llm:
         Optional async callback ``(model, system, messages, tools) -> LLMMessage``.
-        Defaults to :func:`_default_call_llm` (uses litellm).
+        Defaults to `_default_call_llm` (uses litellm).
     approval_callback:
         Optional async callback ``(tool, args) -> bool`` invoked when a tool
         with ``requires_approval=True`` is about to run. Defaults to a HITL
-        prompt via a flyte-native condition (:func:`flyte.new_condition`).
+        prompt via a flyte-native condition (`flyte.new_condition`).
     parallel_tool_calls:
         When ``True`` (default) tool calls returned in a single assistant
         message are executed concurrently. Set to ``False`` to force strict
@@ -366,10 +366,10 @@ class Agent:
         return self._system_prompt
 
     def tool_descriptions(self) -> list[dict[str, str]]:
-        """Conform to :class:`~flyte.ai.agents.protocol.Agent`.
+        """Conform to `flyte.ai.agents.protocol.Agent`.
 
         MCP tools loaded lazily are only listed after the first
-        :meth:`run` call.
+        `run` call.
         """
         return [
             {
@@ -481,19 +481,19 @@ class Agent:
     ) -> AgentResult:
         """Drive the LLM ↔ tool loop until the assistant returns a final reply.
 
-        Implements the :class:`~flyte.ai.agents.protocol.AgentProtocol` so
+        Implements the `flyte.ai.agents.protocol.AgentProtocol` so
         instances can be plugged directly into
-        :class:`~flyte.ai.chat.AgentChatAppEnvironment`.
+        `flyte.ai.chat.AgentChatAppEnvironment`.
 
         The agent is decoupled from any persistent state: memory is passed in
         per call rather than attached to the agent. ``memory`` may be:
 
         - ``None``: a stateless, single-shot conversation.
         - a ``list[dict]``: prior messages to prepend (e.g. a chat ``history``).
-          The returned :class:`AgentResult` carries no memory in this case.
-        - a :class:`MemoryStore`: its transcript is prepended, the in-flight
+          The returned `AgentResult` carries no memory in this case.
+        - a `MemoryStore`: its transcript is prepended, the in-flight
           transcript is appended back to it, and it is returned on
-          :attr:`AgentResult.memory`. Persistence is the caller's
+          `AgentResult.memory`. Persistence is the caller's
           responsibility: call ``memory.save()`` (or ``.save.aio()``) after
           ``run`` to write the updated transcript back to its keyed remote path.
 
@@ -635,7 +635,7 @@ class Agent:
     ) -> tuple[MemoryStore | None, int, list[dict[str, Any]]]:
         """Seed the message list from prior context and the new user message.
 
-        Returns the backing :class:`MemoryStore` (if any), the number of prior
+        Returns the backing `MemoryStore` (if any), the number of prior
         messages (so the in-flight tail can be sliced off later), and the
         message list to drive the loop with.
         """
@@ -664,10 +664,10 @@ class Agent:
         cadence (with error handling), the ``max_turns`` guard, and memory
         finalization. The mode-specific per-turn behavior is delegated to
         *step*, which appends messages, emits its own events, runs tools or the
-        sandbox, and signals via :class:`_TurnResult` whether to stop.
+        sandbox, and signals via `_TurnResult` whether to stop.
 
         ``memory`` is mutated in place (the in-flight transcript is appended back
-        to a passed :class:`MemoryStore`) but never saved; persistence is the
+        to a passed `MemoryStore`) but never saved; persistence is the
         caller's responsibility.
         """
         run_id = uuid.uuid4().hex[:8]

--- a/src/flyte/ai/agents/memory.py
+++ b/src/flyte/ai/agents/memory.py
@@ -1,6 +1,6 @@
-"""Dir-backed memory for :class:`flyte.ai.agents.Agent`.
+"""Dir-backed memory for `flyte.ai.agents.Agent`.
 
-This module implements :class:`MemoryStore`, a directory-backed store that
+This module implements `MemoryStore`, a directory-backed store that
 combines a managed conversation transcript with path-addressed artifact files,
 plus optional auditing, read-only prefixes, version snapshots, and optimistic
 concurrency. It is intentionally decoupled from the agent loop so non-agent
@@ -12,7 +12,7 @@ path, with audit + version history" pattern.
 
 The path-addressed I/O methods (``read_text``, ``read_json``, ``get_meta``,
 ``current_sha``, ``write_text``, ``write_json``) — like the keyed-store methods
-``create`` / ``get_or_create`` / ``save`` — are :func:`~flyte.syncify.syncify`-wrapped:
+``create`` / ``get_or_create`` / ``save`` — are `flyte.syncify.syncify`-wrapped:
 call them synchronously (``memory.read_text(...)``) or await the ``.aio(...)``
 companion in async code. The remaining helpers (``flush_messages``, ``audit_tail``)
 stay async-by-default with explicit ``*_sync`` companions, and ``list_paths`` is
@@ -56,13 +56,13 @@ MESSAGES_PATH = "messages.json"
 #: Path of the append-only audit log inside the memory root.
 _AUDIT_LOG_PATH = "audit/log.jsonl"
 
-#: Top-level directory names managed internally by :class:`MemoryStore`.
-#: Direct writes through :meth:`MemoryStore.write_text` /
-#: :meth:`MemoryStore.write_json` to these prefixes are rejected; they are
-#: also excluded from :meth:`list_paths`.
+#: Top-level directory names managed internally by `MemoryStore`.
+#: Direct writes through `MemoryStore.write_text` /
+#: `MemoryStore.write_json` to these prefixes are rejected; they are
+#: also excluded from `list_paths`.
 _INTERNAL_DIRS: frozenset[str] = frozenset({"audit", "meta", "versions"})
 
-#: ``"<dir>/"`` prefixes derived from :data:`_INTERNAL_DIRS`. Used for
+#: ``"<dir>/"`` prefixes derived from `_INTERNAL_DIRS`. Used for
 #: relative-path comparisons (``rel.startswith(prefix)``).
 _INTERNAL_PREFIXES: tuple[str, ...] = tuple(f"{d}/" for d in sorted(_INTERNAL_DIRS))
 
@@ -71,7 +71,7 @@ _HASH_CHUNK_BYTES = 1 << 20  # 1 MiB
 
 #: Namespace fragments + schema version that locate keyed MemoryStores under the
 #: active storage root: ``{storage_root}/agents/memory-store/v0/...``. Bump
-#: :data:`_MEMORY_SCHEMA_VERSION` when the persisted layout changes in a way that
+#: `_MEMORY_SCHEMA_VERSION` when the persisted layout changes in a way that
 #: older stores cannot be read by newer code (or vice versa).
 _MEMORY_NAMESPACE: tuple[str, ...] = ("agents", "memory-store")
 _MEMORY_SCHEMA_VERSION = "v0"
@@ -94,7 +94,7 @@ _LOCAL_RAW_DATA_DIR = "raw_data"
 
 
 class MemoryStoreError(RuntimeError):
-    """Base class for :class:`MemoryStore` errors."""
+    """Base class for `MemoryStore` errors."""
 
 
 class AccessDenied(MemoryStoreError):
@@ -191,7 +191,7 @@ def _ensure_namespace_segment(value: str, *, name: str) -> str:
     Memory-store keys become durable object-store prefixes, so they must be
     stable single path segments rather than relative paths. This keeps
     ``{memory_key}`` from escaping or reshaping the managed memory namespace
-    (see :data:`_MEMORY_NAMESPACE`).
+    (see `_MEMORY_NAMESPACE`).
     """
     if not value:
         raise MemoryStoreError(f"{name} must not be empty")
@@ -243,9 +243,9 @@ def _memory_storage_root(raw_data_path: str, *, path_rewrite: PathRewrite | None
     - **Remote URIs** are anchored at the provider root (``scheme://netloc``),
       dropping every bucket-internal prefix.
     - **Local paths** strip the per-run tail: either a trailing ``/rd/<run_id>``
-      scratch suffix (see :data:`_RAW_DATA_SCRATCH_SEGMENT`) or, for the default
+      scratch suffix (see `_RAW_DATA_SCRATCH_SEGMENT`) or, for the default
       ``.../raw_data/<action_name>`` local layout, the per-run ``<action_name>``
-      segment (anchoring at :data:`_LOCAL_RAW_DATA_DIR`).
+      segment (anchoring at `_LOCAL_RAW_DATA_DIR`).
     """
     trimmed = _normalize_raw_data_path(raw_data_path, path_rewrite)
 
@@ -320,24 +320,24 @@ class _MemoryStoreExists:
 
 @dataclass
 class MemoryStore(SerializableType):
-    """Conversation transcript + path-addressed artifact memory backed by :class:`flyte.io.Dir`.
+    """Conversation transcript + path-addressed artifact memory backed by `flyte.io.Dir`.
 
     The construct combines two complementary stores:
 
     - ``messages``: the live LLM conversation transcript (managed by
-      :class:`~flyte.ai.agents.Agent`; mutate via :meth:`append` /
-      :meth:`extend` only).
+      `flyte.ai.agents.Agent`; mutate via `append` /
+      `extend` only).
     - **Path-addressed files** under a working directory ``root``. Use
-      :meth:`write_text` / :meth:`read_text` / :meth:`write_json` /
-      :meth:`read_json` / :meth:`list_paths` for arbitrary named blobs that
+      `write_text` / `read_text` / `write_json` /
+      `read_json` / `list_paths` for arbitrary named blobs that
       should round-trip through Flyte object storage.
 
-    Persistence is :class:`flyte.io.Dir`-backed. Obtain a store via
-    :meth:`create` or :meth:`get_or_create`; it saves to a deterministic
+    Persistence is `flyte.io.Dir`-backed. Obtain a store via
+    `create` or `get_or_create`; it saves to a deterministic
     blob-store namespace under the active Flyte raw-data bucket, derived from
-    its ``key``. :meth:`save` always targets that deterministic
-    :attr:`remote_path`. :meth:`create`, :meth:`get_or_create`, and
-    :meth:`save` are sync-by-default (``MemoryStore.create(...)``) with an
+    its ``key``. `save` always targets that deterministic
+    `remote_path`. `create`, `get_or_create`, and
+    `save` are sync-by-default (``MemoryStore.create(...)``) with an
     ``.aio(...)`` companion for async call sites, mirroring the rest of the
     Flyte SDK.
 
@@ -362,17 +362,17 @@ class MemoryStore(SerializableType):
       storage on every mutation).
 
     Optimistic concurrency is supported via the ``expected_sha=`` argument on
-    :meth:`write_text` / :meth:`write_json`; mismatches raise
-    :class:`ConcurrencyError`.
+    `write_text` / `write_json`; mismatches raise
+    `ConcurrencyError`.
 
     Public I/O methods are async by default. Each one has a ``*_sync``
     companion that runs the same logic on the calling thread; the async
     version simply dispatches the sync version to a background thread via
-    :func:`asyncio.to_thread`.
+    `asyncio.to_thread`.
 
-    Every :class:`MemoryStore` is **keyed**: it is bound to a deterministic
+    Every `MemoryStore` is **keyed**: it is bound to a deterministic
     blob-store namespace derived from its ``key``. Obtain one via
-    :meth:`create` or :meth:`get_or_create` (the recommended entry points);
+    `create` or `get_or_create` (the recommended entry points);
     direct construction is supported for serialization / advanced use but still
     requires a ``key``. There is no such thing as an unkeyed / ephemeral store.
 
@@ -380,20 +380,20 @@ class MemoryStore(SerializableType):
     ----------
     key:
         Deterministic memory key (a single path segment). Determines the
-        durable :attr:`remote_path` under the active raw-data root.
+        durable `remote_path` under the active raw-data root.
     messages:
         Pre-existing conversation transcript. Defaults to empty.
     root:
         Local working directory backing the store. When omitted, a fresh
         temporary directory is created (and automatically cleaned up when
-        the :class:`MemoryStore` is garbage-collected). When pointing at an
+        the `MemoryStore` is garbage-collected). When pointing at an
         existing directory that contains ``messages.json``, the transcript
         is auto-loaded. This is an internal staging directory; callers
         normally never set it.
     remote_path:
-        Durable destination for :meth:`save`. Usually resolved from ``key``
-        (and the Flyte context) by :meth:`create` / :meth:`get_or_create`;
-        when omitted it is resolved lazily on first :meth:`save` / hydration.
+        Durable destination for `save`. Usually resolved from ``key``
+        (and the Flyte context) by `create` / `get_or_create`;
+        when omitted it is resolved lazily on first `save` / hydration.
     read_only_prefixes:
         Prefixes that direct writes are not permitted to target.
     audit:
@@ -432,7 +432,7 @@ class MemoryStore(SerializableType):
         # Whether the local working root still needs to be populated from the
         # keyed ``remote_path``. Stores produced locally (fresh or via an
         # explicit root) are already authoritative; only stores rebuilt from a
-        # serialized payload (see :meth:`_deserialize`) defer the download.
+        # serialized payload (see `_deserialize`) defer the download.
         self._needs_remote_hydration = False
 
         # Auto-load messages.json when pointing at an existing directory and
@@ -447,14 +447,14 @@ class MemoryStore(SerializableType):
 
     @property
     def _root(self) -> pathlib.Path:
-        """Return :attr:`root` narrowed to :class:`pathlib.Path` (always set after ``__post_init__``)."""
+        """Return `root` narrowed to `pathlib.Path` (always set after ``__post_init__``)."""
         return cast(pathlib.Path, self.root)
 
     def _require_remote_path(self) -> str:
-        """Return :attr:`remote_path`, resolving it from :attr:`key` on first use.
+        """Return `remote_path`, resolving it from `key` on first use.
 
         Resolution needs the active Flyte context (org / project / domain); it is
-        deferred until a durable operation (:meth:`save` / hydration) actually
+        deferred until a durable operation (`save` / hydration) actually
         needs it so a store can be constructed outside a task context.
         """
         if self.remote_path is None:
@@ -469,8 +469,8 @@ class MemoryStore(SerializableType):
         """Serialize to a Flyte-portable payload (msgpack-native types only).
 
         The local working directory is intentionally omitted: keyed stores are
-        re-hydrated from :attr:`remote_path` on first local access (see
-        :meth:`_ensure_hydrated`), and the transcript travels inline so common
+        re-hydrated from `remote_path` on first local access (see
+        `_ensure_hydrated`), and the transcript travels inline so common
         message-only consumers need no download.
         """
         return {
@@ -484,10 +484,10 @@ class MemoryStore(SerializableType):
 
     @classmethod
     def _deserialize(cls, value: dict[str, Any]) -> "MemoryStore":
-        """Rebuild a store from a :meth:`_serialize` payload.
+        """Rebuild a store from a `_serialize` payload.
 
         The store is created against a fresh local working directory; when it is
-        keyed, the working directory is downloaded from :attr:`remote_path` lazily
+        keyed, the working directory is downloaded from `remote_path` lazily
         on first artifact access / save.
         """
         store = cls(
@@ -538,7 +538,7 @@ class MemoryStore(SerializableType):
             {storage_root}/agents/memory-store/v0/{org}/{project}/{domain}/{key}
 
         The ``agents/memory-store`` prefix and ``v0`` version come from
-        :data:`_MEMORY_NAMESPACE` / :data:`_MEMORY_SCHEMA_VERSION`.
+        `_MEMORY_NAMESPACE` / `_MEMORY_SCHEMA_VERSION`.
         """
         key = _ensure_namespace_segment(key, name="key")
         if org is None:
@@ -591,9 +591,9 @@ class MemoryStore(SerializableType):
         Call synchronously via ``MemoryStore.create(...)``; in async contexts use
         ``MemoryStore.create.aio(...)``.
 
-        Raises :class:`MemoryStoreError` if the keyed blob-store path already
+        Raises `MemoryStoreError` if the keyed blob-store path already
         exists. This preserves the explicit "create means new" contract while
-        keeping subsequent saves deterministic via :meth:`save`.
+        keeping subsequent saves deterministic via `save`.
         """
         remote_path = cls.remote_path_for_key(key=key, org=org, project=project, domain=domain)
         if await cls._remote_store_exists(remote_path):
@@ -668,9 +668,9 @@ class MemoryStore(SerializableType):
         """Resolve ``rel_path`` to an absolute path under ``self._root``.
 
         Defends against path traversal *and* symlink escape: the candidate
-        is resolved with :meth:`pathlib.Path.resolve` (which collapses
+        is resolved with `pathlib.Path.resolve` (which collapses
         ``..`` and follows existing symlinks) and then verified to live
-        under :attr:`_root_real`. Any escape — including via a malicious
+        under `_root_real`. Any escape — including via a malicious
         symlink installed inside the memory directory after download — is
         rejected.
         """
@@ -770,7 +770,7 @@ class MemoryStore(SerializableType):
 
     @syncify
     async def get_meta(self, rel_path: str) -> MemoryMeta | None:
-        """Return the :class:`MemoryMeta` sidecar for ``rel_path`` if present.
+        """Return the `MemoryMeta` sidecar for ``rel_path`` if present.
 
         Sync-by-default (``memory.get_meta(...)``) with an ``.aio(...)`` companion.
         """
@@ -827,10 +827,10 @@ class MemoryStore(SerializableType):
             reason: Optional human-readable explanation.
             expected_sha: When provided, the write succeeds only if the
                 current sha256 of ``rel_path`` matches. Mismatches raise
-                :class:`ConcurrencyError`.
+                `ConcurrencyError`.
 
         Returns:
-            The :class:`MemoryMeta` describing the new content.
+            The `MemoryMeta` describing the new content.
         """
         await self._ensure_hydrated()
         rel = _ensure_relative_posix(rel_path)
@@ -895,7 +895,7 @@ class MemoryStore(SerializableType):
         reason: str = "",
         expected_sha: str | None = None,
     ) -> MemoryMeta:
-        """JSON-encode ``obj`` and write it via :meth:`write_text`.
+        """JSON-encode ``obj`` and write it via `write_text`.
 
         Sync-by-default (``memory.write_json(...)``) with an ``.aio(...)`` companion.
         """
@@ -913,7 +913,7 @@ class MemoryStore(SerializableType):
             f.write(json.dumps(event, sort_keys=True, default=str) + "\n")
 
     def audit_tail_sync(self, n: int = 20) -> list[dict[str, Any]]:
-        """Synchronous variant of :meth:`audit_tail`."""
+        """Synchronous variant of `audit_tail`."""
         ap = self._audit_path()
         if not ap.exists():
             return []
@@ -943,7 +943,7 @@ class MemoryStore(SerializableType):
     # ------------------------------------------------------------------
 
     def flush_messages_sync(self) -> None:
-        """Synchronous variant of :meth:`flush_messages`."""
+        """Synchronous variant of `flush_messages`."""
         p = self._root / MESSAGES_PATH
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(json.dumps(self.messages, default=str, indent=2), encoding="utf-8")
@@ -961,8 +961,8 @@ class MemoryStore(SerializableType):
 
         Flushes the conversation transcript to ``messages.json`` under the working
         root, then uploads the whole root (live files plus audit log, metadata
-        sidecars, and any version snapshots) to :attr:`remote_path` (resolved
-        from :attr:`key` if not already set).
+        sidecars, and any version snapshots) to `remote_path` (resolved
+        from `key` if not already set).
         """
         remote_destination = self._require_remote_path()
         # Pull any remote artifacts/audit/versions into the local root before we
@@ -991,13 +991,13 @@ class MemoryStore(SerializableType):
         audit: bool = True,
         keep_versions: bool = False,
     ) -> "MemoryStore":
-        """Restore memory previously written by :meth:`save`.
+        """Restore memory previously written by `save`.
 
         Downloads ``dir`` into a fresh local working directory and
         re-hydrates the conversation transcript. Subsequent writes are
         appended in the local copy and re-uploaded by the next
-        :meth:`save` call. The local working directory is cleaned
-        up automatically when the returned :class:`MemoryStore` is garbage
+        `save` call. The local working directory is cleaned
+        up automatically when the returned `MemoryStore` is garbage
         collected.
         """
         local_root = pathlib.Path(tempfile.mkdtemp(prefix="flyte_agent_mem_"))

--- a/src/flyte/ai/agents/protocol.py
+++ b/src/flyte/ai/agents/protocol.py
@@ -24,14 +24,14 @@ class AgentResult:
 @runtime_checkable
 class AgentProtocol(Protocol):
     """Minimal protocol that any agent must satisfy to work with
-    :class:`AgentChatAppEnvironment`.
+    `AgentChatAppEnvironment`.
     """
 
     def run(self, message: str, memory: list[dict[str, Any]] | "MemoryStore" | None = None) -> AgentResult:
-        """Process *message* (with prior *memory*) and return an :class:`AgentResult`.
+        """Process *message* (with prior *memory*) and return an `AgentResult`.
 
         ``memory`` may be a ``list[dict]`` of prior messages (e.g. a chat
-        ``history``) or a :class:`MemoryStore` for durable, cross-run state.
+        ``history``) or a `MemoryStore` for durable, cross-run state.
 
         Synchronous entry point. In async contexts, use ``run.aio(...)``.
         """

--- a/src/flyte/ai/chat/app.py
+++ b/src/flyte/ai/chat/app.py
@@ -27,7 +27,7 @@ from ._html import build_chat_html
 
 _HEX_RE = re.compile(r"^#(?:[0-9a-fA-F]{3}){1,2}$")
 
-# Translate the agent loop's :class:`~flyte.ai.agents.AgentEvent` types onto the
+# Translate the agent loop's `flyte.ai.agents.AgentEvent` types onto the
 # three UI progress steps the chat JS understands ("Creating plan" / "Executing
 # plan" / "Formatting answer"). Event types not listed here are not surfaced as
 # progress steps. See ``CODE_MODE_PHASE_TO_STEP`` in ``_html.py``.
@@ -144,7 +144,7 @@ class _ChatResponse(BaseModel):
 
 
 async def _task_run_error_message(run_handle: Any) -> str:
-    """Human-readable explanation when a remote :class:`~flyte.remote.Run` ends unsuccessfully."""
+    """Human-readable explanation when a remote `flyte.remote.Run` ends unsuccessfully."""
     phase = getattr(run_handle, "phase", "unknown")
     parts: list[str] = [f"Task run ended in state {phase}."]
     details_aio = getattr(getattr(run_handle, "details", None), "aio", None)
@@ -176,7 +176,7 @@ async def _forward_remote_run_watch_to_progress_queue(
     """Push NDJSON progress lines while a Flyte run executes (``task_entrypoint`` chat).
 
     The agent runs inside the worker, so ``agent_progress_cb`` never fires in the
-    FastAPI process. We approximate progress phases from :meth:`~flyte.remote.Run.watch`:
+    FastAPI process. We approximate progress phases from `flyte.remote.Run.watch`:
 
     Pre-``RUNNING`` phases (``QUEUED``, ``WAITING_FOR_RESOURCES``, ``INITIALIZING``) emit a
     ``task_phase`` progress event so the UI can update the step-0 subtitle (cold-start of
@@ -240,13 +240,13 @@ async def _forward_remote_run_watch_to_progress_queue(
 @rich.repr.auto
 @dataclass(kw_only=True, repr=True)
 class AgentChatAppEnvironment(flyte.app.AppEnvironment):
-    """An :class:`~flyte.app.AppEnvironment` that spins up a FastAPI chat
-    interface backed by any object satisfying the :class:`AgentProtocol`.
+    """An `flyte.app.AppEnvironment` that spins up a FastAPI chat
+    interface backed by any object satisfying the `AgentProtocol`.
 
     Parameters
     ----------
     agent:
-        Any object implementing the :class:`AgentProtocol`.
+        Any object implementing the `AgentProtocol`.
     title:
         Title displayed in the UI header and browser tab. Defaults to
         the environment *name*.
@@ -258,14 +258,14 @@ class AgentChatAppEnvironment(flyte.app.AppEnvironment):
         message.  Each entry is a dict with ``"label"`` (short card
         title) and ``"prompt"`` (the query text sent when clicked).
     theme:
-        Optional :class:`CustomTheme` instance that controls the UI
+        Optional `CustomTheme` instance that controls the UI
         accent colors via human-readable attributes.  When provided,
         the theme CSS is generated automatically and prepended to any
         *custom_css*.
     custom_css:
         Optional CSS string appended **after** the default styles
         (and after theme CSS, if a *theme* is provided).  Use this
-        for fine-grained overrides beyond what :class:`CustomTheme`
+        for fine-grained overrides beyond what `CustomTheme`
         exposes.
     logo_url:
         Optional URL to an image displayed to the left of the title
@@ -296,7 +296,7 @@ class AgentChatAppEnvironment(flyte.app.AppEnvironment):
         of calling ``agent.run`` directly. This is useful for agents whose tool
         calls must run under a parent task context (e.g. an ``Agent`` in
         ``code_mode`` using durable ``@env.task`` tools). When streaming chat
-        (``stream: true``), progress lines use :meth:`~flyte.remote.Run.watch`
+        (``stream: true``), progress lines use `flyte.remote.Run.watch`
         on the returned run (first ``RUNNING`` → ``generating_code``, next →
         ``executing``). Fine-grained per-turn phases still require
         ``agent.run`` in the web process, or future worker-side signaling.
@@ -306,7 +306,7 @@ class AgentChatAppEnvironment(flyte.app.AppEnvironment):
         - ``(message: str, history: list[dict[str, str]])``; or
         - ``(message: str)``.
 
-        The return value may be an :class:`~flyte.ai.agents.protocol.AgentResult`,
+        The return value may be an `flyte.ai.agents.protocol.AgentResult`,
         a dict with keys like ``summary``/``charts``/``code``, or a plain string
         (treated as ``summary``).
     """
@@ -345,7 +345,7 @@ class AgentChatAppEnvironment(flyte.app.AppEnvironment):
         """Construct the FastAPI application (routes, HTML shell, optional auth).
 
         Useful for tests and advanced mounting; the deployed server uses this via
-        :meth:`_fastapi_server`.
+        `_fastapi_server`.
         """
         from fastapi import FastAPI
         from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
@@ -515,14 +515,14 @@ class AgentChatAppEnvironment(flyte.app.AppEnvironment):
 
             queue: asyncio.Queue[str | None] = asyncio.Queue()
 
-            # Map :class:`AgentEvent` types onto the UI's three progress steps
+            # Map `AgentEvent` types onto the UI's three progress steps
             # (plan → execute → format) so the existing chat JS works unchanged.
             #
             # Only the top-level run drives the UI: the first ``run_id`` seen is
             # latched, and events stamped with a different ``run_id`` (sub-agents
             # invoked as tools) are dropped so their ``turn_start`` doesn't clobber
             # the attempt counter and their ``agent_end`` doesn't flip the phase
-            # early. Unstamped events (custom :class:`AgentProtocol`
+            # early. Unstamped events (custom `AgentProtocol`
             # implementations emitting hand-built events) pass through unchanged.
             top_run_id: str | None = None
 

--- a/src/flyte/ai/mcp/_flyte_mcp_app.py
+++ b/src/flyte/ai/mcp/_flyte_mcp_app.py
@@ -144,8 +144,8 @@ ALL_MCP_TOOL_GROUPS: tuple[MCPToolGroup, ...] = get_args(MCPToolGroup)
 class ToolInfo:
     """Static metadata for one MCP tool: which group it belongs to and how it behaves.
 
-    This is the single source of truth behind :data:`TOOL_GROUP_MAPPING`, the ``read_only``
-    derivation, and the :class:`~mcp.types.ToolAnnotations` attached at registration time —
+    This is the single source of truth behind `TOOL_GROUP_MAPPING`, the ``read_only``
+    derivation, and the `mcp.types.ToolAnnotations` attached at registration time —
     so a new tool cannot be added to the server without also declaring its group and hints.
     """
 
@@ -229,7 +229,7 @@ READ_ONLY_MCP_TOOLS: tuple[MCPTool, ...] = tuple(name for name, info in TOOL_REG
 
 
 def _build_group_mapping() -> dict[MCPToolGroup, tuple[MCPTool, ...]]:
-    """Derive the group -> tools mapping from :data:`TOOL_REGISTRY`.
+    """Derive the group -> tools mapping from `TOOL_REGISTRY`.
 
     ``core`` is intentionally empty: the transport endpoints (MCP mount, ``/health``) are HTTP
     routes, not MCP "tools".
@@ -267,8 +267,8 @@ def resolve_tools(
     If both ``tool_groups`` and ``tools`` are omitted, all tools are enabled. Otherwise pass
     either one (not both). The ``core`` group selects no tools; only the HTTP routes are served.
 
-    :param tool_groups: Group names from :data:`TOOL_GROUP_MAPPING`
-    :param tools: Explicit tool names from :data:`ALL_MCP_TOOLS`
+    :param tool_groups: Group names from `TOOL_GROUP_MAPPING`
+    :param tools: Explicit tool names from `ALL_MCP_TOOLS`
     :param read_only: Drop every tool that is not annotated ``readOnlyHint=True``
     :return: The enabled tool names
     """
@@ -300,7 +300,7 @@ def resolve_tools(
 
 
 def _resolve_tools(tool_groups: list[str] | None, tools: list[str] | None) -> set[str]:
-    """Deprecated alias for :func:`resolve_tools`, kept for out-of-tree callers."""
+    """Deprecated alias for `resolve_tools`, kept for out-of-tree callers."""
     return resolve_tools(tool_groups, tools)
 
 
@@ -353,7 +353,7 @@ class FlyteMCPAppEnvironment(MCPAppEnvironment):
     **Image**
 
     When ``image`` is omitted (or set to ``"auto"``), the environment uses
-    :data:`DEFAULT_IMAGE`, which preinstalls the MCP/Starlette/Uvicorn stack
+    `DEFAULT_IMAGE`, which preinstalls the MCP/Starlette/Uvicorn stack
     and clones the flyte-sdk + unionai-examples repos and the Union docs
     ``llms.txt`` into ``/root`` so the search tools have content to scan.
     """
@@ -480,7 +480,7 @@ class FlyteMCPAppEnvironment(MCPAppEnvironment):
     async def _starlette_lifespan_startup(self) -> None:
         """Initialize the Flyte SDK in passthrough mode so that Flyte remote calls
         made by tool handlers use the per-request ``Authorization`` header
-        (populated by :class:`FastAPIPassthroughAuthMiddleware`) instead of the
+        (populated by `FastAPIPassthroughAuthMiddleware`) instead of the
         cluster-injected credentials from ``init_in_cluster``.
         """
         project = os.environ.get("FLYTE_PROJECT") or os.environ.get("FLYTE_INTERNAL_EXECUTION_PROJECT")

--- a/src/flyte/ai/mcp/_mcp_app.py
+++ b/src/flyte/ai/mcp/_mcp_app.py
@@ -44,7 +44,7 @@ class MCPAppEnvironment(flyte.app.AppEnvironment):
     app, no ``/health`` route, no links, and ``mcp_mount_path`` is unused.
 
     stdio is a *local* transport and cannot be deployed or served via
-    :func:`flyte.serve` — that path runs the server on a background thread and polls
+    `flyte.serve` — that path runs the server on a background thread and polls
     an HTTP health check, neither of which applies to a process-bound stdio stream.
     Run it directly instead::
 
@@ -105,7 +105,7 @@ class MCPAppEnvironment(flyte.app.AppEnvironment):
     async def run_stdio_async(self) -> None:
         """Serve MCP over this process's stdin/stdout until the client disconnects.
 
-        Validates the transport and then delegates to the wrapped :class:`FastMCP`,
+        Validates the transport and then delegates to the wrapped `FastMCP`,
         whose method of the same name does the actual serving.
 
         :raises ValueError: if ``transport`` is not ``"stdio"``.
@@ -119,14 +119,14 @@ class MCPAppEnvironment(flyte.app.AppEnvironment):
         await self.mcp.run_stdio_async()
 
     def run_stdio(self) -> None:
-        """Blocking wrapper around :meth:`run_stdio_async`, for use as a process entry point."""
+        """Blocking wrapper around `run_stdio_async`, for use as a process entry point."""
         import anyio
 
         anyio.run(self.run_stdio_async)
 
     @property
     def _mcp_server(self) -> FastMCP:
-        """Alias for :attr:`mcp` (matches historical attribute name)."""
+        """Alias for `mcp` (matches historical attribute name)."""
         return self.mcp
 
     def _starlette_middleware(self) -> list[Middleware]:

--- a/src/flyte/ai/mcp/_tools.py
+++ b/src/flyte/ai/mcp/_tools.py
@@ -1,9 +1,9 @@
-"""MCP tool implementations for :class:`~flyte.ai.mcp.FlyteMCPAppEnvironment`.
+"""MCP tool implementations for `flyte.ai.mcp.FlyteMCPAppEnvironment`.
 
 The tools live here rather than in ``_flyte_mcp_app.py`` purely for size: the environment
 module owns configuration, the tool registry and registration, this one owns the bodies.
 Every tool closes over the environment (``env``) for its allowlists, search paths and the
-per-call project/domain scoping, so they are built by :func:`build_tool_functions` rather
+per-call project/domain scoping, so they are built by `build_tool_functions` rather
 than defined at module level.
 
 Each function's docstring is what the MCP client shows the model, so they are written for an
@@ -252,7 +252,7 @@ def _search_files_blocking(
     before_context_lines: int = 5,
     after_context_lines: int = 5,
 ) -> str:
-    """Synchronous body of :func:`_search_files`; always called in a worker thread."""
+    """Synchronous body of `_search_files`; always called in a worker thread."""
     deadline = time.monotonic() + SEARCH_TIMEOUT_S
     try:
         p = pathlib.Path(path)

--- a/src/flyte/app/_app_environment.py
+++ b/src/flyte/app/_app_environment.py
@@ -49,8 +49,8 @@ def _is_sdk_frame(filename: str) -> bool:
 def _find_user_caller_frame() -> inspect.Traceback | None:
     """Walk up the call stack to the first user-code frame outside the SDK.
 
-    Returns an :class:`inspect.Traceback` pointing at whatever line of user
-    code triggered the construction of an :class:`AppEnvironment`. The walker
+    Returns an `inspect.Traceback` pointing at whatever line of user
+    code triggered the construction of an `AppEnvironment`. The walker
     skips:
 
     * frames whose source file lives inside the SDK source tree (covers every

--- a/src/flyte/app/_parameter.py
+++ b/src/flyte/app/_parameter.py
@@ -275,7 +275,7 @@ class Parameter:
 
     :param name: Name of parameter.
     :param value: Value for parameter. When ``None``, the value must be supplied at
-        serving time via ``parameter_values`` in :func:`flyte.with_servecontext`.
+        serving time via ``parameter_values`` in `flyte.with_servecontext`.
     :param type: Type of parameter. If ``None``, the type will be inferred from the value.
     :param env_var: Environment name to set the value in the serving environment.
     :param download: When True, the parameter will be automatically downloaded. This

--- a/src/flyte/extras/_dynamic_batcher.py
+++ b/src/flyte/extras/_dynamic_batcher.py
@@ -113,13 +113,13 @@ ProcessFn = Callable[[list[RecordT]], Awaitable[list[ResultT]]]
 same order.  Must be a native coroutine (`async def`)."""
 
 InferenceFn = ProcessFn
-"""Alias for :data:`ProcessFn` — kept for LLM inference use cases."""
+"""Alias for `ProcessFn` — kept for LLM inference use cases."""
 
 CostEstimatorFn = Callable[[RecordT], int]
 """Optional callable `(record) -> int` for cost estimation."""
 
 TokenEstimatorFn = CostEstimatorFn
-"""Alias for :data:`CostEstimatorFn` — kept for token estimation use cases."""
+"""Alias for `CostEstimatorFn` — kept for token estimation use cases."""
 
 
 # ---------------------------------------------------------------------------

--- a/src/flyte/extras/shell/__init__.py
+++ b/src/flyte/extras/shell/__init__.py
@@ -4,7 +4,7 @@ Designed as the foundation for bio module libraries (bedtools, samtools,
 bcftools, GATK, etc.) and any other case where a user wants to call a
 pre-built binary in a published container with typed inputs and outputs.
 
-Compared to :class:`flyte.extras.ContainerTask`, this layer adds:
+Compared to `flyte.extras.ContainerTask`, this layer adds:
 
 - A Python ``str.format``-style template surface (``{inputs.x}``, ``{flags.x}``,
   ``{outputs.x}``) instead of ``{{.inputs.x}}`` syntax.
@@ -19,9 +19,9 @@ Compared to :class:`flyte.extras.ContainerTask`, this layer adds:
   ``File``, ``Dir``, ``int`` / ``float`` / ``str`` / ``bool`` — and
   three small collector classes for the cases that need extra semantics:
 
-  * :class:`Glob` — pattern-filtered ``list[File]`` (the script writes
+  * `Glob` — pattern-filtered ``list[File]`` (the script writes
     files into ``/var/outputs/<name>/`` and the wrapper unpacks).
-  * :class:`Stdout` / :class:`Stderr` — wrapper redirects the
+  * `Stdout` / `Stderr` — wrapper redirects the
     corresponding stream straight to ``/var/outputs/<name>``.
 
 ``Glob`` has two observable shapes:

--- a/src/flyte/extras/shell/_runtime.py
+++ b/src/flyte/extras/shell/_runtime.py
@@ -27,7 +27,7 @@ from ._types import (
 
 @dataclass
 class _Shell:
-    """Configured shell task. Returned by :func:`create`."""
+    """Configured shell task. Returned by `create`."""
 
     name: str
     image: Union[str, flyte.Image]
@@ -180,7 +180,7 @@ class _Shell:
     async def _unpack_outputs(self, raw: Any) -> Any:
         """Convert wire-typed outputs back to user-facing types.
 
-        Currently only :class:`Glob` needs unpacking: the runtime/wire type
+        Currently only `Glob` needs unpacking: the runtime/wire type
         is ``Dir``, while the Python-facing type is ``list[File]``.
         """
         single = not isinstance(raw, tuple)
@@ -401,10 +401,10 @@ def create(
         name: Task name; should be unique within the project.
         image: Either a pre-built URI string
             (e.g. ``"quay.io/biocontainers/bedtools:2.31.1--hf5e1c6e_0"``,
-            ``"debian:12-slim"``) or a :class:`flyte.Image` /
+            ``"debian:12-slim"``) or a `flyte.Image` /
             ImageSpec instance (layered: base + apt / pip / Dockerfile
             layers). When you pass a ``flyte.Image``, the shell layer
-            builds it for you on first call via :func:`flyte.build` —
+            builds it for you on first call via `flyte.build` —
             using the configured builder (``cfg.image_builder``:
             ``"local"`` by default, ``"remote"`` when opted in) — and
             hands the resulting URI down to ContainerTask. Subsequent
@@ -459,25 +459,25 @@ def create(
             - ``int`` / ``float`` / ``str`` / ``bool`` — primitive; the
               script writes the value as text to ``/var/outputs/<name>``
               and CoPilot casts to the declared type
-            - :class:`Glob` (``pattern="*"``) — pattern-filtered
+            - `Glob` (``pattern="*"``) — pattern-filtered
               ``list[File]``. The wrapper pre-creates the directory; the
               script writes files into it; the serialized task exposes
               that output as ``Dir`` on the wire, and the Python shell
               wrapper unpacks it back to ``list[File]`` post-execution.
-            - :class:`Stdout` (``type=File`` by default) — the wrapper
+            - `Stdout` (``type=File`` by default) — the wrapper
               redirects the script's stdout straight to
               ``/var/outputs/<name>``. ``type`` can also be a primitive,
               in which case the captured text is cast.
-            - :class:`Stderr` — symmetric for stderr.
+            - `Stderr` — symmetric for stderr.
 
             All declared outputs live at ``/var/outputs/<name>``; the
             user references them as ``{outputs.<name>}`` in the script
-            (except :class:`Stdout` / :class:`Stderr`, which are managed
+            (except `Stdout` / `Stderr`, which are managed
             by the wrapper).
         script: Bash script template. Reference inputs as ``{inputs.x}``,
             CLI flags as ``{flags.x}``, and outputs as ``{outputs.x}``
-            (which renders to ``/var/outputs/<x>``). :class:`Stdout` /
-            :class:`Stderr` outputs cannot be referenced — the wrapper
+            (which renders to ``/var/outputs/<x>``). `Stdout` /
+            `Stderr` outputs cannot be referenced — the wrapper
             redirects the corresponding stream there for you.
 
             **Do not wrap ``{inputs.x}`` in your own quotes**. Scalar values
@@ -520,7 +520,7 @@ def create(
             these messages.
 
     Returns:
-        A configured :class:`_Shell` instance. Call it like a coroutine for
+        A configured `_Shell` instance. Call it like a coroutine for
         local execution; access ``.env`` to plug it into a pipeline's
         ``depends_on`` for deploy-time image building and registration.
 

--- a/src/flyte/extras/shell/_types.py
+++ b/src/flyte/extras/shell/_types.py
@@ -30,7 +30,7 @@ class Stdout:
 
 @dataclass(frozen=True)
 class Stderr:
-    """Capture the task's stderr as a typed output. See :class:`Stdout`."""
+    """Capture the task's stderr as a typed output. See `Stdout`."""
 
     type: Type = File
 

--- a/src/flyte/io/_dir.py
+++ b/src/flyte/io/_dir.py
@@ -36,7 +36,7 @@ from flyte.types import TypeEngine, TypeTransformer, TypeTransformerFailedError
 # without an explicit annotation on the assignment target.
 T = TypeVar("T", default=Any)
 
-# Sentinel path stamped onto :class:`EmptyDir` instances. Anything created via ``Dir.empty()``
+# Sentinel path stamped onto `EmptyDir` instances. Anything created via ``Dir.empty()``
 # or ``EmptyDir()`` carries this path; ``Dir.is_empty`` detects it. We deliberately use a path
 # that cannot collide with any real local or object-store path users might pass (no scheme,
 # leading colons, illegal in filesystems and URIs alike).
@@ -244,7 +244,7 @@ class Dir(BaseModel, Generic[T], SerializableType):
 
     @property
     def is_empty(self) -> bool:
-        """True when this is a sentinel ``Dir`` produced by :class:`EmptyDir`/``Dir.empty()`` —
+        """True when this is a sentinel ``Dir`` produced by `EmptyDir`/``Dir.empty()`` —
         i.e. the task didn't actually produce a directory. Use this to branch on whether the
         upstream task emitted real data without dealing with ``Optional[Dir]`` (which the type
         engine cannot round-trip correctly through ``SerializableType``)."""
@@ -255,7 +255,7 @@ class Dir(BaseModel, Generic[T], SerializableType):
         """Return a sentinel ``Dir`` representing 'no directory was produced'.
 
         Use as the return value when a task may or may not produce an output directory; the
-        caller can check :attr:`Dir.is_empty` to detect the sentinel. Round-trips cleanly
+        caller can check `Dir.is_empty` to detect the sentinel. Round-trips cleanly
         through Flyte serialization (unlike ``Optional[Dir]``)."""
         return EmptyDir()
 
@@ -970,7 +970,7 @@ class Dir(BaseModel, Generic[T], SerializableType):
 
 
 class EmptyDir(Dir):
-    """A sentinel :class:`Dir` representing 'no directory was produced'.
+    """A sentinel `Dir` representing 'no directory was produced'.
 
     Use this as a return value when a task may or may not produce an output directory,
     e.g. ``flyte.run_python_script`` when the user did not request ``output_dir``::
@@ -982,7 +982,7 @@ class EmptyDir(Dir):
             return Output(output_dir=EmptyDir())
 
     On the receiving side, the value comes back as a plain ``Dir`` with
-    :attr:`Dir.is_empty` set to ``True`` (the deserializer doesn't preserve the
+    `Dir.is_empty` set to ``True`` (the deserializer doesn't preserve the
     ``EmptyDir`` subclass identity, but the sentinel path round-trips). Callers should
     branch on ``dir.is_empty`` rather than ``isinstance(dir, EmptyDir)``.
 

--- a/src/flyte/models.py
+++ b/src/flyte/models.py
@@ -373,9 +373,9 @@ class TaskContext:
 
 
 class _NullTaskContext(TaskContext):
-    """Falsy stand-in returned by :func:`flyte.ctx` outside a task execution.
+    """Falsy stand-in returned by `flyte.ctx` outside a task execution.
 
-    Exposes the full :class:`TaskContext` interface with every field set to ``None``, so
+    Exposes the full `TaskContext` interface with every field set to ``None``, so
     task code can read ``flyte.ctx().<field>`` without a None-guard. It is falsy, so
     ``if flyte.ctx():`` still answers "am I running inside a task?". Env-var-backed
     properties (``rank``, ``world_size``, ...) behave exactly as on a real context, and

--- a/src/flyte/remote/_action.py
+++ b/src/flyte/remote/_action.py
@@ -1047,7 +1047,7 @@ class ActionDetails(ToJSONMixin):
         Fetch the action's raw inputs/outputs from the data proxy, caching the response on the
         instance. This deliberately does not reconstruct any types, so it never fails (or pays the
         cost) when an input/output type can't be reconstructed on the client -- see
-        :meth:`output_literals` / :meth:`typed_outputs`.
+        `output_literals` / `typed_outputs`.
         """
         if self._action_data is None:
             self._action_data = await get_client().dataproxy_service.get_action_data(
@@ -1128,9 +1128,9 @@ class ActionDetails(ToJSONMixin):
         Return the action's raw output literals keyed by output name (``o0``, ``o1``, ...) without
         reconstructing the producer's types from the stored schema.
 
-        Unlike :meth:`outputs`, this never calls ``guess_python_type``, so it can't fail (or pay the
+        Unlike `outputs`, this never calls ``guess_python_type``, so it can't fail (or pay the
         cost) when an output's type isn't reconstructable on the client, and it returns every output
-        even if a sibling's type is un-guessable. Pair it with :meth:`typed_outputs` (or
+        even if a sibling's type is un-guessable. Pair it with `typed_outputs` (or
         ``TypeEngine.literal_map_to_kwargs``) to decode the specific outputs you care about.
         """
         resp = await self._fetch_action_data()
@@ -1141,7 +1141,7 @@ class ActionDetails(ToJSONMixin):
     async def input_literals(self) -> Dict[str, literals_pb2.Literal]:
         """
         Return the action's raw input literals keyed by input name, without reconstructing types.
-        The input-side equivalent of :meth:`output_literals`.
+        The input-side equivalent of `output_literals`.
         """
         resp = await self._fetch_action_data()
         if not resp.inputs:
@@ -1181,7 +1181,7 @@ class ActionDetails(ToJSONMixin):
     ) -> Dict[str, Any]:
         """
         Fetch the action's inputs and re-hydrate the requested ones into caller-supplied types.
-        The input-side equivalent of :meth:`typed_outputs`; ``deserializers`` works the same way.
+        The input-side equivalent of `typed_outputs`; ``deserializers`` works the same way.
         """
         return await self._typed_literals(await self.input_literals(), types, deserializers)
 

--- a/src/flyte/remote/_condition.py
+++ b/src/flyte/remote/_condition.py
@@ -24,10 +24,10 @@ class Condition(ToJSONMixin):
 
     Conditions pause a run until an external signal is delivered. On the backend a condition is
     backed by a *condition action*, so a ``Condition`` simply wraps the condition
-    :class:`~flyteidl2.workflow.run_definition_pb2.Action` it represents.
+    `flyteidl2.workflow.run_definition_pb2.Action` it represents.
 
-    Use :meth:`listall` to discover the conditions of a run, :meth:`get` to look one up by
-    name, and :meth:`signal` to resolve one with a typed payload.
+    Use `listall` to discover the conditions of a run, `get` to look one up by
+    name, and `signal` to resolve one with a typed payload.
     """
 
     pb2: run_definition_pb2.Action

--- a/src/flyte/remote/_run.py
+++ b/src/flyte/remote/_run.py
@@ -288,7 +288,7 @@ class Run(ToJSONMixin):
         then downloads the report from that URL and returns its contents as an HTML string.
 
         To fetch the report for a specific action nested inside the run (rather than the root
-        action), use :meth:`Action.get_report` on that action, e.g. via ``Action.get`` or by
+        action), use `Action.get_report` on that action, e.g. via ``Action.get`` or by
         iterating ``Action.listall``.
 
         :param attempt: The attempt number to fetch the report for. Defaults to the latest attempt.
@@ -327,7 +327,7 @@ class Run(ToJSONMixin):
     async def output_literals(self) -> Dict[str, literals_pb2.Literal]:
         """Raw output literals of the run's action, without reconstructing types.
 
-        See :meth:`ActionDetails.output_literals`.
+        See `ActionDetails.output_literals`.
         """
         details = await self.details.aio()
         return await details.output_literals()
@@ -336,7 +336,7 @@ class Run(ToJSONMixin):
     async def input_literals(self) -> Dict[str, literals_pb2.Literal]:
         """Raw input literals of the run's action, without reconstructing types.
 
-        See :meth:`ActionDetails.input_literals`.
+        See `ActionDetails.input_literals`.
         """
         details = await self.details.aio()
         return await details.input_literals()
@@ -349,7 +349,7 @@ class Run(ToJSONMixin):
     ) -> Dict[str, Any]:
         """Re-hydrate the run's requested outputs into caller-supplied types.
 
-        See :meth:`ActionDetails.typed_outputs`.
+        See `ActionDetails.typed_outputs`.
         """
         details = await self.details.aio()
         return await details.typed_outputs(types, deserializers)
@@ -362,7 +362,7 @@ class Run(ToJSONMixin):
     ) -> Dict[str, Any]:
         """Re-hydrate the run's requested inputs into caller-supplied types.
 
-        See :meth:`ActionDetails.typed_inputs`.
+        See `ActionDetails.typed_inputs`.
         """
         details = await self.details.aio()
         return await details.typed_inputs(types, deserializers)
@@ -532,11 +532,11 @@ class RunDetails(ToJSONMixin):
         return await self.action_details.outputs()
 
     async def output_literals(self) -> Dict[str, literals_pb2.Literal]:
-        """Raw output literals without reconstructing types. See :meth:`ActionDetails.output_literals`."""
+        """Raw output literals without reconstructing types. See `ActionDetails.output_literals`."""
         return await self.action_details.output_literals()
 
     async def input_literals(self) -> Dict[str, literals_pb2.Literal]:
-        """Raw input literals without reconstructing types. See :meth:`ActionDetails.input_literals`."""
+        """Raw input literals without reconstructing types. See `ActionDetails.input_literals`."""
         return await self.action_details.input_literals()
 
     async def typed_outputs(
@@ -544,7 +544,7 @@ class RunDetails(ToJSONMixin):
         types: Dict[str, type],
         deserializers: Dict[type, Callable[[Any], Any]] | None = None,
     ) -> Dict[str, Any]:
-        """Re-hydrate requested outputs into caller-supplied types. See :meth:`ActionDetails.typed_outputs`."""
+        """Re-hydrate requested outputs into caller-supplied types. See `ActionDetails.typed_outputs`."""
         return await self.action_details.typed_outputs(types, deserializers)
 
     async def typed_inputs(
@@ -552,7 +552,7 @@ class RunDetails(ToJSONMixin):
         types: Dict[str, type],
         deserializers: Dict[type, Callable[[Any], Any]] | None = None,
     ) -> Dict[str, Any]:
-        """Re-hydrate requested inputs into caller-supplied types. See :meth:`ActionDetails.typed_inputs`."""
+        """Re-hydrate requested inputs into caller-supplied types. See `ActionDetails.typed_inputs`."""
         return await self.action_details.typed_inputs(types, deserializers)
 
     def __rich_repr__(self) -> rich.repr.Result:

--- a/src/flyte/remote/_settings.py
+++ b/src/flyte/remote/_settings.py
@@ -223,7 +223,7 @@ _LEAF_EXAMPLES: dict[str, str] = {dotkey: _PLACEHOLDER_BY_KIND[kind] for dotkey,
 def _extract_leaf_value(leaf: Any, leaf_type: str) -> Any | None:
     """Extract the Python value from a typed ``*Setting`` proto.
 
-    Returns ``None`` for INHERIT state, :data:`UNSET` for UNSET state, or the
+    Returns ``None`` for INHERIT state, `UNSET` for UNSET state, or the
     concrete value for VALUE state.
     """
     if leaf.state == settings_definition_pb2.SETTING_STATE_UNSET:
@@ -237,7 +237,7 @@ def _extract_leaf_value(leaf: Any, leaf_type: str) -> Any | None:
 def _build_leaf(leaf_type: str, value: Any) -> Any:
     """Build a typed ``*Setting`` proto from a Python value.
 
-    When ``value`` is :data:`UNSET`, the leaf carries ``state=SETTING_STATE_UNSET``
+    When ``value`` is `UNSET`, the leaf carries ``state=SETTING_STATE_UNSET``
     and no payload fields. Otherwise ``state=SETTING_STATE_VALUE``.
     """
     io = _LEAF_IO.get(leaf_type)
@@ -442,7 +442,7 @@ class Settings(ToJSONMixin):
         """Return the YAML content split into labelled sections.
 
         Each tuple is ``(section_title, yaml_body)``; sections are omitted
-        when they have no entries. See :meth:`to_yaml` for the comment-prefix
+        when they have no entries. See `to_yaml` for the comment-prefix
         convention.
 
         Section titles: ``"Local overrides"``, ``"Inherited settings"``, ``"Available settings"``.

--- a/src/flyte/report/_widgets.py
+++ b/src/flyte/report/_widgets.py
@@ -1,9 +1,9 @@
 """Reusable report widgets — a timeline of rows plus the formatting helpers.
 
-These sit on top of the low-level report primitives (:func:`get_tab`, :func:`flush`)
+These sit on top of the low-level report primitives (`get_tab`, `flush`)
 and give any long-running task a consistent way to render a chronological log into a
 report tab. The agent stack uses them (both the native ``flyte.ai.agents`` loop and the
-``flyteplugins.agents.*`` adapters render through the same :class:`Timeline`).
+``flyteplugins.agents.*`` adapters render through the same `Timeline`).
 """
 
 from __future__ import annotations

--- a/src/flyte/types/_json_coercion.py
+++ b/src/flyte/types/_json_coercion.py
@@ -203,14 +203,14 @@ def coerce_json_value_sync(
     *,
     string_blob_converter: StringBlobConverter | None = None,
 ) -> Any:
-    """Synchronous wrapper around :func:`coerce_json_value` for CLI use."""
+    """Synchronous wrapper around `coerce_json_value` for CLI use."""
     from flyte._utils.asyn import run_sync
 
     return run_sync(coerce_json_value, value, py_type, string_blob_converter=string_blob_converter)
 
 
 def serialize_json_value_sync(value: Any, py_type: Any | None = None) -> Any:
-    """Synchronous wrapper around :func:`serialize_json_value`."""
+    """Synchronous wrapper around `serialize_json_value`."""
     from flyte._utils.asyn import run_sync
 
     return run_sync(serialize_json_value, value, py_type)
@@ -220,7 +220,7 @@ async def coerce_json_args(
     args: dict[str, Any],
     inputs: dict[str, tuple[Any, Any]],
 ) -> dict[str, Any]:
-    """Coerce a kwargs dict using a :class:`~flyte.models.NativeInterface` inputs map."""
+    """Coerce a kwargs dict using a `flyte.models.NativeInterface` inputs map."""
     coerced: dict[str, Any] = {}
     for name, value in args.items():
         input_info = inputs.get(name)

--- a/src/flyte/types/_type_engine.py
+++ b/src/flyte/types/_type_engine.py
@@ -659,9 +659,9 @@ def _get_pydantic_element_type(
 ) -> Type:
     """Resolve a JSON-schema fragment to a Python type for dynamic Pydantic models.
 
-    Like :func:`_get_element_type`, but nested objects and ``$ref`` targets become
+    Like `_get_element_type`, but nested objects and ``$ref`` targets become
     dynamic Pydantic models instead of mashumaro dataclasses so ``model_validate``
-    and msgpack field ordering stay consistent with :class:`PydanticTransformer`.
+    and msgpack field ordering stay consistent with `PydanticTransformer`.
     """
     if not isinstance(element_property, dict):
         return _get_element_type(element_property, schema)
@@ -721,7 +721,7 @@ def _get_pydantic_element_type(
 def _is_noarg_constructible_model(tp: typing.Any) -> bool:
     """Return True if ``tp`` is a Pydantic model class instantiable with no arguments.
 
-    The Pydantic-path analogue of :func:`_is_noarg_constructible_dataclass`: used to decide whether a
+    The Pydantic-path analogue of `_is_noarg_constructible_dataclass`: used to decide whether a
     non-required nested-model field (a ``default_factory=SomeModel`` field, which omits ``default``
     from the JSON schema) can rebuild its default by constructing the reconstructed nested model.
     """
@@ -736,7 +736,7 @@ def _pydantic_not_required_field(field_type: typing.Any) -> typing.Tuple[typing.
     """``create_model`` field spec for a non-required field that has no explicit schema default.
 
     Pydantic omits ``default`` from the JSON schema for ``default_factory`` fields, so they land here.
-    Mirrors :func:`_append_schema_field` (the untagged dataclass path) so a model reconstructs the
+    Mirrors `_append_schema_field` (the untagged dataclass path) so a model reconstructs the
     same way whichever path it takes: list/dict ``default_factory`` fields rebuild empty collections,
     a no-arg-constructible nested model rebuilds an instance, and anything else (scalars, unions,
     non-constructible models) becomes ``Optional[...] = None``. Returning a required ``(field_type,
@@ -2922,7 +2922,7 @@ class _FloatTransformer(SimpleTransformer[float]):
     rejecting — means a call like ``issue_refund(amount_usd=42)`` for a ``float``-typed
     parameter is converted and the action is created, rather than failing invisibly during
     input conversion before any action node exists. This mirrors the read side
-    (:func:`_check_and_covert_float`), which already accepts an integer literal for a float.
+    (`_check_and_covert_float`), which already accepts an integer literal for a float.
 
     ``bool`` is excluded (it subclasses ``int``) so ``True`` is not silently turned into
     ``1.0``.


### PR DESCRIPTION
> Stacked on #1391 — base is `remove/mcp-central-mode`, so this PR shows only the docstring change. Merge #1391 first; GitHub retargets this to `main` automatically when that branch is deleted.

## Why

flyte-sdk builds no Sphinx docs — there is no `conf.py`, no `docs/` tree, and no sphinx dependency anywhere in the repo. The cross-reference roles in our docstrings are a convention carried over from flytekit v1, and nothing renders them. They show up verbatim as ``:class:`Name` `` in `help()`, in IDE tooltips, and on the docs site, where 337 of them across 51 files reach the published pages.

## What

Converts all 438 roles across 94 files to Markdown code spans. Docstrings only — no code changed.

The `~` prefix is **dropped rather than resolved to the last component**:

```
:class:`~flyte.report.Timeline`   ->   `flyte.report.Timeline`
:func:`tool`                      ->   `tool`
:meth:`the resolver <pkg.Thing>`  ->   `the resolver`
```

RST would display only `Timeline` for the first form, but the docs site's autolinker keys on fully-qualified names for the SDK linkmap, so `flyte.report.Timeline` becomes a link where a bare `Timeline` would not — and the full path is unambiguous in `help()` output. An explicit RST title keeps its title.

## Verification

- Every changed file byte-compiles.
- Zero roles remain under `src/` and `plugins/`.
- `ruff format` reports **1634 files left unchanged** and `ruff check .` passes, so `make fmt && git diff --exit-code` is clean in CI.
- The diff touches no code lines — only docstring text.

## Related

unionai/unionai-docs-infra#231 adds an RST-role converter to the docs generator. That stays regardless: it is the only thing that handles docstrings from dependencies (LangChain, pydantic) that we do not control, and it catches any roles that drift back in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)