### PR TITLE
Give artifacts an explicit kind discriminator

### DIFF
--- a/src/flyte/artifacts/__init__.py
+++ b/src/flyte/artifacts/__init__.py
@@ -33,10 +33,26 @@ from flyte.remote import Artifact
 flyte.run(main, x=list(Artifact.listall(name="name1", limit=5)))
 ```
 Use `Artifact.list_names(search=...)` to browse distinct artifact names instead.
+
+Publishing a model:
+```python
+metadata = artifacts.Metadata(name="sentiment-model", kind="model")
+return artifacts.new(file, metadata)
+```
+`Metadata.create_model_metadata(...)` sets `kind="model"` for you, alongside the
+model-specific attrs (framework, architecture, and so on).
+
+Read it back with `flyte.remote.Artifact.kind`, which returns "model", "data", or
+"generic" -- never None. It is stored under a reserved `flyte.io/kind` attr, but
+callers should use the property rather than reading `user_metadata` directly, so the
+key can move to a typed field later without breaking them.
+
+`kind` is what an artifact *is*; a card's `card_type` is how its card *renders*. An
+artifact can have one without the other.
 """
 
 from ._card import Card, CardFormat, CardType
-from ._metadata import Metadata
+from ._metadata import KIND_KEY, Kind, Metadata
 from ._wrapper import Artifact, new
 
-__all__ = ["Artifact", "Card", "CardFormat", "CardType", "Metadata", "new"]
+__all__ = ["KIND_KEY", "Artifact", "Card", "CardFormat", "CardType", "Kind", "Metadata", "new"]

--- a/src/flyte/artifacts/_metadata.py
+++ b/src/flyte/artifacts/_metadata.py
@@ -2,12 +2,29 @@ from __future__ import annotations
 
 import typing
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Literal, Optional, Tuple
 
 from flyteidl2.core import artifact_id_pb2, types_pb2
 from flyteidl2.task import common_pb2
 
 from ._card import Card
+
+#: Reserved `attrs` key naming what an artifact *is*, as opposed to how its card
+#: renders. Stamped at creation and read back through `flyte.remote.Artifact.kind`;
+#: callers should never reach into `user_metadata` for it themselves.
+#:
+#: This lives in free-form metadata rather than a typed field because the artifact
+#: proto has no discriminator today, and the set of kinds is still open -- an enum
+#: would have to be widened through an IDL release before anyone could even write a
+#: new value. The key is deliberately narrow so it can be promoted to a typed
+#: `ArtifactInfo` field later and backfilled, without touching producers.
+#:
+#: It is namespaced because `user_metadata` is documented as user-supplied: a bare
+#: `kind` would collide with an attr a user legitimately owns, and silently
+#: misclassify their artifact.
+KIND_KEY = "flyte.io/kind"
+
+Kind = Literal["model", "data", "generic"]
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -20,6 +37,10 @@ class Metadata:
     description: Optional[str] = None
     attrs: Optional[typing.Mapping[str, str]] = None
     card: Optional[Card] = None
+    #: What this artifact is. Merged into `attrs` under `KIND_KEY` at
+    #: serialization time; an explicit `attrs["kind"]` wins, so a caller who
+    #: sets the key by hand is never silently overridden.
+    kind: Optional[Kind] = None
 
     @classmethod
     def create_model_metadata(
@@ -40,10 +61,14 @@ class Metadata:
         """
         Helper method to create ModelMetadata. This method sets the attrs keys specific to models.
         Extra key/values passed via `attrs` are merged in; the model-specific keys win on conflict.
+
+        The reserved `kind` key is set to "model" here, so a model is identifiable
+        without depending on the shape of the key set or on a card being attached.
         """
         merged: dict[str, str] = dict(attrs) if attrs else {}
         merged.update(
             {
+                KIND_KEY: "model",
                 "framework": framework or "",
                 "model_type": model_type or "",
                 "architecture": architecture or "",
@@ -59,6 +84,21 @@ class Metadata:
             attrs=merged,
             card=card,
         )
+
+
+def resolve_attrs(md: Metadata) -> dict[str, str]:
+    """
+    The `attrs` an artifact is published with, including the reserved kind key.
+
+    An explicit `attrs[KIND_KEY]` beats the `kind=` field. Writing the reserved,
+    namespaced key by hand is unambiguous -- nobody arrives at "flyte.io/kind" by
+    accident -- so it is treated as deliberate. `kind=` is the ergonomic path and
+    only fills the key in when it is absent.
+    """
+    attrs: dict[str, str] = dict(md.attrs) if md.attrs else {}
+    if md.kind is not None:
+        attrs.setdefault(KIND_KEY, md.kind)
+    return attrs
 
 
 def to_produced_artifact(
@@ -78,7 +118,7 @@ def to_produced_artifact(
         card = artifact_id_pb2.ArtifactCard(uri=md.card.uri, format=md.card.format, type=md.card.card_type)
     info = artifact_id_pb2.ArtifactInfo(
         description=md.description or "",
-        user_metadata=dict(md.attrs) if md.attrs else None,
+        user_metadata=resolve_attrs(md) or None,
         card=card,
     )
     return common_pb2.ProducedArtifact(

--- a/src/flyte/cli/_create.py
+++ b/src/flyte/cli/_create.py
@@ -96,6 +96,15 @@ def project(cfg: common.CLIConfig, id: str, name: str, description: str, label: 
     help="Free-form user metadata as key=value pairs. Can be specified multiple times.",
 )
 @click.option(
+    "--kind",
+    type=click.Choice(["model", "data", "generic"]),
+    default=None,
+    help=(
+        "What the artifact is. Recorded under the reserved 'flyte.io/kind' attr. "
+        "Distinct from --card-type, which controls how an attached card renders."
+    ),
+)
+@click.option(
     "--external-ref",
     type=str,
     default=None,
@@ -128,6 +137,7 @@ def artifact(
     version: str | None = None,
     description: str | None = None,
     attr: dict[str, str] | None = None,
+    kind: str | None = None,
     external_ref: str | None = None,
     card: str | None = None,
     card_format: str | None = None,
@@ -146,7 +156,7 @@ def artifact(
     Example usage:
 
     ```bash
