### PR TITLE
Do not serialize None from a PyTorch replica that ran no rank 0

### DIFF
--- a/plugins/pytorch/src/flyteplugins/pytorch/task.py
+++ b/plugins/pytorch/src/flyteplugins/pytorch/task.py
@@ -9,6 +9,7 @@ from cloudpickle import cloudpickle
 from flyte import system_logger as logger
 from flyte._context import internal_ctx
 from flyte._task import P, R
+from flyte.errors import IgnoreOutputs
 from flyte.extend import AsyncFunctionTaskTemplate, TaskPluginRegistry
 from flyte.models import SerializationContext, TaskContext
 from flyteidl2.plugins.kubeflow import common_pb2
@@ -370,9 +371,13 @@ class TorchFunctionTask(AsyncFunctionTaskTemplate):
             finally:
                 watchdog_stop.set()
 
-            # `out` is a dictionary of rank (not local rank) -> result
-            # Rank 0 returns the result of the task function
-            result = out[0] if 0 in out else None
+            # `out` is a dictionary of rank (not local rank) -> result, holding only the ranks that
+            # ran in this pod. With nnodes>1 only the master pod runs global rank 0, so every other
+            # pod has no result to report: substituting None here would serialize None against the
+            # declared output type and fail the replica.
+            if 0 not in out:
+                raise IgnoreOutputs
+            result = out[0]
             await self.post(result)
 
         return result

--- a/plugins/pytorch/tests/test_task.py
+++ b/plugins/pytorch/tests/test_task.py
@@ -1,10 +1,16 @@
 import asyncio
 import os
+import threading
+from contextlib import contextmanager
+from types import SimpleNamespace
 
 import flyte
+import pytest
 from cloudpickle import cloudpickle
+from flyte.errors import IgnoreOutputs
 from flyte.models import SerializationContext
 
+from flyteplugins.pytorch import task as pytorch_task
 from flyteplugins.pytorch.task import Elastic, RunPolicy, TorchFunctionTask
 
 
@@ -309,3 +315,47 @@ def test_launcher_entrypoint_overrides_nccl_default(monkeypatch):
     # restore
     torch.distributed.constants.default_pg_nccl_timeout = orig_constants
     torch.distributed.distributed_c10d.default_pg_nccl_timeout = orig_c10d
+
+
+# --- output ownership across replicas ---
+#
+# `elastic_launch` returns {global rank -> result} for the ranks that ran in *this* pod. With
+# nnodes>1 only the master pod holds rank 0, so the others own no output.
+
+
+class _FakeCtx:
+    """Enough of the internal context for TorchFunctionTask.execute to run without a cluster."""
+
+    def __init__(self):
+        self.data = SimpleNamespace(task_context=SimpleNamespace(mode="remote", replace=lambda **kw: self))
+
+    @contextmanager
+    def replace_task_context(self, _tctx):
+        yield
+
+
+def _execute_with_ranks(monkeypatch, out):
+    task = TorchFunctionTask(
+        name="n",
+        interface=None,
+        func=lambda: None,
+        image="pytorch/pytorch:2.8.0-cuda12.9-cudnn9-runtime",
+        resources=flyte.Resources(cpu=1, memory="1Gi"),
+        plugin_config=Elastic(nnodes=2, nproc_per_node=4),
+    )
+    monkeypatch.setattr(pytorch_task, "internal_ctx", _FakeCtx)
+    monkeypatch.setattr(pytorch_task, "_start_zombie_watchdog", lambda nproc: threading.Event())
+    monkeypatch.setattr(pytorch_task, "elastic_launch", lambda config, entrypoint: lambda *a: out)
+    monkeypatch.setattr(flyte, "ctx", lambda: SimpleNamespace(action=SimpleNamespace(run_name="r")))
+    return asyncio.run(task.execute())
+
+
+def test_master_replica_returns_rank_zero_result(monkeypatch):
+    # Node 0 runs ranks 0-3, so it owns the output.
+    assert _execute_with_ranks(monkeypatch, {0: 0.5, 1: 0.5, 2: 0.5, 3: 0.5}) == 0.5
+
+
+def test_worker_replica_ignores_outputs(monkeypatch):
+    # Node 1 runs ranks 4-7. Returning None here would fail type conversion against `-> float`.
+    with pytest.raises(IgnoreOutputs):
+        _execute_with_ranks(monkeypatch, {4: 0.5, 5: 0.5, 6: 0.5, 7: 0.5})

--- a/src/flyte/_internal/runtime/taskrunner.py
+++ b/src/flyte/_internal/runtime/taskrunner.py
@@ -17,7 +17,7 @@ from flyte._logging import log, logger
 from flyte._metrics import Stopwatch
 from flyte._observe import Recorder, TaskInfo, has_observers, observe_task
 from flyte._task import TaskTemplate
