### PR TITLE
Filter artifacts by attrs from the API and CLI

### DIFF
--- a/src/flyte/cli/_get.py
+++ b/src/flyte/cli/_get.py
@@ -83,6 +83,22 @@ def project(cfg: common.CLIConfig, name: str | None = None, archived: bool = Fal
     default=None,
     help="Only artifact versions imported from this external reference.",
 )
+@click.option(
+    "--kind",
+    type=click.Choice(["model", "data", "generic"]),
+    default=None,
+    help="Only artifacts of this kind. Shorthand for --attr on the reserved kind key.",
+)
+@click.option(
+    "--attr",
+    "attr_filters",
+    multiple=True,
+    callback=common.key_value_callback,
+    help=(
+        "Only artifacts whose attrs match, as key=value. Repeatable; separate keys "
+        "must all match. Filtering happens server-side."
+    ),
+)
 @click.pass_obj
 def artifact(
     cfg: common.CLIConfig,
@@ -94,6 +110,8 @@ def artifact(
     source_run: str | None = None,
     source_action: str | None = None,
     source_external_ref: str | None = None,
+    kind: str | None = None,
+    attr_filters: dict[str, str] | None = None,
     project: str | None = None,
     domain: str | None = None,
 ):
@@ -119,7 +137,7 @@ def artifact(
         # Details of one pinned version.
         a = remote.Artifact.get(name, version=version, project=project, domain=domain)
         console.print(common.format("Artifact", [a], "json"))
-    elif name or source_run or source_action or source_external_ref or created_after:
+    elif name or source_run or source_action or source_external_ref or created_after or kind or attr_filters:
         # Every version of the named artifact (or versions matching the
         # source/time filters), newest first.
         console.print(
@@ -134,6 +152,8 @@ def artifact(
                     source_run=source_run,
                     source_action=source_action,
                     source_external_ref=source_external_ref,
+                    kind=kind,  # type: ignore[arg-type]
+                    attrs=attr_filters or None,
                 ),
                 cfg.output_format,
             )

--- a/src/flyte/remote/_artifact.py
+++ b/src/flyte/remote/_artifact.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, AsyncIterator, Literal, Mapping, Type
+from typing import Any, AsyncIterator, Literal, Mapping, Sequence, Type
 
 import rich.repr
 from flyteidl2.artifact import artifact_pb2, artifact_service_pb2
@@ -16,6 +16,11 @@ from flyte.artifacts._metadata import KIND_KEY, Kind, Metadata, resolve_attrs
 from flyte.artifacts._wrapper import ArtifactWrapper, ensure_artifactable
 from flyte.remote._common import ToJSONMixin
 from flyte.syncify import syncify
+
+#: Filter-field prefix the artifact service uses for one key of an artifact's
+#: attrs (its `user_metadata` map), mirroring how runs key label filters off
+#: "labels.".
+METADATA_FIELD_PREFIX = "user_metadata."
 
 _LIST_PAGE_SIZE = 100
 
@@ -355,6 +360,8 @@ class Artifact(ToJSONMixin):
         source_run: str | None = None,
         source_action: str | None = None,
         source_external_ref: str | None = None,
+        kind: Kind | None = None,
+        attrs: Mapping[str, str | Sequence[str]] | None = None,
     ) -> AsyncIterator[Artifact]:
         """
         List artifacts, newest first.
@@ -368,9 +375,19 @@ class Artifact(ToJSONMixin):
             source_run: Only artifacts produced by this run.
             source_action: Only artifacts produced by this action; usually combined with source_run.
             source_external_ref: Only artifacts imported from this external reference.
+            kind: Only artifacts of this kind, e.g. "model". Shorthand for filtering
+                on the reserved kind attr.
+            attrs: Only artifacts whose attrs match. A value may be a single string or
+                a sequence, in which case any of them matches. Separate keys must all
+                match.
 
         Returns:
             An async iterator of artifacts.
+
+        Filtering happens server-side, so it pages through matches rather than
+        scanning everything client-side. It requires a control plane that supports
+        `user_metadata` filters; older ones reject the request rather than silently
+        returning unfiltered results.
         """
         ensure_client()
         cfg = get_init_config()
@@ -383,6 +400,23 @@ class Artifact(ToJSONMixin):
         ):
             if value is not None:
                 filters.append(list_pb2.Filter(function=list_pb2.Filter.EQUAL, field=field, values=[value]))