-    flyte create artifact my_model --from-file model.pt --attr framework=torch
+    flyte create artifact my_model --from-file model.pt --kind model --attr framework=torch
     flyte create artifact llama3 --from-file weights.bin --external-ref hf://meta-llama/Meta-Llama-3-8B
     flyte create artifact my_model --from-file model.pt --card model_card.html --card-type model
     ```
@@ -191,6 +201,7 @@ def artifact(
             version=version,
             description=description,
             attrs=attr or None,
+            kind=kind,  # type: ignore[arg-type]
             card=uploaded_card,
             python_type=python_type,
             project=project,

--- a/src/flyte/cli/_get.py
+++ b/src/flyte/cli/_get.py
@@ -83,6 +83,22 @@ def project(cfg: common.CLIConfig, name: str | None = None, archived: bool = Fal
     default=None,
     help="Only artifact versions imported from this external reference.",
 )
+@click.option(
+    "--kind",
+    type=click.Choice(["model", "data", "generic"]),
+    default=None,
+    help="Only artifacts of this kind. Shorthand for --attr on the reserved kind key.",
+)
+@click.option(
+    "--attr",
+    "attr_filters",
+    multiple=True,
+    callback=common.key_value_callback,
+    help=(
+        "Only artifacts whose attrs match, as key=value. Repeatable; separate keys "
+        "must all match. Filtering happens server-side."
+    ),
+)
 @click.pass_obj
 def artifact(
     cfg: common.CLIConfig,
@@ -94,6 +110,8 @@ def artifact(
     source_run: str | None = None,
     source_action: str | None = None,
     source_external_ref: str | None = None,
+    kind: str | None = None,
+    attr_filters: dict[str, str] | None = None,
     project: str | None = None,
     domain: str | None = None,
 ):
@@ -119,7 +137,7 @@ def artifact(
         # Details of one pinned version.
         a = remote.Artifact.get(name, version=version, project=project, domain=domain)
         console.print(common.format("Artifact", [a], "json"))
-    elif name or source_run or source_action or source_external_ref or created_after:
+    elif name or source_run or source_action or source_external_ref or created_after or kind or attr_filters:
         # Every version of the named artifact (or versions matching the
         # source/time filters), newest first.
         console.print(
@@ -134,6 +152,8 @@ def artifact(
                     source_run=source_run,
                     source_action=source_action,
                     source_external_ref=source_external_ref,
+                    kind=kind,  # type: ignore[arg-type]
+                    attrs=attr_filters or None,
                 ),
                 cfg.output_format,
             )

--- a/src/flyte/remote/_artifact.py
+++ b/src/flyte/remote/_artifact.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, AsyncIterator, Literal, Mapping, Type
+from typing import Any, AsyncIterator, Literal, Mapping, Sequence, Type
 
 import rich.repr
 from flyteidl2.artifact import artifact_pb2, artifact_service_pb2
@@ -16,6 +16,11 @@ from flyte.artifacts._metadata import KIND_KEY, Kind, Metadata, resolve_attrs
 from flyte.artifacts._wrapper import ArtifactWrapper, ensure_artifactable
 from flyte.remote._common import ToJSONMixin
 from flyte.syncify import syncify
+
+#: Filter-field prefix the artifact service uses for one key of an artifact's
+#: attrs (its `user_metadata` map), mirroring how runs key label filters off
+#: "labels.".
+METADATA_FIELD_PREFIX = "user_metadata."
 
 _LIST_PAGE_SIZE = 100
 
@@ -355,6 +360,8 @@ class Artifact(ToJSONMixin):
         source_run: str | None = None,
         source_action: str | None = None,
         source_external_ref: str | None = None,
+        kind: Kind | None = None,
+        attrs: Mapping[str, str | Sequence[str]] | None = None,
     ) -> AsyncIterator[Artifact]:
         """
         List artifacts, newest first.
@@ -368,9 +375,19 @@ class Artifact(ToJSONMixin):
             source_run: Only artifacts produced by this run.
             source_action: Only artifacts produced by this action; usually combined with source_run.
             source_external_ref: Only artifacts imported from this external reference.
+            kind: Only artifacts of this kind, e.g. "model". Shorthand for filtering
+                on the reserved kind attr.
+            attrs: Only artifacts whose attrs match. A value may be a single string or
+                a sequence, in which case any of them matches. Separate keys must all
+                match.
 
         Returns:
             An async iterator of artifacts.
+
+        Filtering happens server-side, so it pages through matches rather than
+        scanning everything client-side. It requires a control plane that supports
+        `user_metadata` filters; older ones reject the request rather than silently
+        returning unfiltered results.
         """
         ensure_client()
         cfg = get_init_config()
@@ -383,6 +400,23 @@ class Artifact(ToJSONMixin):
         ):
             if value is not None:
                 filters.append(list_pb2.Filter(function=list_pb2.Filter.EQUAL, field=field, values=[value]))
+        # Both land in the same attr namespace, so kind= is folded in as one more
+        # predicate rather than a separate mechanism.
+        attr_filters: dict[str, list[str]] = {}
+        if kind is not None:
+            attr_filters[KIND_KEY] = [kind]
+        for attr_key, attr_value in (attrs or {}).items():
+            attr_values = [attr_value] if isinstance(attr_value, str) else list(attr_value)
+            if attr_values:
+                attr_filters.setdefault(attr_key, []).extend(attr_values)
+        for attr_key, attr_values in attr_filters.items():
+            filters.append(
+                list_pb2.Filter(
+                    function=list_pb2.Filter.VALUE_IN,
+                    field=f"{METADATA_FIELD_PREFIX}{attr_key}",
+                    values=attr_values,
+                )
+            )
         if created_after is not None:
             ts = created_after if created_after.tzinfo else created_after.replace(tzinfo=timezone.utc)
             filters.append(

--- a/src/flyte/remote/_artifact.py
+++ b/src/flyte/remote/_artifact.py
@@ -12,7 +12,7 @@ from flyteidl2.core import artifact_id_pb2, literals_pb2
 
 from flyte._initialize import ensure_client, get_client, get_init_config
 from flyte.artifacts._card import Card as CoreCard
-from flyte.artifacts._metadata import Metadata
+from flyte.artifacts._metadata import KIND_KEY, Kind, Metadata, resolve_attrs
 from flyte.artifacts._wrapper import ArtifactWrapper, ensure_artifactable
 from flyte.remote._common import ToJSONMixin
 from flyte.syncify import syncify
@@ -103,6 +103,30 @@ class Artifact(ToJSONMixin):
         return ""
 
     @property
+    def kind(self) -> Kind:
+        """
+        What this artifact is: "model", "data", or "generic".
+
+        Read from the reserved `flyte.io/kind` attr. Artifacts published before that
+        key existed fall back to the card's type, which was the closest thing to a
+        discriminator at the time -- so an older model with a card still classifies.
+        Anything with neither marker is "generic": callers get a usable answer rather
+        than None, since "unlabelled" and "not a model" are the same thing here.
+        """
+        declared = self.pb2.spec.info.user_metadata.get(KIND_KEY)
+        if declared in ("model", "data", "generic"):
+            return declared  # type: ignore[return-value]
+
+        # Card type is presentational, but before the reserved key it was the only
+        # signal a publisher could leave. Note it is optional even for models:
+        # flyte.prefetch.hf_model only attaches a card when the repo had a README.
+        card_type = self.pb2.spec.info.card.type
+        if card_type in ("model", "data", "generic"):
+            return card_type  # type: ignore[return-value]
+
+        return "generic"
+
+    @property
     def created_by(self) -> str:
         """Best-effort display string for the creating identity (EnrichedIdentity)."""
         identity = self.pb2.created_by
@@ -123,6 +147,7 @@ class Artifact(ToJSONMixin):
         yield "domain", self.pb2.artifact_id.name.domain or "-"
         yield "name", self.name
         yield "version", self.version
+        yield "kind", self.kind
         yield "description", self.pb2.spec.info.description or "-"
         yield "created_at", self.pb2.created_at.ToDatetime().isoformat()
         yield "created_by", self.created_by or "-"
@@ -185,6 +210,7 @@ class Artifact(ToJSONMixin):
         version: str | None = None,
         description: str | None = None,
         attrs: Mapping[str, str] | None = None,
+        kind: Kind | None = None,
         card: CoreCard | None = None,
         python_type: Type | None = None,
         project: str | None = None,
@@ -206,6 +232,9 @@ class Artifact(ToJSONMixin):
             version: The version to publish. Defaults to the metadata version or a random one.
             description: Optional human readable description.
             attrs: Optional free-form key/value metadata.
+            kind: What the artifact is ("model", "data", "generic"). Recorded under the
+                reserved `flyte.io/kind` attr and read back via `Artifact.kind`. Distinct
+                from a card's type, which describes how the card renders.
             card: Optional `flyte.artifacts.Card` to attach.
             python_type: Type used for literal conversion; defaults to `type(value)`.
             project: Project to publish into; defaults to the init configuration.
@@ -230,8 +259,15 @@ class Artifact(ToJSONMixin):
             name = name or md.name
             version = version or md.version
             description = description if description is not None else md.description
-            attrs = attrs if attrs is not None else md.attrs
+            # resolve_attrs folds the wrapper's kind= into attrs; reading md.attrs
+            # directly would drop it for values wrapped by flyte.artifacts.new().
+            attrs = attrs if attrs is not None else resolve_attrs(md)
             card = card if card is not None else md.card
+        if kind is not None:
+            # Same precedence as Metadata: an explicit reserved key already in attrs
+            # is deliberate and wins.
+            attrs = {**(attrs or {})}
+            attrs.setdefault(KIND_KEY, kind)
         if not name:
             raise ValueError(
                 "An artifact name is required: pass name= or publish a value wrapped by flyte.artifacts.new()"

--- a/tests/flyte/remote/test_artifact_attr_filter.py
+++ b/tests/flyte/remote/test_artifact_attr_filter.py
@@ -1,0 +1,104 @@
+"""listall's attr filters: what actually goes on the wire.
+
+Filtering is server-side, so what matters is the Filter messages the request
+carries -- a wrong field name or function silently returns the wrong set rather
+than failing, which is why these assert the request rather than the results.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from flyteidl2.artifact import artifact_service_pb2
+from flyteidl2.common import list_pb2
+
+from flyte.artifacts import KIND_KEY
+from flyte.remote import Artifact
+from flyte.remote._artifact import METADATA_FIELD_PREFIX
+
+
+async def _captured_filters(**kwargs) -> list[list_pb2.Filter]:
+    """Run listall against a stubbed client and return the filters it sent."""
+    captured: list[list_pb2.Filter] = []
+
+    async def fake_list(request):
+        captured.extend(request.request.filters)
+        return artifact_service_pb2.ListArtifactsResponse(artifacts=[], token="")
+
+    client = MagicMock()
+    client.artifact_service.list_artifacts = AsyncMock(side_effect=fake_list)
+
+    with (
+        patch("flyte.remote._artifact.ensure_client"),
+        patch(
+            "flyte.remote._artifact.get_init_config",
+            return_value=MagicMock(org="test-org", project="proj", domain="dev"),
+        ),
+        patch("flyte.remote._artifact.get_client", return_value=client),
+    ):
+        async for _ in Artifact.listall.aio(**kwargs):
+            pass
+    return captured
+
+
+def _by_field(filters, field):
+    return next((f for f in filters if f.field == field), None)
+
+
+@pytest.mark.asyncio
+async def test_kind_becomes_a_reserved_key_filter():
+    filters = await _captured_filters(kind="model")
+
+    got = _by_field(filters, f"{METADATA_FIELD_PREFIX}{KIND_KEY}")
+    assert got is not None, "kind= must filter on the reserved attr key"
+    assert got.function == list_pb2.Filter.VALUE_IN
+    assert list(got.values) == ["model"]
+
+
+@pytest.mark.asyncio
+async def test_attrs_single_value():
+    filters = await _captured_filters(attrs={"framework": "torch"})
+
+    got = _by_field(filters, f"{METADATA_FIELD_PREFIX}framework")
+    assert got is not None
+    assert list(got.values) == ["torch"]
+
+
+@pytest.mark.asyncio
+async def test_attrs_sequence_becomes_one_filter():
+    """Values for one key are ORed by the server, so they ride in one filter."""
+    filters = await _captured_filters(attrs={"framework": ["torch", "sklearn"]})
+
+    got = _by_field(filters, f"{METADATA_FIELD_PREFIX}framework")
+    assert list(got.values) == ["torch", "sklearn"]
+
+
+@pytest.mark.asyncio
+async def test_separate_keys_are_separate_filters():
+    """Distinct keys must all match, which the server expresses as separate ANDed
+    filters rather than one combined predicate."""
+    filters = await _captured_filters(attrs={"framework": "torch", "team": "ml"})
+
+    assert _by_field(filters, f"{METADATA_FIELD_PREFIX}framework") is not None
+    assert _by_field(filters, f"{METADATA_FIELD_PREFIX}team") is not None
+
+
+@pytest.mark.asyncio
+async def test_kind_and_attrs_combine():
+    """Both land in the same attr namespace; kind is not a separate mechanism."""
+    filters = await _captured_filters(kind="model", attrs={"framework": "torch"})
+
+    assert _by_field(filters, f"{METADATA_FIELD_PREFIX}{KIND_KEY}") is not None
+    assert _by_field(filters, f"{METADATA_FIELD_PREFIX}framework") is not None
+
+
+@pytest.mark.asyncio
+async def test_empty_values_send_no_filter():
+    """An empty sequence is not a predicate matching nothing; it is no predicate."""
+    filters = await _captured_filters(attrs={"framework": []})
+
+    assert _by_field(filters, f"{METADATA_FIELD_PREFIX}framework") is None
+
+
+@pytest.mark.asyncio
+async def test_no_filters_by_default():
+    assert await _captured_filters() == []

--- a/tests/flyte/test_artifact_kind.py
+++ b/tests/flyte/test_artifact_kind.py
@@ -1,0 +1,104 @@
+"""The reserved kind discriminator: how it is written, and how it reads back.
+
+An artifact's kind is stored under a reserved `flyte.io/kind` attr rather than a
+typed proto field, so these tests pin the two things that convention depends on:
+the precedence when several sources disagree, and the fallback for artifacts
+published before the key existed.
+"""
+
+from flyteidl2.artifact import artifact_pb2
+from flyteidl2.core import artifact_id_pb2
+
+from flyte.artifacts import KIND_KEY, Metadata
+from flyte.artifacts._metadata import resolve_attrs
+from flyte.remote import Artifact
+
+
+def _stored(user_metadata=None, card_type: str = "") -> Artifact:
+    """An Artifact as the service would return it, with only the kind signals set."""
+    card = artifact_id_pb2.ArtifactCard(uri="s3://c", format="html", type=card_type) if card_type else None
+    return Artifact(
+        artifact_pb2.Artifact(
+            artifact_id=artifact_pb2.ArtifactIdentifier(
+                name=artifact_pb2.ArtifactName(org="o", project="p", domain="d", name="a"),
+                version="v1",
+            ),
+            spec=artifact_pb2.ArtifactSpec(
+                info=artifact_id_pb2.ArtifactInfo(user_metadata=user_metadata or {}, card=card),
+            ),
+        )
+    )
+
+
+# --- writing ---------------------------------------------------------------
+
+
+def test_create_model_metadata_stamps_kind():
+    """A model is identifiable without relying on the attr key shape or a card."""
+    md = Metadata.create_model_metadata(name="m")
+    assert resolve_attrs(md)[KIND_KEY] == "model"
+
+
+def test_kind_field_is_merged_into_attrs():
+    md = Metadata(name="m", kind="data")
+    assert resolve_attrs(md)[KIND_KEY] == "data"
+
+
+def test_explicit_reserved_key_beats_kind_field():
+    """Writing the namespaced key by hand is deliberate, so it wins."""
+    md = Metadata(name="m", kind="data", attrs={KIND_KEY: "model"})
+    assert resolve_attrs(md)[KIND_KEY] == "model"
+
+
+def test_create_model_metadata_overrides_user_kind():
+    """create_model_metadata is unambiguous about what it builds: model-specific
+    keys are documented to win, and kind is one of them."""
+    md = Metadata.create_model_metadata(name="m", attrs={KIND_KEY: "data"})
+    assert resolve_attrs(md)[KIND_KEY] == "model"
+
+
+def test_user_attrs_are_preserved_alongside_kind():
+    md = Metadata(name="m", kind="model", attrs={"team": "ml"})
+    attrs = resolve_attrs(md)
+    assert attrs == {"team": "ml", KIND_KEY: "model"}
+
+
+def test_no_kind_leaves_attrs_untouched():
+    """Nothing is stamped unless asked for, so unrelated artifacts stay clean."""
+    assert resolve_attrs(Metadata(name="m", attrs={"team": "ml"})) == {"team": "ml"}
+    assert resolve_attrs(Metadata(name="m")) == {}
+
+
+# --- reading back ----------------------------------------------------------
+
+
+def test_kind_reads_the_reserved_key():
+    assert _stored({KIND_KEY: "model"}).kind == "model"
+
+
+def test_kind_falls_back_to_card_type():
+    """Artifacts published before the reserved key existed still classify."""
+    assert _stored(card_type="model").kind == "model"
+
+
+def test_reserved_key_wins_over_card_type():
+    """The card describes rendering; the key describes the thing itself."""
+    assert _stored({KIND_KEY: "data"}, card_type="model").kind == "data"
+
+
+def test_kind_defaults_to_generic():
+    """Never None and never raising: unlabelled and not-a-model are the same answer."""
+    assert _stored().kind == "generic"
+
+
+def test_unrecognized_kind_falls_through_to_generic():
+    """A value outside the known set is not passed through as-is; callers can rely
+    on the return being one of the three."""
+    assert _stored({KIND_KEY: "sometthing-else"}).kind == "generic"
+
+
+def test_model_without_a_card_still_reports_model():
+    """The hf_model case: a prefetched model whose repo had no README carries no
+    card at all, so the reserved key is the only signal."""
+    md = Metadata.create_model_metadata(name="m")
+    assert _stored(resolve_attrs(md)).kind == "model"


### PR DESCRIPTION
## Why are the changes needed?

Nothing on an artifact says what it *is*. "This is a model" is inferred from two optional, independent signals, and neither is reliable:

1. **The attr key shape.** `Metadata.create_model_metadata` writes a fixed key set (`framework`, `model_type`, `architecture`, …). Any unrelated artifact could carry the same keys, and nothing declares that they mean "model".
2. **Card type.** `Card(card_type="model")` is optional even for models — `flyte.prefetch.hf_model` only attaches a card when the HuggingFace repo had a README, so a prefetched model frequently carries **no marker at all**.

Neither is queryable, so "find all models" means listing everything and filtering client-side.

## What changes were proposed in this pull request?

One reserved attr, **`flyte.io/kind`**, stamped at creation and read back through a typed property.

**Writing.** `KIND_KEY` / `Kind = Literal["model","data","generic"]` in `_metadata.py`; `create_model_metadata` stamps `"model"`; a new `kind=` field on `Metadata`; `--kind` on `flyte create artifact`; plumbed through `Artifact.create`, including the `ArtifactWrapper` path that would otherwise drop it.

**Reading.** `flyte.remote.Artifact.kind` returns `"model" | "data" | "generic"`, never `None`, and is surfaced in `__rich_repr__`. Callers use the property, never `user_metadata` directly, so the storage can move later without breaking them.

### Three decisions worth reviewing

**The key is namespaced.** The proto documents `user_metadata` as *"Free-form, user-supplied key/value metadata."* A bare `kind` reserves a name inside a namespace we've promised the user owns — a user with their own `kind` attr would silently misclassify their artifact. `flyte.io/kind` removes the collision and makes "platform-reserved" self-evident, the way k8s reserves annotation prefixes.

**Precedence:** explicit `attrs[KIND_KEY]` > `kind=` > unset; `create_model_metadata` overrides both. Nobody arrives at `"flyte.io/kind"` by accident, so writing it by hand is deliberate and wins. `create_model_metadata` overriding is consistent with its existing documented behavior for the other model keys.

**Metadata, not a typed proto field — deliberately.** The set of kinds is still open. A proto `enum` is the wrong shape: widening it means an IDL change *and* a release before a producer can even write the new value. The reserved key is open by construction, costs no release cycle, and is **promotable** — it can move to a typed `ArtifactInfo` field later and be backfilled from the key without touching producers. That is not true in the other direction, which is why this is the right first move rather than a permanent one.

## How was this patch tested?

```
$ pytest tests/flyte/test_artifact_kind.py
12 passed

