### PR TITLE
rs_controller: support condition actions and decoupled start/wait

### DIFF
--- a/rs_controller/src/action.rs
+++ b/rs_controller/src/action.rs
@@ -1,9 +1,9 @@
 use flyteidl2::{
     flyteidl::{
         common::{ActionIdentifier, ActionPhase, RunIdentifier},
-        core::{ExecutionError, TypedInterface},
+        core::{ExecutionError, Literal, TypedInterface},
         task::{OutputReferences, TaskSpec, TraceSpec},
-        workflow::{ActionUpdate, TraceAction},
+        workflow::{ActionUpdate, ConditionAction, TraceAction},
     },
     google::protobuf::Timestamp,
 };
@@ -16,6 +16,9 @@ use tracing::debug;
 pub enum ActionType {
     Task = 0,
     Trace = 1,
+    /// A condition (signal) action: enqueued PAUSED, resolved out-of-band by a
+    /// signal, and its value delivered inline on `ActionUpdate.value`.
+    Condition = 2,
 }
 
 #[pyclass(dict, get_all, set_all)]
@@ -38,6 +41,10 @@ pub struct Action {
     pub cache_key: Option<String>,
     pub queue: Option<String>,
     pub trace: Option<TraceAction>,
+    pub condition: Option<ConditionAction>,
+    /// The value a condition action was signalled with, delivered inline on
+    /// `ActionUpdate.value` rather than through object storage.
+    pub condition_output: Option<Literal>,
 }
 
 impl Action {
@@ -109,12 +116,22 @@ impl Action {
         if !obj.output_uri.is_empty() {
             self.realized_outputs_uri = Some(obj.output_uri.clone());
         }
+        // Condition actions carry their resolved value inline. Captured un-gated
+        // (rather than only when action_type == Condition) because a cache entry
+        // created by `new_from_update` is typed Task until a later submit repairs
+        // it -- gating here would drop the value of an already-signalled
+        // condition on a retry.
+        if obj.value.is_some() {
+            self.condition_output = obj.value.clone();
+        }
         self.started = true;
     }
 
     pub fn new_from_update(parent_action_name: String, obj: ActionUpdate) -> Self {
         let action_id = obj.action_id.unwrap();
         let phase = ActionPhase::try_from(obj.phase).unwrap();
+        // An ActionUpdate carries no action type, so this entry is typed Task
+        // until the matching submit repairs it via `merge_from_submit`.
         Action {
             action_id: action_id.clone(),
             parent_action_name,
@@ -133,6 +150,8 @@ impl Action {
             cache_key: None,
             queue: None,
             trace: None,
+            condition: None,
+            condition_output: obj.value,
         }
     }
 
@@ -153,12 +172,45 @@ impl Action {
         }
     }
 
+    /// True when the action reached a terminal phase that means success.
+    ///
+    /// `Recovered` counts: the action was adopted as-is from a prior run and did
+    /// not execute here, but its outputs are valid and control flow should treat
+    /// it exactly like `Succeeded`. Callers should use this rather than testing
+    /// `phase == Succeeded`, which silently mistreats a recovered action, or
+    /// inverting `Failed`, which also swallows `Aborted` and `TimedOut`.
+    pub fn is_action_successful(&self) -> bool {
+        matches!(
+            self.phase,
+            Some(ActionPhase::Succeeded) | Some(ActionPhase::Recovered)
+        )
+    }
+
+    /// True while a condition action is waiting to be signalled. Not terminal --
+    /// a paused action is still in flight, so waiters must keep waiting.
+    pub fn is_action_paused(&self) -> bool {
+        self.phase == Some(ActionPhase::Paused)
+    }
+
     // action here is the submitted action, invoked by the informer's manual submit.
     pub fn merge_from_submit(&mut self, action: &Action) {
         self.run_output_base = action.run_output_base.clone();
         self.inputs_uri = action.inputs_uri.clone();
         self.group = action.group.clone();
         self.friendly_name = action.friendly_name.clone();
+
+        // A cache entry created from a watch update is typed Task with no spec
+        // (see `new_from_update`). The submit is the only thing that knows the
+        // real type, so adopt it here -- otherwise a condition whose update
+        // arrived first would never be recognised as one, and `launch_task`
+        // would find no spec to enqueue.
+        self.action_type = action.action_type;
+        if action.condition.is_some() {
+            self.condition = action.condition.clone();
+        }
+        if action.trace.is_some() {
+            self.trace = action.trace.clone();
+        }
 
         if !self.started {
             self.task = action.task.clone();
@@ -215,6 +267,8 @@ impl Action {
             cache_key,
             queue,
             trace: None,
+            condition: None,
+            condition_output: None,
         })
     }
 
@@ -305,6 +359,76 @@ impl Action {
             cache_key: None,
             queue: None,
             trace: Some(trace_action),
+            condition: None,
+            condition_output: None,
+        })
+    }
+
+    /// Create a condition (signal) action.
+    ///
+    /// A condition is enqueued like a task but is resolved out-of-band: the
+    /// backend inserts it in phase PAUSED, and it becomes terminal only when
+    /// someone signals it (or it times out server-side). The signalled value
+    /// arrives inline on `ActionUpdate.value` -- never through object storage --
+    /// and lands in `condition_output`.
+    ///
+    /// `condition_action_bytes` is an encoded `ConditionAction`, following the
+    /// same convention as `from_trace`'s `typed_interface_bytes`: callers own the
+    /// proto and pass it as bytes.
+    ///
+    /// `inputs_uri` is a placeholder -- conditions have no inputs and nothing is
+    /// written there -- but it must be non-empty: the server's enqueue validator
+    /// rejects an empty value, and `build_action_scalars` errors on a missing one
+    /// before any RPC is made.
+    #[staticmethod]
+    pub fn from_condition(
+        parent_action_name: String,
+        action_id_bytes: &[u8],
+        condition_action_bytes: &[u8],
+        inputs_uri: String,
+        run_output_base: String,
+        group_data: Option<String>,
+    ) -> PyResult<Self> {
+        let action_id = ActionIdentifier::decode(action_id_bytes).map_err(|e| {
+            pyo3::exceptions::PyValueError::new_err(format!(
+                "Failed to decode ActionIdentifier: {}",
+                e
+            ))
+        })?;
+
+        let condition_action = ConditionAction::decode(condition_action_bytes).map_err(|e| {
+            pyo3::exceptions::PyValueError::new_err(format!(
+                "Failed to decode ConditionAction: {}",
+                e
+            ))
+        })?;
+
+        debug!("Creating Action from condition for ID {:?}", &action_id);
+        Ok(Action {
+            action_id,
+            parent_action_name,
+            action_type: ActionType::Condition,
+            friendly_name: Some(condition_action.name.clone()),
+            group: group_data,
+            task: None,
+            inputs_uri: Some(inputs_uri),
+            run_output_base: Some(run_output_base),
+            // Conditions deliver their value inline, so there is no outputs URI.
+            realized_outputs_uri: None,
+            err: None,
+            // Unspecified, not Succeeded: unlike a trace (which is recorded after
+            // the fact) a condition is launched and resolved later. A terminal
+            // phase here would make `is_action_terminal` true immediately and fire
+            // completion before any value arrived.
+            phase: Some(ActionPhase::Unspecified),
+            started: false,
+            retries: 0,
+            client_err: None,
+            cache_key: None,
+            queue: None,
+            trace: None,
+            condition: Some(condition_action),
+            condition_output: None,
         })
     }
 
