### PR TITLE
Rename artifact Metadata.data to attrs, CLI --data flag to --attr

### DIFF
--- a/examples/artifacts/artifact_example.py
+++ b/examples/artifacts/artifact_example.py
@@ -59,7 +59,7 @@ async def produce_dir() -> Dir:
 @env.task(produces_artifacts=True)
 async def produce_dataframe() -> DataFrame:
     df = pd.DataFrame({"feature": [1, 2, 3], "label": [0, 1, 0]})
-    metadata = artifacts.Metadata(name="training-set", description="Toy training data", data={"rows": "3"})
+    metadata = artifacts.Metadata(name="training-set", description="Toy training data", attrs={"rows": "3"})
     return artifacts.new(DataFrame.from_df(df), metadata)
 
 

--- a/src/flyte/artifacts/_metadata.py
+++ b/src/flyte/artifacts/_metadata.py
@@ -18,7 +18,7 @@ class Metadata:
     name: str
     version: Optional[str] = None
     description: Optional[str] = None
-    data: Optional[typing.Mapping[str, str]] = None
+    attrs: Optional[typing.Mapping[str, str]] = None
     card: Optional[Card] = None
 
     @classmethod
@@ -35,13 +35,13 @@ class Metadata:
         task: Optional[str] = None,
         modality: Tuple[str, ...] = ("text",),
         serial_format: str = "safetensors",
-        data: Optional[typing.Mapping[str, str]] = None,
+        attrs: Optional[typing.Mapping[str, str]] = None,
     ) -> Metadata:
         """
-        Helper method to create ModelMetadata. This method sets the data keys specific to models.
-        Extra key/values passed via `data` are merged in; the model-specific keys win on conflict.
+        Helper method to create ModelMetadata. This method sets the attrs keys specific to models.
+        Extra key/values passed via `attrs` are merged in; the model-specific keys win on conflict.
         """