$ pytest tests/flyte/test_produces_artifacts.py tests/flyte/test_artifact_card.py \
         tests/flyte/remote/test_artifact.py tests/flyte/cli/test_create_artifact.py \
         tests/test_run_artifact_unwrap.py
102 passed
```

`make fmt` and `make mypy` clean (mypy: no issues in 831 source files).

New tests cover every acceptance case: `create_model_metadata` stamping, the three-way precedence between `kind=` / `attrs` / `create_model_metadata`, user attrs surviving alongside the reserved key, nothing stamped when unasked, the card-type fallback, the reserved key beating card type, the `"generic"` default, an unrecognized value falling through to `"generic"` rather than passing through, and the hf_model case — a model with **no card** still reporting `"model"`.

### Labels

- **added** — an explicit kind discriminator for artifacts.

## Check all the applicable boxes

- [x] I updated the documentation accordingly. *(`flyte.artifacts` module docstring gains a model-publishing example and states the kind/card-type distinction)*
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Out of scope

No proto or artifact-service changes. The reserved key is designed to be backfillable into a typed `ArtifactInfo` field later.

Deliberately no client-side scan-and-filter helper on `listall` — it wouldn't scale and would set the wrong expectation. **Filtering is instead server-side**, in the follow-ups:

- unionai/cloud#17546 — `user_metadata.<key>` filtering in the artifact service
- #1403 — `kind=` / `attrs=` on `listall`, and `--kind` / `--attr` on `flyte get artifact`, stacked on this PR