@@ -320,6 +444,24 @@ impl Action {
 
     fn has_error(&self) -> bool {
         self.err.is_some() || self.client_err.is_some()
+    }
+
+    /// Terminal and successful, counting `Recovered` (see `is_action_successful`).
+    #[pyo3(name = "is_successful")]
+    fn py_is_successful(&self) -> bool {
+        self.is_action_successful()
+    }
+
+    /// Waiting to be signalled (condition actions).
+    #[pyo3(name = "is_paused")]
+    fn py_is_paused(&self) -> bool {
+        self.is_action_paused()
+    }
+
+    /// The signalled value of a condition action, as serialized `Literal` bytes.
+    #[getter]
+    fn condition_output_bytes(&self) -> Option<Vec<u8>> {
+        self.condition_output.as_ref().map(|v| v.encode_to_vec())
     }
 
     /// Get action_id as serialized bytes for Python interop
@@ -344,5 +486,181 @@ impl Action {
     #[getter]
     fn phase_value(&self) -> Option<i32> {
         self.phase.map(|p| p as i32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use flyteidl2::flyteidl::core::{literal::Value, primitive, Literal, Primitive, Scalar};
+
+    use super::*;
+
+    fn action_id(name: &str) -> ActionIdentifier {
+        ActionIdentifier {
+            run: Some(RunIdentifier {
+                org: "org".into(),
+                project: "proj".into(),
+                domain: "dev".into(),
+                name: "run".into(),
+            }),
+            name: name.into(),
+        }
+    }
+
+    fn bool_literal(v: bool) -> Literal {
+        Literal {
+            value: Some(Value::Scalar(Box::new(Scalar {
+                value: Some(scalar_primitive(v)),
+            }))),
+            ..Default::default()
+        }
+    }
+
+    fn scalar_primitive(v: bool) -> flyteidl2::flyteidl::core::scalar::Value {
+        flyteidl2::flyteidl::core::scalar::Value::Primitive(Primitive {
+            value: Some(primitive::Value::Boolean(v)),
+        })
+    }
+
+    fn update(name: &str, phase: ActionPhase, value: Option<Literal>) -> ActionUpdate {
+        ActionUpdate {
+            action_id: Some(action_id(name)),
+            phase: phase as i32,
+            error: None,
+            output_uri: String::new(),
+            value,
+        }
+    }
+
+    fn condition(name: &str) -> Action {
+        let spec = ConditionAction {
+            name: name.into(),
+            ..Default::default()
+        };
+        Action::from_condition(
+            "a0".into(),
+            &action_id(name).encode_to_vec(),
+            &spec.encode_to_vec(),
+            "s3://base/c1/inputs.pb".into(),
+            "s3://base".into(),
+            None,
+        )
+        .expect("from_condition")
+    }
+
+    #[test]
+    fn from_condition_is_launchable_and_not_pre_resolved() {
+        let action = condition("c1");
+        assert_eq!(action.action_type, ActionType::Condition);
+        assert_eq!(
+            action.condition.as_ref().map(|c| c.name.as_str()),
+            Some("c1")
+        );
+        // Must be launchable: started=false and a spec present, or launch_task
+        // silently skips the enqueue.
+        assert!(!action.started);
+        // Not terminal at birth, or completion would fire before any value.
+        assert!(!action.is_action_terminal());
+        assert_eq!(action.phase, Some(ActionPhase::Unspecified));
+        // The value arrives inline, never via an outputs URI.
+        assert!(action.realized_outputs_uri.is_none());
+        assert!(action.condition_output.is_none());
+    }
+
+    #[test]
+    fn merge_update_captures_the_signalled_value() {
+        let mut action = condition("c1");
+        action.merge_update(&update("c1", ActionPhase::Paused, None));
+        assert!(action.is_action_paused());
+        assert!(!action.is_action_terminal(), "paused is not terminal");
+        assert!(action.condition_output.is_none());
+
+        action.merge_update(&update(
+            "c1",
+            ActionPhase::Succeeded,
+            Some(bool_literal(true)),
+        ));
+        assert!(action.is_action_terminal());
+        assert!(action.is_action_successful());
+        assert_eq!(action.condition_output, Some(bool_literal(true)));
+    }
+
+    #[test]
+    fn new_from_update_captures_the_signalled_value() {
+        // The watch stream can deliver a condition update before the local submit
+        // registers the action; the value must survive that ordering.
+        let action = Action::new_from_update(
+            "a0".into(),
+            update("c1", ActionPhase::Succeeded, Some(bool_literal(false))),
+        );
+        assert_eq!(action.condition_output, Some(bool_literal(false)));
+    }
+
+    #[test]
+    fn merge_from_submit_repairs_type_and_spec_after_an_early_update() {
+        // Update first: typed Task, no spec, but the value is kept.
+        let mut cached = Action::new_from_update(
+            "a0".into(),
+            update("c1", ActionPhase::Succeeded, Some(bool_literal(true))),
+        );
+        assert_eq!(cached.action_type, ActionType::Task);
+        assert!(cached.condition.is_none());
+
+        // Submit second: adopts the real type and spec without losing the value.
+        cached.merge_from_submit(&condition("c1"));
+        assert_eq!(cached.action_type, ActionType::Condition);
+        assert!(cached.condition.is_some());
+        assert_eq!(cached.condition_output, Some(bool_literal(true)));
+    }
+
+    #[test]
+    fn recovered_is_terminal_and_successful() {
+        let mut action = condition("c1");
+        action.merge_update(&update(
+            "c1",
+            ActionPhase::Recovered,
+            Some(bool_literal(true)),
+        ));
+        // Adopted from a prior run: it did not execute here, but its outcome is
+        // valid and must be treated exactly like Succeeded.
+        assert!(action.is_action_terminal());
+        assert!(action.is_action_successful());
+        assert_eq!(action.condition_output, Some(bool_literal(true)));
+    }
+
+    #[test]
+    fn unsuccessful_terminal_phases_are_terminal_but_not_successful() {
+        for phase in [
+            ActionPhase::Failed,
+            ActionPhase::Aborted,
+            ActionPhase::TimedOut,
+        ] {
+            let mut action = condition("c1");
+            action.merge_update(&update("c1", phase, None));
+            assert!(action.is_action_terminal(), "{phase:?} should be terminal");
+            assert!(
+                !action.is_action_successful(),
+                "{phase:?} should not be successful"
+            );
+        }
+    }
+
+    #[test]
+    fn non_terminal_phases_keep_waiters_waiting() {
+        for phase in [
+            ActionPhase::Unspecified,
+            ActionPhase::Queued,
+            ActionPhase::WaitingForResources,
+            ActionPhase::Initializing,
+            ActionPhase::Running,
+            ActionPhase::Paused,
+        ] {
+            let mut action = condition("c1");
+            action.merge_update(&update("c1", phase, None));
+            assert!(
+                !action.is_action_terminal(),
+                "{phase:?} should not be terminal"
+            );
+        }
     }
 }

--- a/rs_controller/src/core.rs
+++ b/rs_controller/src/core.rs
@@ -23,7 +23,7 @@ use flyteidl2::{
 use google::protobuf::StringValue;
 use pyo3_async_runtimes::tokio::get_runtime;
 use tokio::{
-    sync::{mpsc, oneshot},
+    sync::mpsc,
     time::{sleep, timeout},
 };
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
@@ -701,6 +701,14 @@ impl CoreBaseController {
                     )))?;
                 Ok(enqueue_action_request::Spec::Trace(trace))
             }
+            // The legacy QueueService has no condition support server-side, so
+            // fail loudly here rather than enqueue something that would be
+            // silently dropped.
+            ActionType::Condition => Err(ControllerError::RuntimeError(format!(
+                "Condition actions require the unified ActionsService (set _U_USE_ACTIONS=1); \
+                 cannot enqueue {:?} over the legacy QueueService",
+                action.action_id.name
+            ))),
         }
     }
 