+        # Both land in the same attr namespace, so kind= is folded in as one more
+        # predicate rather than a separate mechanism.
+        attr_filters: dict[str, list[str]] = {}
+        if kind is not None:
+            attr_filters[KIND_KEY] = [kind]
+        for attr_key, attr_value in (attrs or {}).items():
+            attr_values = [attr_value] if isinstance(attr_value, str) else list(attr_value)
+            if attr_values:
+                attr_filters.setdefault(attr_key, []).extend(attr_values)
+        for attr_key, attr_values in attr_filters.items():
+            filters.append(
+                list_pb2.Filter(
+                    function=list_pb2.Filter.VALUE_IN,
+                    field=f"{METADATA_FIELD_PREFIX}{attr_key}",
+                    values=attr_values,
+                )
+            )
         if created_after is not None:
             ts = created_after if created_after.tzinfo else created_after.replace(tzinfo=timezone.utc)
             filters.append(

--- a/tests/flyte/remote/test_artifact_attr_filter.py
+++ b/tests/flyte/remote/test_artifact_attr_filter.py
@@ -1,0 +1,104 @@
+"""listall's attr filters: what actually goes on the wire.
+
+Filtering is server-side, so what matters is the Filter messages the request
+carries -- a wrong field name or function silently returns the wrong set rather
+than failing, which is why these assert the request rather than the results.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from flyteidl2.artifact import artifact_service_pb2
+from flyteidl2.common import list_pb2
+
+from flyte.artifacts import KIND_KEY
+from flyte.remote import Artifact
+from flyte.remote._artifact import METADATA_FIELD_PREFIX
+
+
+async def _captured_filters(**kwargs) -> list[list_pb2.Filter]:
+    """Run listall against a stubbed client and return the filters it sent."""
+    captured: list[list_pb2.Filter] = []
+
+    async def fake_list(request):
+        captured.extend(request.request.filters)
+        return artifact_service_pb2.ListArtifactsResponse(artifacts=[], token="")
+
+    client = MagicMock()
+    client.artifact_service.list_artifacts = AsyncMock(side_effect=fake_list)
+
+    with (
+        patch("flyte.remote._artifact.ensure_client"),
+        patch(
+            "flyte.remote._artifact.get_init_config",
+            return_value=MagicMock(org="test-org", project="proj", domain="dev"),
+        ),
+        patch("flyte.remote._artifact.get_client", return_value=client),
+    ):
+        async for _ in Artifact.listall.aio(**kwargs):
+            pass
+    return captured
+
+
+def _by_field(filters, field):
+    return next((f for f in filters if f.field == field), None)
+
+
+@pytest.mark.asyncio
+async def test_kind_becomes_a_reserved_key_filter():
+    filters = await _captured_filters(kind="model")
+
+    got = _by_field(filters, f"{METADATA_FIELD_PREFIX}{KIND_KEY}")
+    assert got is not None, "kind= must filter on the reserved attr key"
+    assert got.function == list_pb2.Filter.VALUE_IN
+    assert list(got.values) == ["model"]
+
+
+@pytest.mark.asyncio
+async def test_attrs_single_value():
+    filters = await _captured_filters(attrs={"framework": "torch"})
+
+    got = _by_field(filters, f"{METADATA_FIELD_PREFIX}framework")
+    assert got is not None
+    assert list(got.values) == ["torch"]
+
+
+@pytest.mark.asyncio
+async def test_attrs_sequence_becomes_one_filter():
+    """Values for one key are ORed by the server, so they ride in one filter."""
+    filters = await _captured_filters(attrs={"framework": ["torch", "sklearn"]})
+
+    got = _by_field(filters, f"{METADATA_FIELD_PREFIX}framework")
+    assert list(got.values) == ["torch", "sklearn"]
+
+
+@pytest.mark.asyncio
+async def test_separate_keys_are_separate_filters():
+    """Distinct keys must all match, which the server expresses as separate ANDed
+    filters rather than one combined predicate."""
+    filters = await _captured_filters(attrs={"framework": "torch", "team": "ml"})
+
+    assert _by_field(filters, f"{METADATA_FIELD_PREFIX}framework") is not None
+    assert _by_field(filters, f"{METADATA_FIELD_PREFIX}team") is not None
+
+
+@pytest.mark.asyncio
+async def test_kind_and_attrs_combine():
+    """Both land in the same attr namespace; kind is not a separate mechanism."""
+    filters = await _captured_filters(kind="model", attrs={"framework": "torch"})
+
+    assert _by_field(filters, f"{METADATA_FIELD_PREFIX}{KIND_KEY}") is not None
+    assert _by_field(filters, f"{METADATA_FIELD_PREFIX}framework") is not None
+
+
+@pytest.mark.asyncio
+async def test_empty_values_send_no_filter():
+    """An empty sequence is not a predicate matching nothing; it is no predicate."""
+    filters = await _captured_filters(attrs={"framework": []})
+
+    assert _by_field(filters, f"{METADATA_FIELD_PREFIX}framework") is None
+
+
+@pytest.mark.asyncio
+async def test_no_filters_by_default():
+    assert await _captured_filters() == []


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #1402**, which adds the `flyte.io/kind` key this filters on. Review that first.

## Why are the changes needed?

#1402 made the kind discriminator writable but not *askable*. `listall` could filter on name, time and source, but not on attrs — so "find all models" still meant listing everything and filtering client-side, which is exactly what that PR declined to build a helper for.

unionai/cloud#17546 adds server-side `user_metadata.<key>` filtering. This is the SDK half.

## What changes were proposed in this pull request?

**API:** `Artifact.listall(kind=..., attrs=...)`. `attrs` values may be a single string or a sequence.

```python
Artifact.listall(kind="model")
Artifact.listall(kind="model", attrs={"framework": ["torch", "sklearn"]})
```

**CLI:** `--kind` and a repeatable `--attr key=value` on `flyte get artifact`.

```
flyte get artifact --kind model
flyte get artifact --kind model --attr framework=torch
```

Both compile to `user_metadata.<key>` filters on the existing `ListRequest.filters`, so the work happens **server-side** and paging returns matches rather than scanning.

### Decisions worth reviewing

**`kind=` is folded into the attr namespace**, not implemented separately — it's shorthand for the reserved key, and the two combine into one predicate set. One mechanism, not two.

**Value grouping follows the server's semantics:** values for one key ride in a *single* filter because the server ORs them; separate keys become *separate* filters because the server ANDs those. Getting this backwards would silently return the wrong set.

**An empty sequence sends no filter.** `attrs={"framework": []}` means "no constraint", not "match nothing" — the alternative silently returns zero rows for what reads like an unset filter.

**Forward dependency, deliberately loud.** This needs a control plane carrying unionai/cloud#17546. An older one **rejects** the request rather than returning unfiltered results — the right failure mode, since a filter that silently doesn't filter is worse than one that errors.

## How was this patch tested?

```
$ pytest tests/flyte/remote/test_artifact_attr_filter.py
7 passed

$ pytest tests/flyte/test_artifact_kind.py tests/flyte/remote/test_artifact.py \
         tests/flyte/cli/test_create_artifact.py tests/flyte/test_produces_artifacts.py
82 passed
```

`make fmt` clean, `make mypy` clean (831 source files).

The new tests assert **the request that goes on the wire**, not the results: filtering is server-side, so a wrong field name or function returns the wrong set silently rather than failing. They cover `kind=` mapping to the reserved key, single and sequence values, separate keys becoming separate filters, `kind` + `attrs` combining, the empty-sequence case, and no filters by default.

**Verified end-to-end** against a local devbox running unionai/cloud#17546, with seeded artifacts:

| filter | result |
|---|---|
| none | 13 artifacts |
| `kind=model` | 2 |
| `kind=data` | 1 |
| `kind in (model,data)` | 3 |
| `kind!=model` | 11 |
| `kind EXISTS` | 3 |
| `kind NOT_EXISTS` | 10 |
| `kind=model AND framework=torch` | 1 |

That run also caught a **NULL-metadata bug in the backend** — negated filters were dropping every artifact with no metadata at all (`kind!=model` returned 4 instead of 11), since `NULL @> x` is NULL and `WHERE NULL` excludes. Fixed in unionai/cloud#17546.

### Labels

- **added** — attr and kind filtering on artifact listing.

## Check all the applicable boxes

- [x] I updated the documentation accordingly. *(docstrings on `listall`, including the control-plane requirement; CLI help text)*
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

- #1402 — the `flyte.io/kind` key (base)
- unionai/cloud#17546 — the server-side filter this depends on
- flyteorg/flyte#7814 — IDL doc comment describing these filters
