### PR TITLE
fix(devbox): Resolving the kubeconfig path for devbox start command

### DIFF
--- a/src/flyte/cli/_devbox.py
+++ b/src/flyte/cli/_devbox.py
@@ -126,7 +126,7 @@ def _run_container(
         "--env",
         "K3S_KUBECONFIG_OUTPUT=/.kube/kubeconfig",
         "--volume",
-        f"{kube_dir}:/.kube",
+        f"{kube_dir.resolve()}:/.kube",
         "--volume",
         f"{flyte_devbox_config_dir}:/var/lib/flyte/config",
         "--volume",

--- a/tests/cli/test_devbox.py
+++ b/tests/cli/test_devbox.py
@@ -55,6 +55,27 @@ class TestRunContainerGpuFlag:
         cmd = self._invoke(gpu=True)
         assert cmd.index("--gpus") < cmd.index("ghcr.io/flyteorg/flyte-devbox:gpu-latest")
 
+    def test_kube_dir_mount_resolves_symlinks(self, tmp_path):
+        kube_dir = tmp_path / "real-kube-dir"
+        kube_dir.mkdir()
+        kube_dir_symlink = tmp_path / "kube-dir-symlink"
+        kube_dir_symlink.symlink_to(kube_dir, target_is_directory=True)
+
+        with patch("flyte.cli._devbox.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            _run_container(
+                image="flyte-devbox:latest",
+                is_dev_mode=False,
+                container_name="flyte-devbox",
+                kube_dir=kube_dir_symlink,
+                flyte_devbox_config_dir=tmp_path / "devbox",
+                volume_name="flyte-devbox",
+                ports=[],
+            )
+
+        cmd = mock_run.call_args.args[0]
+        assert f"{kube_dir}:/.kube" in cmd
+
 
 class TestMergeKubeconfigRetry:
     """Verify the chown-retry fallback for a root-owned kubeconfig on Linux."""


### PR DESCRIPTION
## Changelog

Fixed `flyte start devbox` failing to locate the generated kubeconfig when using Podman Machine on macOS.

On macOS, `/tmp` is a symlink to `/private/tmp`. Flyte previously passed `/tmp/.kube` directly to the container runtime, causing Podman to mount its VM-local `/tmp/.kube` instead of the corresponding macOS directory. K3s successfully generated the kubeconfig inside the VM, but the Flyte CLI could not see it and timed out after 60 seconds.

The kubeconfig bind-mount source is now resolved before starting the container:

```python
kube_dir.resolve()
```

This converts `/tmp/.kube` to `/private/tmp/.kube` on macOS, which Podman Machine shares with the host. Linux behavior remains unchanged.

Added a regression test verifying that symlinked kubeconfig directories are resolved before being passed to Docker.

Validated locally with both a pinned devbox image (`ghcr.io/flyteorg/flyte-devbox:sha-79914307a52a413a85e3996e22366a00b353ee22`) and the default `cr.flyte.org/flyteorg/flyte-devbox:latest` image. Both completed startup successfully and returned HTTP 200 from the readiness endpoint.