@@ -717,6 +725,16 @@ impl CoreBaseController {
                         action
                     )))?;
                 Ok(actions_action::Spec::Trace(trace))
+            }
+            ActionType::Condition => {
+                let condition = action
+                    .condition
+                    .clone()
+                    .ok_or(ControllerError::RuntimeError(format!(
+                        "ConditionAction missing from condition Action {:?}",
+                        action
+                    )))?;
+                Ok(actions_action::Spec::Condition(condition))
             }
         }
     }
@@ -797,6 +815,7 @@ impl CoreBaseController {
         let has_spec = match action.action_type {
             ActionType::Task => action.task.is_some(),
             ActionType::Trace => action.trace.is_some(),
+            ActionType::Condition => action.condition.is_some(),
         };
         if !action.started && has_spec {
             if let Some(actions_client) = self.actions_client.as_ref() {
@@ -841,7 +860,14 @@ impl CoreBaseController {
         }
     }
 
-    pub async fn submit_action(&self, action: Action) -> Result<Action, ControllerError> {
+    /// Enqueue an action without waiting for it to finish.
+    ///
+    /// Pairs with [`Self::wait_for_action`]: the completion channel is registered
+    /// here and parked in the informer, so the wait can be claimed later -- by
+    /// this caller or another. That is what lets a condition action be created
+    /// now (so it is visible, and its webhook fires) and awaited at some later
+    /// point in the task.
+    pub async fn start_action(&self, action: Action) -> Result<(), ControllerError> {
         let action_name = action.action_id.name.clone();
         // The first action that gets submitted determines the run_id that will be used.
         // This is obviously not going to work,
@@ -859,11 +885,51 @@ impl CoreBaseController {
             .informer_cache
             .get_or_create_informer(&action.get_run_identifier(), &action.parent_action_name)
             .await;
-        let is_trace = action.action_type == ActionType::Trace;
-        let (done_tx, done_rx) = oneshot::channel();
-        informer.submit_action(action, done_tx).await?;
+        informer.submit_action(action).await
+    }
 
-        if is_trace {
+    /// Wait for an action started by [`Self::start_action`] to reach a terminal
+    /// phase, and return its final state.
+    ///
+    /// The wait is bounded only for traces, which the server may never echo an
+    /// update for because they are already terminal when enqueued. Tasks and
+    /// conditions wait indefinitely: a condition may legitimately sit PAUSED for
+    /// hours until someone signals it, and it is bounded server-side by
+    /// `ConditionAction.timeout`, which arrives as a TIMED_OUT update.
+    pub async fn wait_for_action(
+        &self,
+        run_id: &RunIdentifier,
+        parent_action_name: &str,
+        action_name: &str,
+        action_type: ActionType,
+    ) -> Result<Action, ControllerError> {
+        let informer = self
+            .informer_cache
+            .get(run_id, parent_action_name)
+            .await
+            .ok_or(ControllerError::BadContext(format!(
+                "Informer missing while waiting for action {}",
+                action_name
+            )))?;
+
+        // A oneshot send buffers, so a completion that already fired before this
+        // receiver was claimed resolves immediately rather than being lost.
+        let done_rx = informer.take_completion_waiter(action_name).await.ok_or(
+            ControllerError::BadContext(format!(
+                "Action {} was never started, or its wait was already claimed",
+                action_name
+            )),
+        )?;
+
+        let bounded_wait = match action_type {
+            // Recorded after the fact, so the server may never echo an update.
+            ActionType::Trace => true,
+            // Both run on the server's clock, and a condition may wait for a
+            // human. Bounding these client-side would be wrong.
+            ActionType::Task | ActionType::Condition => false,
+        };
+
+        if bounded_wait {
             // Server may not echo an ActionUpdate for trace actions, so bound the wait
             // and fire a local completion on timeout to avoid hanging the caller.
             const DEFAULT_SECS: f64 = 60.0;
@@ -899,7 +965,7 @@ impl CoreBaseController {
                         "Trace completion wait timed out after {}s for {}, firing local completion",
                         timeout_secs, action_name
                     );
-                    informer.fire_completion_event(&action_name).await?;
+                    informer.fire_completion_event(action_name).await?;
                 }
             }
         } else {
@@ -915,13 +981,38 @@ impl CoreBaseController {
         );
 
         // get the action and return it
-        let final_action = informer.get_action(&action_name).await;
+        let final_action = informer.get_action(action_name).await;
         let final_action = final_action.ok_or(ControllerError::BadContext(String::from(
             "Action not found after done",
         )));
         // Also remove. May be can do with prior step in the future.
-        informer.remove_action(&action_name).await;
+        informer.remove_action(action_name).await;
         final_action
+    }
+
+    /// Enqueue an action and wait for it to finish.
+    ///
+    /// Equivalent to [`Self::start_action`] followed by [`Self::wait_for_action`];
+    /// behavior for tasks and traces is unchanged.
+    pub async fn submit_action(&self, action: Action) -> Result<Action, ControllerError> {
+        let action_name = action.action_id.name.clone();
+        let parent_action_name = action.parent_action_name.clone();
+        let action_type = action.action_type;
+        // Read the run id the same way `start_action` does rather than via
+        // `get_run_identifier`, which panics when it is absent -- a missing run id
+        // must stay a returned error.
+        let run_id = action
+            .action_id
+            .run
+            .clone()
+            .ok_or(ControllerError::RuntimeError(format!(
+                "Run ID missing from submit action {}",
+                action_name
+            )))?;
+
+        self.start_action(action).await?;
+        self.wait_for_action(&run_id, &parent_action_name, &action_name, action_type)
+            .await
     }
 
     pub async fn finalize_parent_action(&self, run_id: &RunIdentifier, parent_action_name: &str) {

--- a/rs_controller/src/informer.rs
+++ b/rs_controller/src/informer.rs
@@ -57,6 +57,13 @@ pub struct Informer {
     ready: Arc<Notify>,
     is_ready: Arc<AtomicBool>,
     completion_events: Arc<RwLock<HashMap<String, oneshot::Sender<()>>>>,
+    /// Receivers for the senders above, parked here so a caller can claim the
+    /// wait for an action it did not itself submit. That is what allows an
+    /// action to be started now and awaited later (see
+    /// `CoreBaseController::start_action` / `wait_for_action`). A `oneshot` send
+    /// buffers, so a completion that fires before anyone claims the receiver is
+    /// not lost -- the later await resolves immediately.
+    completion_waiters: Arc<RwLock<HashMap<String, oneshot::Receiver<()>>>>,
     cancellation_token: CancellationToken,
     watch_handle: Arc<RwLock<Option<tokio::task::JoinHandle<()>>>>,
 }
@@ -79,6 +86,7 @@ impl Informer {
             ready: Arc::new(Notify::new()),
             is_ready: Arc::new(AtomicBool::new(false)),
             completion_events: Arc::new(RwLock::new(HashMap::new())),
+            completion_waiters: Arc::new(RwLock::new(HashMap::new())),
             cancellation_token: CancellationToken::new(),
             watch_handle: Arc::new(RwLock::new(None)),
         }
@@ -340,15 +348,25 @@ impl Informer {
             events.remove(action_name);
         }
 
+        {
+            let mut waiters = self.completion_waiters.write().await;
+            waiters.remove(action_name);
+        }
+
         debug!("Removed action and completion event for {}", action_name);
         dropped_action
     }
 
-    pub async fn submit_action(
-        &self,
-        action: Action,
-        done_tx: oneshot::Sender<()>,
-    ) -> Result<(), ControllerError> {
+    /// Claim the completion receiver for `action_name`, if one is still parked.
+    ///
+    /// Returns `None` when the action was never submitted through this informer,
+    /// or when its wait has already been claimed.
+    pub async fn take_completion_waiter(&self, action_name: &str) -> Option<oneshot::Receiver<()>> {
+        let mut waiters = self.completion_waiters.write().await;
+        waiters.remove(action_name)
+    }
+
+    pub async fn submit_action(&self, action: Action) -> Result<(), ControllerError> {
         let action_name = action.action_id.name.clone();
 
         let merged_action = {
@@ -365,14 +383,25 @@ impl Informer {
         };
         warn!("Merged action: ===> {} {:?}", action_name, merged_action);
 
-        // Store the completion event sender
+        // Register the completion channel, keeping the sender addressable by name
+        // and parking the receiver for whoever waits. Only on first submit: a
+        // resubmit of the same action must not orphan an existing waiter.
         {
             let mut completion_events = self.completion_events.write().await;
-            completion_events.insert(action_name.clone(), done_tx);
-            warn!(
-                "---------> Adding completion event in submit action {:?}",
-                action_name
-            );
+            if let std::collections::hash_map::Entry::Vacant(slot) =
+                completion_events.entry(action_name.clone())
+            {
+                let (done_tx, done_rx) = oneshot::channel();
+                slot.insert(done_tx);
+                let mut waiters = self.completion_waiters.write().await;
+                waiters.insert(action_name.clone(), done_rx);
+                debug!("Registered completion channel for action {}", action_name);
+            } else {
+                debug!(
+                    "Completion channel already registered for action {}, keeping it",
+                    action_name
+                );
+            }
         }
 
         // Add action to shared queue


### PR DESCRIPTION
## Why

The Rust SDK ([flyte-sdk-rs](https://github.com/unionai/flyte-sdk-rs)) consumes this crate as an rlib, and needs to wait on **condition (signal) actions** so a Rust task can pause for a human approval or an external callback.

The wire protocol and the backend already support this — `flyteidl2` generates `ConditionAction`, `Action.spec::Condition`, `ActionUpdate.value` and `ActionPhase::Paused`, and the actions service resolves conditions today. The gap is entirely in this crate: it models only `Task` and `Trace`, and `merge_update` reads `output_uri` but never `value`, so a signalled value can never reach a caller.

The pure-Python remote controller already implements conditions end to end; this is a port of that behavior into the Rust crate, not a new design.

**Everything here is additive. Task and trace behavior is unchanged.**

## What changed

**`action.rs`**
- `ActionType::Condition`, plus `Action.condition` and `Action.condition_output`.
- `Action::from_condition`, following `from_trace`'s bytes convention. Phase is `Unspecified`, not `Succeeded` — a trace is *recorded* after the fact, but a condition is *launched* and resolved later, and a terminal phase at birth would fire completion before any value arrived.
- `merge_update` captures `ActionUpdate.value`. **Un-gated on action type**, because an entry created by `new_from_update` is typed `Task` until a later submit repairs it — gating would drop the value of an already-signalled condition on a retry.
- `new_from_update` captures the value too, for when the watch stream delivers an update before the local submit registers the action.
- `merge_from_submit` adopts `action_type` and the type-specific spec. Without this, a condition whose update arrived first stays typed `Task` with no spec, and `launch_task` finds nothing to enqueue.
- `is_action_successful()` treats **`Recovered`** as success-equivalent, so callers stop either testing `phase == Succeeded` (which mistreats a recovered action) or inverting `Failed` (which also swallows `Aborted`/`TimedOut`). `is_action_paused()` names the non-terminal condition wait. Both exposed to Python as `is_successful` / `is_paused`, with `condition_output_bytes`.

**`core.rs`**
- `Condition` arms in `build_actions_spec` and `launch_task`'s spec check. The legacy `QueueService` arm returns a clear error instead — the backend has no condition support there, so an enqueue would be silently dropped.
- `submit_action` is split into `start_action` (enqueue, return) and `wait_for_action` (await terminal), with `submit_action` as their composition. This is what allows a condition to be created early — so it is visible in the console and its webhook fires — and awaited later, possibly elsewhere in the task. Mirrors the Python controller's start/wait split.
- The trace wait bound is now an explicit `match` over action type rather than an equality test, so a future action type must choose its policy. Conditions deliberately take the unbounded wait: they are bounded server-side by `ConditionAction.timeout`, which arrives as a `TIMED_OUT` update.

**`informer.rs`**
- Completion receivers are parked by action name so a wait can be claimed by a caller that did not submit the action; previously the receiver lived only on `submit_action`'s stack, which is the one thing that made decoupled start/wait impossible. A `oneshot` send buffers, so a completion that fires before the receiver is claimed is not lost.
- The completion channel is registered only on first submit, so resubmitting an action no longer orphans an existing waiter.

## Tests

Adds the crate's first tests that run **without a live control plane** (the existing informer test needs one on `localhost:8090`, which is presumably why CI does not run `cargo test`):

```
cargo test --lib action::
```

Seven cases: value capture on both paths, the early-update ordering repair, `Recovered` as terminal *and* successful, unsuccessful terminal phases, and which phases keep a waiter waiting.

## Verification

- `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo +nightly fmt --check` — all clean.
- `cargo test --lib action::` — 7 passed.
- The downstream Rust SDK builds and its full suite (26 tests) passes against this branch via its path dependency.
- Python consumers are unaffected: `_r_controller.py` constructs `Action` only through the two `from_*` staticmethods with keyword arguments and never reads `action_type`, and the new `ActionType` variant is additive on an `eq_int` pyclass.

Not verified against a live cluster — that needs the Rust SDK side, which is the follow-up.

## Note

`rs_controller/Cargo.lock` is left untouched, though it is stale: it pins `flyteidl2 2.0.32` while `rs_controller/Cargo.toml` declares `=2.0.37`, so any build rewrites it. That drift predates this change, so it seemed better left out of this diff than swept in.