-from flyte.errors import CustomError, RuntimeSystemError, RuntimeUnknownError, RuntimeUserError
+from flyte.errors import CustomError, IgnoreOutputs, RuntimeSystemError, RuntimeUnknownError, RuntimeUserError
 from flyte.models import ActionID, CheckpointPaths, CodeBundle, RawDataPath, TaskContext
 
 from .. import Controller
@@ -34,6 +34,10 @@ from .io import _is_clustered_worker, load_inputs, upload_error, upload_outputs
 # Exit code a clustered/jobset worker uses to fail its pod so the JobSet controller triggers a
 # whole-set restart. The JobSet keys off the pod exit code, not error.pb.
 _CLUSTERED_FAILURE_EXIT_CODE = 1
+
+# Returned in place of a task's outputs when it raised IgnoreOutputs. Distinct from None, which is
+# the legitimate return value of a task that declares no outputs.
+_IGNORE_OUTPUTS = object()
 
 
 def replace_task_cli(args: List[str], inputs: Inputs, tmp_path: pathlib.Path, action: ActionID) -> List[str]:
@@ -121,6 +125,9 @@ async def run_task(
                 outputs = await task.execute(**inputs)
                 logger.info(f"Parent task completed successfully, {tctx.action}")
                 return outputs, None
+            except IgnoreOutputs:
+                logger.info(f"Task {task.name} produces no outputs on this replica, {tctx.action}")
+                return _IGNORE_OUTPUTS, None
             except (RuntimeSystemError, RuntimeUnknownError, RuntimeUserError) as e:
                 logger.exception(f"Task failed with error: {e}")
                 recorder.record_error(e)
@@ -212,6 +219,12 @@ async def convert_and_run(
             # worker reports (from Elastic/distributed tasks) with empty main process report
             if ctx.get_report():
                 await flyte.report.flush.aio()
+
+        # A replica that raised IgnoreOutputs does not own the action's outputs — converting its
+        # return value would type-check None against the declared output type. Its report has
+        # already been flushed above, so only the output write is skipped.
+        if out is _IGNORE_OUTPUTS:
+            return None, None
 
         sw = Stopwatch("convert_outputs_from_native")
         sw.start()

--- a/src/flyte/errors.py
+++ b/src/flyte/errors.py
@@ -376,3 +376,14 @@ class ConditionNotFoundError(RuntimeUserError):
 
     def __init__(self, message: str):
         super().__init__("ConditionNotFoundError", message, "user")
+
+
+class IgnoreOutputs(Exception):
+    """
+    Raised by a task to signal that this replica produces no outputs at all.
+
+    Distributed tasks schedule several replicas for one action, but only one of them owns the
+    action's outputs. A replica that does not own them raises this instead of returning a value:
+    the runtime then skips output conversion and upload for that replica, leaving the owner's
+    outputs untouched. It is not a failure — the replica still exits successfully.
+    """

--- a/tests/flyte/internal/runtime/test_taskrunner.py
+++ b/tests/flyte/internal/runtime/test_taskrunner.py
@@ -13,6 +13,8 @@ import pytest
 
 from flyte._internal.runtime import taskrunner
 from flyte._internal.runtime.taskrunner import extract_download_run_upload, run_task
+from flyte.errors import IgnoreOutputs
+from flyte.models import ActionID, RawDataPath
 
 
 class _FakeTask:
@@ -85,3 +87,52 @@ def test_clustered_worker_success_does_not_exit(monkeypatch):
     monkeypatch.setattr(taskrunner, "upload_outputs", AsyncMock())
 
     assert _run_extract() is None
+
+
+# --- IgnoreOutputs: a replica that owns no outputs ---
+
+
+class _IgnoringTask:
+    name = "t"
+
+    async def execute(self, **kwargs):
+        raise IgnoreOutputs
+
+
+def test_run_task_ignore_outputs_is_not_an_error():
+    tctx = SimpleNamespace(action="act-1")
+    out, err = asyncio.run(run_task(tctx=tctx, controller=None, task=_IgnoringTask(), inputs={}))
+    assert err is None
+    assert out is taskrunner._IGNORE_OUTPUTS
+
+
+def test_ignored_outputs_are_not_uploaded(monkeypatch):
+    upload_outputs = AsyncMock()
+    monkeypatch.setattr(taskrunner, "convert_and_run", AsyncMock(return_value=(None, None)))
+    monkeypatch.setattr(taskrunner, "upload_outputs", upload_outputs)
+
+    assert _run_extract() is None
+    upload_outputs.assert_not_awaited()
+
+
+def test_convert_and_run_skips_conversion_for_ignoring_replica(monkeypatch):
+    """The replica's return value is never type-checked against the declared outputs."""
+    convert_outputs = AsyncMock()
+    monkeypatch.setattr(taskrunner, "convert_inputs_to_native", AsyncMock(return_value={}))
+    monkeypatch.setattr(taskrunner, "run_task", AsyncMock(return_value=(taskrunner._IGNORE_OUTPUTS, None)))
+    monkeypatch.setattr(taskrunner, "convert_from_native_to_outputs", convert_outputs)
+
+    outputs, err = asyncio.run(
+        taskrunner.convert_and_run(
+            task=SimpleNamespace(name="t", report=False, native_interface=None),
+            action=ActionID(name="a0"),
+            controller=None,
+            raw_data_path=RawDataPath(path="s3://bucket/raw"),
+            version="v1",
+            output_path="s3://bucket/outputs",
+            run_base_dir="s3://bucket",
+        )
+    )
+
+    assert (outputs, err) == (None, None)
+    convert_outputs.assert_not_awaited()


### PR DESCRIPTION
## What

A non-master replica of an `Elastic(nnodes>1)` task now raises `flyte.errors.IgnoreOutputs`
instead of returning `None`, and the runtime skips output conversion and upload for it.

```diff
-# `out` is a dictionary of rank (not local rank) -> result
-# Rank 0 returns the result of the task function
-result = out[0] if 0 in out else None
+if 0 not in out:
+    raise IgnoreOutputs()
+result = out[0]
```

Three pieces:

- **`flyte/errors.py`** — new `IgnoreOutputs`, a plain `Exception`: "this replica produces no
  outputs." Not a failure; the replica still exits successfully.
- **`taskrunner.py`** — `run_task` catches it and returns the `_IGNORE_OUTPUTS` sentinel (distinct
  from `None`, which is the legitimate return of a task declaring no outputs); `convert_and_run`
  returns `(None, None)` for it, so `extract_download_run_upload` takes its existing
  "no outputs" path and uploads nothing. The report is still flushed first, so worker decks from
  distributed tasks are unaffected.
- **`flyteplugins/pytorch/task.py`** — raises it when this pod ran no global rank 0.

## Why

`elastic_launch` returns `{global rank -> result}` for the ranks that ran **in this pod**. With
`Elastic(nnodes=2, nproc_per_node=4)`, node 0 runs ranks 0-3 and node 1 runs ranks 4-7, so node 1
has no rank 0:

| pod | ranks | `0 in out` |
| --- | --- | --- |
| node 0 (master) | 0, 1, 2, 3 | yes |
| node 1 (worker) | 4, 5, 6, 7 | **no** |

`out[0] if 0 in out else None` therefore hands `None` to the output serializer on every non-master
pod, which then type-checks it against the declared signature and fails the task:

```
In task ..._train_multinode_task_env.train_multinode_task variable o0,
Expected value of type <class 'float'> but got 'None' of type <class 'NoneType'>
```

The user's function is fine — it returns a float on every rank. The `None` is manufactured by the
plugin wrapper after the function has already returned. Any multi-node elastic task with a
non-`Optional` return type fails this way; only `nnodes=1` escapes it.

This is a regression from v1, which had exactly this case covered
(`flytekitplugins/kfpytorch/task.py:487`):

```python
if 0 in out:
    return out[0].return_value
else:
    raise IgnoreOutputs()   # this replica writes no outputs at all
```

`IgnoreOutputs` restores that contract. Skipping the write on non-owning replicas is also what the
clustered/jobset path already does — `io.upload_outputs` and `io.upload_error` bail out for
`_is_nonzero_rank_clustered_worker()` with the same "only rank 0 owns the output" reasoning. That
gate does not help here because the elastic agent process is not itself a torchrun worker
(`TORCHELASTIC_RUN_ID` is set only in the child env), and because the failure happens during
conversion, before upload is ever reached.

## How was this tested

`uv run pytest tests/flyte/internal plugins/pytorch/tests tests/flyte/clustered` — 344 passed,
1 skipped. Four new tests:

- `plugins/pytorch/tests/test_task.py` — patches `elastic_launch` to return worker ranks
  `{4..7}` and asserts `execute` raises `IgnoreOutputs`; the master case `{0..3}` still returns
  rank 0's value.
- `tests/flyte/internal/runtime/test_taskrunner.py` — `IgnoreOutputs` is not turned into an error,
  and nothing is uploaded for a replica that raised it.

Not yet run on a real multi-node cluster — the repro is
`flyte-migrate`'s `test_pytorch_multinode`, currently `xfail(strict=True)` citing this line, so
that mark should come off once this lands.

Note for review: this touches the same block in `convert_and_run` as #1397 (the report-flush
guard). The lines do not overlap, but whichever merges second will want a look.

https://claude.ai/code/session_01AH57st8CtDLFou4VKJM4hc