-        merged: dict[str, str] = dict(data) if data else {}
+        merged: dict[str, str] = dict(attrs) if attrs else {}
         merged.update(
             {
                 "framework": framework or "",
@@ -56,7 +56,7 @@ class Metadata:
             name=name,
             version=version,
             description=description,
-            data=merged,
+            attrs=merged,
             card=card,
         )
 
@@ -78,7 +78,7 @@ def to_produced_artifact(
         card = artifact_id_pb2.ArtifactCard(uri=md.card.uri, format=md.card.format, type=md.card.card_type)
     info = artifact_id_pb2.ArtifactInfo(
         description=md.description or "",
-        user_metadata=dict(md.data) if md.data else None,
+        user_metadata=dict(md.attrs) if md.attrs else None,
         card=card,
     )
     return common_pb2.ProducedArtifact(

--- a/src/flyte/cli/_create.py
+++ b/src/flyte/cli/_create.py
@@ -90,7 +90,7 @@ def project(cfg: common.CLIConfig, id: str, name: str, description: str, label: 
 @click.option("--version", type=str, default=None, help="Version to publish. Defaults to a random version.")
 @click.option("--description", type=str, default=None, help="Human readable description.")
 @click.option(
-    "--data",
+    "--attr",
     multiple=True,
     callback=common.key_value_callback,
     help="Free-form user metadata as key=value pairs. Can be specified multiple times.",
@@ -127,7 +127,7 @@ def artifact(
     from_file: str,
     version: str | None = None,
     description: str | None = None,
-    data: dict[str, str] | None = None,
+    attr: dict[str, str] | None = None,
     external_ref: str | None = None,
     card: str | None = None,
     card_format: str | None = None,
@@ -146,7 +146,7 @@ def artifact(
     Example usage:
 
     ```bash
-    flyte create artifact my_model --from-file model.pt --data framework=torch
+    flyte create artifact my_model --from-file model.pt --attr framework=torch
     flyte create artifact llama3 --from-file weights.bin --external-ref hf://meta-llama/Meta-Llama-3-8B
     flyte create artifact my_model --from-file model.pt --card model_card.html --card-type model
     ```
@@ -190,7 +190,7 @@ def artifact(
             name=name,
             version=version,
             description=description,
-            data=data or None,
+            attrs=attr or None,
             card=uploaded_card,
             python_type=python_type,
             project=project,

--- a/src/flyte/prefetch/_hf_model.py
+++ b/src/flyte/prefetch/_hf_model.py
@@ -405,9 +405,9 @@ def _wrap_as_model_artifact(
         except Exception as e:
             logger.warning(f"Could not upload model card: {e}")
 
-    data = {"source_repo": info.repo, "source_commit": commit}
+    attrs = {"source_repo": info.repo, "source_commit": commit}
     if info.shard_config is not None:
-        data["sharding"] = f"{info.shard_config.engine}-tp{info.shard_config.args.tensor_parallel_size}"
+        attrs["sharding"] = f"{info.shard_config.engine}-tp{info.shard_config.args.tensor_parallel_size}"
 
     metadata = artifacts.Metadata.create_model_metadata(
         name=artifact_name,
@@ -420,7 +420,7 @@ def _wrap_as_model_artifact(
         task=info.task,
         modality=info.modality,
         serial_format=info.serial_format or "safetensors",
-        data=data,
+        attrs=attrs,
     )
     return artifacts.new(result_dir, metadata)
 

--- a/src/flyte/remote/_artifact.py
+++ b/src/flyte/remote/_artifact.py
@@ -184,7 +184,7 @@ class Artifact(ToJSONMixin):
         name: str | None = None,
         version: str | None = None,
         description: str | None = None,
-        data: Mapping[str, str] | None = None,
+        attrs: Mapping[str, str] | None = None,
         card: CoreCard | None = None,
         python_type: Type | None = None,
         project: str | None = None,
@@ -201,11 +201,11 @@ class Artifact(ToJSONMixin):
         Args:
             value: The File, Dir, or DataFrame to publish. May be wrapped
                 with `flyte.artifacts.new(...)`; wrapper metadata seeds name/version/
-                description/data/card, and explicit keyword arguments override it.
+                description/attrs/card, and explicit keyword arguments override it.
             name: The artifact name; required when value carries no metadata.
             version: The version to publish. Defaults to the metadata version or a random one.
             description: Optional human readable description.
-            data: Optional free-form key/value metadata.
+            attrs: Optional free-form key/value metadata.
             card: Optional `flyte.artifacts.Card` to attach.
             python_type: Type used for literal conversion; defaults to `type(value)`.
             project: Project to publish into; defaults to the init configuration.
@@ -230,7 +230,7 @@ class Artifact(ToJSONMixin):
             name = name or md.name
             version = version or md.version
             description = description if description is not None else md.description
-            data = data if data is not None else md.data
+            attrs = attrs if attrs is not None else md.attrs
             card = card if card is not None else md.card
         if not name:
             raise ValueError(
@@ -262,7 +262,7 @@ class Artifact(ToJSONMixin):
                 type=lt,
                 info=artifact_id_pb2.ArtifactInfo(
                     description=description or "",
-                    user_metadata=dict(data) if data else None,
+                    user_metadata=dict(attrs) if attrs else None,
                     card=_card_to_pb2(card),
                 ),
                 source=source,

--- a/tests/flyte/prefetch/test_hf_model.py
+++ b/tests/flyte/prefetch/test_hf_model.py
@@ -501,7 +501,7 @@ def test_prefetch_hf_model_task_nonexistent_repo_raises():
 
 def test_wrap_as_model_artifact_metadata():
     """The stored Dir is wrapped with model artifact metadata: name, HF commit
-    as version, model facts + source repo/commit as data, README as card."""
+    as version, model facts + source repo/commit as attrs, README as card."""
     from flyte.io import Dir
     from flyte.prefetch._hf_model import _wrap_as_model_artifact
 
@@ -530,14 +530,14 @@ def test_wrap_as_model_artifact_metadata():
     assert md.version == "abc123"
     assert md.description == "Llama 2 7B"
     assert md.card == fake_card
-    assert md.data["architecture"] == "LlamaForCausalLM"
-    assert md.data["model_type"] == "llama"
-    assert md.data["task"] == "generate"
-    assert md.data["framework"] == "huggingface"
-    assert md.data["serial_format"] == "safetensors"
-    assert md.data["source_repo"] == "meta-llama/Llama-2-7b-hf"
-    assert md.data["source_commit"] == "abc123"
-    assert "sharding" not in md.data
+    assert md.attrs["architecture"] == "LlamaForCausalLM"
+    assert md.attrs["model_type"] == "llama"
+    assert md.attrs["task"] == "generate"
+    assert md.attrs["framework"] == "huggingface"
+    assert md.attrs["serial_format"] == "safetensors"
+    assert md.attrs["source_repo"] == "meta-llama/Llama-2-7b-hf"
+    assert md.attrs["source_commit"] == "abc123"
+    assert "sharding" not in md.attrs
     # The wrapper preserves the Dir interface.
     assert wrapped.path == "s3://bucket/models/llama"
 
@@ -565,7 +565,7 @@ def test_wrap_as_model_artifact_sharded_records_sharding():
         shard_config=ShardConfig(args=VLLMShardArgs(tensor_parallel_size=8)),
     )
     wrapped = _wrap_as_model_artifact(Dir(path="s3://b/m"), info, "model", "c1", None)
-    assert wrapped.get_flyte_metadata().data["sharding"] == "vllm-tp8"
+    assert wrapped.get_flyte_metadata().attrs["sharding"] == "vllm-tp8"
 
 
 def test_wrap_as_model_artifact_strips_readme_frontmatter():

--- a/tests/flyte/remote/test_artifact.py
+++ b/tests/flyte/remote/test_artifact.py
@@ -76,7 +76,7 @@ class TestCreate:
             name="wrapped",
             version="2.0",
             description="from metadata",
-            data={"framework": "torch"},
+            attrs={"framework": "torch"},
             card=artifacts.Card(uri="s3://b/card.html", format="html", card_type="model"),
         )
 

--- a/tests/flyte/test_produces_artifacts.py
+++ b/tests/flyte/test_produces_artifacts.py
@@ -134,7 +134,7 @@ class TestToProducedArtifact:
                 name="my-model",
                 version="1.0",
                 description="a model",
-                data={"framework": "torch"},
+                attrs={"framework": "torch"},
                 card=artifacts.Card(uri="s3://b/card.html", format="html", card_type="model"),
             ),
             output="o0",
@@ -149,11 +149,11 @@ class TestToProducedArtifact:
         md = Metadata.create_model_metadata(
             name="m",
             framework="torch",
-            data={"source_repo": "org/model", "framework": "should-lose"},
+            attrs={"source_repo": "org/model", "framework": "should-lose"},
         )
-        assert md.data["source_repo"] == "org/model"
+        assert md.attrs["source_repo"] == "org/model"
         # Model-specific keys win on conflict.
-        assert md.data["framework"] == "torch"
+        assert md.attrs["framework"] == "torch"
 
 
 class TestOutputDeclarations:


### PR DESCRIPTION
## Summary
- Renamed `flyte.artifacts.Metadata.data` to `Metadata.attrs` (and the matching `create_model_metadata(data=...)` param to `attrs=...`), since "data" was easily confused with an artifact's payload rather than its free-form key/value attributes.
- Updated all call sites: `to_produced_artifact`, `Artifact.create` (param renamed `data` → `attrs`), and the HuggingFace prefetch model wrapper.
- Renamed the `flyte create artifact` CLI flag from `--data` to `--attr` to match.
- Updated examples, docstrings, and tests accordingly.

## Test plan
- [x] `uv run pytest tests/flyte/test_produces_artifacts.py tests/flyte/remote/test_artifact.py tests/flyte/prefetch/test_hf_model.py tests/flyte/cli/test_create_artifact.py -q` — all pass
- [x] `uv run ruff check` on changed files — clean
- [x] `flyte create artifact --help` shows `--attr` flag with updated example usage