### PR TITLE
Add ArtifactLineageAppEnvironment example: track artifact producer/consumer lineage

### DIFF
--- a/examples/artifacts/artifact_lineage_example.py
+++ b/examples/artifacts/artifact_lineage_example.py
@@ -1,0 +1,128 @@
+"""Artifact lineage: track producers and consumers of artifacts across runs and apps.
+
+`ArtifactLineageAppEnvironment` (see `lineage/`) renders, for any published
+artifact, the chain of everything connected to it: every producing run back to
+the original run/artifact in the chain, and every consuming run, artifact, or
+app downstream of it. Two signals feed the graph:
+
+1. **Automatic** — when an artifact is bound as a typed task input (a plain
+   `flyte.run(task, model=artifact)` call, or an `OnArtifact` trigger binding
+   `flyte.TriggeredArtifact`), the platform stamps the artifact's identity on
+   the input literal itself. No extra code needed; see `train_model` below,
+   which consumes `raw-data` this way.
+2. **Fallback label** — a task that resolves an artifact's value without
+   binding it as a typed input (e.g. it only takes a plain string), or an app
+   that reads an artifact at startup, leaves nothing for the platform to see.
+   For those, the caller stamps a private `__upstream_artifact__` label —
+   `flyte.with_runcontext(labels=...)` for a run, `AppEnvironment(labels=...)`
+   for an app — that the dashboard scans for. `audit_model` and
+   `model_server` below both need this.
+
+Try it:
+
+    python examples/artifacts/artifact_lineage_example.py
+
+then open the printed dashboard URL, or `<endpoint>/lineage` if you deploy it
+separately.
+"""
+
+import tempfile
+
+from lineage import LABEL_UPSTREAM_ARTIFACT, ArtifactLineageAppEnvironment
+
+import flyte
+import flyte.artifacts as artifacts
+from flyte.app import AppEnvironment
+from flyte.io import File
+
+env = flyte.TaskEnvironment(
+    name="artifact_lineage_example",
+    image=flyte.Image.from_debian_base().with_pip_packages("fastapi", "uvicorn"),
+)
+
+
+@env.task(produces_artifacts=True)
+async def produce_raw_data() -> File:
+    with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False) as f:
+        f.write("feature,label\n1,0\n2,1\n")
+    file = await File.from_local(f.name)
+    return artifacts.new(file, artifacts.Metadata(name="raw-data", description="Raw ingested training data"))
+
+
+# Automatic detection: `data` binds the artifact as a typed `File` input, so the
+# platform stamps `Literal.artifact_id` on it — the dashboard finds this edge by
+# scanning `train_model`'s runs for artifact-bound inputs, no label required.
+@env.task(produces_artifacts=True)
+async def train_model(data: File) -> File:
+    async with data.open("rb") as fh:
+        rows = bytes(await fh.read()).decode().splitlines()
+    with tempfile.NamedTemporaryFile("w", suffix=".bin", delete=False) as f:
+        f.write(f"weights trained on {len(rows) - 1} rows")
+    weights = await File.from_local(f.name)
+    return artifacts.new(weights, artifacts.Metadata(name="trained-model", description="Trained model weights"))
+
+
+# Fallback label: `model_ref` is a plain string, not a bound `Artifact`/`File` — the
+# platform has no way to know this run consumed anything. The caller (see `__main__`)
+# stamps the `__upstream_artifact__` label explicitly so the dashboard can still find it.
+@env.task
+async def audit_model(model_ref: str) -> str:
+    return f"audited {model_ref}"
+
+
+# Apps can't bind artifacts as typed inputs at all, so the label is the *only* way to
+# declare "this app serves artifact X". The label value is only known once the model
+# exists, so it's attached via `clone_with(labels=...)` + redeploy in `__main__`,
+# not at module-definition time.
+model_server = AppEnvironment(
+    name="artifact-lineage-model-server",
+    image=env.image,
+    command="python -m http.server 8080",
+    requires_auth=False,
+)
+
+lineage_dashboard = ArtifactLineageAppEnvironment(
+    name="artifact-lineage-dashboard",
+    image=flyte.Image.from_debian_base().with_pip_packages("fastapi", "uvicorn"),
+    include=("lineage/*.py",),
+    requires_auth=False,
+    # `train_model` is discovered via the automatic bound-input scan; `audit_model` is
+    # discovered via the label (listed here too so the bound-input scan also covers it).
+    watched_tasks=["artifact_lineage_example.train_model", "artifact_lineage_example.audit_model"],
+    watched_apps=[model_server.name],
+)
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+
+    from flyte.remote import Artifact
+
+    data_run = flyte.run(produce_raw_data)
+    print(data_run.url)
+    data_run.wait()
+    data = Artifact.get("raw-data")
+
+    model_run = flyte.run(train_model, data=data)
+    print(model_run.url)
+    model_run.wait()
+    model = Artifact.get("trained-model")
+
+    # Fallback path #1 (run): stamp the label before launching, since `audit_model`
+    # only takes a plain string and the platform can't infer the artifact linkage.
+    audit_run = flyte.with_runcontext(labels={LABEL_UPSTREAM_ARTIFACT: model.tracker}).run(
+        audit_model, model_ref=model.tracker
+    )
+    print(audit_run.url)
+    audit_run.wait()
+
+    # Fallback path #2 (app): redeploy the model server with the label now that the
+    # model artifact's identity is known.
+    labeled_model_server = model_server.clone_with(
+        name=model_server.name, labels={LABEL_UPSTREAM_ARTIFACT: model.tracker}
+    )
+    flyte.serve(labeled_model_server)
+
+    handle = flyte.serve(lineage_dashboard)
+    print(f"Lineage dashboard: {handle.url}/lineage")
+    print(f"Lineage graph for trained-model: {handle.url}/lineage/artifact/trained-model")

--- a/examples/artifacts/artifact_lineage_example.py
+++ b/examples/artifacts/artifact_lineage_example.py
@@ -10,10 +10,10 @@ app downstream of it. Two signals feed the graph:
    `flyte.TriggeredArtifact`), the platform stamps the artifact's identity on
    the input literal itself. No extra code needed; see `train_model` below,
    which consumes `raw-data` this way.
-2. **Fallback label** — a task that resolves an artifact's value without
+2. **Fallback labels** — a task that resolves an artifact's value without
    binding it as a typed input (e.g. it only takes a plain string), or an app
    that reads an artifact at startup, leaves nothing for the platform to see.
-   For those, the caller stamps a private `__upstream_artifact__` label —
+   For those, the caller stamps a pair of private labels —
    `flyte.with_runcontext(labels=...)` for a run, `AppEnvironment(labels=...)`
    for an app — that the dashboard scans for. `audit_model` and
    `model_server` below both need this.
@@ -27,13 +27,37 @@ separately.
 """
 
 import tempfile
+import time
 
-from lineage import LABEL_UPSTREAM_ARTIFACT, ArtifactLineageAppEnvironment
+from lineage import LABEL_UPSTREAM_ARTIFACT_NAME, LABEL_UPSTREAM_ARTIFACT_VERSION, ArtifactLineageAppEnvironment
 
 import flyte
 import flyte.artifacts as artifacts
 from flyte.app import AppEnvironment
 from flyte.io import File
+
+
+def _wait_for_artifact(name: str, *, retries: int = 15, delay_s: float = 2.0):
+    """`Artifact.get` right after a run completes can race artifact indexing; retry briefly."""
+    from flyte.remote import Artifact
+
+    for attempt in range(retries):
+        try:
+            return Artifact.get(name)
+        except Exception:
+            if attempt == retries - 1:
+                raise
+            time.sleep(delay_s)
+
+
+def _run_and_wait(run):
+    """`.wait()` alone doesn't raise on failure -- surface it immediately instead of
+    letting a later `_wait_for_artifact` call fail with a confusing "not found"."""
+    run.wait()
+    if run.phase != "succeeded":
+        raise RuntimeError(f"{run.url} finished in phase {run.phase!r}")
+    return run
+
 
 env = flyte.TaskEnvironment(
     name="artifact_lineage_example",
@@ -62,18 +86,20 @@ async def train_model(data: File) -> File:
     return artifacts.new(weights, artifacts.Metadata(name="trained-model", description="Trained model weights"))
 
 
-# Fallback label: `model_ref` is a plain string, not a bound `Artifact`/`File` — the
-# platform has no way to know this run consumed anything. The caller (see `__main__`)
-# stamps the `__upstream_artifact__` label explicitly so the dashboard can still find it.
+# Fallback labels: `model_ref` is a plain string, not a bound `Artifact`/`File` — the
+# platform has no way to know this run consumed anything. The caller (see `run_pipeline`)
+# stamps the labels explicitly so the dashboard can still find it.
 @env.task
 async def audit_model(model_ref: str) -> str:
     return f"audited {model_ref}"
 
 
-# Apps can't bind artifacts as typed inputs at all, so the label is the *only* way to
-# declare "this app serves artifact X". The label value is only known once the model
-# exists, so it's attached via `clone_with(labels=...)` + redeploy in `__main__`,
-# not at module-definition time.
+# Apps can't bind artifacts as typed inputs at all, so the labels are the *only* way to
+# declare "this app serves artifact X". The label values are only known once the model
+# exists, so they're set on this module-level object (not a `clone_with()` copy -- a
+# clone made inside `run_pipeline` would be a local variable, and the app resolver needs
+# to find the deployed `AppEnvironment` by name in this module's *global* namespace) once
+# `run_pipeline` runs, before `flyte.serve()`.
 model_server = AppEnvironment(
     name="artifact-lineage-model-server",
     image=env.image,
@@ -84,41 +110,44 @@ lineage_dashboard = ArtifactLineageAppEnvironment(
     name="artifact-lineage-dashboard",
     image=flyte.Image.from_debian_base().with_pip_packages("fastapi", "uvicorn"),
     # `train_model` is discovered via the automatic bound-input scan; `audit_model` is
-    # discovered via the label (listed here too so the bound-input scan also covers it).
+    # discovered via the labels (listed here too so the bound-input scan also covers it).
     watched_tasks=["artifact_lineage_example.train_model", "artifact_lineage_example.audit_model"],
     watched_apps=[model_server.name],
 )
 
 
+def run_pipeline() -> None:
+    """Produce, train, and audit, exercising both lineage-detection signals.
+
+    Assumes `flyte.init_from_config()` has already run. Does *not* touch
+    `lineage_dashboard` — callers that want the dashboard too (e.g. this
+    module's own `__main__`, or a driver combining several example pipelines)
+    deploy it separately, so multiple pipelines never fight over redeploying
+    the same shared app with different `watched_tasks`/`watched_apps`.
+    """
+    data_run = _run_and_wait(flyte.run(produce_raw_data))
+    print(data_run.url)
+    data = _wait_for_artifact("raw-data")
+
+    model_run = _run_and_wait(flyte.run(train_model, data=data))
+    print(model_run.url)
+    model = _wait_for_artifact("trained-model")
+
+    # Fallback path #1 (run): stamp the labels before launching, since `audit_model`
+    # only takes a plain string and the platform can't infer the artifact linkage.
+    audit_labels = {LABEL_UPSTREAM_ARTIFACT_NAME: model.name, LABEL_UPSTREAM_ARTIFACT_VERSION: model.version}
+    audit_run = _run_and_wait(flyte.with_runcontext(labels=audit_labels).run(audit_model, model_ref=model.tracker))
+    print(audit_run.url)
+
+    # Fallback path #2 (app): redeploy the model server with the labels now that the
+    # model artifact's identity is known.
+    model_server.labels = audit_labels
+    flyte.serve(model_server)
+
+
 if __name__ == "__main__":
     flyte.init_from_config()
-
-    from flyte.remote import Artifact
-
-    data_run = flyte.run(produce_raw_data)
-    print(data_run.url)
-    data_run.wait()
-    data = Artifact.get("raw-data")
-
-    model_run = flyte.run(train_model, data=data)
-    print(model_run.url)
-    model_run.wait()
-    model = Artifact.get("trained-model")
-
-    # Fallback path #1 (run): stamp the label before launching, since `audit_model`
-    # only takes a plain string and the platform can't infer the artifact linkage.
-    audit_run = flyte.with_runcontext(labels={LABEL_UPSTREAM_ARTIFACT: model.tracker}).run(
-        audit_model, model_ref=model.tracker
-    )
-    print(audit_run.url)
-    audit_run.wait()
-
-    # Fallback path #2 (app): redeploy the model server with the label now that the
-    # model artifact's identity is known.
-    labeled_model_server = model_server.clone_with(
-        name=model_server.name, labels={LABEL_UPSTREAM_ARTIFACT: model.tracker}
-    )
-    flyte.serve(labeled_model_server)
+    run_pipeline()
 
     handle = flyte.serve(lineage_dashboard)
     print(f"Lineage dashboard: {handle.url}/lineage")

--- a/examples/artifacts/artifact_lineage_example.py
+++ b/examples/artifacts/artifact_lineage_example.py
@@ -78,14 +78,11 @@ model_server = AppEnvironment(
     name="artifact-lineage-model-server",
     image=env.image,
     command="python -m http.server 8080",
-    requires_auth=False,
 )
 
 lineage_dashboard = ArtifactLineageAppEnvironment(
     name="artifact-lineage-dashboard",
     image=flyte.Image.from_debian_base().with_pip_packages("fastapi", "uvicorn"),
-    include=("lineage/*.py",),
-    requires_auth=False,
     # `train_model` is discovered via the automatic bound-input scan; `audit_model` is
     # discovered via the label (listed here too so the bound-input scan also covers it).
     watched_tasks=["artifact_lineage_example.train_model", "artifact_lineage_example.audit_model"],

--- a/examples/artifacts/lineage/__init__.py
+++ b/examples/artifacts/lineage/__init__.py
@@ -1,0 +1,4 @@
+from ._lineage import LABEL_UPSTREAM_ARTIFACT
+from .dashboard import ArtifactLineageAppEnvironment
+
+__all__ = ["LABEL_UPSTREAM_ARTIFACT", "ArtifactLineageAppEnvironment"]

--- a/examples/artifacts/lineage/__init__.py
+++ b/examples/artifacts/lineage/__init__.py
@@ -1,4 +1,4 @@
-from ._lineage import LABEL_UPSTREAM_ARTIFACT
+from ._lineage import LABEL_UPSTREAM_ARTIFACT_NAME, LABEL_UPSTREAM_ARTIFACT_VERSION
 from .dashboard import ArtifactLineageAppEnvironment
 
-__all__ = ["LABEL_UPSTREAM_ARTIFACT", "ArtifactLineageAppEnvironment"]
+__all__ = ["LABEL_UPSTREAM_ARTIFACT_NAME", "LABEL_UPSTREAM_ARTIFACT_VERSION", "ArtifactLineageAppEnvironment"]

--- a/examples/artifacts/lineage/_lineage.py
+++ b/examples/artifacts/lineage/_lineage.py
@@ -99,6 +99,12 @@ class LineageGraph:
     root: str  # node_id of the artifact the graph was built for
     nodes: dict = field(default_factory=dict)  # node_id -> asdict(node)
     edges: list = field(default_factory=list)  # list[asdict(Edge)]
+    # True when the walk stopped at the requested depth with more lineage beyond it --
+    # i.e. there's a "load more" affordance in that direction, not necessarily that more
+    # exists (a downstream boundary node might turn out to have no consumers at all; the
+    # UI just finds nothing new on expand, which is cheap and harmless).
+    has_more_upstream: bool = False
+    has_more_downstream: bool = False
 
 
 def _artifact_node_id(tracker: str) -> str:
@@ -233,29 +239,44 @@ async def _consumer_apps_of_artifact(artifact, watched_apps: Iterable[str]) -> l
     return apps
 
 
+# Hard ceiling on requested depth, independent of what the UI asks for -- a safety net
+# against a runaway "load more" click chain, not a default (the default is 1: "one step").
+_MAX_REQUESTABLE_DEPTH = 12
+
+
 async def build_artifact_lineage(
     artifact,
     *,
     watched_tasks: Iterable[str] = (),
     watched_apps: Iterable[str] = (),
-    scan_limit: int = 50,
-    max_depth: int = 25,
+    scan_limit: int = 20,
+    upstream_depth: int = 1,
+    downstream_depth: int = 1,
 ) -> LineageGraph:
-    """The full lineage of `artifact`: every ancestor back to the origin run/artifact,
-    and every descendant run/artifact/app downstream of it.
+    """The lineage of `artifact` out to `upstream_depth`/`downstream_depth` hops.
 
-    Walks two directions from the root artifact:
+    A hop is one producer or consumer edge: `upstream_depth=1` (the default) adds the
+    artifact's producing run and that run's own consumed artifacts (but not *their*
+    producers); `downstream_depth=1` adds runs/apps that consumed the artifact and
+    artifacts those runs produced (but not *their* consumers). Bump either to walk
+    further in that direction -- see `LineageGraph.has_more_upstream`/`_downstream` for
+    whether there's more to find.
 
-    - **upstream**: the artifact's producing run, that run's own consumed artifacts,
-      their producing runs, and so on, until a run consumed nothing (the origin).
-    - **downstream**: runs/apps that consumed the artifact, artifacts *those* runs in
-      turn produced, their consumers, and so on.
+    This is deliberately shallow by default: the downstream walk in particular can issue
+    several RPCs per hop (a label-filtered run scan plus, per `watched_tasks` entry, a
+    full recent-run scan with an `input_literals` fetch per run), so an unbounded walk
+    over a long or bushy lineage is slow. Callers building an interactive view should
+    start at the default depth and grow it on demand rather than requesting a large depth
+    up front.
 
     `watched_tasks`/`watched_apps` (task/app names) opt into the bound-input scan for
-    consumer discovery beyond what the `upstream-artifact-name`/`upstream-artifact-version` labels
-    already find — see the module docstring for why that scan can't be global.
+    consumer discovery beyond what the `upstream-artifact-name`/`upstream-artifact-version`
+    labels already find — see the module docstring for why that scan can't be global.
     """
     from flyte.remote import Artifact, Run
+
+    upstream_depth = max(0, min(upstream_depth, _MAX_REQUESTABLE_DEPTH))
+    downstream_depth = max(0, min(downstream_depth, _MAX_REQUESTABLE_DEPTH))
 
     graph = LineageGraph(root=_artifact_node_id(artifact.tracker))
     seen_artifacts: set[str] = set()
@@ -278,7 +299,7 @@ async def build_artifact_lineage(
             graph.edges.append(edge)
 
     async def walk_upstream(a, depth: int) -> None:
-        if a.tracker in seen_artifacts or depth > max_depth:
+        if a.tracker in seen_artifacts:
             return
         seen_artifacts.add(a.tracker)
         artifact_id = add_artifact(a)
@@ -287,9 +308,13 @@ async def build_artifact_lineage(
         if src.WhichOneof("source") != "task_action":
             return  # externally published (or no source) — this is the origin
         run_name = src.task_action.action.run.name
-        if not run_name or run_name in seen_runs:
-            if run_name:
-                add_edge(_run_node_id(run_name), artifact_id, "produces")
+        if not run_name:
+            return
+        if depth <= 0:
+            graph.has_more_upstream = True
+            return
+        if run_name in seen_runs:
+            add_edge(_run_node_id(run_name), artifact_id, "produces")
             return
         seen_runs.add(run_name)
         try:
@@ -301,7 +326,7 @@ async def build_artifact_lineage(
         add_edge(run_id, artifact_id, "produces")
 
         consumed = await _consumed_artifacts_of_run(run)
-        await asyncio.gather(*(_upstream_consumed(run_id, upstream, depth + 1) for upstream in consumed))
+        await asyncio.gather(*(_upstream_consumed(run_id, upstream, depth - 1) for upstream in consumed))
 
     async def _upstream_consumed(run_id: str, a, depth: int) -> None:
         artifact_id = add_artifact(a)
@@ -309,9 +334,10 @@ async def build_artifact_lineage(
         await walk_upstream(a, depth)
 
     async def walk_downstream(a, depth: int) -> None:
-        if depth > max_depth:
-            return
         artifact_id = add_artifact(a)
+        if depth <= 0:
+            graph.has_more_downstream = True
+            return
 
         consumer_runs, consumer_apps = await asyncio.gather(
             _consumer_runs_of_artifact(a, watched_tasks, scan_limit),
@@ -335,7 +361,7 @@ async def build_artifact_lineage(
                     produced.append(produced_artifact)
             except Exception:
                 logger.exception("Could not list artifacts produced by run %s", run.name)
-            await asyncio.gather(*(_downstream_produced(run_id, p, depth + 1) for p in produced))
+            await asyncio.gather(*(_downstream_produced(run_id, p, depth - 1) for p in produced))
 
     async def _downstream_produced(run_id: str, a, depth: int) -> None:
         artifact_id = add_artifact(a)
@@ -344,7 +370,7 @@ async def build_artifact_lineage(
             seen_artifacts.add(a.tracker)
             await walk_downstream(a, depth)
 
-    await walk_upstream(artifact, 0)
-    await walk_downstream(artifact, 0)
+    await walk_upstream(artifact, upstream_depth)
+    await walk_downstream(artifact, downstream_depth)
 
     return graph

--- a/examples/artifacts/lineage/_lineage.py
+++ b/examples/artifacts/lineage/_lineage.py
@@ -1,0 +1,338 @@
+"""Artifact-lineage graph collection.
+
+Three kinds of node make up an artifact's lineage: **artifacts**, **runs**, and
+**apps**. Two relations wire them together: ``produces`` (run/action -> artifact)
+and ``consumes`` (artifact -> run/app).
+
+The ``produces`` side is always knowable from the backend: every artifact
+records its own provenance (:attr:`flyte.remote.Artifact.pb2.spec.source`, a
+``task_action`` pointing at the run/action that created it), and
+``Artifact.listall(source_run=...)`` answers "what did this run produce".
+
+The ``consumes`` side is knowable from the backend *only* when the artifact
+was bound as a typed run input — the platform stamps ``core.Literal.artifact_id``
+on any literal that came from (or round-tripped through) an ``Artifact``, and
+that survives as a run's input literal. That covers both manual
+``flyte.run(task, model=artifact)`` calls and artifact-triggered runs (an
+``OnArtifact`` trigger binding ``flyte.TriggeredArtifact`` to an input writes
+the same stamp). See :func:`flyte.types._string_literals.artifact_annotation`.
+
+Nothing else is knowable automatically — a task that resolves an artifact's
+URI itself (rather than binding the ``Artifact``/``File``/``Dir`` as an input),
+or an ``AppEnvironment`` that reads an artifact at startup, leaves no trace the
+backend can query. For those cases this module falls back to a private label,
+``__upstream_artifact__``, set to the artifact's ``tracker`` string
+(``org/project/domain/name@version``). Runs pick it up via
+``flyte.with_runcontext(labels={LABEL_UPSTREAM_ARTIFACT: artifact.tracker})``
+(labels have been a first-class ``with_runcontext`` parameter all along); apps
+pick it up via the ``labels=`` field on ``flyte.app.AppEnvironment``.
+
+Lineage is not stored anywhere — it is re-derived on every scan from these two
+signals, exactly as the reference ``RunLineageDashboard`` re-derives run
+lineage from labels rather than a stored graph.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import asdict, dataclass, field
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+# Private label key stamped on runs/apps that consume an artifact in a way the
+# backend can't otherwise see. Value is the artifact's `tracker` string
+# (org/project/domain/name@version).
+LABEL_UPSTREAM_ARTIFACT = "__upstream_artifact__"
+
+_TERMINAL_PHASES = {"succeeded", "failed", "aborted", "timed_out"}
+
+
+@dataclass
+class ArtifactNode:
+    node_id: str
+    name: str
+    version: str
+    tracker: str
+    url: str
+    description: str
+    created_by: str
+    produced_by_run: str = ""  # "" when externally published (no producing run)
+    kind: str = "artifact"
+
+
+@dataclass
+class RunNode:
+    node_id: str
+    run_name: str
+    task_name: str
+    url: str
+    phase: str
+    kind: str = "run"
+
+
+@dataclass
+class AppNode:
+    node_id: str
+    app_name: str
+    url: str
+    endpoint: str
+    kind: str = "app"
+
+
+@dataclass
+class Edge:
+    source: str
+    target: str
+    relation: str  # "produces" | "consumes"
+
+
+@dataclass
+class LineageGraph:
+    root: str  # node_id of the artifact the graph was built for
+    nodes: dict = field(default_factory=dict)  # node_id -> asdict(node)
+    edges: list = field(default_factory=list)  # list[asdict(Edge)]
+
+
+def _artifact_node_id(tracker: str) -> str:
+    return f"artifact:{tracker}"
+
+
+def _run_node_id(run_name: str) -> str:
+    return f"run:{run_name}"
+
+
+def _app_node_id(app_name: str) -> str:
+    return f"app:{app_name}"
+
+
+def _artifact_to_node(artifact) -> ArtifactNode:
+    src = artifact.pb2.spec.source
+    produced_by_run = src.task_action.action.run.name if src.WhichOneof("source") == "task_action" else ""
+    return ArtifactNode(
+        node_id=_artifact_node_id(artifact.tracker),
+        name=artifact.name,
+        version=artifact.version,
+        tracker=artifact.tracker,
+        url=artifact.url,
+        description=artifact.pb2.spec.info.description or "",
+        created_by=artifact.created_by,
+        produced_by_run=produced_by_run,
+    )
+
+
+def _run_to_node(run) -> RunNode:
+    return RunNode(
+        node_id=_run_node_id(run.name),
+        run_name=run.name,
+        task_name="",
+        url=run.url,
+        phase=run.phase.value,
+    )
+
+
+async def _app_to_node(app) -> AppNode:
+    return AppNode(
+        node_id=_app_node_id(app.name),
+        app_name=app.name,
+        url=app.url,
+        endpoint=app.endpoint,
+    )
+
+
+def _run_task_name(run) -> str:
+    return run.action.task_name or ""
+
+
+async def _consumed_artifacts_of_run(run) -> list:
+    """Every artifact this run consumed, via bound-input literals or the fallback label.
+
+    Bound-input detection covers manual `flyte.run(task, model=artifact)` calls and
+    `OnArtifact`-triggered runs alike (both stamp `Literal.artifact_id`). The label is
+    the only signal for runs that resolved an artifact's value without binding it as a
+    typed input.
+    """
+    from flyte.remote import Artifact
+
+    trackers: set[str] = set()
+
+    label_value = dict(run.pb2.labels).get(LABEL_UPSTREAM_ARTIFACT) if run.pb2.labels else None
+    if label_value:
+        trackers.add(label_value)
+
+    try:
+        literals = await run.input_literals.aio()
+    except Exception:
+        logger.debug("Could not fetch input literals for run %s", run.name, exc_info=True)
+        literals = {}
+    for lit in literals.values():
+        if lit.HasField("artifact_id"):
+            key = lit.artifact_id.key
+            trackers.add(f"{key.org}/{key.project}/{key.domain}/{key.name}@{lit.artifact_id.version}")
+
+    artifacts = []
+    for tracker in trackers:
+        try:
+            _org, project, domain, rest = tracker.split("/", 3)
+            name, version = rest.rsplit("@", 1)
+            artifacts.append(await Artifact.get.aio(name=name, version=version, project=project, domain=domain))
+        except Exception:
+            logger.debug("Could not resolve consumed artifact %s", tracker, exc_info=True)
+    return artifacts
+
+
+async def _consumer_runs_of_artifact(artifact, watched_tasks: Iterable[str], scan_limit: int) -> list:
+    """Runs that consumed `artifact`, found via the fallback label plus (optionally) a
+    bound-input scan over `watched_tasks`'s recent runs."""
+    from flyte.remote import Run
+
+    by_name: dict[str, object] = {}
+
+    async for run in Run.listall.aio(with_labels={LABEL_UPSTREAM_ARTIFACT: artifact.tracker}, limit=scan_limit):
+        by_name[run.name] = run
+
+    for task_name in watched_tasks:
+        try:
+            async for run in Run.listall.aio(task_name=task_name, limit=scan_limit, sort_by=("created_at", "desc")):
+                if run.name in by_name:
+                    continue
+                consumed = await _consumed_artifacts_of_run(run)
+                if any(a.tracker == artifact.tracker for a in consumed):
+                    by_name[run.name] = run
+        except Exception:
+            logger.exception("Consumer scan failed for task %s", task_name)
+
+    return list(by_name.values())
+
+
+async def _consumer_apps_of_artifact(artifact, watched_apps: Iterable[str]) -> list:
+    from flyte.remote import App
+
+    apps = []
+    for app_name in watched_apps:
+        try:
+            app = await App.get.aio(name=app_name)
+        except Exception:
+            logger.debug("Could not fetch app %s", app_name, exc_info=True)
+            continue
+        if dict(app.pb2.metadata.labels).get(LABEL_UPSTREAM_ARTIFACT) == artifact.tracker:
+            apps.append(app)
+    return apps
+
+
+async def build_artifact_lineage(
+    artifact,
+    *,
+    watched_tasks: Iterable[str] = (),
+    watched_apps: Iterable[str] = (),
+    scan_limit: int = 50,
+    max_depth: int = 25,
+) -> LineageGraph:
+    """The full lineage of `artifact`: every ancestor back to the origin run/artifact,
+    and every descendant run/artifact/app downstream of it.
+
+    Walks two directions from the root artifact:
+
+    - **upstream**: the artifact's producing run, that run's own consumed artifacts,
+      their producing runs, and so on, until a run consumed nothing (the origin).
+    - **downstream**: runs/apps that consumed the artifact, artifacts *those* runs in
+      turn produced, their consumers, and so on.
+
+    `watched_tasks`/`watched_apps` (task/app names) opt into the bound-input scan for
+    consumer discovery beyond what the `__upstream_artifact__` label already finds —
+    see the module docstring for why that scan can't be global.
+    """
+    from flyte.remote import Artifact, Run
+
+    graph = LineageGraph(root=_artifact_node_id(artifact.tracker))
+    seen_artifacts: set[str] = set()
+    seen_runs: set[str] = set()
+
+    def add_artifact(a) -> str:
+        node = _artifact_to_node(a)
+        graph.nodes.setdefault(node.node_id, asdict(node))
+        return node.node_id
+
+    def add_run(run) -> str:
+        node = _run_to_node(run)
+        node.task_name = _run_task_name(run)
+        graph.nodes[node.node_id] = asdict(node)
+        return node.node_id
+
+    def add_edge(source: str, target: str, relation: str) -> None:
+        edge = asdict(Edge(source=source, target=target, relation=relation))
+        if edge not in graph.edges:
+            graph.edges.append(edge)
+
+    async def walk_upstream(a, depth: int) -> None:
+        if a.tracker in seen_artifacts or depth > max_depth:
+            return
+        seen_artifacts.add(a.tracker)
+        artifact_id = add_artifact(a)
+
+        src = a.pb2.spec.source
+        if src.WhichOneof("source") != "task_action":
+            return  # externally published (or no source) — this is the origin
+        run_name = src.task_action.action.run.name
+        if not run_name or run_name in seen_runs:
+            if run_name:
+                add_edge(_run_node_id(run_name), artifact_id, "produces")
+            return
+        seen_runs.add(run_name)
+        try:
+            run = await Run.get.aio(name=run_name)
+        except Exception:
+            logger.debug("Could not fetch producing run %s", run_name, exc_info=True)
+            return
+        run_id = add_run(run)
+        add_edge(run_id, artifact_id, "produces")
+
+        consumed = await _consumed_artifacts_of_run(run)
+        await asyncio.gather(*(_upstream_consumed(run_id, upstream, depth + 1) for upstream in consumed))
+
+    async def _upstream_consumed(run_id: str, a, depth: int) -> None:
+        artifact_id = add_artifact(a)
+        add_edge(artifact_id, run_id, "consumes")
+        await walk_upstream(a, depth)
+
+    async def walk_downstream(a, depth: int) -> None:
+        if depth > max_depth:
+            return
+        artifact_id = add_artifact(a)
+
+        consumer_runs, consumer_apps = await asyncio.gather(
+            _consumer_runs_of_artifact(a, watched_tasks, scan_limit),
+            _consumer_apps_of_artifact(a, watched_apps),
+        )
+
+        for app in consumer_apps:
+            app_node = await _app_to_node(app)
+            graph.nodes.setdefault(app_node.node_id, asdict(app_node))
+            add_edge(artifact_id, app_node.node_id, "consumes")
+
+        for run in consumer_runs:
+            run_id = add_run(run)
+            add_edge(artifact_id, run_id, "consumes")
+            if run.name in seen_runs:
+                continue
+            seen_runs.add(run.name)
+            produced = []
+            try:
+                async for produced_artifact in Artifact.listall.aio(source_run=run.name):
+                    produced.append(produced_artifact)
+            except Exception:
+                logger.exception("Could not list artifacts produced by run %s", run.name)
+            await asyncio.gather(*(_downstream_produced(run_id, p, depth + 1) for p in produced))
+
+    async def _downstream_produced(run_id: str, a, depth: int) -> None:
+        artifact_id = add_artifact(a)
+        add_edge(run_id, artifact_id, "produces")
+        if a.tracker not in seen_artifacts:
+            seen_artifacts.add(a.tracker)
+            await walk_downstream(a, depth)
+
+    await walk_upstream(artifact, 0)
+    await walk_downstream(artifact, 0)
+
+    return graph

--- a/examples/artifacts/lineage/_lineage.py
+++ b/examples/artifacts/lineage/_lineage.py
@@ -193,9 +193,32 @@ async def _consumed_artifacts_of_run(run) -> list:
     return artifacts
 
 
+# Bounds how many RPCs the consumer scan issues at once. Each watched task can fan out
+# to `scan_limit` per-run detail fetches, so without a cap a dashboard watching many
+# tasks would fire a burst the control plane doesn't need to see all at once.
+_SCAN_CONCURRENCY = 16
+
+
+async def _gather_bounded(coros) -> list:
+    sem = asyncio.Semaphore(_SCAN_CONCURRENCY)
+
+    async def _run(coro):
+        async with sem:
+            return await coro
+
+    return await asyncio.gather(*(_run(c) for c in coros))
+
+
 async def _consumer_runs_of_artifact(artifact, watched_tasks: Iterable[str], scan_limit: int) -> list:
     """Runs that consumed `artifact`, found via the fallback label plus (optionally) a
-    bound-input scan over `watched_tasks`'s recent runs."""
+    bound-input scan over `watched_tasks`'s recent runs.
+
+    The label-filtered listing is one RPC regardless of how many tasks are watched. The
+    bound-input scan is the expensive part: naively it's `len(watched_tasks)` listing
+    calls plus one details fetch per unmatched run, and since none of that depends on any
+    other task's results, it's all issued concurrently (bounded by `_SCAN_CONCURRENCY`)
+    rather than one task -- and one run -- at a time.
+    """
     from flyte.remote import Run
 
     by_name: dict[str, object] = {}
@@ -207,16 +230,29 @@ async def _consumer_runs_of_artifact(artifact, watched_tasks: Iterable[str], sca
     async for run in Run.listall.aio(with_labels=label_filter, limit=scan_limit):
         by_name[run.name] = run
 
-    for task_name in watched_tasks:
+    async def _check(run) -> object | None:
+        consumed = await _consumed_artifacts_of_run(run)
+        if any(a.name == artifact.name and a.version == artifact.version for a in consumed):
+            return run
+        return None
+
+    async def _scan_task(task_name: str) -> list:
         try:
-            async for run in Run.listall.aio(task_name=task_name, limit=scan_limit, sort_by=("created_at", "desc")):
-                if run.name in by_name:
-                    continue
-                consumed = await _consumed_artifacts_of_run(run)
-                if any(a.name == artifact.name and a.version == artifact.version for a in consumed):
-                    by_name[run.name] = run
+            candidates = [
+                run
+                async for run in Run.listall.aio(task_name=task_name, limit=scan_limit, sort_by=("created_at", "desc"))
+                if run.name not in by_name
+            ]
         except Exception:
             logger.exception("Consumer scan failed for task %s", task_name)
+            return []
+        matched = await _gather_bounded(_check(run) for run in candidates)
+        return [run for run in matched if run is not None]
+
+    per_task = await asyncio.gather(*(_scan_task(t) for t in watched_tasks))
+    for matched in per_task:
+        for run in matched:
+            by_name[run.name] = run
 
     return list(by_name.values())
 
@@ -224,19 +260,21 @@ async def _consumer_runs_of_artifact(artifact, watched_tasks: Iterable[str], sca
 async def _consumer_apps_of_artifact(artifact, watched_apps: Iterable[str]) -> list:
     from flyte.remote import App
 
-    apps = []
-    for app_name in watched_apps:
+    async def _check(app_name: str) -> object | None:
         try:
             app = await App.get.aio(name=app_name)
         except Exception:
             logger.debug("Could not fetch app %s", app_name, exc_info=True)
-            continue
+            return None
         labels = dict(app.pb2.metadata.labels)
         if labels.get(LABEL_UPSTREAM_ARTIFACT_NAME) == artifact.name and (
             labels.get(LABEL_UPSTREAM_ARTIFACT_VERSION) == artifact.version
         ):
-            apps.append(app)
-    return apps
+            return app
+        return None
+
+    apps = await _gather_bounded(_check(name) for name in watched_apps)
+    return [a for a in apps if a is not None]
 
 
 # Hard ceiling on requested depth, independent of what the UI asks for -- a safety net

--- a/examples/artifacts/lineage/_lineage.py
+++ b/examples/artifacts/lineage/_lineage.py
@@ -20,12 +20,16 @@ the same stamp). See :func:`flyte.types._string_literals.artifact_annotation`.
 Nothing else is knowable automatically — a task that resolves an artifact's
 URI itself (rather than binding the ``Artifact``/``File``/``Dir`` as an input),
 or an ``AppEnvironment`` that reads an artifact at startup, leaves no trace the
-backend can query. For those cases this module falls back to a private label,
-``__upstream_artifact__``, set to the artifact's ``tracker`` string
-(``org/project/domain/name@version``). Runs pick it up via
-``flyte.with_runcontext(labels={LABEL_UPSTREAM_ARTIFACT: artifact.tracker})``
+backend can query. For those cases this module falls back to a pair of private
+labels, ``upstream-artifact-name`` and ``upstream-artifact-version``,
+set to the artifact's ``name``/``version``. Two plain labels rather than one
+composite value (e.g. the artifact's ``tracker`` string) because label
+*values* are constrained (roughly ``[A-Za-z0-9_.-]``, no ``/`` or ``@``) —
+``tracker`` violates that, so runs carrying it as a label are rejected
+outright. Runs pick the labels up via
+``flyte.with_runcontext(labels={LABEL_UPSTREAM_ARTIFACT_NAME: artifact.name, ...})``
 (labels have been a first-class ``with_runcontext`` parameter all along); apps
-pick it up via the ``labels=`` field on ``flyte.app.AppEnvironment``.
+pick them up via the ``labels=`` field on ``flyte.app.AppEnvironment``.
 
 Lineage is not stored anywhere — it is re-derived on every scan from these two
 signals, exactly as the reference ``RunLineageDashboard`` re-derives run
@@ -41,10 +45,12 @@ from typing import Iterable
 
 logger = logging.getLogger(__name__)
 
-# Private label key stamped on runs/apps that consume an artifact in a way the
-# backend can't otherwise see. Value is the artifact's `tracker` string
-# (org/project/domain/name@version).
-LABEL_UPSTREAM_ARTIFACT = "__upstream_artifact__"
+# Label keys stamped on runs/apps that consume an artifact in a way the backend can't
+# otherwise see. Two keys (not one composite value) because label values can't contain
+# `/` or `@` -- see the module docstring. Kubernetes label names must start and end with
+# an alphanumeric character, which also rules out a `__dunder__`-style "private" key.
+LABEL_UPSTREAM_ARTIFACT_NAME = "upstream-artifact-name"
+LABEL_UPSTREAM_ARTIFACT_VERSION = "upstream-artifact-version"
 
 _TERMINAL_PHASES = {"succeeded", "failed", "aborted", "timed_out"}
 
@@ -155,11 +161,13 @@ async def _consumed_artifacts_of_run(run) -> list:
     """
     from flyte.remote import Artifact
 
-    trackers: set[str] = set()
+    identities: set[tuple[str, str]] = set()
 
-    label_value = dict(run.pb2.labels).get(LABEL_UPSTREAM_ARTIFACT) if run.pb2.labels else None
-    if label_value:
-        trackers.add(label_value)
+    labels = dict(run.pb2.labels) if run.pb2.labels else {}
+    label_name = labels.get(LABEL_UPSTREAM_ARTIFACT_NAME)
+    label_version = labels.get(LABEL_UPSTREAM_ARTIFACT_VERSION)
+    if label_name and label_version:
+        identities.add((label_name, label_version))
 
     try:
         literals = await run.input_literals.aio()
@@ -168,17 +176,14 @@ async def _consumed_artifacts_of_run(run) -> list:
         literals = {}
     for lit in literals.values():
         if lit.HasField("artifact_id"):
-            key = lit.artifact_id.key
-            trackers.add(f"{key.org}/{key.project}/{key.domain}/{key.name}@{lit.artifact_id.version}")
+            identities.add((lit.artifact_id.key.name, lit.artifact_id.version))
 
     artifacts = []
-    for tracker in trackers:
+    for name, version in identities:
         try:
-            _org, project, domain, rest = tracker.split("/", 3)
-            name, version = rest.rsplit("@", 1)
-            artifacts.append(await Artifact.get.aio(name=name, version=version, project=project, domain=domain))
+            artifacts.append(await Artifact.get.aio(name=name, version=version))
         except Exception:
-            logger.debug("Could not resolve consumed artifact %s", tracker, exc_info=True)
+            logger.debug("Could not resolve consumed artifact %s@%s", name, version, exc_info=True)
     return artifacts
 
 
@@ -188,8 +193,12 @@ async def _consumer_runs_of_artifact(artifact, watched_tasks: Iterable[str], sca
     from flyte.remote import Run
 
     by_name: dict[str, object] = {}
+    label_filter = {
+        LABEL_UPSTREAM_ARTIFACT_NAME: artifact.name,
+        LABEL_UPSTREAM_ARTIFACT_VERSION: artifact.version,
+    }
 
-    async for run in Run.listall.aio(with_labels={LABEL_UPSTREAM_ARTIFACT: artifact.tracker}, limit=scan_limit):
+    async for run in Run.listall.aio(with_labels=label_filter, limit=scan_limit):
         by_name[run.name] = run
 
     for task_name in watched_tasks:
@@ -198,7 +207,7 @@ async def _consumer_runs_of_artifact(artifact, watched_tasks: Iterable[str], sca
                 if run.name in by_name:
                     continue
                 consumed = await _consumed_artifacts_of_run(run)
-                if any(a.tracker == artifact.tracker for a in consumed):
+                if any(a.name == artifact.name and a.version == artifact.version for a in consumed):
                     by_name[run.name] = run
         except Exception:
             logger.exception("Consumer scan failed for task %s", task_name)
@@ -216,7 +225,10 @@ async def _consumer_apps_of_artifact(artifact, watched_apps: Iterable[str]) -> l
         except Exception:
             logger.debug("Could not fetch app %s", app_name, exc_info=True)
             continue
-        if dict(app.pb2.metadata.labels).get(LABEL_UPSTREAM_ARTIFACT) == artifact.tracker:
+        labels = dict(app.pb2.metadata.labels)
+        if labels.get(LABEL_UPSTREAM_ARTIFACT_NAME) == artifact.name and (
+            labels.get(LABEL_UPSTREAM_ARTIFACT_VERSION) == artifact.version
+        ):
             apps.append(app)
     return apps
 
@@ -240,8 +252,8 @@ async def build_artifact_lineage(
       turn produced, their consumers, and so on.
 
     `watched_tasks`/`watched_apps` (task/app names) opt into the bound-input scan for
-    consumer discovery beyond what the `__upstream_artifact__` label already finds —
-    see the module docstring for why that scan can't be global.
+    consumer discovery beyond what the `upstream-artifact-name`/`upstream-artifact-version` labels
+    already find — see the module docstring for why that scan can't be global.
     """
     from flyte.remote import Artifact, Run
 

--- a/examples/artifacts/lineage/dashboard.py
+++ b/examples/artifacts/lineage/dashboard.py
@@ -107,6 +107,7 @@ def _render_dashboard_html(
     min-height: 32px;
   }}
   .main-head h2 {{ font-size: 1.05rem; margin: 0; font-weight: 600; }}
+  .title-group {{ flex: 1; display: flex; align-items: center; gap: 14px; min-width: 0; }}
   .main-head .version {{
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; color: var(--muted);
     background: #1c1c22; border: 1px solid #2a2a33; border-radius: 999px; padding: 2px 9px;
@@ -119,6 +120,9 @@ def _render_dashboard_html(
   .main-head .console-link:hover {{ color: var(--text); border-color: #4d4d59; }}
   .legend {{ display: flex; gap: 12px; font-size: 10.5px; color: var(--muted); flex: none; }}
   .legend .dot {{ display: inline-block; width: 7px; height: 7px; border-radius: 999px; margin-right: 4px; }}
+  .legend .dot.artifact {{ background: var(--artifact); }}
+  .legend .dot.run {{ background: var(--run); }}
+  .legend .dot.app {{ background: var(--app); }}
   .canvas {{ flex: 1; position: relative; background: #101015; }}
   .placeholder {{
     position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
@@ -165,6 +169,17 @@ def _render_dashboard_html(
 <div id="shell">
   <div class="placeholder" style="position:static;height:100%;">Loading…</div>
 </div>
+<script type="importmap">
+{{
+  "imports": {{
+    "react": "https://esm.sh/react@18.3.1",
+    "react-dom/client": "https://esm.sh/react-dom@18.3.1/client?deps=react@18.3.1",
+    "@xyflow/react": "https://esm.sh/@xyflow/react@12.8.2?deps=react@18.3.1,react-dom@18.3.1",
+    "@dagrejs/dagre": "https://esm.sh/@dagrejs/dagre@1.1.4",
+    "htm": "https://esm.sh/htm@3.1.1"
+  }}
+}}
+</script>
 <script id="lineage-data" type="application/json">{boot_json}</script>
 <script type="module">
 try {{
@@ -222,9 +237,9 @@ try {{
 
   const Legend = () => html`
     <div class="legend">
-      <span><span class="dot" style="background:var(--artifact)"></span>artifact</span>
-      <span><span class="dot" style="background:var(--run)"></span>run</span>
-      <span><span class="dot" style="background:var(--app)"></span>app</span>
+      <span><span class="dot artifact"></span>artifact</span>
+      <span><span class="dot run"></span>run</span>
+      <span><span class="dot app"></span>app</span>
     </div>`;
 
   const Sidebar = ({{ artifacts, filter, onFilter, selected, onSelect }}) => {{
@@ -293,24 +308,26 @@ try {{
     const rootNode = graph ? graph.nodes[graph.root] : null;
 
     return html`
-      <${{Sidebar}} artifacts=${{artifacts}} filter=${{filter}} onFilter=${{setFilter}}
+      <${{Sidebar}} key="sidebar" artifacts=${{artifacts}} filter=${{filter}} onFilter=${{setFilter}}
           selected=${{selected}} onSelect=${{(name) => select(name)}} />
-      <div class="main">
+      <div key="main" class="main">
         <div class="main-head">
           ${{rootNode ? html`
-            <h2>${{rootNode.name}}</h2>
-            <span class="version">${{rootNode.version}}</span>
-            ${{rootNode.description ? html`<span class="desc">${{rootNode.description}}</span>` : null}}
-            ${{rootNode.url ? html`<a class="console-link" target="_blank" rel="noopener"
-                href=${{CONSOLE_BASE + rootNode.url}}>Open in console ↗</a>` : null}}
-          ` : html`<h2>Select an artifact</h2>`}}
-          <${{Legend}} />
+            <div key="title" class="title-group">
+              <h2>${{rootNode.name}}</h2>
+              <span class="version">${{rootNode.version}}</span>
+              ${{rootNode.description ? html`<span class="desc">${{rootNode.description}}</span>` : null}}
+              ${{rootNode.url ? html`<a class="console-link" target="_blank" rel="noopener"
+                  href=${{CONSOLE_BASE + rootNode.url}}>Open in console ↗</a>` : null}}
+            </div>
+          ` : html`<h2 key="title">Select an artifact</h2>`}}
+          <${{Legend}} key="legend" />
         </div>
         <div class="canvas">
-          ${{status === "idle" ? html`<div class="placeholder">
+          ${{status === "idle" ? html`<div key="idle" class="placeholder">
               Select an artifact from the sidebar to view its lineage.</div>` : null}}
-          ${{status === "loading" ? html`<div class="placeholder">Loading lineage…</div>` : null}}
-          ${{status === "error" ? html`<div class="placeholder">Could not build the lineage graph —
+          ${{status === "loading" ? html`<div key="loading" class="placeholder">Loading lineage…</div>` : null}}
+          ${{status === "error" ? html`<div key="error" class="placeholder">Could not build the lineage graph —
               is the artifact name/version correct? Check app logs.</div>` : null}}
           ${{status === "ok" ? html`
             <${{ReactFlow}} key=${{selected.name + ":" + selected.version}} nodes=${{flowNodes}}

--- a/examples/artifacts/lineage/dashboard.py
+++ b/examples/artifacts/lineage/dashboard.py
@@ -1,11 +1,18 @@
 """ArtifactLineageAppEnvironment — dashboard app for artifact lineage.
 
-Renders, for any published artifact, the full chain of producers and
-consumers around it: walk upstream to the original run/artifact that started
-the chain, and downstream through every run, artifact, and app that consumed
-it (directly or transitively). See `_lineage.py` for how the graph is built
-and why two signals (bound-input literals, and the `upstream-artifact-name`/
+Renders, for any published artifact, the chain of producers and consumers
+around it: upstream to the run/artifact that started the chain, and
+downstream through every run, artifact, and app that consumed it (directly or
+transitively). See `_lineage.py` for how the graph is built and why two
+signals (bound-input literals, and the `upstream-artifact-name`/
 `upstream-artifact-version` labels) are both needed.
+
+The graph loads incrementally: the initial view is one hop upstream and one
+hop downstream from the selected artifact (see `build_artifact_lineage`'s
+`upstream_depth`/`downstream_depth`), with "load more" buttons on the canvas
+to walk further in either direction on demand -- the downstream walk in
+particular can be expensive per hop, so starting shallow keeps the common case
+fast.
 
 A single page (`GET /lineage`) does everything: a searchable sidebar lists
 every published artifact, and clicking one renders its lineage graph inline
@@ -18,6 +25,7 @@ Endpoints:
   redirect to the same thing, for direct links)
 - `GET /lineage/artifacts` — every published artifact, as JSON (sidebar data)
 - `GET /lineage/graph/{name}` — one artifact's lineage graph, as JSON
+  (`?upstream_depth=`/`&downstream_depth=`, both default 1)
 """
 
 from __future__ import annotations
@@ -41,13 +49,11 @@ def _html_escape(text: str) -> str:
 
 def _render_dashboard_html(
     title: str,
-    console_base: str,
     *,
     artifacts_url: str = "/lineage/artifacts",
     graph_url_base: str = "/lineage/graph",
     preselect: dict | None = None,
 ) -> str:
-    base = console_base.rstrip("/")
     boot = {"preselect": preselect, "artifactsUrl": artifacts_url, "graphUrlBase": graph_url_base}
     boot_json = json.dumps(boot).replace("</", "<\\/")
     return f"""<!DOCTYPE html>
@@ -128,6 +134,16 @@ def _render_dashboard_html(
     position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
     color: var(--muted); font-size: 0.85rem; text-align: center; padding: 2rem; flex-direction: column; gap: 6px;
   }}
+  .expand-btn {{
+    position: absolute; top: 12px; z-index: 5; display: flex; align-items: center; gap: 6px;
+    background: var(--card); border: 1px solid var(--card-border); color: var(--text);
+    font-size: 11.5px; padding: 6px 12px; border-radius: 999px; cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+  }}
+  .expand-btn:hover {{ border-color: var(--accent); }}
+  .expand-btn:disabled {{ opacity: 0.4; cursor: default; }}
+  .expand-btn.upstream {{ left: 12px; }}
+  .expand-btn.downstream {{ right: 12px; }}
   .react-flow__controls {{ box-shadow: none; border: 1px solid #2a2a33; border-radius: 8px; overflow: hidden; }}
   .react-flow__controls-button {{ background: var(--card); border-bottom: 1px solid #2a2a33; fill: var(--muted); }}
   .react-flow__edge-path {{ stroke: #4a4a55; }}
@@ -192,13 +208,12 @@ try {{
   const html = htm.bind(React.createElement);
 
   const BOOT = JSON.parse(document.getElementById("lineage-data").textContent);
-  const CONSOLE_BASE = {json.dumps(base)};
   const NODE_W = 226, NODE_H = 74;
 
   const LinNode = ({{ data }}) => html`
     <div class="lin-card ${{data.kind}} ${{data.isRoot ? "root" : ""}}"
          title=${{data.title}}
-         onClick=${{() => data.url && window.open(CONSOLE_BASE + data.url, "_blank")}}>
+         onClick=${{() => data.url && window.open(data.url, "_blank")}}>
       <${{Handle}} type="target" position=${{Position.Left}} style=${{{{ opacity: 0 }}}} />
       <div class="kind">${{data.kind}}</div>
       <div class="title">${{data.title}}</div>
@@ -272,10 +287,17 @@ try {{
       </aside>`;
   }};
 
+  // Depth starts at 1 ("one step" in each direction) and grows only when the user asks
+  // for more -- the downstream walk in particular can issue several RPCs per hop, so an
+  // upfront deep walk is slow. See build_artifact_lineage()'s docstring in _lineage.py.
+  const DEFAULT_DEPTH = 1;
+
   const App = () => {{
     const [artifacts, setArtifacts] = React.useState([]);
     const [filter, setFilter] = React.useState("");
     const [selected, setSelected] = React.useState(BOOT.preselect || null);
+    const [upstreamDepth, setUpstreamDepth] = React.useState(DEFAULT_DEPTH);
+    const [downstreamDepth, setDownstreamDepth] = React.useState(DEFAULT_DEPTH);
     const [graph, setGraph] = React.useState(null);
     const [status, setStatus] = React.useState(selected ? "loading" : "idle");
 
@@ -287,6 +309,8 @@ try {{
 
     const select = React.useCallback((name, version) => {{
       setSelected({{ name, version: version || "latest" }});
+      setUpstreamDepth(DEFAULT_DEPTH);
+      setDownstreamDepth(DEFAULT_DEPTH);
       const qs = version && version !== "latest" ? `?version=${{encodeURIComponent(version)}}` : "";
       history.replaceState(null, "", `/lineage/artifact/${{encodeURIComponent(name)}}${{qs}}`);
     }}, []);
@@ -294,18 +318,20 @@ try {{
     React.useEffect(() => {{
       if (!selected) return;
       setStatus("loading");
-      const v = selected.version && selected.version !== "latest" ? `?version=${{selected.version}}` : "";
-      fetch(`${{BOOT.graphUrlBase}}/${{encodeURIComponent(selected.name)}}${{v}}`, {{ cache: "no-store" }})
+      const params = new URLSearchParams({{ upstream_depth: upstreamDepth, downstream_depth: downstreamDepth }});
+      if (selected.version && selected.version !== "latest") params.set("version", selected.version);
+      fetch(`${{BOOT.graphUrlBase}}/${{encodeURIComponent(selected.name)}}?${{params}}`, {{ cache: "no-store" }})
         .then((r) => {{ if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); }})
         .then((g) => {{ setGraph(g); setStatus("ok"); }})
         .catch((e) => {{ console.warn("graph fetch failed", e); setStatus("error"); }});
-    }}, [selected]);
+    }}, [selected, upstreamDepth, downstreamDepth]);
 
     const {{ flowNodes, flowEdges }} = React.useMemo(
       () => (graph ? layout(graph.nodes, graph.edges, graph.root) : {{ flowNodes: [], flowEdges: [] }}),
       [graph]
     );
     const rootNode = graph ? graph.nodes[graph.root] : null;
+    const loading = status === "loading";
 
     return html`
       <${{Sidebar}} key="sidebar" artifacts=${{artifacts}} filter=${{filter}} onFilter=${{setFilter}}
@@ -318,7 +344,7 @@ try {{
               <span class="version">${{rootNode.version}}</span>
               ${{rootNode.description ? html`<span class="desc">${{rootNode.description}}</span>` : null}}
               ${{rootNode.url ? html`<a class="console-link" target="_blank" rel="noopener"
-                  href=${{CONSOLE_BASE + rootNode.url}}>Open in console ↗</a>` : null}}
+                  href=${{rootNode.url}}>Open in console ↗</a>` : null}}
             </div>
           ` : html`<h2 key="title">Select an artifact</h2>`}}
           <${{Legend}} key="legend" />
@@ -326,11 +352,24 @@ try {{
         <div class="canvas">
           ${{status === "idle" ? html`<div key="idle" class="placeholder">
               Select an artifact from the sidebar to view its lineage.</div>` : null}}
-          ${{status === "loading" ? html`<div key="loading" class="placeholder">Loading lineage…</div>` : null}}
+          ${{status === "loading" && !graph
+            ? html`<div key="loading" class="placeholder">Loading lineage…</div>`
+            : null}}
           ${{status === "error" ? html`<div key="error" class="placeholder">Could not build the lineage graph —
               is the artifact name/version correct? Check app logs.</div>` : null}}
-          ${{status === "ok" ? html`
-            <${{ReactFlow}} key=${{selected.name + ":" + selected.version}} nodes=${{flowNodes}}
+          ${{graph && (status === "ok" || loading) ? html`
+            <button key="up" class="expand-btn upstream" disabled=${{loading || !graph.has_more_upstream}}
+                onClick=${{() => setUpstreamDepth((d) => d + 1)}}>
+              ← ${{loading ? "Loading…" : (graph.has_more_upstream ? "Load more upstream" : "Origin reached")}}
+            </button>
+            <button key="down" class="expand-btn downstream" disabled=${{loading || !graph.has_more_downstream}}
+                onClick=${{() => setDownstreamDepth((d) => d + 1)}}>
+              ${{loading
+                ? "Loading…"
+                : (graph.has_more_downstream ? "Load more downstream" : "No further consumers")}} →
+            </button>
+            <${{ReactFlow}} key=${{selected.name + ":" + selected.version + ":" + Object.keys(graph.nodes).length}}
+                nodes=${{flowNodes}}
                 edges=${{flowEdges}} nodeTypes=${{nodeTypes}}
                 fitView fitViewOptions=${{{{ padding: 0.15, maxZoom: 1 }}}} minZoom=${{0.2}}
                 proOptions=${{{{ hideAttribution: true }}}} nodesConnectable=${{false}} colorMode="dark">
@@ -351,16 +390,6 @@ try {{
 </script>
 </body>
 </html>"""
-
-
-def _derive_console_base() -> str:
-    try:
-        from flyte._initialize import get_client
-
-        url = get_client().console.run_url(project="p", domain="d", run_name="r")
-        return url.split("/v2/", 1)[0]
-    except Exception:
-        return ""
 
 
 def _ensure_client() -> None:
@@ -395,16 +424,13 @@ class ArtifactLineageAppEnvironment(FastAPIAppEnvironment):
     # `upstream-artifact-name`/`upstream-artifact-version` labels already find (see `_lineage.py`).
     watched_tasks: list[str] = field(default_factory=list)
     watched_apps: list[str] = field(default_factory=list)
-    scan_limit: int = 50
-    max_depth: int = 25
-    console_base: str = ""
+    # Per-task run-scan cap during downstream consumer discovery -- not a lineage depth
+    # control (see `upstream_depth`/`downstream_depth` on `/lineage/graph/{name}`).
+    scan_limit: int = 20
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "app", self._build_fastapi_app())
         super().__post_init__()
-
-    def _console_base(self) -> str:
-        return self.console_base or _derive_console_base()
 
     async def _artifact_groups(self) -> list[dict]:
         from flyte.remote import Artifact
@@ -426,7 +452,7 @@ class ArtifactLineageAppEnvironment(FastAPIAppEnvironment):
 
         return await Artifact.get.aio(name=name, version=version)
 
-    async def _graph_json(self, name: str, version: str) -> dict:
+    async def _graph_json(self, name: str, version: str, *, upstream_depth: int, downstream_depth: int) -> dict:
         from dataclasses import asdict
 
         _ensure_client()
@@ -436,7 +462,8 @@ class ArtifactLineageAppEnvironment(FastAPIAppEnvironment):
             watched_tasks=self.watched_tasks,
             watched_apps=self.watched_apps,
             scan_limit=self.scan_limit,
-            max_depth=self.max_depth,
+            upstream_depth=upstream_depth,
+            downstream_depth=downstream_depth,
         )
         return asdict(graph)
 
@@ -459,7 +486,7 @@ class ArtifactLineageAppEnvironment(FastAPIAppEnvironment):
         @app.get("/lineage", response_class=fastapi.responses.HTMLResponse)
         async def lineage_page(artifact: str = "", version: str = "latest") -> str:
             preselect = {"name": artifact, "version": version} if artifact else None
-            return _render_dashboard_html(env.name, env._console_base(), preselect=preselect)
+            return _render_dashboard_html(env.name, preselect=preselect)
 
         @app.get("/lineage/artifacts")
         async def lineage_artifacts() -> list[dict]:
@@ -471,11 +498,15 @@ class ArtifactLineageAppEnvironment(FastAPIAppEnvironment):
                 return []
 
         @app.get("/lineage/graph/{name}")
-        async def lineage_graph(name: str, version: str = "latest") -> dict:
-            return await env._graph_json(name, version)
+        async def lineage_graph(
+            name: str, version: str = "latest", upstream_depth: int = 1, downstream_depth: int = 1
+        ) -> dict:
+            return await env._graph_json(
+                name, version, upstream_depth=upstream_depth, downstream_depth=downstream_depth
+            )
 
         @app.get("/lineage/artifact/{name}", response_class=fastapi.responses.HTMLResponse)
         async def lineage_artifact(name: str, version: str = "latest") -> str:
-            return _render_dashboard_html(env.name, env._console_base(), preselect={"name": name, "version": version})
+            return _render_dashboard_html(env.name, preselect={"name": name, "version": version})
 
         return app

--- a/examples/artifacts/lineage/dashboard.py
+++ b/examples/artifacts/lineage/dashboard.py
@@ -1,0 +1,381 @@
+"""ArtifactLineageAppEnvironment — dashboard app for artifact lineage.
+
+Renders, for any published artifact, the full chain of producers and
+consumers around it: walk upstream to the original run/artifact that started
+the chain, and downstream through every run, artifact, and app that consumed
+it (directly or transitively). See `_lineage.py` for how the graph is built
+and why two signals (bound-input literals, and the `__upstream_artifact__`
+label) are both needed.
+
+Endpoints:
+
+- `GET /lineage` — list of published artifacts (click through to a graph)
+- `GET /lineage/artifact/{name}` — lineage graph for one artifact, as HTML
+  (`?version=` selects a version; defaults to latest)
+- `GET /lineage/graph/{name}` — the same lineage graph as JSON
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+
+import fastapi
+
+from flyte.app.extras import FastAPIAppEnvironment
+
+from ._lineage import LABEL_UPSTREAM_ARTIFACT, build_artifact_lineage
+
+logger = logging.getLogger(__name__)
+
+
+def _html_escape(text: str) -> str:
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
+
+
+def _render_artifact_list_html(groups: list, title: str) -> str:
+    rows = "".join(
+        f"""<a class="row" href="/lineage/artifact/{_html_escape(g["name"])}">
+              <span class="name">{_html_escape(g["name"])}</span>
+              <span class="version mono">{_html_escape(g["latest_version"])}</span>
+              <span class="count">{g["versions"]} version{"s" if g["versions"] != 1 else ""}</span>
+              <span class="desc">{_html_escape(g["description"])}</span>
+            </a>"""
+        for g in groups
+    )
+    empty = '<p class="empty">No artifacts published yet.</p>' if not groups else ""
+    return f"""<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>{_html_escape(title)}</title>
+<style>
+  :root {{ --bg: #0a0a0f; --panel: #131318; --card: #1c1c22; --card-border: #33333c;
+           --text: #e7e7ea; --muted: #8a8a94; --accent: #a98fd1; }}
+  * {{ box-sizing: border-box; }}
+  body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+          margin: 0; background: var(--bg); color: var(--text); }}
+  header {{ padding: 1.2rem 2rem 0.6rem; }}
+  h1 {{ font-size: 1.15rem; margin: 0; font-weight: 600; }}
+  .sub {{ color: var(--muted); font-size: 0.8rem; margin: 0.35rem 0 0; }}
+  .sub code {{ background: #1e1e25; padding: 0 0.3rem; border-radius: 4px; }}
+  main {{ padding: 0.8rem 2rem 2rem; max-width: 920px; }}
+  .row {{ display: flex; align-items: center; gap: 14px; padding: 12px 14px;
+          background: var(--card); border: 1px solid var(--card-border); border-radius: 10px;
+          margin-bottom: 8px; text-decoration: none; color: var(--text); transition: border-color 0.15s; }}
+  .row:hover {{ border-color: var(--accent); }}
+  .name {{ font-weight: 600; font-size: 13.5px; min-width: 220px; }}
+  .version {{ color: var(--muted); font-size: 11.5px; min-width: 90px; }}
+  .count {{ color: var(--muted); font-size: 11px; background: #26262e; border-radius: 999px;
+            padding: 2px 9px; flex: none; }}
+  .desc {{ color: var(--muted); font-size: 12px; overflow: hidden; text-overflow: ellipsis;
+           white-space: nowrap; }}
+  .mono {{ font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }}
+  .empty {{ color: var(--muted); font-size: 13px; }}
+</style>
+</head>
+<body>
+<header>
+  <h1>{_html_escape(title)}</h1>
+  <p class="sub">Click an artifact to trace its lineage — every producer back to the origin,
+  every consumer downstream. Built live from artifact provenance and the
+  <code>{LABEL_UPSTREAM_ARTIFACT}</code> label — no stored lineage state.</p>
+</header>
+<main>{empty}{rows}</main>
+</body>
+</html>"""
+
+
+def _render_graph_html(graph_json: dict, title: str, console_base: str, graph_url: str) -> str:
+    base = console_base.rstrip("/")
+    boot_json = json.dumps(graph_json).replace("</", "<\\/")
+    return f"""<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>{_html_escape(title)}</title>
+<link rel="stylesheet" href="https://unpkg.com/@xyflow/react@12.8.2/dist/style.css"/>
+<style>
+  :root {{
+    --bg: #0a0a0f; --panel: #131318; --card: #1c1c22; --card-border: #33333c;
+    --text: #e7e7ea; --muted: #8a8a94;
+    --artifact: #a98fd1; --run: #f59e0b; --app: #38bdf8;
+  }}
+  * {{ box-sizing: border-box; }}
+  body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+          margin: 0; background: var(--bg); color: var(--text); }}
+  header {{ padding: 1.2rem 2rem 0.6rem; display: flex; align-items: center; gap: 14px; }}
+  h1 {{ font-size: 1.15rem; margin: 0; font-weight: 600; }}
+  .back {{ color: var(--muted); text-decoration: none; font-size: 0.8rem; border: 1px solid #2a2a33;
+           border-radius: 8px; padding: 5px 12px; }}
+  .back:hover {{ color: var(--text); border-color: #4d4d59; }}
+  .legend {{ margin-left: auto; display: flex; gap: 14px; font-size: 11.5px; color: var(--muted); }}
+  .legend .dot {{ display: inline-block; width: 8px; height: 8px; border-radius: 999px; margin-right: 5px; }}
+  main {{ padding: 0.8rem 2rem 1.2rem; }}
+  #app {{ height: 78vh; min-height: 460px; border: 1px solid #23232b; border-radius: 12px; background: #101015; }}
+  .fallback {{ display: flex; height: 100%; align-items: center; justify-content: center;
+               color: var(--muted); font-size: 0.85rem; }}
+  .react-flow__controls {{ box-shadow: none; border: 1px solid #2a2a33; border-radius: 8px; overflow: hidden; }}
+  .react-flow__controls-button {{ background: var(--card); border-bottom: 1px solid #2a2a33; fill: var(--muted); }}
+  .react-flow__edge-path {{ stroke: #4a4a55; }}
+  .react-flow__edge-textbg {{ fill: #101015; }}
+  .react-flow__edge-text {{ fill: var(--muted); font-size: 10px; }}
+  .react-flow__attribution {{ background: transparent; color: #55555f; }}
+  .lin-card {{ width: 236px; background: var(--card); border: 1px solid var(--card-border);
+               border-radius: 10px; padding: 10px 12px; cursor: pointer; border-left-width: 3px; }}
+  .lin-card:hover {{ border-color: #4d4d59; }}
+  .lin-card.artifact {{ border-left-color: var(--artifact); }}
+  .lin-card.artifact.root {{ border-color: var(--artifact); }}
+  .lin-card.run {{ border-left-color: var(--run); }}
+  .lin-card.app {{ border-left-color: var(--app); }}
+  .lin-card .kind {{ font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); }}
+  .lin-card .title {{ font-size: 12.5px; font-weight: 600; margin-top: 2px; white-space: nowrap;
+                       overflow: hidden; text-overflow: ellipsis; }}
+  .lin-card .sub {{ font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 10.5px;
+                     color: var(--muted); margin-top: 5px; white-space: nowrap; overflow: hidden;
+                     text-overflow: ellipsis; }}
+  .lin-card .pill {{ display: inline-block; margin-top: 6px; font-size: 9.5px; padding: 1px 7px;
+                      border-radius: 999px; text-transform: capitalize; }}
+  .pill.succeeded {{ background: rgba(22,163,74,0.15); color: #4ade80; }}
+  .pill.failed, .pill.aborted, .pill.timed_out {{ background: rgba(220,38,38,0.15); color: #f87171; }}
+  .pill.running {{ background: rgba(2,132,199,0.18); color: #60a5fa; }}
+  .pill.queued, .pill.initializing, .pill.waiting_for_resources {{
+    background: rgba(148,148,160,0.15); color: #a1a1ab;
+  }}
+</style>
+</head>
+<body>
+<header>
+  <a class="back" href="/lineage">&larr; All artifacts</a>
+  <h1>{_html_escape(title)}</h1>
+  <div class="legend">
+    <span><span class="dot" style="background:var(--artifact)"></span>artifact</span>
+    <span><span class="dot" style="background:var(--run)"></span>run</span>
+    <span><span class="dot" style="background:var(--app)"></span>app</span>
+  </div>
+</header>
+<main>
+  <div id="app"><div class="fallback">Lineage graph could not render (CDN unreachable?) — see the
+    <a href="{_html_escape(graph_url)}">raw graph JSON</a>.</div></div>
+</main>
+<script type="importmap">
+{{
+  "imports": {{
+    "react": "https://esm.sh/react@18.3.1",
+    "react-dom/client": "https://esm.sh/react-dom@18.3.1/client?deps=react@18.3.1",
+    "@xyflow/react": "https://esm.sh/@xyflow/react@12.8.2?deps=react@18.3.1,react-dom@18.3.1",
+    "@dagrejs/dagre": "https://esm.sh/@dagrejs/dagre@1.1.4",
+    "htm": "https://esm.sh/htm@3.1.1"
+  }}
+}}
+</script>
+<script id="lineage-data" type="application/json">{boot_json}</script>
+<script type="module">
+try {{
+  const React = (await import("react")).default;
+  const {{ createRoot }} = await import("react-dom/client");
+  const {{ ReactFlow, Background, BackgroundVariant, Controls, Handle, Position, MarkerType }} =
+    await import("@xyflow/react");
+  const dagre = (await import("@dagrejs/dagre")).default;
+  const htm = (await import("htm")).default;
+  const html = htm.bind(React.createElement);
+
+  const GRAPH = JSON.parse(document.getElementById("lineage-data").textContent);
+  const CONSOLE_BASE = {json.dumps(base)};
+  const NODE_W = 236, NODE_H = 74;
+
+  const LinNode = ({{ data }}) => html`
+    <div class="lin-card ${{data.kind}} ${{data.isRoot ? "root" : ""}}"
+         title=${{data.title}}
+         onClick=${{() => data.url && window.open(CONSOLE_BASE + data.url, "_blank")}}>
+      <${{Handle}} type="target" position=${{Position.Left}} style=${{{{ opacity: 0 }}}} />
+      <div class="kind">${{data.kind}}</div>
+      <div class="title">${{data.title}}</div>
+      <div class="sub">${{data.sub}}</div>
+      ${{data.phase ? html`<span class="pill ${{data.phase}}">${{data.phase}}</span>` : null}}
+      <${{Handle}} type="source" position=${{Position.Right}} style=${{{{ opacity: 0 }}}} />
+    </div>`;
+  const nodeTypes = {{ lineage: LinNode }};
+
+  function layout(nodesById, edges, rootId) {{
+    const g = new dagre.graphlib.Graph();
+    g.setGraph({{ rankdir: "LR", nodesep: 30, ranksep: 90 }});
+    g.setDefaultEdgeLabel(() => ({{}}));
+    Object.keys(nodesById).forEach((id) => g.setNode(id, {{ width: NODE_W, height: NODE_H }}));
+    edges.forEach((e) => g.setEdge(e.source, e.target));
+    dagre.layout(g);
+
+    const flowNodes = Object.entries(nodesById).map(([id, n]) => {{
+      const p = g.node(id);
+      let title = "", sub = "", url = "";
+      if (n.kind === "artifact") {{ title = n.name; sub = n.version; url = n.url; }}
+      else if (n.kind === "run") {{ title = (n.task_name || "?").split(".").pop(); sub = n.run_name; url = n.url; }}
+      else {{ title = n.app_name; sub = n.endpoint || ""; url = n.url; }}
+      return {{
+        id, type: "lineage", position: {{ x: p.x - NODE_W / 2, y: p.y - NODE_H / 2 }},
+        data: {{ kind: n.kind, title, sub, url, phase: n.phase || "", isRoot: id === rootId }},
+      }};
+    }});
+    const flowEdges = edges.map((e, i) => ({{
+      id: "e" + i, source: e.source, target: e.target, type: "smoothstep",
+      label: e.relation, style: e.relation === "consumes" ? {{ strokeDasharray: "4 3" }} : undefined,
+      markerEnd: {{ type: MarkerType.ArrowClosed, color: "#4a4a55", width: 16, height: 16 }},
+    }}));
+    return {{ flowNodes, flowEdges }};
+  }}
+
+  const {{ flowNodes, flowEdges }} = layout(GRAPH.nodes, GRAPH.edges, GRAPH.root);
+  const App = () => html`
+    <${{ReactFlow}} nodes=${{flowNodes}} edges=${{flowEdges}} nodeTypes=${{nodeTypes}}
+        fitView fitViewOptions=${{{{ padding: 0.15, maxZoom: 1 }}}} minZoom=${{0.2}}
+        proOptions=${{{{ hideAttribution: true }}}} nodesConnectable=${{false}} colorMode="dark">
+      <${{Background}} variant=${{BackgroundVariant.Dots}} gap=${{22}} size=${{1.4}} color="#26262e" />
+      <${{Controls}} showInteractive=${{false}} />
+    <//>`;
+  createRoot(document.getElementById("app")).render(html`<${{App}} />`);
+}} catch (err) {{
+  console.error(err);
+}}
+</script>
+</body>
+</html>"""
+
+
+def _derive_console_base() -> str:
+    try:
+        from flyte._initialize import get_client
+
+        url = get_client().console.run_url(project="p", domain="d", run_name="r")
+        return url.split("/v2/", 1)[0]
+    except Exception:
+        return ""
+
+
+def _ensure_client() -> None:
+    from flyte._initialize import ensure_client
+
+    ensure_client()
+
+
+@dataclass(kw_only=True)
+class ArtifactLineageAppEnvironment(FastAPIAppEnvironment):
+    """AppEnvironment serving a dashboard of artifact producer/consumer lineage.
+
+    Given the name of a published artifact, renders the graph of everything
+    connected to it: every run that produced an ancestor artifact (traced back
+    to the original run/artifact in the chain) and every run, artifact, or app
+    downstream of it. See `_lineage.build_artifact_lineage` for how the graph
+    is assembled, and the module docstring in `_lineage.py` for why some
+    consumers need the `__upstream_artifact__` label to be discoverable at all.
+
+    ```python
+    lineage_app = ArtifactLineageAppEnvironment(
+        name="artifact-lineage",
+        watched_tasks=["artifact_lineage_example.consume", "artifact_lineage_example.re_export"],
+        watched_apps=["artifact-lineage-consumer-app"],
+    )
+    ```
+    """
+
+    app: fastapi.FastAPI = field(default_factory=fastapi.FastAPI)
+    # Task/app names to include in the bound-input consumer scan, beyond what the
+    # `__upstream_artifact__` label already finds on its own (see `_lineage.py`).
+    watched_tasks: list[str] = field(default_factory=list)
+    watched_apps: list[str] = field(default_factory=list)
+    scan_limit: int = 50
+    max_depth: int = 25
+    console_base: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "app", self._build_fastapi_app())
+        super().__post_init__()
+
+    def _console_base(self) -> str:
+        return self.console_base or _derive_console_base()
+
+    async def _artifact_groups(self) -> list[dict]:
+        from flyte.remote import Artifact
+
+        groups = []
+        async for group in Artifact.list_names.aio():
+            groups.append(
+                {
+                    "name": group.name,
+                    "latest_version": group.latest.version,
+                    "versions": group.versions,
+                    "description": group.pb2.latest.spec.info.description or "",
+                }
+            )
+        return groups
+
+    async def _resolve_artifact(self, name: str, version: str = "latest"):
+        from flyte.remote import Artifact
+
+        return await Artifact.get.aio(name=name, version=version)
+
+    async def _graph_json(self, name: str, version: str) -> dict:
+        from dataclasses import asdict
+
+        _ensure_client()
+        artifact = await self._resolve_artifact(name, version)
+        graph = await build_artifact_lineage(
+            artifact,
+            watched_tasks=self.watched_tasks,
+            watched_apps=self.watched_apps,
+            scan_limit=self.scan_limit,
+            max_depth=self.max_depth,
+        )
+        return asdict(graph)
+
+    def _build_fastapi_app(self):
+        app = fastapi.FastAPI(title="ArtifactLineage")
+        env = self
+
+        @app.get("/health")
+        async def health() -> dict[str, str]:
+            return {
+                "status": "ok",
+                "watched_tasks": str(len(env.watched_tasks)),
+                "watched_apps": str(len(env.watched_apps)),
+            }
+
+        @app.get("/", include_in_schema=False)
+        async def index() -> fastapi.responses.RedirectResponse:
+            return fastapi.responses.RedirectResponse(url="/lineage")
+
+        @app.get("/lineage", response_class=fastapi.responses.HTMLResponse)
+        async def lineage_list() -> str:
+            try:
+                _ensure_client()
+                groups = await env._artifact_groups()
+            except Exception:
+                logger.exception("Failed to list artifacts")
+                return "<html><body><p>Could not list artifacts — check app logs.</p></body></html>"
+            return _render_artifact_list_html(groups, title=f"{env.name} — artifacts")
+
+        @app.get("/lineage/graph/{name}")
+        async def lineage_graph(name: str, version: str = "latest") -> dict:
+            return await env._graph_json(name, version)
+
+        @app.get("/lineage/artifact/{name}", response_class=fastapi.responses.HTMLResponse)
+        async def lineage_artifact(name: str, version: str = "latest") -> str:
+            try:
+                graph = await env._graph_json(name, version)
+            except Exception:
+                logger.exception("Failed to build lineage graph for %s", name)
+                return (
+                    "<html><body><p>Could not build lineage graph — is the artifact "
+                    "name/version correct? Check app logs.</p></body></html>"
+                )
+            graph_url = f"/lineage/graph/{name}" + (f"?version={version}" if version != "latest" else "")
+            return _render_graph_html(
+                graph,
+                title=f"{env.name} — {name}",
+                console_base=env._console_base(),
+                graph_url=graph_url,
+            )
+
+        return app

--- a/examples/artifacts/lineage/dashboard.py
+++ b/examples/artifacts/lineage/dashboard.py
@@ -4,15 +4,20 @@ Renders, for any published artifact, the full chain of producers and
 consumers around it: walk upstream to the original run/artifact that started
 the chain, and downstream through every run, artifact, and app that consumed
 it (directly or transitively). See `_lineage.py` for how the graph is built
-and why two signals (bound-input literals, and the `__upstream_artifact__`
-label) are both needed.
+and why two signals (bound-input literals, and the `upstream-artifact-name`/
+`upstream-artifact-version` labels) are both needed.
+
+A single page (`GET /lineage`) does everything: a searchable sidebar lists
+every published artifact, and clicking one renders its lineage graph inline
+in the same view — no page navigation, just a client-side fetch + re-render.
 
 Endpoints:
 
-- `GET /lineage` — list of published artifacts (click through to a graph)
-- `GET /lineage/artifact/{name}` — lineage graph for one artifact, as HTML
-  (`?version=` selects a version; defaults to latest)
-- `GET /lineage/graph/{name}` — the same lineage graph as JSON
+- `GET /lineage` — the dashboard (`?artifact=` preselects one, `&version=`
+  optionally pins a version; `GET /lineage/artifact/{name}` is a shorthand
+  redirect to the same thing, for direct links)
+- `GET /lineage/artifacts` — every published artifact, as JSON (sidebar data)
+- `GET /lineage/graph/{name}` — one artifact's lineage graph, as JSON
 """
 
 from __future__ import annotations
@@ -25,7 +30,7 @@ import fastapi
 
 from flyte.app.extras import FastAPIAppEnvironment
 
-from ._lineage import LABEL_UPSTREAM_ARTIFACT, build_artifact_lineage
+from ._lineage import LABEL_UPSTREAM_ARTIFACT_NAME, LABEL_UPSTREAM_ARTIFACT_VERSION, build_artifact_lineage
 
 logger = logging.getLogger(__name__)
 
@@ -34,63 +39,17 @@ def _html_escape(text: str) -> str:
     return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
 
 
-def _render_artifact_list_html(groups: list, title: str) -> str:
-    rows = "".join(
-        f"""<a class="row" href="/lineage/artifact/{_html_escape(g["name"])}">
-              <span class="name">{_html_escape(g["name"])}</span>
-              <span class="version mono">{_html_escape(g["latest_version"])}</span>
-              <span class="count">{g["versions"]} version{"s" if g["versions"] != 1 else ""}</span>
-              <span class="desc">{_html_escape(g["description"])}</span>
-            </a>"""
-        for g in groups
-    )
-    empty = '<p class="empty">No artifacts published yet.</p>' if not groups else ""
-    return f"""<!DOCTYPE html>
-<html>
-<head>
-<meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>{_html_escape(title)}</title>
-<style>
-  :root {{ --bg: #0a0a0f; --panel: #131318; --card: #1c1c22; --card-border: #33333c;
-           --text: #e7e7ea; --muted: #8a8a94; --accent: #a98fd1; }}
-  * {{ box-sizing: border-box; }}
-  body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-          margin: 0; background: var(--bg); color: var(--text); }}
-  header {{ padding: 1.2rem 2rem 0.6rem; }}
-  h1 {{ font-size: 1.15rem; margin: 0; font-weight: 600; }}
-  .sub {{ color: var(--muted); font-size: 0.8rem; margin: 0.35rem 0 0; }}
-  .sub code {{ background: #1e1e25; padding: 0 0.3rem; border-radius: 4px; }}
-  main {{ padding: 0.8rem 2rem 2rem; max-width: 920px; }}
-  .row {{ display: flex; align-items: center; gap: 14px; padding: 12px 14px;
-          background: var(--card); border: 1px solid var(--card-border); border-radius: 10px;
-          margin-bottom: 8px; text-decoration: none; color: var(--text); transition: border-color 0.15s; }}
-  .row:hover {{ border-color: var(--accent); }}
-  .name {{ font-weight: 600; font-size: 13.5px; min-width: 220px; }}
-  .version {{ color: var(--muted); font-size: 11.5px; min-width: 90px; }}
-  .count {{ color: var(--muted); font-size: 11px; background: #26262e; border-radius: 999px;
-            padding: 2px 9px; flex: none; }}
-  .desc {{ color: var(--muted); font-size: 12px; overflow: hidden; text-overflow: ellipsis;
-           white-space: nowrap; }}
-  .mono {{ font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }}
-  .empty {{ color: var(--muted); font-size: 13px; }}
-</style>
-</head>
-<body>
-<header>
-  <h1>{_html_escape(title)}</h1>
-  <p class="sub">Click an artifact to trace its lineage — every producer back to the origin,
-  every consumer downstream. Built live from artifact provenance and the
-  <code>{LABEL_UPSTREAM_ARTIFACT}</code> label — no stored lineage state.</p>
-</header>
-<main>{empty}{rows}</main>
-</body>
-</html>"""
-
-
-def _render_graph_html(graph_json: dict, title: str, console_base: str, graph_url: str) -> str:
+def _render_dashboard_html(
+    title: str,
+    console_base: str,
+    *,
+    artifacts_url: str = "/lineage/artifacts",
+    graph_url_base: str = "/lineage/graph",
+    preselect: dict | None = None,
+) -> str:
     base = console_base.rstrip("/")
-    boot_json = json.dumps(graph_json).replace("</", "<\\/")
+    boot = {"preselect": preselect, "artifactsUrl": artifacts_url, "graphUrlBase": graph_url_base}
+    boot_json = json.dumps(boot).replace("</", "<\\/")
     return f"""<!DOCTYPE html>
 <html>
 <head>
@@ -101,44 +60,99 @@ def _render_graph_html(graph_json: dict, title: str, console_base: str, graph_ur
 <style>
   :root {{
     --bg: #0a0a0f; --panel: #131318; --card: #1c1c22; --card-border: #33333c;
-    --text: #e7e7ea; --muted: #8a8a94;
+    --text: #e7e7ea; --muted: #8a8a94; --accent: #a98fd1;
     --artifact: #a98fd1; --run: #f59e0b; --app: #38bdf8;
   }}
   * {{ box-sizing: border-box; }}
-  body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-          margin: 0; background: var(--bg); color: var(--text); }}
-  header {{ padding: 1.2rem 2rem 0.6rem; display: flex; align-items: center; gap: 14px; }}
-  h1 {{ font-size: 1.15rem; margin: 0; font-weight: 600; }}
-  .back {{ color: var(--muted); text-decoration: none; font-size: 0.8rem; border: 1px solid #2a2a33;
-           border-radius: 8px; padding: 5px 12px; }}
-  .back:hover {{ color: var(--text); border-color: #4d4d59; }}
-  .legend {{ margin-left: auto; display: flex; gap: 14px; font-size: 11.5px; color: var(--muted); }}
-  .legend .dot {{ display: inline-block; width: 8px; height: 8px; border-radius: 999px; margin-right: 5px; }}
-  main {{ padding: 0.8rem 2rem 1.2rem; }}
-  #app {{ height: 78vh; min-height: 460px; border: 1px solid #23232b; border-radius: 12px; background: #101015; }}
-  .fallback {{ display: flex; height: 100%; align-items: center; justify-content: center;
-               color: var(--muted); font-size: 0.85rem; }}
+  html, body {{ height: 100%; }}
+  body {{
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    margin: 0; background: var(--bg); color: var(--text);
+  }}
+  code {{ background: #1e1e25; padding: 0 0.3rem; border-radius: 4px; }}
+  a {{ color: #93c5fd; }}
+  #shell {{ display: flex; height: 100vh; }}
+  .sidebar {{
+    width: 300px; flex: none; background: var(--panel); border-right: 1px solid #23232b;
+    display: flex; flex-direction: column; min-height: 0;
+  }}
+  .sidebar-head {{ padding: 1rem 1rem 0.7rem; border-bottom: 1px solid #23232b; }}
+  .sidebar-head h1 {{ font-size: 1rem; margin: 0 0 2px; font-weight: 600; }}
+  .sidebar-head .sub {{ color: var(--muted); font-size: 0.72rem; line-height: 1.5; margin: 6px 0 10px; }}
+  .search {{
+    width: 100%; background: #0e0e13; border: 1px solid #23232b; border-radius: 8px;
+    color: var(--text); font-size: 12.5px; padding: 7px 10px; outline: none;
+  }}
+  .search:focus {{ border-color: #4d4d59; }}
+  .sidebar-list {{ flex: 1; overflow-y: auto; padding: 8px; }}
+  .art-item {{
+    display: flex; flex-direction: column; gap: 3px; padding: 9px 11px; border-radius: 9px;
+    cursor: pointer; border: 1px solid transparent; margin-bottom: 3px;
+  }}
+  .art-item:hover {{ background: #1a1a20; }}
+  .art-item.active {{ background: #22222b; border-color: var(--accent); }}
+  .art-row1 {{ display: flex; align-items: center; gap: 8px; }}
+  .art-name {{ font-weight: 600; font-size: 12.5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }}
+  .art-count {{
+    margin-left: auto; flex: none; font-size: 9px; color: var(--muted); background: #26262e;
+    border-radius: 999px; padding: 1px 7px;
+  }}
+  .art-desc {{
+    color: var(--muted); font-size: 10.5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }}
+  .empty-list {{ color: var(--muted); font-size: 12px; padding: 10px 6px; }}
+  .main {{ flex: 1; display: flex; flex-direction: column; min-width: 0; }}
+  .main-head {{
+    padding: 1rem 1.5rem; border-bottom: 1px solid #23232b; display: flex; align-items: center; gap: 14px;
+    min-height: 32px;
+  }}
+  .main-head h2 {{ font-size: 1.05rem; margin: 0; font-weight: 600; }}
+  .main-head .version {{
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; color: var(--muted);
+    background: #1c1c22; border: 1px solid #2a2a33; border-radius: 999px; padding: 2px 9px;
+  }}
+  .main-head .desc {{ color: var(--muted); font-size: 12px; }}
+  .main-head .console-link {{
+    margin-left: auto; font-size: 0.75rem; color: var(--muted); text-decoration: none;
+    border: 1px solid #2a2a33; border-radius: 8px; padding: 5px 12px; flex: none;
+  }}
+  .main-head .console-link:hover {{ color: var(--text); border-color: #4d4d59; }}
+  .legend {{ display: flex; gap: 12px; font-size: 10.5px; color: var(--muted); flex: none; }}
+  .legend .dot {{ display: inline-block; width: 7px; height: 7px; border-radius: 999px; margin-right: 4px; }}
+  .canvas {{ flex: 1; position: relative; background: #101015; }}
+  .placeholder {{
+    position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+    color: var(--muted); font-size: 0.85rem; text-align: center; padding: 2rem; flex-direction: column; gap: 6px;
+  }}
   .react-flow__controls {{ box-shadow: none; border: 1px solid #2a2a33; border-radius: 8px; overflow: hidden; }}
   .react-flow__controls-button {{ background: var(--card); border-bottom: 1px solid #2a2a33; fill: var(--muted); }}
   .react-flow__edge-path {{ stroke: #4a4a55; }}
   .react-flow__edge-textbg {{ fill: #101015; }}
   .react-flow__edge-text {{ fill: var(--muted); font-size: 10px; }}
   .react-flow__attribution {{ background: transparent; color: #55555f; }}
-  .lin-card {{ width: 236px; background: var(--card); border: 1px solid var(--card-border);
-               border-radius: 10px; padding: 10px 12px; cursor: pointer; border-left-width: 3px; }}
+  .lin-card {{
+    width: 226px; background: var(--card); border: 1px solid var(--card-border);
+    border-radius: 10px; padding: 10px 12px; cursor: pointer; border-left-width: 3px;
+    transition: border-color 0.12s ease;
+  }}
   .lin-card:hover {{ border-color: #4d4d59; }}
   .lin-card.artifact {{ border-left-color: var(--artifact); }}
-  .lin-card.artifact.root {{ border-color: var(--artifact); }}
+  .lin-card.artifact.root {{ border-color: var(--artifact); box-shadow: 0 0 0 1px var(--artifact); }}
   .lin-card.run {{ border-left-color: var(--run); }}
   .lin-card.app {{ border-left-color: var(--app); }}
   .lin-card .kind {{ font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); }}
-  .lin-card .title {{ font-size: 12.5px; font-weight: 600; margin-top: 2px; white-space: nowrap;
-                       overflow: hidden; text-overflow: ellipsis; }}
-  .lin-card .sub {{ font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 10.5px;
-                     color: var(--muted); margin-top: 5px; white-space: nowrap; overflow: hidden;
-                     text-overflow: ellipsis; }}
-  .lin-card .pill {{ display: inline-block; margin-top: 6px; font-size: 9.5px; padding: 1px 7px;
-                      border-radius: 999px; text-transform: capitalize; }}
+  .lin-card .title {{
+    font-size: 12.5px; font-weight: 600; margin-top: 2px; white-space: nowrap; overflow: hidden;
+    text-overflow: ellipsis;
+  }}
+  .lin-card .sub {{
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 10.5px; color: var(--muted);
+    margin-top: 5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }}
+  .lin-card .pill {{
+    display: inline-block; margin-top: 6px; font-size: 9.5px; padding: 1px 7px; border-radius: 999px;
+    text-transform: capitalize;
+  }}
   .pill.succeeded {{ background: rgba(22,163,74,0.15); color: #4ade80; }}
   .pill.failed, .pill.aborted, .pill.timed_out {{ background: rgba(220,38,38,0.15); color: #f87171; }}
   .pill.running {{ background: rgba(2,132,199,0.18); color: #60a5fa; }}
@@ -148,30 +162,9 @@ def _render_graph_html(graph_json: dict, title: str, console_base: str, graph_ur
 </style>
 </head>
 <body>
-<header>
-  <a class="back" href="/lineage">&larr; All artifacts</a>
-  <h1>{_html_escape(title)}</h1>
-  <div class="legend">
-    <span><span class="dot" style="background:var(--artifact)"></span>artifact</span>
-    <span><span class="dot" style="background:var(--run)"></span>run</span>
-    <span><span class="dot" style="background:var(--app)"></span>app</span>
-  </div>
-</header>
-<main>
-  <div id="app"><div class="fallback">Lineage graph could not render (CDN unreachable?) — see the
-    <a href="{_html_escape(graph_url)}">raw graph JSON</a>.</div></div>
-</main>
-<script type="importmap">
-{{
-  "imports": {{
-    "react": "https://esm.sh/react@18.3.1",
-    "react-dom/client": "https://esm.sh/react-dom@18.3.1/client?deps=react@18.3.1",
-    "@xyflow/react": "https://esm.sh/@xyflow/react@12.8.2?deps=react@18.3.1,react-dom@18.3.1",
-    "@dagrejs/dagre": "https://esm.sh/@dagrejs/dagre@1.1.4",
-    "htm": "https://esm.sh/htm@3.1.1"
-  }}
-}}
-</script>
+<div id="shell">
+  <div class="placeholder" style="position:static;height:100%;">Loading…</div>
+</div>
 <script id="lineage-data" type="application/json">{boot_json}</script>
 <script type="module">
 try {{
@@ -183,9 +176,9 @@ try {{
   const htm = (await import("htm")).default;
   const html = htm.bind(React.createElement);
 
-  const GRAPH = JSON.parse(document.getElementById("lineage-data").textContent);
+  const BOOT = JSON.parse(document.getElementById("lineage-data").textContent);
   const CONSOLE_BASE = {json.dumps(base)};
-  const NODE_W = 236, NODE_H = 74;
+  const NODE_W = 226, NODE_H = 74;
 
   const LinNode = ({{ data }}) => html`
     <div class="lin-card ${{data.kind}} ${{data.isRoot ? "root" : ""}}"
@@ -227,17 +220,116 @@ try {{
     return {{ flowNodes, flowEdges }};
   }}
 
-  const {{ flowNodes, flowEdges }} = layout(GRAPH.nodes, GRAPH.edges, GRAPH.root);
-  const App = () => html`
-    <${{ReactFlow}} nodes=${{flowNodes}} edges=${{flowEdges}} nodeTypes=${{nodeTypes}}
-        fitView fitViewOptions=${{{{ padding: 0.15, maxZoom: 1 }}}} minZoom=${{0.2}}
-        proOptions=${{{{ hideAttribution: true }}}} nodesConnectable=${{false}} colorMode="dark">
-      <${{Background}} variant=${{BackgroundVariant.Dots}} gap=${{22}} size=${{1.4}} color="#26262e" />
-      <${{Controls}} showInteractive=${{false}} />
-    <//>`;
-  createRoot(document.getElementById("app")).render(html`<${{App}} />`);
+  const Legend = () => html`
+    <div class="legend">
+      <span><span class="dot" style="background:var(--artifact)"></span>artifact</span>
+      <span><span class="dot" style="background:var(--run)"></span>run</span>
+      <span><span class="dot" style="background:var(--app)"></span>app</span>
+    </div>`;
+
+  const Sidebar = ({{ artifacts, filter, onFilter, selected, onSelect }}) => {{
+    const q = filter.trim().toLowerCase();
+    const visible = q ? artifacts.filter((a) => a.name.toLowerCase().includes(q)) : artifacts;
+    return html`
+      <aside class="sidebar">
+        <div class="sidebar-head">
+          <h1>Artifact lineage</h1>
+          <p class="sub">Every producer back to the origin, every consumer downstream —
+            built live from artifact provenance and the
+            <code>{LABEL_UPSTREAM_ARTIFACT_NAME}</code>/<code>{LABEL_UPSTREAM_ARTIFACT_VERSION}</code> labels.</p>
+          <input class="search" placeholder="Filter artifacts…" value=${{filter}}
+                 onInput=${{(e) => onFilter(e.target.value)}} />
+        </div>
+        <div class="sidebar-list">
+          ${{visible.length === 0
+            ? html`<div class="empty-list">${{artifacts.length === 0
+                ? "No artifacts published yet." : "No artifacts match your filter."}}</div>`
+            : visible.map((a) => html`
+                <div key=${{a.name}} class="art-item ${{selected && selected.name === a.name ? "active" : ""}}"
+                     onClick=${{() => onSelect(a.name)}}>
+                  <div class="art-row1">
+                    <span class="art-name">${{a.name}}</span>
+                    <span class="art-count">${{a.versions}}</span>
+                  </div>
+                  <span class="art-desc">${{a.description || a.latest_version}}</span>
+                </div>`)}}
+        </div>
+      </aside>`;
+  }};
+
+  const App = () => {{
+    const [artifacts, setArtifacts] = React.useState([]);
+    const [filter, setFilter] = React.useState("");
+    const [selected, setSelected] = React.useState(BOOT.preselect || null);
+    const [graph, setGraph] = React.useState(null);
+    const [status, setStatus] = React.useState(selected ? "loading" : "idle");
+
+    React.useEffect(() => {{
+      fetch(BOOT.artifactsUrl, {{ cache: "no-store" }})
+        .then((r) => r.json()).then(setArtifacts)
+        .catch((e) => console.warn("artifact list fetch failed", e));
+    }}, []);
+
+    const select = React.useCallback((name, version) => {{
+      setSelected({{ name, version: version || "latest" }});
+      const qs = version && version !== "latest" ? `?version=${{encodeURIComponent(version)}}` : "";
+      history.replaceState(null, "", `/lineage/artifact/${{encodeURIComponent(name)}}${{qs}}`);
+    }}, []);
+
+    React.useEffect(() => {{
+      if (!selected) return;
+      setStatus("loading");
+      const v = selected.version && selected.version !== "latest" ? `?version=${{selected.version}}` : "";
+      fetch(`${{BOOT.graphUrlBase}}/${{encodeURIComponent(selected.name)}}${{v}}`, {{ cache: "no-store" }})
+        .then((r) => {{ if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); }})
+        .then((g) => {{ setGraph(g); setStatus("ok"); }})
+        .catch((e) => {{ console.warn("graph fetch failed", e); setStatus("error"); }});
+    }}, [selected]);
+
+    const {{ flowNodes, flowEdges }} = React.useMemo(
+      () => (graph ? layout(graph.nodes, graph.edges, graph.root) : {{ flowNodes: [], flowEdges: [] }}),
+      [graph]
+    );
+    const rootNode = graph ? graph.nodes[graph.root] : null;
+
+    return html`
+      <${{Sidebar}} artifacts=${{artifacts}} filter=${{filter}} onFilter=${{setFilter}}
+          selected=${{selected}} onSelect=${{(name) => select(name)}} />
+      <div class="main">
+        <div class="main-head">
+          ${{rootNode ? html`
+            <h2>${{rootNode.name}}</h2>
+            <span class="version">${{rootNode.version}}</span>
+            ${{rootNode.description ? html`<span class="desc">${{rootNode.description}}</span>` : null}}
+            ${{rootNode.url ? html`<a class="console-link" target="_blank" rel="noopener"
+                href=${{CONSOLE_BASE + rootNode.url}}>Open in console ↗</a>` : null}}
+          ` : html`<h2>Select an artifact</h2>`}}
+          <${{Legend}} />
+        </div>
+        <div class="canvas">
+          ${{status === "idle" ? html`<div class="placeholder">
+              Select an artifact from the sidebar to view its lineage.</div>` : null}}
+          ${{status === "loading" ? html`<div class="placeholder">Loading lineage…</div>` : null}}
+          ${{status === "error" ? html`<div class="placeholder">Could not build the lineage graph —
+              is the artifact name/version correct? Check app logs.</div>` : null}}
+          ${{status === "ok" ? html`
+            <${{ReactFlow}} key=${{selected.name + ":" + selected.version}} nodes=${{flowNodes}}
+                edges=${{flowEdges}} nodeTypes=${{nodeTypes}}
+                fitView fitViewOptions=${{{{ padding: 0.15, maxZoom: 1 }}}} minZoom=${{0.2}}
+                proOptions=${{{{ hideAttribution: true }}}} nodesConnectable=${{false}} colorMode="dark">
+              <${{Background}} variant=${{BackgroundVariant.Dots}} gap=${{22}} size=${{1.4}} color="#26262e" />
+              <${{Controls}} showInteractive=${{false}} />
+            <//>` : null}}
+        </div>
+      </div>`;
+  }};
+  createRoot(document.getElementById("shell")).render(html`<${{App}} />`);
 }} catch (err) {{
   console.error(err);
+  document.getElementById("shell").innerHTML =
+    '<div class="placeholder" style="position:static;height:100%;">Dashboard failed to load ' +
+    '(CDN unreachable?) — see <a href="/lineage/artifacts">/lineage/artifacts</a> and ' +
+    '<a href="/lineage/graph/&lt;name&gt;">/lineage/graph/&lt;name&gt;</a> for the raw JSON.</div>';
 }}
 </script>
 </body>
@@ -269,7 +361,8 @@ class ArtifactLineageAppEnvironment(FastAPIAppEnvironment):
     to the original run/artifact in the chain) and every run, artifact, or app
     downstream of it. See `_lineage.build_artifact_lineage` for how the graph
     is assembled, and the module docstring in `_lineage.py` for why some
-    consumers need the `__upstream_artifact__` label to be discoverable at all.
+    consumers need the `upstream-artifact-name`/`upstream-artifact-version`
+    labels to be discoverable at all.
 
     ```python
     lineage_app = ArtifactLineageAppEnvironment(
@@ -282,7 +375,7 @@ class ArtifactLineageAppEnvironment(FastAPIAppEnvironment):
 
     app: fastapi.FastAPI = field(default_factory=fastapi.FastAPI)
     # Task/app names to include in the bound-input consumer scan, beyond what the
-    # `__upstream_artifact__` label already finds on its own (see `_lineage.py`).
+    # `upstream-artifact-name`/`upstream-artifact-version` labels already find (see `_lineage.py`).
     watched_tasks: list[str] = field(default_factory=list)
     watched_apps: list[str] = field(default_factory=list)
     scan_limit: int = 50
@@ -347,14 +440,18 @@ class ArtifactLineageAppEnvironment(FastAPIAppEnvironment):
             return fastapi.responses.RedirectResponse(url="/lineage")
 
         @app.get("/lineage", response_class=fastapi.responses.HTMLResponse)
-        async def lineage_list() -> str:
+        async def lineage_page(artifact: str = "", version: str = "latest") -> str:
+            preselect = {"name": artifact, "version": version} if artifact else None
+            return _render_dashboard_html(env.name, env._console_base(), preselect=preselect)
+
+        @app.get("/lineage/artifacts")
+        async def lineage_artifacts() -> list[dict]:
             try:
                 _ensure_client()
-                groups = await env._artifact_groups()
+                return await env._artifact_groups()
             except Exception:
                 logger.exception("Failed to list artifacts")
-                return "<html><body><p>Could not list artifacts — check app logs.</p></body></html>"
-            return _render_artifact_list_html(groups, title=f"{env.name} — artifacts")
+                return []
 
         @app.get("/lineage/graph/{name}")
         async def lineage_graph(name: str, version: str = "latest") -> dict:
@@ -362,20 +459,6 @@ class ArtifactLineageAppEnvironment(FastAPIAppEnvironment):
 
         @app.get("/lineage/artifact/{name}", response_class=fastapi.responses.HTMLResponse)
         async def lineage_artifact(name: str, version: str = "latest") -> str:
-            try:
-                graph = await env._graph_json(name, version)
-            except Exception:
-                logger.exception("Failed to build lineage graph for %s", name)
-                return (
-                    "<html><body><p>Could not build lineage graph — is the artifact "
-                    "name/version correct? Check app logs.</p></body></html>"
-                )
-            graph_url = f"/lineage/graph/{name}" + (f"?version={version}" if version != "latest" else "")
-            return _render_graph_html(
-                graph,
-                title=f"{env.name} — {name}",
-                console_base=env._console_base(),
-                graph_url=graph_url,
-            )
+            return _render_dashboard_html(env.name, env._console_base(), preselect={"name": name, "version": version})
 
         return app

--- a/examples/artifacts/lineage_examples/bi_pipeline.py
+++ b/examples/artifacts/lineage_examples/bi_pipeline.py
@@ -1,0 +1,173 @@
+"""Business intelligence use case: ingest -> two aggregation levels -> report, fan-in.
+
+A fan-in lineage: `aggregate_weekly` extends the chain from `aggregate_daily`,
+but `build_report` then consumes *both* `daily-aggregates` and
+`weekly-aggregates` -- a run with two upstream artifacts at different chain
+depths, rather than the ETL example's two-independent-roots diamond.
+`bi_dashboard_app` serves the report and, like the other two examples, needs
+the `upstream-artifact-name`/`upstream-artifact-version` labels since
+it fetches the report by name rather than binding it as a typed input.
+
+Try it:
+
+    python examples/artifacts/lineage_examples/bi_pipeline.py
+"""
+
+import csv
+import io
+import json
+import tempfile
+import time
+from collections import defaultdict
+
+import fastapi
+from lineage import LABEL_UPSTREAM_ARTIFACT_NAME, LABEL_UPSTREAM_ARTIFACT_VERSION
+
+import flyte
+import flyte.artifacts as artifacts
+from flyte.app.extras import FastAPIAppEnvironment
+from flyte.io import File
+
+# Shared by the task env and the dashboard app below: the module imports `fastapi` at
+# top level (for `bi_app`), so any task defined here needs it too, even ones that never
+# touch FastAPI themselves -- task loading imports the whole module.
+image = flyte.Image.from_debian_base().with_pip_packages("fastapi", "uvicorn")
+env = flyte.TaskEnvironment(name="bi_pipeline", image=image)
+
+
+def _wait_for_artifact(name: str, *, retries: int = 15, delay_s: float = 2.0):
+    """`Artifact.get` right after a run completes can race artifact indexing; retry briefly."""
+    from flyte.remote import Artifact
+
+    for attempt in range(retries):
+        try:
+            return Artifact.get(name)
+        except Exception:
+            if attempt == retries - 1:
+                raise
+            time.sleep(delay_s)
+
+
+def _run_and_wait(run):
+    """`.wait()` alone doesn't raise on failure -- surface it immediately instead of
+    letting a later `_wait_for_artifact` call fail with a confusing "not found"."""
+    run.wait()
+    if run.phase != "succeeded":
+        raise RuntimeError(f"{run.url} finished in phase {run.phase!r}")
+    return run
+
+
+_EVENTS = [
+    ("2024-01-01", "1", "12.50"),
+    ("2024-01-01", "2", "4.00"),
+    ("2024-01-02", "3", "9.25"),
+    ("2024-01-08", "4", "30.00"),
+    ("2024-01-08", "5", "5.75"),
+]
+
+
+@env.task(produces_artifacts=True)
+async def ingest_events() -> File:
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(["day", "event_id", "revenue"])
+    writer.writerows(_EVENTS)
+    with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False) as f:
+        f.write(buf.getvalue())
+    file = await File.from_local(f.name)
+    return artifacts.new(file, artifacts.Metadata(name="raw-events", description="Raw revenue events"))
+
+
+@env.task(produces_artifacts=True)
+async def aggregate_daily(events: File) -> File:
+    async with events.open("rb") as fh:
+        rows = list(csv.DictReader(io.StringIO(bytes(await fh.read()).decode())))
+    by_day: dict[str, float] = defaultdict(float)
+    for row in rows:
+        by_day[row["day"]] += float(row["revenue"])
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump(dict(by_day), f)
+    file = await File.from_local(f.name)
+    return artifacts.new(file, artifacts.Metadata(name="daily-aggregates", description="Revenue summed per day"))
+
+
+@env.task(produces_artifacts=True)
+async def aggregate_weekly(daily: File) -> File:
+    async with daily.open("rb") as fh:
+        by_day = json.loads(bytes(await fh.read()).decode())
+    # ISO week number from the date string, no datetime parsing needed for this toy range.
+    week_of = {"2024-01-01": "w1", "2024-01-02": "w1", "2024-01-08": "w2"}
+    by_week: dict[str, float] = defaultdict(float)
+    for day, revenue in by_day.items():
+        by_week[week_of[day]] += revenue
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump(dict(by_week), f)
+    file = await File.from_local(f.name)
+    return artifacts.new(file, artifacts.Metadata(name="weekly-aggregates", description="Revenue summed per week"))
+
+
+# Fan-in: consumes both the daily and weekly aggregates, at different chain depths.
+# Both edges are found via the automatic bound-input scan.
+@env.task(produces_artifacts=True)
+async def build_report(daily: File, weekly: File) -> File:
+    async with daily.open("rb") as fh:
+        by_day = json.loads(bytes(await fh.read()).decode())
+    async with weekly.open("rb") as fh:
+        by_week = json.loads(bytes(await fh.read()).decode())
+    report = {"total_revenue": sum(by_day.values()), "by_day": by_day, "by_week": by_week}
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump(report, f)
+    file = await File.from_local(f.name)
+    return artifacts.new(file, artifacts.Metadata(name="bi-report", description="Revenue report"))
+
+
+bi_app = fastapi.FastAPI(title="BI Dashboard")
+
+
+@bi_app.get("/report")
+async def report() -> dict:
+    import json as _json
+
+    from flyte.io import File as _File
+    from flyte.remote import Artifact
+
+    report_artifact = await Artifact.get.aio(name="bi-report")
+    report_file = await report_artifact.to_python(_File)
+    async with report_file.open("rb") as fh:
+        return _json.loads(bytes(await fh.read()).decode())
+
+
+# Labels are set on this module-level object in `run_pipeline` below, once the report's
+# identity is known -- not via `clone_with()`, which would return a local-variable copy
+# the app resolver can't find by name in this module.
+bi_dashboard_app = FastAPIAppEnvironment(name="bi-dashboard-app", app=bi_app, image=image)
+
+
+def run_pipeline() -> None:
+    """Ingest, aggregate at two levels, build the report, and serve it. Assumes init_from_config() ran."""
+    ingest_run = _run_and_wait(flyte.run(ingest_events))
+    print(ingest_run.url)
+    events = _wait_for_artifact("raw-events")
+
+    daily_run = _run_and_wait(flyte.run(aggregate_daily, events=events))
+    print(daily_run.url)
+    daily = _wait_for_artifact("daily-aggregates")
+
+    weekly_run = _run_and_wait(flyte.run(aggregate_weekly, daily=daily))
+    print(weekly_run.url)
+    weekly = _wait_for_artifact("weekly-aggregates")
+
+    report_run = _run_and_wait(flyte.run(build_report, daily=daily, weekly=weekly))
+    print(report_run.url)
+    report_artifact = _wait_for_artifact("bi-report")
+
+    bi_dashboard_app.labels = {
+        LABEL_UPSTREAM_ARTIFACT_NAME: report_artifact.name,
+        LABEL_UPSTREAM_ARTIFACT_VERSION: report_artifact.version,
+    }
+    flyte.serve(bi_dashboard_app)
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run_pipeline()

--- a/examples/artifacts/lineage_examples/dashboard.py
+++ b/examples/artifacts/lineage_examples/dashboard.py
@@ -1,0 +1,71 @@
+"""The consolidated lineage dashboard: watches every example pipeline at once.
+
+Deploys a single `ArtifactLineageAppEnvironment` (reusing the
+`artifact-lineage-dashboard` app name from `artifact_lineage_example.py`, so
+there's exactly one dashboard running rather than one per pipeline) with
+`watched_tasks`/`watched_apps` covering the mechanism walkthrough plus all
+three use-case pipelines in this directory: ML (`ml_pipeline.py`), ETL
+(`etl_pipeline.py`), and BI (`bi_pipeline.py`).
+
+Try it:
+
+    python examples/artifacts/lineage_examples/dashboard.py
+
+This runs every pipeline first (so the dashboard has real lineage to show)
+and then deploys/serves the dashboard itself.
+"""
+
+import sys
+from pathlib import Path
+
+from lineage import ArtifactLineageAppEnvironment
+
+import flyte
+
+# `lineage_examples` is a package (this file is a member of it), but
+# `artifact_lineage_example` is a flat sibling module one directory up --
+# make both importable the same way regardless of how this script was invoked.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+lineage_dashboard = ArtifactLineageAppEnvironment(
+    name="artifact-lineage-dashboard",
+    image=flyte.Image.from_debian_base().with_pip_packages("fastapi", "uvicorn"),
+    watched_tasks=[
+        # artifact_lineage_example.py -- the mechanism walkthrough
+        "artifact_lineage_example.train_model",
+        "artifact_lineage_example.audit_model",
+        # ml_pipeline.py -- dataset -> train -> evaluate (merge) -> serve
+        "lineage_examples.ml_pipeline.train_model",
+        "lineage_examples.ml_pipeline.evaluate_model",
+        # etl_pipeline.py -- two sources (diamond) -> transform -> join -> load
+        "lineage_examples.etl_pipeline.transform_orders",
+        "lineage_examples.etl_pipeline.join_orders_customers",
+        "lineage_examples.etl_pipeline.load_warehouse",
+        # bi_pipeline.py -- ingest -> daily/weekly aggregates -> report (fan-in)
+        "lineage_examples.bi_pipeline.aggregate_daily",
+        "lineage_examples.bi_pipeline.aggregate_weekly",
+        "lineage_examples.bi_pipeline.build_report",
+    ],
+    watched_apps=[
+        "artifact-lineage-model-server",
+        "ml-model-server",
+        "etl-monitor-app",
+        "bi-dashboard-app",
+    ],
+)
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+
+    import artifact_lineage_example
+
+    from lineage_examples import bi_pipeline, etl_pipeline, ml_pipeline
+
+    artifact_lineage_example.run_pipeline()
+    ml_pipeline.run_pipeline()
+    etl_pipeline.run_pipeline()
+    bi_pipeline.run_pipeline()
+
+    handle = flyte.serve(lineage_dashboard)
+    print(f"Lineage dashboard: {handle.url}/lineage")

--- a/examples/artifacts/lineage_examples/etl_pipeline.py
+++ b/examples/artifacts/lineage_examples/etl_pipeline.py
@@ -1,0 +1,182 @@
+"""ETL use case: two independent sources converge, then load to a warehouse table.
+
+A diamond-shaped lineage: `extract_orders` and `extract_customers` are two
+unrelated producers with no shared ancestor; `join_orders_customers` is a merge
+point that consumes one artifact from each side of the diamond. `load_warehouse`
+adds one more hop, and `etl_monitor_app` demonstrates the app-consumption
+fallback again, this time watching the final loaded table.
+
+Try it:
+
+    python examples/artifacts/lineage_examples/etl_pipeline.py
+"""
+
+import csv
+import io
+import tempfile
+import time
+
+import fastapi
+from lineage import LABEL_UPSTREAM_ARTIFACT_NAME, LABEL_UPSTREAM_ARTIFACT_VERSION
+
+import flyte
+import flyte.artifacts as artifacts
+from flyte.app.extras import FastAPIAppEnvironment
+from flyte.io import File
+
+# Shared by the task env and the monitor app below: the module imports `fastapi` at top
+# level (for `etl_app`), so any task defined here needs it too, even ones that never
+# touch FastAPI themselves -- task loading imports the whole module.
+image = flyte.Image.from_debian_base().with_pip_packages("fastapi", "uvicorn")
+env = flyte.TaskEnvironment(name="etl_pipeline", image=image)
+
+
+def _wait_for_artifact(name: str, *, retries: int = 15, delay_s: float = 2.0):
+    """`Artifact.get` right after a run completes can race artifact indexing; retry briefly."""
+    from flyte.remote import Artifact
+
+    for attempt in range(retries):
+        try:
+            return Artifact.get(name)
+        except Exception:
+            if attempt == retries - 1:
+                raise
+            time.sleep(delay_s)
+
+
+def _run_and_wait(run):
+    """`.wait()` alone doesn't raise on failure -- surface it immediately instead of
+    letting a later `_wait_for_artifact` call fail with a confusing "not found"."""
+    run.wait()
+    if run.phase != "succeeded":
+        raise RuntimeError(f"{run.url} finished in phase {run.phase!r}")
+    return run
+
+
+def _write_csv(rows: list[dict], fieldnames: list[str]) -> str:
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=fieldnames)
+    writer.writeheader()
+    writer.writerows(rows)
+    with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False) as f:
+        f.write(buf.getvalue())
+        return f.name
+
+
+async def _read_csv(file: File) -> list[dict]:
+    async with file.open("rb") as fh:
+        text = bytes(await fh.read()).decode()
+    return list(csv.DictReader(io.StringIO(text)))
+
+
+@env.task(produces_artifacts=True)
+async def extract_orders() -> File:
+    rows = [
+        {"order_id": "1", "customer_id": "c1", "amount": "19.99"},
+        {"order_id": "2", "customer_id": "c2", "amount": "42.00"},
+        {"order_id": "3", "customer_id": "c1", "amount": "8.50"},
+    ]
+    path = _write_csv(rows, ["order_id", "customer_id", "amount"])
+    file = await File.from_local(path)
+    return artifacts.new(file, artifacts.Metadata(name="raw-orders", description="Raw orders extract"))
+
+
+@env.task(produces_artifacts=True)
+async def extract_customers() -> File:
+    rows = [
+        {"customer_id": "c1", "name": "Ada", "region": "us"},
+        {"customer_id": "c2", "name": "Grace", "region": "eu"},
+    ]
+    path = _write_csv(rows, ["customer_id", "name", "region"])
+    file = await File.from_local(path)
+    return artifacts.new(file, artifacts.Metadata(name="raw-customers", description="Raw customers extract"))
+
+
+@env.task(produces_artifacts=True)
+async def transform_orders(orders: File) -> File:
+    rows = await _read_csv(orders)
+    for row in rows:
+        row["amount"] = f"{float(row['amount']):.2f}"
+    path = _write_csv(rows, ["order_id", "customer_id", "amount"])
+    file = await File.from_local(path)
+    return artifacts.new(file, artifacts.Metadata(name="clean-orders", description="Normalized orders"))
+
+
+# Merge point: one artifact from each side of the diamond. Both edges are found via
+# the automatic bound-input scan.
+@env.task(produces_artifacts=True)
+async def join_orders_customers(orders: File, customers: File) -> File:
+    order_rows = await _read_csv(orders)
+    customer_by_id = {c["customer_id"]: c for c in await _read_csv(customers)}
+    joined = [
+        {
+            **row,
+            "name": customer_by_id[row["customer_id"]]["name"],
+            "region": customer_by_id[row["customer_id"]]["region"],
+        }
+        for row in order_rows
+    ]
+    path = _write_csv(joined, ["order_id", "customer_id", "amount", "name", "region"])
+    file = await File.from_local(path)
+    return artifacts.new(file, artifacts.Metadata(name="orders-enriched", description="Orders joined with customers"))
+
+
+@env.task(produces_artifacts=True)
+async def load_warehouse(enriched: File) -> File:
+    rows = await _read_csv(enriched)
+    path = _write_csv(rows, ["order_id", "customer_id", "amount", "name", "region"])
+    file = await File.from_local(path)
+    metadata = artifacts.Metadata(
+        name="warehouse-orders-table", description="Loaded orders table", data={"rows": str(len(rows))}
+    )
+    return artifacts.new(file, metadata)
+
+
+etl_app = fastapi.FastAPI(title="ETL Monitor")
+
+
+@etl_app.get("/status")
+async def status() -> dict:
+    from flyte.remote import Artifact
+
+    table = await Artifact.get.aio(name="warehouse-orders-table")
+    return {"table": table.name, "version": table.version, "rows": table.pb2.spec.info.user_metadata.get("rows")}
+
+
+# Fetches the table artifact's metadata by name at request time -- the labels (set on
+# this module-level object below, once the table's identity is known) make it
+# discoverable as a consumer, same fallback as the ML example's serving app. Setting
+# `.labels` in place (not `clone_with()`) keeps the object the resolver looks up by name.
+etl_monitor_app = FastAPIAppEnvironment(name="etl-monitor-app", app=etl_app, image=image)
+
+
+def run_pipeline() -> None:
+    """Extract both sources, transform, join, load, and serve. Assumes init_from_config() ran."""
+    orders_run = flyte.run(extract_orders)
+    print(orders_run.url)
+    customers_run = flyte.run(extract_customers)
+    print(customers_run.url)
+    _run_and_wait(orders_run)
+    _run_and_wait(customers_run)
+    orders = _wait_for_artifact("raw-orders")
+    customers = _wait_for_artifact("raw-customers")
+
+    transform_run = _run_and_wait(flyte.run(transform_orders, orders=orders))
+    print(transform_run.url)
+    clean_orders = _wait_for_artifact("clean-orders")
+
+    join_run = _run_and_wait(flyte.run(join_orders_customers, orders=clean_orders, customers=customers))
+    print(join_run.url)
+    enriched = _wait_for_artifact("orders-enriched")
+
+    load_run = _run_and_wait(flyte.run(load_warehouse, enriched=enriched))
+    print(load_run.url)
+    table = _wait_for_artifact("warehouse-orders-table")
+
+    etl_monitor_app.labels = {LABEL_UPSTREAM_ARTIFACT_NAME: table.name, LABEL_UPSTREAM_ARTIFACT_VERSION: table.version}
+    flyte.serve(etl_monitor_app)
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run_pipeline()

--- a/examples/artifacts/lineage_examples/ml_pipeline.py
+++ b/examples/artifacts/lineage_examples/ml_pipeline.py
@@ -1,0 +1,150 @@
+"""ML use case: dataset -> train -> evaluate -> serve.
+
+A four-hop lineage chain with a merge point: `evaluate_model` consumes *two*
+upstream artifacts (the model it's grading and the dataset it grades against),
+so its node in the graph has two parents instead of one. The "model" is a
+closed-form linear regression (slope + intercept over a handful of points) —
+no ML framework needed, so the image stays tiny and the run is instant.
+
+`ml_model_server` demonstrates the app-consumption fallback: it fetches the
+model artifact directly by name at request time (a realistic pattern for a
+serving app), which leaves no bound-input trace for the platform to see, so
+the `upstream-artifact-name`/`upstream-artifact-version` labels are
+what make it show up in the dashboard.
+
+Try it:
+
+    python examples/artifacts/lineage_examples/ml_pipeline.py
+"""
+
+import json
+import tempfile
+import time
+
+import fastapi
+from lineage import LABEL_UPSTREAM_ARTIFACT_NAME, LABEL_UPSTREAM_ARTIFACT_VERSION
+
+import flyte
+import flyte.artifacts as artifacts
+from flyte.app.extras import FastAPIAppEnvironment
+from flyte.io import File
+
+# Shared by the task env and the serving app below: the module imports `fastapi` at top
+# level (for `ml_app`), so any task defined here needs it too, even ones that never touch
+# FastAPI themselves -- task loading imports the whole module.
+image = flyte.Image.from_debian_base().with_pip_packages("fastapi", "uvicorn")
+env = flyte.TaskEnvironment(name="ml_pipeline", image=image)
+
+
+def _wait_for_artifact(name: str, *, retries: int = 15, delay_s: float = 2.0):
+    """`Artifact.get` right after a run completes can race artifact indexing; retry briefly."""
+    from flyte.remote import Artifact
+
+    for attempt in range(retries):
+        try:
+            return Artifact.get(name)
+        except Exception:
+            if attempt == retries - 1:
+                raise
+            time.sleep(delay_s)
+
+
+def _run_and_wait(run):
+    """`.wait()` alone doesn't raise on failure -- surface it immediately instead of
+    letting a later `_wait_for_artifact` call fail with a confusing "not found"."""
+    run.wait()
+    if run.phase != "succeeded":
+        raise RuntimeError(f"{run.url} finished in phase {run.phase!r}")
+    return run
+
+
+@env.task(produces_artifacts=True)
+async def produce_dataset() -> File:
+    points = [(1.0, 2.1), (2.0, 4.0), (3.0, 5.9), (4.0, 8.1), (5.0, 9.9)]
+    with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False) as f:
+        f.write("x,y\n")
+        f.writelines(f"{x},{y}\n" for x, y in points)
+    file = await File.from_local(f.name)
+    return artifacts.new(file, artifacts.Metadata(name="ml-dataset", description="Toy (x, y) points for regression"))
+
+
+@env.task(produces_artifacts=True)
+async def train_model(dataset: File) -> File:
+    async with dataset.open("rb") as fh:
+        rows = bytes(await fh.read()).decode().splitlines()[1:]
+    points = [tuple(map(float, row.split(","))) for row in rows]
+    n = len(points)
+    mean_x = sum(x for x, _ in points) / n
+    mean_y = sum(y for _, y in points) / n
+    slope = sum((x - mean_x) * (y - mean_y) for x, y in points) / sum((x - mean_x) ** 2 for x, _ in points)
+    intercept = mean_y - slope * mean_x
+
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump({"slope": slope, "intercept": intercept}, f)
+    model_file = await File.from_local(f.name)
+    return artifacts.new(model_file, artifacts.Metadata(name="ml-model", description="Fitted slope/intercept"))
+
+
+# Merge point: two upstream artifacts feed one run. The dashboard finds both edges
+# via the automatic bound-input scan -- no labels needed for this hop.
+@env.task(produces_artifacts=True)
+async def evaluate_model(model: File, dataset: File) -> File:
+    async with model.open("rb") as fh:
+        params = json.loads(bytes(await fh.read()))
+    async with dataset.open("rb") as fh:
+        rows = bytes(await fh.read()).decode().splitlines()[1:]
+    points = [tuple(map(float, row.split(","))) for row in rows]
+    mse = sum((params["slope"] * x + params["intercept"] - y) ** 2 for x, y in points) / len(points)
+
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump({"mse": mse, "n": len(points)}, f)
+    report_file = await File.from_local(f.name)
+    return artifacts.new(report_file, artifacts.Metadata(name="ml-eval-report", description="MSE against the dataset"))
+
+
+ml_app = fastapi.FastAPI(title="ML Model Server")
+
+
+@ml_app.get("/predict")
+async def predict(x: float) -> dict:
+    import json as _json
+
+    from flyte.io import File as _File
+    from flyte.remote import Artifact
+
+    model_artifact = await Artifact.get.aio(name="ml-model")
+    model_file = await model_artifact.to_python(_File)
+    async with model_file.open("rb") as fh:
+        params = _json.loads(bytes(await fh.read()))
+    return {"x": x, "y_pred": params["slope"] * x + params["intercept"]}
+
+
+# Fetches the model by name at request time rather than binding it as a typed input, so
+# the platform sees no artifact linkage here -- the labels (set on this module-level
+# object in `run_pipeline` below, once the model's identity is known) are what make this
+# app discoverable as a consumer. Setting `.labels` in place (not `clone_with()`, which
+# would return a local-variable copy the app resolver can't find by name in this module)
+# keeps the object the resolver looks up by name in this module's global namespace.
+ml_model_server = FastAPIAppEnvironment(name="ml-model-server", app=ml_app, image=image)
+
+
+def run_pipeline() -> None:
+    """Produce the dataset, train, evaluate, and serve. Assumes init_from_config() ran."""
+    dataset_run = _run_and_wait(flyte.run(produce_dataset))
+    print(dataset_run.url)
+    dataset = _wait_for_artifact("ml-dataset")
+
+    train_run = _run_and_wait(flyte.run(train_model, dataset=dataset))
+    print(train_run.url)
+    model = _wait_for_artifact("ml-model")
+
+    eval_run = _run_and_wait(flyte.run(evaluate_model, model=model, dataset=dataset))
+    print(eval_run.url)
+
+    ml_model_server.labels = {LABEL_UPSTREAM_ARTIFACT_NAME: model.name, LABEL_UPSTREAM_ARTIFACT_VERSION: model.version}
+    flyte.serve(ml_model_server)
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run_pipeline()

--- a/src/flyte/app/_app_environment.py
+++ b/src/flyte/app/_app_environment.py
@@ -5,7 +5,7 @@ import os
 import re
 import shlex
 from dataclasses import dataclass, field, replace
-from typing import Any, Callable, List, Literal, Optional, TypeVar, Union
+from typing import Any, Callable, List, Literal, Mapping, Optional, TypeVar, Union
 
 import rich.repr
 
@@ -126,6 +126,9 @@ class AppEnvironment(Environment):
             to connect app parameters to task outputs, `ArtifactValue` to resolve a
             published artifact (e.g. a prefetched model), or `AppEndpoint` to
             reference other app endpoints.
+        labels: Optional user-defined labels to attach to the app as KEY=VALUE pairs, used
+            for filtering and organizing apps (analogous to the `labels` accepted by
+            `flyte.with_runcontext()` for runs).
         cluster_pool: Cluster pool for scheduling. Default `"default"`.
         timeouts: `Timeouts` object for startup/health check timeouts.
         name: Name of the app (required). Must be lowercase alphanumeric with hyphens.
@@ -150,6 +153,9 @@ class AppEnvironment(Environment):
 
     # Code
     parameters: List[Parameter] = field(default_factory=list)
+
+    # Metadata
+    labels: Optional[Mapping[str, str]] = None
 
     # queue / cluster_pool
     cluster_pool: str = "default"
@@ -192,6 +198,8 @@ class AppEnvironment(Environment):
                 raise TypeError(f"Expected links to be of type List[Link], got {type(link)}")
         if not isinstance(self.timeouts, Timeouts):
             raise TypeError(f"Expected timeouts to be of type Timeouts, got {type(self.timeouts)}")
+        if self.labels is not None and not isinstance(self.labels, Mapping):
+            raise TypeError(f"Expected labels to be of type Mapping[str, str], got {type(self.labels)}")
 
         if self.parameters and self.command is not None:
             cmd_head = self.command.split()[0] if isinstance(self.command, str) else self.command[0]
@@ -390,6 +398,7 @@ class AppEnvironment(Environment):
         links = kwargs.pop("links", None)
         include = kwargs.pop("include", None)
         parameters = kwargs.pop("parameters", None)
+        labels = kwargs.pop("labels", None)
         cluster_pool = kwargs.pop("cluster_pool", None)
         pod_template = kwargs.pop("pod_template", None)
         timeouts = kwargs.pop("timeouts", None)
@@ -433,6 +442,8 @@ class AppEnvironment(Environment):
             kwargs["include"] = tuple(include) if not isinstance(include, tuple) else include
         if parameters is not None:
             kwargs["parameters"] = parameters
+        if labels is not None:
+            kwargs["labels"] = labels
         if cluster_pool is not None:
             kwargs["cluster_pool"] = cluster_pool
         if timeouts is not None:

--- a/src/flyte/app/_runtime/app_serde.py
+++ b/src/flyte/app/_runtime/app_serde.py
@@ -414,6 +414,7 @@ async def translate_app_env_to_idl(
             ),
             code_bundle_uri=_get_code_bundle_uri(serialization_context),
             source_code=_get_source_code(),
+            labels=dict(app_env.labels) if app_env.labels else None,
         ),
         spec=app_definition_pb2.Spec(
             desired_state=desired_state,


### PR DESCRIPTION
## Summary

- Adds `ArtifactLineageAppEnvironment` (`examples/artifacts/lineage/`), an example `AppEnvironment` construct that renders, for any published artifact, the full lineage graph around it: every producing run traced back to the original run/artifact in the chain, and every downstream run/artifact/app that consumed it (directly or transitively). List view at `GET /lineage`, per-artifact graph view at `GET /lineage/artifact/{name}`. Modeled on the `RunLineageDashboard` pattern from [unionai-oss/experimental-flyte-plugins](https://github.com/unionai-oss/experimental-flyte-plugins/tree/main/sensor) (label-driven, no stored lineage state — everything is re-derived from the backend on each request).
- Lineage is derived from two signals:
  - **Automatic**: artifacts bound as typed run inputs (manual `flyte.run(task, model=artifact)` or `OnArtifact`-triggered runs via `flyte.TriggeredArtifact`) already stamp `Literal.artifact_id` — no extra code needed.
  - **Fallback**: a private `__upstream_artifact__` label (set to the artifact's `tracker` string) for cases the backend can't see on its own — a task that resolves an artifact's value without binding it as a typed input, or an app that consumes an artifact at all. Runs pick this up via the existing `flyte.with_runcontext(labels=...)`; apps needed a new `labels` field (see below).
- `examples/artifacts/artifact_lineage_example.py`: an end-to-end runnable script exercising both signals — a multi-hop task chain (`produce_raw_data -> train_model`, automatic detection), a task that only takes a plain string input (`audit_model`, label fallback), and an app that "serves" the trained model (`model_server`, label fallback via the new `AppEnvironment.labels`).

## SDK change

- `flyte.app.AppEnvironment` gains a `labels: Mapping[str, str] | None` field, wired into `translate_app_env_to_idl` (`app_definition_pb2.Meta(labels=...)`). This mirrors the `labels` already accepted by `flyte.with_runcontext()` for runs — apps had no declarative way to carry labels before this (only a post-hoc `flyte.remote.App.replace(..., labels=...)`), which is what the lineage dashboard needs to detect artifact-consuming apps.

## Test plan

- [x] `uv run pytest tests/flyte/app/ tests/user_api_apps/ -q` — 387 passed (labels field doesn't break existing app serde/dataclass tests)
- [x] `ruff check` / `ruff format --check` clean on all new/changed files
- [x] Unit-level smoke test of `build_artifact_lineage()`'s graph-walking logic against mocked `Run`/`Artifact`/`App` objects — verifies producer chaining, label-based consumer detection, and downstream artifact chaining all produce the correct nodes/edges
- [x] Verified `translate_app_env_to_idl` round-trips `AppEnvironment(labels=...)` into `App.metadata.labels` on the proto
- [x] Imported `artifact_lineage_example.py` and confirmed the `ArtifactLineageAppEnvironment`'s FastAPI routes (`/lineage`, `/lineage/graph/{name}`, `/lineage/artifact/{name}`) wire up correctly
- [ ] Not tested against a live Flyte backend (no cluster available in this environment) — the example's `__main__` deploy/run/serve flow has not been exercised end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)