### PR TITLE
Record serving facts at prefetch, and make the prefetch task registerable

### DIFF
--- a/examples/genai/sglang/sglang_app_artifact.py
+++ b/examples/genai/sglang/sglang_app_artifact.py
@@ -1,0 +1,151 @@
+"""
+Serve a prefetched HuggingFace model from its **artifact**, using SGLang.
+
+This is the artifact-bound counterpart to `sglang_app.py`, and the SGLang twin of
+`examples/genai/vllm/vllm_app_artifact.py`. Instead of pointing the app at a
+specific run (`flyte.app.RunOutput(run_name=...)`), the app declares the model it
+wants by *artifact name*:
+
+```python
+model_path=flyte.app.ArtifactValue(name="SmolLM2-135M-Instruct", type="directory")
+```
+
+Why that matters: `flyte.prefetch.hf_model()` publishes a model artifact whose
+name is the repo tail and whose version is the HuggingFace commit id. Binding to
+the artifact name means the app definition is complete at module scope — it is
+deployable with a plain `flyte deploy`, with no run name to thread through — and
+the resolved artifact version is recorded, so the platform links this app to the
+exact model version it is serving.
+
+The model is `HuggingFaceTB/SmolLM2-135M-Instruct` (135M params, ~270MB bf16),
+the smallest checkpoint that satisfies both ends of this pipeline:
+
+- prefetch requires **safetensors** weights (the streaming serving loader reads
+  nothing else), which rules out e.g. `facebook/opt-125m`;
+- SGLang requires a resolvable `architectures` entry in config.json, which rules
+  out the sub-1MB `hf-internal-testing/tiny-random-gpt2`.
+
+SmolLM2-135M is `LlamaForCausalLM` with head_dim 64 and a chat template, so it
+loads on any attention backend and answers on the OpenAI-compatible route.
+
+Step 1 — prefetch the model (publishes the artifact)
+----------------------------------------------------
+
+```
+python examples/genai/sglang/sglang_app_artifact.py
+```
+
+The repo is public, so `hf_token_key=None` prefetches anonymously — no HF_TOKEN
+secret required. Inspect what was published with:
+
+```
+flyte get artifact SmolLM2-135M-Instruct
+```
+
+The artifact is engine-agnostic: the same prefetch feeds this app and the vLLM
+one. Only unsharded prefetches are portable that way — a `shard_config=` prefetch
+writes per-rank files for one engine at one tensor-parallel degree.
+
+Step 2 — deploy the app
+-----------------------
+
+```
+flyte deploy examples/genai/sglang/sglang_app_artifact.py smollm2_app
+```
+
+`ArtifactValue` is resolved at deploy time: `version=None` picks the latest
+version and pins the app to it, so a later re-prefetch of a new HF commit does
+not silently swap the weights under a running app. Redeploy to move forward.
+
+Usage
+-----
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="<your-app-endpoint>/v1", api_key="<your-api-key>")
+
+response = client.chat.completions.create(
+    model="smollm2-135m",
+    messages=[{"role": "user", "content": "Explain what a Flyte artifact is, briefly."}],
+)
+print(response.choices[0].message.content)
+```
+"""
+
+from flyteplugins.sglang import SGLangAppEnvironment
+
+import flyte
+import flyte.app
+
+MODEL_REPO = "HuggingFaceTB/SmolLM2-135M-Instruct"
+
+# The artifact name that `flyte.prefetch.hf_model` publishes by default: the repo
+# tail, with '.' replaced by '-'. Pass `artifact_name=` to hf_model to override it.
+ARTIFACT_NAME = "SmolLM2-135M-Instruct"
+
+image = (
+    flyte.Image.from_debian_base(name="sglang-app-image", install_flyte=False)
+    .with_apt_packages("libnuma-dev", "wget", "curl", "openssl", "pkg-config", "libssl-dev", "build-essential")
+    .with_commands(
+        [
+            "wget https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/cuda-keyring_1.1-1_all.deb",
+            "dpkg -i cuda-keyring_1.1-1_all.deb",
+            "apt-get update",
+            "apt-get install -y cuda-toolkit-12-8",
+        ]
+    )
+    .with_commands(["curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && . $HOME/.cargo/env"])
+    .with_env_vars({"CUDA_HOME": "/usr/local/cuda-12.8", "PATH": "/root/.cargo/bin:/usr/local/cuda-12.8/bin:$PATH"})
+    .with_pip_packages("flashinfer-python", "flashinfer-cubin")
+    .with_pip_packages("flashinfer-jit-cache", index_url="https://flashinfer.ai/whl/cu128")
+    .with_pip_packages("sglang==0.5.7")
+    .with_pip_packages("flyteplugins-sglang")
+)
+
+smollm2_app = SGLangAppEnvironment(
+    name="smollm2-135m-sglang",
+    model_id="smollm2-135m",
+    # The whole point of this example: bind to the artifact, not to a run.
+    # Add `version="<hf-commit-sha>"` to pin a specific checkpoint instead of
+    # resolving the latest at deploy time.
+    model_path=flyte.app.ArtifactValue(name=ARTIFACT_NAME, type="directory"),
+    # bf16 weights, so the GPU needs compute capability >= 8.0 — L4 (Ada) is the
+    # cheapest that qualifies. T4 is Turing and would fall over on bfloat16.
+    resources=flyte.Resources(cpu="2", memory="8Gi", gpu="L4:1", disk="10Gi"),
+    image=image,
+    # Stream the safetensors straight from the blob store into GPU memory rather
+    # than staging them on local disk first.
+    stream_model=True,
+    scaling=flyte.app.Scaling(
+        replicas=(0, 1),
+        scaledown_after=300,
+    ),
+    requires_auth=True,
+    # SGLang spells this `--context-length`; `--max-model-len` is the vLLM flag
+    # and SGLang's launcher rejects it. Passed pre-split, one token per element.
+    extra_args=["--context-length", "8192"],
+)
+
+
+if __name__ == "__main__":
+    import flyte.prefetch
+    from flyte.remote import Run
+
+    flyte.init_from_config()
+
+    # Prefetch the model into the Flyte object store. On success this publishes a
+    # model artifact named ARTIFACT_NAME, versioned by the HuggingFace commit id,
+    # with the repo README attached as the model card.
+    run: Run = flyte.prefetch.hf_model(
+        repo=MODEL_REPO,
+        hf_token_key=None,  # public repo: prefetch anonymously
+        resources=flyte.Resources(cpu="2", memory="4Gi", disk="10Gi"),
+    )
+    print(f"Prefetching {MODEL_REPO}: {run.url}")
+    run.wait()
+
+    # Nothing needs to be passed from the run to the app — `smollm2_app` already
+    # names the artifact, and deploy resolves it.
+    app = flyte.serve(smollm2_app)
+    print(f"Deployed SGLang app: {app.url}")

--- a/examples/genai/vllm/vllm_app_artifact.py
+++ b/examples/genai/vllm/vllm_app_artifact.py
@@ -1,0 +1,142 @@
+"""
+Serve a prefetched HuggingFace model from its **artifact**, using vLLM.
+
+This is the artifact-bound counterpart to `vllm_app.py`. Instead of pointing the
+app at a specific run (`flyte.app.RunOutput(run_name=...)`), the app declares the
+model it wants by *artifact name*:
+
+```python
+model_path=flyte.app.ArtifactValue(name="SmolLM2-135M-Instruct", type="directory")
+```
+
+Why that matters: `flyte.prefetch.hf_model()` publishes a model artifact whose
+name is the repo tail and whose version is the HuggingFace commit id. Binding to
+the artifact name means the app definition is complete at module scope — it is
+deployable with a plain `flyte deploy`, with no run name to thread through — and
+the resolved artifact version is recorded, so the platform links this app to the
+exact model version it is serving.
+
+The model is `HuggingFaceTB/SmolLM2-135M-Instruct` (135M params, ~270MB bf16),
+the smallest checkpoint that satisfies both ends of this pipeline:
+
+- prefetch requires **safetensors** weights (the streaming serving loader reads
+  nothing else), which rules out e.g. `facebook/opt-125m`;
+- vLLM requires a resolvable `architectures` entry in config.json, which rules
+  out the sub-1MB `hf-internal-testing/tiny-random-gpt2`.
+
+SmolLM2-135M is `LlamaForCausalLM` with head_dim 64 and a chat template, so it
+loads on any attention backend and answers on the OpenAI-compatible route.
+
+Step 1 — prefetch the model (publishes the artifact)
+----------------------------------------------------
+
+```
+python examples/genai/vllm/vllm_app_artifact.py
+```
+
+The repo is public, so `hf_token_key=None` prefetches anonymously — no HF_TOKEN
+secret required. Inspect what was published with:
+
+```
+flyte get artifact SmolLM2-135M-Instruct
+```
+
+Step 2 — deploy the app
+-----------------------
+
+```
+flyte deploy examples/genai/vllm/vllm_app_artifact.py smollm2_app
+```
+
+`ArtifactValue` is resolved at deploy time: `version=None` picks the latest
+version and pins the app to it, so a later re-prefetch of a new HF commit does
+not silently swap the weights under a running app. Redeploy to move forward.
+
+Usage
+-----
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="<your-app-endpoint>/v1", api_key="<your-api-key>")
+
+response = client.chat.completions.create(
+    model="smollm2-135m",
+    messages=[{"role": "user", "content": "Explain what a Flyte artifact is, briefly."}],
+)
+print(response.choices[0].message.content)
+```
+"""
+
+from flyteplugins.vllm import VLLMAppEnvironment
+
+import flyte
+import flyte.app
+
+MODEL_REPO = "HuggingFaceTB/SmolLM2-135M-Instruct"
+
+# The artifact name that `flyte.prefetch.hf_model` publishes by default: the repo
+# tail, with '.' replaced by '-'. Pass `artifact_name=` to hf_model to override it.
+ARTIFACT_NAME = "SmolLM2-135M-Instruct"
+
+image = (
+    flyte.Image.from_debian_base(
+        name="vllm-app-image",
+        install_flyte=False,
+    )
+    .with_pip_packages("flashinfer-python", "flashinfer-cubin")
+    .with_pip_packages("flashinfer-jit-cache", index_url="https://flashinfer.ai/whl/cu129")
+    # transformers is pinned deliberately: newer releases break the tokenizer load
+    # path used by the plugin's fserve entrypoint.
+    .with_pip_packages("vllm==0.11.0", "transformers==4.57.6")
+    .with_pip_packages("flyteplugins-vllm")
+)
+
+smollm2_app = VLLMAppEnvironment(
+    name="smollm2-135m-vllm",
+    model_id="smollm2-135m",
+    # The whole point of this example: bind to the artifact, not to a run.
+    # Add `version="<hf-commit-sha>"` to pin a specific checkpoint instead of
+    # resolving the latest at deploy time.
+    model_path=flyte.app.ArtifactValue(name=ARTIFACT_NAME, type="directory"),
+    # bf16 weights, so the GPU needs compute capability >= 8.0 — L4 (Ada) is the
+    # cheapest that qualifies. T4 is Turing and would fall over on bfloat16.
+    resources=flyte.Resources(cpu="2", memory="8Gi", gpu="L4:1", disk="10Gi"),
+    image=image,
+    # Stream the safetensors straight from the blob store into GPU memory rather
+    # than staging them on local disk first.
+    stream_model=True,
+    scaling=flyte.app.Scaling(
+        replicas=(0, 1),
+        scaledown_after=300,
+    ),
+    requires_auth=True,
+    # String form: the plugin shlex-splits it into separate argv tokens. A list
+    # here must already be split ( ["--max-model-len", "8192"] ) — a single
+    # "--max-model-len 8192" element reaches vLLM's argparse as one unrecognized
+    # option.
+    extra_args="--max-model-len 8192",
+)
+
+
+if __name__ == "__main__":
+    import flyte.prefetch
+    from flyte.remote import Run
+
+    flyte.init_from_config()
+
+    # Prefetch the model into the Flyte object store. On success this publishes a
+    # model artifact named ARTIFACT_NAME, versioned by the HuggingFace commit id,
+    # with the repo README attached as the model card.
+    run: Run = flyte.prefetch.hf_model(
+        repo=MODEL_REPO,
+        hf_token_key=None,  # public repo: prefetch anonymously
+        resources=flyte.Resources(cpu="2", memory="4Gi", disk="10Gi"),
+    )
+    print(f"Prefetching {MODEL_REPO}: {run.url}")
+    run.wait()
+
+    # Nothing needs to be passed from the run to the app — `smollm2_app` already
+    # names the artifact, and deploy resolves it.
+    app = flyte.serve(smollm2_app)
+    print(f"Deployed vLLM app: {app.url}")

--- a/examples/ml/image_classification/README.md
+++ b/examples/ml/image_classification/README.md
@@ -1,36 +1,90 @@
-# Image Classification: Fine-tuning, Serving, and Batch Inference
+# Image Classification: Artifacts, Triggers, and Lineage
 
-This example demonstrates a complete end-to-end ML workflow in Flyte 2.0:
-1. **Training**: Fine-tune a vision transformer model on HuggingFace datasets
-2. **Serving**: Deploy the trained model as a FastAPI service
-3. **Batch Inference**: Process thousands of images efficiently with reusable containers
+This example demonstrates a complete end-to-end ML workflow in Flyte 2.0, wired
+together by **artifacts** rather than by hard-coded run names:
+
+1. **Training**: Fine-tune a vision transformer and publish it as a *model artifact*
+2. **Batch Inference**: Auto-triggered by every new model version; publishes its
+   predictions as a *data artifact*
+3. **Serving**: Deploy a FastAPI app that binds to the model artifact by name
+
+### The artifact graph
+
+```
+       flyte run training.py finetune_image_model
+                        │
+                        ▼
+        ┌───────────────────────────────┐
+        │  artifact: beans-classifier   │  kind=model, HTML model card,
+        │  (a flyte.io.Dir of weights)  │  attrs: base_model, dataset, accuracy…
+        └───────────────────────────────┘
+              │                     │
+   OnArtifact trigger fires         │  flyte.app.ArtifactValue
+              ▼                     ▼
+  ┌───────────────────────┐   ┌──────────────────────────┐
+  │ batch_inference_demo  │   │ image-classification-api │
+  │ (scores held-out set) │   │ (FastAPI, /predict)      │
+  └───────────────────────┘   └──────────────────────────┘
+              │
+              ▼
+  ┌──────────────────────────────────────┐
+  │ artifact: beans-classifier-predictions│  kind=data
+  │ (a flyte.io.DataFrame)                │
+  └──────────────────────────────────────┘
+```
+
+Nothing downstream names a run, a run output, or even the training task. Retrain,
+and batch inference re-scores automatically; redeploy the app, and it picks up the
+latest weights. Every hop is recorded, so you can walk a prediction set back to the
+exact model version that produced it, and that model version back to the action
+and inputs that trained it.
 
 ## What This Example Shows
 
 ### Key Flyte 2.0 Features
 
-1. **Separate Training and Serving Scripts**
-   - `training.py`: Contains the model training task
-   - `serving.py`: Contains the FastAPI serving application
-   - Demonstrates how to structure ML projects with separate concerns
+1. **Artifacts as the integration surface**
+   - `finetune_image_model` is marked `produces_artifacts=True` and returns
+     `artifacts.new(model_dir, metadata)` — the platform registers a new version of
+     `beans-classifier` and records the producing action as its source
+   - `Metadata.create_model_metadata(...)` stamps `kind="model"` plus searchable
+     attrs (base model, dataset, epochs, measured accuracy)
+   - An HTML model card, rendered from the *real* evaluation metrics, is attached
+     and shown in the UI (HTML rather than markdown: HTML cards render in an
+     iframe, markdown cards need CORS configured on the bucket)
 
-2. **Dependency Isolation**
+2. **Artifact triggers (`OnArtifact`)**
+   - `batch_inference_demo` carries a `flyte.Trigger` whose automation is
+     `flyte.OnArtifact(name="beans-classifier")` — any new version fires a run
+   - `flyte.TriggeredArtifact` marks which input the fresh artifact binds to
+     (`model_dir`); the rest of the trigger's `inputs` are ordinary defaults
+   - Triggers are registered by `flyte deploy`, not by `flyte run`
+
+3. **Lineage**
+   - Batch inference consumes the model artifact and publishes
+     `beans-classifier-predictions`, so the platform links model → predictions
+   - The serving app's `ArtifactValue` records the resolved artifact version,
+     giving app → model lineage
+   - `flyte get artifact --source-run <run>` walks the graph from the other end
+
+4. **Separate Training, Inference, and Serving Scripts**
+   - `training.py`, `batch_inference.py`, `serving.py`: separate concerns, separate
+     images, separate dependency extras
+   - `model_artifact.py` holds only the shared artifact *names* — the three scripts
+     never import each other
+
+5. **Dependency Isolation**
    - `pyproject.toml` with split optional dependencies
    - Training dependencies (`[training]`): transformers, datasets, accelerate
    - Serving dependencies (`[serving]`): fastapi, uvicorn
    - Minimizes image size and reduces security surface area
 
-3. **RunOutput Integration**
-   - Training task outputs a `flyte.io.Dir` containing the fine-tuned model
-   - Serving app uses `flyte.app.RunOutput` to reference the training output
-   - Automatic model mounting at `/tmp/finetuned_model`
-
-4. **XET Acceleration**
+6. **XET Acceleration**
    - Enables fast dataset transfers from HuggingFace
    - Set via environment variable: `HF_XET_HIGH_PERFORMANCE=1`
 
-5. **GPU Resource Management**
-   - Training task requests GPU resources
+7. **GPU Resource Management**
+   - Training and batch inference request GPU resources
    - Serving app uses CPU only for inference
 
 ## Project Structure
@@ -39,9 +93,10 @@ This example demonstrates a complete end-to-end ML workflow in Flyte 2.0:
 image_classification/
 ├── README.md           # This file
 ├── pyproject.toml      # Dependency management with optional extras
-├── training.py         # Model fine-tuning script
-├── serving.py          # Model serving API
-└── batch_inference.py  # Batch inference with reusable containers
+├── model_artifact.py   # Shared artifact names (the only cross-script coupling)
+├── training.py         # Fine-tuning; publishes the model artifact
+├── serving.py          # Model serving API; binds to the artifact by name
+└── batch_inference.py  # Artifact-triggered batch inference + reusable containers
 ```
 
 ## Installation
@@ -68,7 +123,23 @@ uv pip install .[all]
 
 ## Usage
 
-### 1. Train the Model
+### 1. Register the trigger (once)
+
+Deploy the batch-inference environment so the `score-on-new-model` trigger is
+registered with the platform. Triggers live on *deployed* tasks — `flyte run`
+alone never registers one:
+
+```bash
+flyte deploy batch_inference.py driver_with_report_env
+```
+
+Confirm it landed:
+
+```bash
+flyte get trigger
+```
+
+### 2. Train the Model
 
 Run the training script to fine-tune a ViT-tiny model on the beans dataset:
 
@@ -90,23 +161,48 @@ flyte run training.py finetune_image_model \
 The training task will:
 - Download and preprocess the dataset with XET acceleration
 - Fine-tune a small ViT model (WinKawaks/vit-tiny-patch16-224)
+- Evaluate on the validation split and render an HTML model card from the results
 - Save the model, processor, and label mappings
-- Return a `flyte.io.Dir` containing all artifacts
+- Publish it all as a new version of the `beans-classifier` model artifact
 
-### 2. Serve the Model
+Inspect what was published:
 
-Once training completes, deploy the model as a FastAPI service:
+```bash
+flyte get artifact beans-classifier          # every version, newest first
+flyte get artifact beans-classifier <ver>    # one version's details + card
+flyte get artifact --kind model              # all model artifacts
+```
+
+**Watch the trigger fire.** Shortly after the training action succeeds, a run of
+`batch_inference_demo` appears that nobody launched — the platform bound the fresh
+artifact to its `model_dir` input. That run publishes
+`beans-classifier-predictions`, whose lineage points back at the model version it
+scored with.
+
+> **If no run appears:** the training env sets `cache=flyte.Cache("auto", "1.0")`.
+> Re-running with identical inputs is a cache hit, which reuses the previous
+> outputs and so publishes **no new artifact version** — and a trigger fires on new
+> versions only. Vary an input (`--num_epochs=4`) to get a genuinely new model.
+
+### 3. Serve the Model
+
+Deploy the model as a FastAPI service:
 
 ```bash
 flyte serve serving.py env
 ```
 
 This will:
-- Load the fine-tuned model from the training run output
+- Resolve `beans-classifier` from the artifact service **at deploy time** and mount
+  it at `/tmp/finetuned_model`
 - Start a FastAPI server with inference endpoints
 - Expose the API at a public URL
 
-### 3. Test the API
+`ArtifactValue(version=None)` resolves the latest version and *pins* it, so a later
+training run cannot swap the weights under a live app. Redeploy to move forward, or
+pass `version="<artifact-version>"` to serve a specific checkpoint.
+
+### 4. Test the API
 
 **Using the interactive docs:**
 ```
@@ -129,9 +225,33 @@ response = requests.post(url, files=files)
 print(response.json())
 ```
 
-### 4. Batch Inference
+### 5. Batch Inference (on demand)
 
-For processing large numbers of images efficiently, use the batch inference pipeline:
+Step 1 registered the trigger, so batch inference normally runs *by itself*. To
+kick one off by hand — for a different dataset, or an older checkpoint — bind the
+artifact directly:
+
+```bash
+python batch_inference.py
+```
+
+which is just:
+
+```python
+from flyte.remote import Artifact
+
+model = Artifact.get("beans-classifier")            # or version="<artifact-version>"
+flyte.run(batch_inference_demo, model_dir=model)    # binds to the `Dir` input
+```
+
+An `Artifact` binds straight to a typed task input, and the version consumed is
+recorded on the run — which is what makes the lineage query work later. That beats
+the alternative of listing successful runs of a named training task and fishing the
+`Dir` out of `run.outputs()[0]`: no dependence on the producing task's name, and no
+guessing about which output slot held the model.
+
+For processing large numbers of images from a directory you already have, the
+lower-level pipeline still takes a plain `Dir`:
 
 ```bash
 flyte run batch_inference.py batch_inference_pipeline \
@@ -148,10 +268,23 @@ flyte run batch_inference.py batch_inference_pipeline \
 - Generates a comprehensive report with all predictions
 
 **Key parameters:**
-- `model_dir`: Directory with the trained model (from training.py output)
+- `model_dir`: Directory with the trained model (an `Artifact`, or a raw `Dir`)
 - `images_dir`: Directory containing images to classify
 - `chunk_size`: Number of images per parallel task (default: 100)
 - `batch_size`: Mini-batch size for GPU processing (default: 32)
+
+### 6. Follow the lineage
+
+```bash
+# Which prediction sets exist, and what produced them?
+flyte get artifact beans-classifier-predictions
+
+# Everything a given training run published
+flyte get artifact --source-run <training-run-name>
+
+# All models trained on a particular dataset
+flyte get artifact --kind model --attr dataset=AI-Lab-Makerere/beans
+```
 
 **Performance:**
 - **Reusable containers**: Model loaded once, reused for all chunks
@@ -233,21 +366,24 @@ Get all available classification classes.
 ### Training Pipeline (`training.py`)
 
 ```
-┌─────────────────────────────────────────┐
-│  finetune_image_model Task              │
-│                                         │
-│  1. Load dataset from HuggingFace       │
-│  2. Preprocess images                   │
-│  3. Fine-tune ViT model                 │
-│  4. Save model + processor + labels     │
-│  5. Return flyte.io.Dir                 │
-└─────────────────────────────────────────┘
+┌──────────────────────────────────────────────────┐
+│  finetune_image_model (produces_artifacts=True)  │
+│                                                  │
+│  1. Load dataset from HuggingFace                │
+│  2. Preprocess images                            │
+│  3. Fine-tune ViT model                          │
+│  4. Evaluate → metrics for the card + attrs      │
+│  5. Save model + processor + labels              │
+│  6. Upload HTML model card                       │
+│  7. Return artifacts.new(Dir, Metadata)          │
+└──────────────────────────────────────────────────┘
               │
               ▼
-     ┌─────────────────┐
-     │  Model Artifacts │
-     │  (flyte.io.Dir)  │
-     └─────────────────┘
+   ┌──────────────────────────────────┐
+   │  artifact: beans-classifier@<v>  │
+   │  kind=model · card · attrs       │
+   │  source = this action            │
+   └──────────────────────────────────┘
 ```
 
 ### Serving Application (`serving.py`)
@@ -257,7 +393,9 @@ Get all available classification classes.
 │  FastAPI App Environment                │
 │                                         │
 │  Parameters:                            │
-│    - model: RunOutput from training     │
+│    - model: ArtifactValue(              │
+│        "beans-classifier", directory)   │
+│      resolved + pinned at deploy time   │
 │                                         │
 │  Mounted at: /tmp/finetuned_model       │
 └─────────────────────────────────────────┘
@@ -280,6 +418,19 @@ Get all available classification classes.
 ### Batch Inference Pipeline (`batch_inference.py`)
 
 ```
+   ┌──────────────────────────────────┐
+   │  artifact: beans-classifier@<v>  │
+   └──────────────────────────────────┘
+              │  OnArtifact trigger — binds the new version
+              │  to `model_dir` via flyte.TriggeredArtifact
+              ▼
+┌─────────────────────────────────────────────────┐
+│  batch_inference_demo (triggered)               │
+│    → extract_dataset_images                     │
+│    → batch_inference_with_report                │
+└─────────────────────────────────────────────────┘
+              │
+              ▼
 ┌─────────────────────────────────────────────────┐
 │  Driver Task (batch_inference_pipeline)         │
 │                                                 │
@@ -323,6 +474,12 @@ Get all available classification classes.
      │  - Label distribution │
      │  - All predictions    │
      └──────────────────────┘
+              │
+              ▼
+  ┌────────────────────────────────────────┐
+  │ artifact: beans-classifier-predictions │  kind=data
+  │ (flyte.io.DataFrame)                   │  lineage → the model version
+  └────────────────────────────────────────┘  it was scored with
 ```
 
 **Reusable Container Benefits:**
@@ -367,19 +524,30 @@ Get all available classification classes.
 
 ## Best Practices Demonstrated
 
-1. **Separation of Concerns**: Training, serving, and batch inference are independent scripts
-2. **Dependency Minimization**: Each script only installs what it needs
-3. **Resource Optimization**:
+1. **Couple on artifact names, not run names**: nothing downstream references a run
+   ID, a run output slot, or the producing task's name — rename or rewrite
+   `training.py` and the trigger and the app keep working
+2. **Publish metadata with the weights**: a model card rendered from the *measured*
+   evaluation, plus searchable attrs, so `flyte get artifact --kind model` is a
+   usable model registry rather than a list of opaque directories
+3. **Automate the fan-out**: `OnArtifact` means evaluation happens on every new
+   model without a human remembering to launch it
+4. **Publish downstream results as artifacts too**: predictions are a first-class
+   asset, and their lineage answers "which weights produced this?" months later
+5. **Pin what serves traffic**: `ArtifactValue` resolves *and pins* at deploy time,
+   so a training run can never silently swap the weights under a live app
+6. **Separation of Concerns**: Training, serving, and batch inference are independent scripts
+7. **Dependency Minimization**: Each script only installs what it needs
+8. **Resource Optimization**:
    - Training uses GPU for fine-tuning
    - Serving uses CPU for real-time inference
    - Batch inference uses reusable GPU containers for throughput
-4. **Artifact Management**: Models passed between tasks via `flyte.io.Dir`
-5. **Environment Configuration**: XET acceleration via environment variables
-6. **API Documentation**: OpenAPI/Swagger docs auto-generated
-7. **Health Checks**: Proper health endpoints for monitoring
-8. **Reusable Containers**: Model loaded once, amortized across many images
-9. **Efficient Batching**: Chunk-level and mini-batch-level batching for GPU utilization
-10. **Comprehensive Reporting**: Detailed statistics and error tracking
+9. **Environment Configuration**: XET acceleration via environment variables
+10. **API Documentation**: OpenAPI/Swagger docs auto-generated
+11. **Health Checks**: Proper health endpoints for monitoring
+12. **Reusable Containers**: Model loaded once, amortized across many images
+13. **Efficient Batching**: Chunk-level and mini-batch-level batching for GPU utilization
+14. **Comprehensive Reporting**: Detailed statistics and error tracking
 
 ## Customization
 
@@ -415,12 +583,36 @@ Reduce batch size:
 flyte run training.py finetune_image_model --batch_size=16
 ```
 
+### The Trigger Never Fires
+
+Work through these in order:
+
+1. **Was the trigger registered?** `flyte get trigger` should list
+   `score-on-new-model`. If not, run
+   `flyte deploy batch_inference.py driver_with_report_env`. A `flyte run` does not
+   register triggers.
+2. **Was a new artifact version actually published?**
+   `flyte get artifact beans-classifier` — if the version count did not grow, the
+   training run was a cache hit (see step 2 of Usage) or the task is missing
+   `produces_artifacts=True`.
+3. **Do the names match?** The `OnArtifact(name=...)` in `batch_inference.py` and the
+   `Metadata(name=...)` in `training.py` both read `MODEL_ARTIFACT_NAME` from
+   `model_artifact.py` — a divergence here is silent, the trigger just never fires.
+4. **Same project and domain?** Artifact names are scoped to project/domain, so a
+   model published in `development` will not fire a trigger deployed in `production`.
+
 ### Model Not Loading in Serving
 
 Check that:
-1. Training completed successfully
-2. The `task_name` in `serving.py` matches your training task
-3. The model directory is mounted correctly
+1. Training completed successfully **and published an artifact** —
+   `flyte get artifact beans-classifier` should list at least one version
+2. The artifact name in `serving.py` (`MODEL_ARTIFACT_NAME`) matches what training
+   published, in the same project/domain
+3. The model directory is mounted correctly at `/tmp/finetuned_model`
+
+A deploy that fails with `ParameterMaterializationError` means the artifact could
+not be resolved at all — usually nothing has been published under that name yet, so
+train first.
 
 ### Slow Dataset Loading
 
@@ -465,3 +657,11 @@ flyte run batch_inference.py batch_inference_pipeline \
 - [Flyte 2.0 Documentation](https://docs.flyte.org)
 - [HuggingFace Transformers](https://huggingface.co/docs/transformers)
 - [FastAPI Documentation](https://fastapi.tiangolo.com)
+
+### Related examples
+
+- `examples/artifacts/artifact_example.py` — every way an artifact can be born
+  (File, Dir, DataFrame, multi-output tasks, explicit `Artifact.create`)
+- `examples/triggers/artifact_trigger.py` — the smallest possible `OnArtifact` demo
+- `examples/triggers/artifact_trigger_external.py` — triggers fired by publishes
+  that come from outside Flyte entirely (CLI, or an external system's callback)

--- a/examples/ml/image_classification/batch_inference.py
+++ b/examples/ml/image_classification/batch_inference.py
@@ -1,7 +1,19 @@
 """
 Image Classification - Batch Inference with DataFrames & Reports
 
-Runs batch inference on a large number of images efficiently using:
+Triggered by the model artifact. `batch_inference_demo` carries an `OnArtifact`
+trigger on the `beans-classifier` artifact that `training.py` publishes, so every
+new model version automatically scores a batch of held-out images — nobody has to
+launch this run, and nothing here names a training run. The fresh model binds to
+the `model_dir` input through the `flyte.TriggeredArtifact` sentinel; the
+remaining trigger inputs come from the defaults declared on the trigger.
+
+The run closes the lineage loop by publishing its predictions as a *data*
+artifact, produced by an action whose input was the model artifact — so the
+platform can walk `beans-classifier@<version>` forward to every prediction set
+scored with it, and each prediction set back to the exact weights behind it.
+
+Runs efficiently using:
 - Real dataset images (validation/test splits from HuggingFace datasets)
 - Pipelined downloads (images downloaded on-demand during processing)
 - DataFrame-based processing (efficient serialization and analysis)
@@ -12,6 +24,14 @@ Runs batch inference on a large number of images efficiently using:
 - Interactive HTML reports (charts and visualizations with Flyte reports)
 
 Usage:
+    # Deploy so the artifact trigger is registered (do this once):
+    flyte deploy batch_inference.py driver_with_report_env
+
+    # ...then every `flyte run training.py finetune_image_model` fires a run here.
+
+    # Or run it by hand against the latest published model:
+    python batch_inference.py
+
     # Run end-to-end demo with real dataset images (recommended):
     flyte run batch_inference.py batch_inference_demo \\
         --model_dir=<model_directory> \\
@@ -50,10 +70,12 @@ from typing import Dict, List
 import pyarrow as pa
 import torch
 from batch_inference_report import batch_image, generate_batch_inference_report, report_env
+from model_artifact import MODEL_ARTIFACT_NAME, PREDICTIONS_ARTIFACT_NAME
 from PIL import Image
 from transformers import AutoImageProcessor, AutoModelForImageClassification
 
 import flyte
+import flyte.artifacts as artifacts
 import flyte.io
 
 logging.basicConfig(level=logging.INFO)
@@ -66,7 +88,11 @@ worker_env = flyte.TaskEnvironment(
     image=batch_image,
     resources=flyte.Resources(cpu=2, memory="8Gi", gpu=1),
     reusable=flyte.ReusePolicy(
-        replicas=8,  # 8 replicas running in parallel
+        # 2 replicas is sized for the demo: 50 images at chunk_size=20 is 3 chunks,
+        # so 2 replicas x 2 concurrency already covers the fan-out. Raise this (and
+        # chunk_size) together when pointing the pipeline at a real image corpus —
+        # every replica holds a GPU for `scaledown_ttl` whether it is fed or not.
+        replicas=2,
         concurrency=2,  # Each replica can handle 2 tasks concurrently
         idle_ttl=300,  # Keep alive for 5 minutes after idle
         scaledown_ttl=300,
@@ -391,6 +417,32 @@ driver_with_report_env = driver_env.clone_with(
     "image-classification-report", depends_on=[driver_env, report_env], image=batch_image.with_pip_packages("datasets")
 )
 
+# Fire a batch-inference run whenever training publishes a new model version.
+#
+# `OnArtifact(name=...)` with no `version=` fires on *any* new version of that
+# artifact, whoever created it: a training run, `flyte create artifact`, or a
+# programmatic `Artifact.create` — the trigger does not care how the version was
+# born. Pin `version=` to fire on one exact version instead.
+#
+# `flyte.TriggeredArtifact` is the artifact-trigger analogue of `flyte.TriggerTime`:
+# it marks which task input the freshly published artifact binds to. The backend
+# writes the artifact's value straight into the run's inputs, so `model_dir` arrives
+# as an ordinary `flyte.io.Dir` — the task body needs no artifact-specific code. Only
+# one input may carry the sentinel; the rest are plain defaults for this trigger, and
+# any task input left out here falls back to its own default.
+score_on_new_model = flyte.Trigger(
+    name="score-on-new-model",
+    automation=flyte.OnArtifact(name=MODEL_ARTIFACT_NAME),
+    inputs={
+        "model_dir": flyte.TriggeredArtifact,
+        "dataset_name": "AI-Lab-Makerere/beans",
+        "split": "validation",
+        "max_images": 50,
+        "chunk_size": 20,
+    },
+    description=f"Batch-score held-out images with every new {MODEL_ARTIFACT_NAME} version",
+)
+
 
 @driver_with_report_env.task(cache="auto")
 async def extract_dataset_images(
@@ -524,7 +576,7 @@ async def batch_inference_with_report(
     return results_df
 
 
-@driver_with_report_env.task(cache="auto")
+@driver_with_report_env.task(cache="auto", triggers=(score_on_new_model,), produces_artifacts=True)
 async def batch_inference_demo(
     model_dir: flyte.io.Dir,
     dataset_name: str = "AI-Lab-Makerere/beans",
@@ -535,21 +587,28 @@ async def batch_inference_demo(
     """
     Demo workflow: Extract dataset images and run batch inference with report.
 
+    This is the task the `score-on-new-model` artifact trigger fires. It is an
+    ordinary task otherwise — `model_dir` is a plain Dir whether it arrived from a
+    trigger, from `flyte.run(..., model_dir=Artifact.get(...))`, or from a literal
+    path on the CLI.
+
     This is a complete end-to-end demonstration that:
     1. Extracts validation/test images from the same dataset used for training
     2. Runs batch inference on those images
     3. Generates an interactive report
-    4. Returns the full DataFrame with results
+    4. Publishes the predictions as a data artifact and returns the DataFrame
 
     Args:
-        model_dir: Directory containing the fine-tuned model
+        model_dir: Directory containing the fine-tuned model (bound to the triggering
+            `beans-classifier` artifact version when fired by the trigger)
         dataset_name: HuggingFace dataset name (e.g., "AI-Lab-Makerere/beans", "uoft-cs/cifar10", "ethz/food101")
         split: Dataset split to use ("validation" or "test")
         max_images: Maximum number of images to extract
         chunk_size: Number of images per chunk (affects parallelism)
 
     Returns:
-        DataFrame with all inference results
+        DataFrame with all inference results, published as a new version of the
+        `beans-classifier-predictions` artifact.
     """
     logger.info(f"Starting batch inference demo with {max_images} images from {dataset_name}")
 
@@ -566,28 +625,43 @@ async def batch_inference_demo(
     )
 
     logger.info("Batch inference demo completed successfully")
-    return results_df
+
+    # Publish the predictions as a data artifact. The lineage the platform records is
+    # structural — this action consumed the model artifact and produced this one — so
+    # the attrs below are for humans reading the artifact list, not the graph itself.
+    #
+    # Only this task wraps its output: child tasks hand their results back unwrapped,
+    # so `batch_inference_with_report` returning the same DataFrame publishes nothing.
+    metadata = artifacts.Metadata(
+        name=PREDICTIONS_ARTIFACT_NAME,
+        description=f"Predictions over {max_images} {split} images from {dataset_name}",
+        kind="data",
+        attrs={
+            "model_artifact": MODEL_ARTIFACT_NAME,
+            "model_path": model_dir.path,
+            "dataset": dataset_name,
+            "split": split,
+            "num_images": str(max_images),
+        },
+    )
+    return artifacts.new(results_df, metadata)
 
 
 if __name__ == "__main__":
-    import flyte.models
-    import flyte.remote
+    from flyte.remote import Artifact
 
     flyte.init_from_config(
         root_dir=Path(__file__).parent,
     )
 
-    training_runs = flyte.remote.Run.listall(
-        in_phase=(flyte.models.ActionPhase.SUCCEEDED,),
-        task_name="image_finetune_training.finetune_image_model",
-        sort_by=("created_at", "desc"),
-        limit=1,
-    )
+    # Bind by artifact name instead of digging the Dir out of the latest successful
+    # training run: no dependence on the producing task's name, and the exact version
+    # consumed is recorded on the run. Pass `version=` to score an older checkpoint.
+    model = Artifact.get(MODEL_ARTIFACT_NAME)
+    print(f"Scoring with {model.name}@{model.version}: {model.url}")
 
-    training_run = next(training_runs)
-    outputs = training_run.outputs()
-
-    r = flyte.run(batch_inference_demo, outputs[0])
+    # An Artifact binds straight to a typed task input — here the `model_dir: Dir`.
+    r = flyte.run(batch_inference_demo, model_dir=model)
     print(r.url)
 
     print(
@@ -607,10 +681,16 @@ WORKFLOWS:
 
 3. batch_inference_demo - End-to-end demo with real dataset images
    Extracts validation/test images from HuggingFace dataset, runs inference, and generates report
+   Carries the `score-on-new-model` artifact trigger, and publishes its predictions
+   as the `beans-classifier-predictions` data artifact
    Returns: flyte.io.DataFrame with predictions + HTML report
 
 USAGE:
 ------
+
+# Register the artifact trigger (once). After this, publishing a new
+# `beans-classifier` version automatically launches batch_inference_demo:
+flyte deploy batch_inference.py driver_with_report_env
 
 # Run end-to-end demo with real dataset images (recommended):
 flyte run batch_inference.py batch_inference_demo \\
@@ -640,6 +720,8 @@ flyte run batch_inference.py extract_dataset_images \\
 
 FEATURES:
 ---------
+✓ Auto-triggered by every new model artifact version (OnArtifact)
+✓ Predictions published as a data artifact, lineage-linked to the model
 ✓ Real dataset image extraction (validation/test splits)
 ✓ Pipelined downloads (images downloaded on-demand during processing)
 ✓ Efficient DataFrame-based processing

--- a/examples/ml/image_classification/model_artifact.py
+++ b/examples/ml/image_classification/model_artifact.py
@@ -1,0 +1,29 @@
+"""Artifact names shared by the training, batch-inference, and serving scripts.
+
+The three entrypoints in this example never import each other — they are built
+into different images with disjoint dependency extras (`training`, `batch`,
+`serving`), so importing `training.py` from `serving.py` would drag `datasets`
+and `accelerate` into the serving image. They do have to agree on the *names* of
+the artifacts they pass between themselves, though, which is all this module
+holds: plain strings, no imports, cheap to pull into any of the three images.
+
+The names are the coupling point of the whole example:
+
+    training.finetune_image_model
+        └── publishes MODEL_ARTIFACT_NAME  (a Dir artifact: weights + processor)
+                ├── OnArtifact trigger fires batch_inference.batch_inference_demo
+                │       └── publishes PREDICTIONS_ARTIFACT_NAME (a DataFrame artifact)
+                └── serving.env mounts it via flyte.app.ArtifactValue
+
+Nothing here is a Flyte requirement — an artifact name is just a string scoped to
+the project/domain. Keeping them in one module is how you avoid a typo silently
+turning into "the trigger never fires".
+"""
+
+#: The fine-tuned classifier published by `training.finetune_image_model`.
+#: A new version is created on every successful (non-cached) training run.
+MODEL_ARTIFACT_NAME = "beans-classifier"
+
+#: The batch-inference predictions published by `batch_inference.batch_inference_demo`.
+#: Its lineage points back at the exact model version that produced it.
+PREDICTIONS_ARTIFACT_NAME = "beans-classifier-predictions"

--- a/examples/ml/image_classification/serving.py
+++ b/examples/ml/image_classification/serving.py
@@ -1,8 +1,25 @@
 """
 Image Classification - Serving Script
 
-Serves a fine-tuned vision model via FastAPI with image upload endpoint.
-This script handles model loading and inference.
+Serves the fine-tuned vision model via FastAPI with an image upload endpoint.
+
+The app binds to the **model artifact by name**, not to a training run:
+
+```python
+Parameter(
+    name="model",
+    value=flyte.app.ArtifactValue(name=MODEL_ARTIFACT_NAME, type="directory"),
+    mount="/tmp/finetuned_model",
+)
+```
+
+Why that matters: the app definition is complete at module scope, so it deploys
+with a plain `flyte deploy` — there is no run name to look up and thread through,
+and the training task can be renamed without touching this file. `ArtifactValue`
+resolves at deploy time (`version=None` takes the latest and *pins* it, so a later
+training run cannot silently swap the weights under a live app; redeploy to move
+forward), and the resolved version is recorded, giving the platform app → model
+lineage.
 
 Usage:
     flyte serve serving.py env
@@ -21,6 +38,7 @@ import aiofiles
 import torch
 from fastapi import FastAPI, File, HTTPException, UploadFile
 from fastapi.responses import HTMLResponse
+from model_artifact import MODEL_ARTIFACT_NAME
 from PIL import Image
 from pydantic import BaseModel
 from transformers import AutoImageProcessor, AutoModelForImageClassification
@@ -79,7 +97,10 @@ env = FastAPIAppEnvironment(
     parameters=[
         Parameter(
             name="model",
-            value=flyte.app.RunOutput(task_name="image_finetune_training.finetune_image_model", type="directory"),
+            # Bind to the artifact, not to a run. Add `version="<artifact-version>"`
+            # to serve a specific checkpoint instead of resolving the latest at
+            # deploy time.
+            value=flyte.app.ArtifactValue(name=MODEL_ARTIFACT_NAME, type="directory"),
             mount="/tmp/finetuned_model",
         )
     ],

--- a/examples/ml/image_classification/training.py
+++ b/examples/ml/image_classification/training.py
@@ -1,8 +1,19 @@
 """
 Image Classification - Training Script
 
-Fine-tunes a small vision transformer model on HuggingFace datasets.
-This script handles the model training and saves the fine-tuned model.
+Fine-tunes a small vision transformer model on HuggingFace datasets and
+**publishes the result as a model artifact**.
+
+The task is marked `produces_artifacts=True` and wraps its `flyte.io.Dir` output
+with `flyte.artifacts.new(...)`. On success the platform registers a new version
+of the `beans-classifier` artifact, records this action as its source, and
+attaches the rendered HTML model card. Two things downstream hang off that
+publish, without either of them naming this run:
+
+- `batch_inference.py` deploys an `OnArtifact` trigger, so a new model version
+  automatically kicks off a batch-inference run against it;
+- `serving.py` mounts the artifact with `flyte.app.ArtifactValue`, so a plain
+  `flyte deploy` picks up the model with no run name to thread through.
 
 Usage:
     flyte run training.py finetune_image_model
@@ -12,6 +23,9 @@ Usage:
         --dataset_name="ethz/food101" \\
         --num_epochs=5 \\
         --batch_size=32
+
+Inspect what was published:
+    flyte get artifact beans-classifier
 """
 
 import json
@@ -20,6 +34,7 @@ from pathlib import Path
 
 import numpy as np
 from datasets import load_dataset
+from model_artifact import MODEL_ARTIFACT_NAME
 from transformers import (
     AutoImageProcessor,
     AutoModelForImageClassification,
@@ -28,6 +43,7 @@ from transformers import (
 )
 
 import flyte
+import flyte.artifacts as artifacts
 import flyte.io
 
 logging.basicConfig(level=logging.INFO)
@@ -47,7 +63,108 @@ training_env = flyte.TaskEnvironment(
 )
 
 
-@training_env.task
+def _model_card_html(
+    *,
+    base_model: str,
+    dataset_name: str,
+    labels: list[str],
+    hyperparams: dict[str, str],
+    metrics: dict[str, float],
+) -> str:
+    """
+    Render a self-contained HTML model card from the real training results.
+
+    HTML rather than markdown on purpose: the UI renders HTML cards in an iframe,
+    which works against any object store, while a markdown card needs a browser
+    fetch of the presigned URL and therefore CORS configured on the bucket.
+    """
+    label_chips = "".join(f'<span class="chip">{label}</span>' for label in labels)
+    param_rows = "".join(f"<dt>{name}</dt><dd class='mono'>{value}</dd>" for name, value in hyperparams.items())
+    metric_rows = (
+        "".join(
+            f"""<div class="metric">
+              <div class="metric-head"><span>{name}</span><span class="mono">{value:.1%}</span></div>
+              <div class="bar"><div class="bar-fill" style="width:{min(value, 1.0) * 100:.0f}%"></div></div>
+            </div>"""
+            for name, value in metrics.items()
+        )
+        or "<div class='note'>No validation split in this dataset — nothing was evaluated.</div>"
+    )
+    return f"""<!DOCTYPE html>
+<html><head><meta charset="utf-8"><style>
+  :root {{ --purple: #7652a2; --purple-light: #a98fd1; --ink: #171020; --paper: #f7f5fd; }}
+  * {{ margin: 0; box-sizing: border-box; }}
+  body {{ font-family: -apple-system, 'Segoe UI', Roboto, sans-serif; background: var(--ink);
+         color: var(--paper); padding: 32px; }}
+  .card {{ max-width: 860px; margin: 0 auto; }}
+  .hero {{ background: linear-gradient(135deg, var(--purple) 0%, #4a3070 100%);
+           border-radius: 16px; padding: 28px 32px; }}
+  .hero h1 {{ font-size: 26px; letter-spacing: -0.5px; }}
+  .hero .sub {{ margin-top: 6px; opacity: 0.85; font-size: 14px; }}
+  .badges {{ margin-top: 16px; display: flex; gap: 8px; flex-wrap: wrap; }}
+  .badge {{ background: rgba(255,255,255,0.16); border: 1px solid rgba(255,255,255,0.25);
+            border-radius: 999px; padding: 4px 12px; font-size: 12px; }}
+  .grid {{ display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 16px; }}
+  section {{ background: #221a33; border: 1px solid #372a4f; border-radius: 12px; padding: 20px; }}
+  section.wide {{ grid-column: 1 / -1; }}
+  h2 {{ font-size: 13px; text-transform: uppercase; letter-spacing: 1.2px;
+        color: var(--purple-light); margin-bottom: 14px; }}
+  dl {{ display: grid; grid-template-columns: auto 1fr; gap: 8px 16px; font-size: 14px; }}
+  dt {{ opacity: 0.6; }}
+  dd {{ text-align: right; }}
+  .mono {{ font-family: ui-monospace, 'SF Mono', Menlo, monospace; font-size: 13px;
+           overflow-wrap: anywhere; }}
+  .chip {{ display: inline-block; background: #372a4f; border-radius: 6px; padding: 3px 10px;
+           margin: 0 6px 6px 0; font-size: 13px; }}
+  .metric {{ margin-bottom: 14px; font-size: 14px; }}
+  .metric-head {{ display: flex; justify-content: space-between; margin-bottom: 6px; }}
+  .bar {{ height: 8px; background: #372a4f; border-radius: 4px; overflow: hidden; }}
+  .bar-fill {{ height: 100%; background: linear-gradient(90deg, var(--purple), var(--purple-light));
+               border-radius: 4px; }}
+  .note {{ font-size: 13px; line-height: 1.6; opacity: 0.8; }}
+</style></head><body><div class="card">
+  <div class="hero">
+    <h1>{MODEL_ARTIFACT_NAME}</h1>
+    <div class="sub">{base_model} fine-tuned on {dataset_name} for image classification.</div>
+    <div class="badges">
+      <span class="badge">PyTorch</span><span class="badge">Transformers</span>
+      <span class="badge">Image Classification</span><span class="badge">safetensors</span>
+    </div>
+  </div>
+  <div class="grid">
+    <section>
+      <h2>Training</h2>
+      <dl>{param_rows}</dl>
+    </section>
+    <section>
+      <h2>Evaluation</h2>
+      {metric_rows}
+    </section>
+    <section>
+      <h2>Classes ({len(labels)})</h2>
+      {label_chips}
+    </section>
+    <section>
+      <h2>Intended Use</h2>
+      <div class="note">Demo classifier for the Flyte artifacts + triggers example. Serve it with
+      <span class="mono">serving.py</span>, or score a batch of images with
+      <span class="mono">batch_inference.py</span> — both bind to this artifact by name.</div>
+    </section>
+    <section class="wide">
+      <h2>Limitations</h2>
+      <div class="note">Trained for a handful of epochs on a small public dataset to keep the example
+      cheap to run. Accuracy degrades on out-of-distribution photos, and the label set is closed —
+      every input is forced into one of the classes above. Evaluate on your own data before relying
+      on predictions.</div>
+    </section>
+  </div>
+</div></body></html>"""
+
+
+# `produces_artifacts=True` tells the platform to look for wrapped values among this
+# task's outputs. Without it the `artifacts.new(...)` wrapper is silently unwrapped
+# and you get a plain Dir back — no artifact, no trigger, nothing for the app to bind.
+@training_env.task(produces_artifacts=True)
 async def finetune_image_model(
     dataset_name: str = "AI-Lab-Makerere/beans",
     model_name: str = "WinKawaks/vit-tiny-patch16-224",
@@ -56,7 +173,7 @@ async def finetune_image_model(
     learning_rate: float = 5e-5,
 ) -> flyte.io.Dir:
     """
-    Fine-tune a small vision transformer model on an image classification dataset.
+    Fine-tune a small vision transformer model and publish it as a model artifact.
 
     Args:
         dataset_name: HuggingFace dataset name (e.g., "AI-Lab-Makerere/beans", "uoft-cs/cifar10", "ethz/food101")
@@ -66,7 +183,8 @@ async def finetune_image_model(
         learning_rate: Learning rate for training
 
     Returns:
-        Directory containing the fine-tuned model and processor
+        Directory containing the fine-tuned model and processor, published as a new
+        version of the `beans-classifier` model artifact.
     """
     logger.info(f"Starting fine-tuning: model={model_name}, dataset={dataset_name}")
 
@@ -156,6 +274,15 @@ async def finetune_image_model(
     logger.info(f"Starting training for {num_epochs} epochs...")
     trainer.train()
 
+    # Evaluate so the model card and the artifact attrs carry real numbers rather
+    # than claims. Skipped when the dataset ships no validation split.
+    metrics: dict[str, float] = {}
+    if val_dataset:
+        eval_metrics = trainer.evaluate()
+        logger.info(f"Evaluation metrics: {eval_metrics}")
+        if "eval_accuracy" in eval_metrics:
+            metrics["Accuracy"] = float(eval_metrics["eval_accuracy"])
+
     # Save final model and processor
     final_model_dir = Path("/tmp/final_model")
     final_model_dir.mkdir(parents=True, exist_ok=True)
@@ -168,8 +295,61 @@ async def finetune_image_model(
     with open(final_model_dir / "label_mapping.json", "w") as f:  # noqa: ASYNC230
         json.dump({"id2label": id2label, "label2id": label2id}, f)
 
-    logger.info("Fine-tuning complete!")
-    return await flyte.io.Dir.from_local(final_model_dir)
+    model_dir = await flyte.io.Dir.from_local(final_model_dir)
+
+    # Render and upload the model card. The card is stored alongside the artifact
+    # and rendered by the UI; it is metadata about the model, not part of the Dir.
+    card = await artifacts.Card.create_from.aio(
+        content=_model_card_html(
+            base_model=model_name,
+            dataset_name=dataset_name,
+            labels=[str(label) for label in labels],
+            hyperparams={
+                "Base model": model_name,
+                "Dataset": dataset_name,
+                "Epochs": str(num_epochs),
+                "Batch size": str(batch_size),
+                "Learning rate": f"{learning_rate:g}",
+                "Classes": str(num_labels),
+            },
+            metrics=metrics,
+        ),
+        format="html",
+        card_type="model",
+    )
+
+    # `attrs` are free-form key/values stored on the artifact version and shown in the
+    # UI — keep them to things worth filtering a model list by. `create_model_metadata`
+    # additionally stamps the reserved kind key, so this registers as kind="model".
+    #
+    # No `version=` is passed: the platform derives one from the producing action, which
+    # is what you want here. Pass one explicitly only when an external identifier (a git
+    # sha, an upstream commit) is the real identity of the weights.
+    metadata = artifacts.Metadata.create_model_metadata(
+        name=MODEL_ARTIFACT_NAME,
+        description=f"{model_name} fine-tuned on {dataset_name} ({num_labels} classes)",
+        framework="PyTorch",
+        model_type="Vision Transformer",
+        architecture=model_name,
+        task="Image Classification",
+        modality=("image",),
+        serial_format="safetensors",
+        card=card,
+        attrs={
+            "base_model": model_name,
+            "dataset": dataset_name,
+            "num_classes": str(num_labels),
+            "epochs": str(num_epochs),
+            **({"accuracy": f"{metrics['Accuracy']:.4f}"} if "Accuracy" in metrics else {}),
+        },
+    )
+
+    logger.info(f"Fine-tuning complete! Publishing artifact {MODEL_ARTIFACT_NAME}")
+
+    # `artifacts.new` is a zero-copy wrapper: downstream tasks still receive a plain
+    # flyte.io.Dir. It must be returned as a *top-level* output — nesting it inside a
+    # dataclass or model drops the metadata at serialization time.
+    return artifacts.new(model_dir, metadata)
 
 
 if __name__ == "__main__":
@@ -177,7 +357,12 @@ if __name__ == "__main__":
         root_dir=Path(__file__).parent,
     )
 
-    # Run training pipeline
+    # Run training pipeline. Note the env sets `cache=flyte.Cache("auto", "1.0")`:
+    # re-running with identical inputs is a cache hit, which reuses the previous
+    # outputs and therefore publishes no new artifact version (and fires no
+    # trigger). Vary an input — or use
+    # `flyte.with_runcontext(overwrite_cache=True).run(...)` — to force a
+    # genuinely new model version.
     run = flyte.run(
         finetune_image_model,
         dataset_name="AI-Lab-Makerere/beans",
@@ -186,3 +371,11 @@ if __name__ == "__main__":
         batch_size=32,
     )
     print(f"Training Run URL: {run.url}")
+    run.wait()
+
+    # The artifact is registered once the action succeeds. Anything bound to the
+    # name — the batch-inference trigger, the serving app — picks it up from here.
+    from flyte.remote import Artifact
+
+    published = Artifact.get(MODEL_ARTIFACT_NAME)
+    print(f"Published {published.name}@{published.version} (kind={published.kind}): {published.url}")

--- a/plugins/sglang/README.md
+++ b/plugins/sglang/README.md
@@ -20,7 +20,7 @@ from flyteplugins.sglang import SGLangAppEnvironment
 # Define the SGLang app environment
 sglang_app = SGLangAppEnvironment(
     name="my-llm-app",
-    model="s3://your-bucket/models/your-model",
+    model_path="s3://your-bucket/models/your-model",
     model_id="your-model-id",
     resources=flyte.Resources(cpu="4", memory="16Gi", gpu="L40s:1"),
     stream_model=True,  # Stream model directly from blob store to GPU
@@ -50,9 +50,9 @@ You can pass additional arguments to the SGLang server using the `extra_args` pa
 ```python
 sglang_app = SGLangAppEnvironment(
     name="my-llm-app",
-    model="s3://your-bucket/models/your-model",
+    model_path="s3://your-bucket/models/your-model",
     model_id="your-model-id",
-    extra_args="--max-model-len 8192 --enforce-eager",
+    extra_args="--context-length 8192",
 )
 ```
 

--- a/plugins/sglang/src/flyteplugins/sglang/_app_environment.py
+++ b/plugins/sglang/src/flyteplugins/sglang/_app_environment.py
@@ -7,7 +7,7 @@ from typing import Any, Literal, Optional, Union
 import flyte.app
 import rich.repr
 from flyte import Environment, Image, Resources, SecretRequest
-from flyte.app import Parameter, RunOutput
+from flyte.app import ArtifactValue, Parameter, RunOutput
 from flyte.app._types import Port
 from flyte.models import SerializationContext
 
@@ -60,7 +60,8 @@ class SGLangAppEnvironment(flyte.app.AppEnvironment):
         type: Type of app.
         extra_args: Extra args to pass to `python -m sglang.launch_server`. See
             https://docs.sglang.io/advanced_features/server_arguments.html for details.
-        model_path: Remote path to model (e.g., s3://bucket/path/to/model).
+        model_path: Remote path to model (e.g., s3://bucket/path/to/model), or a
+            `RunOutput`/`ArtifactValue` resolved at deploy time.
         model_hf_path: Hugging Face path to model (e.g., Qwen/Qwen3-0.6B).
         model_id: Model id that is exposed by SGLang.
         stream_model: When `model_path` is set, use True to stream weights from object
@@ -72,7 +73,7 @@ class SGLangAppEnvironment(flyte.app.AppEnvironment):
     port: int | Port = 8080
     type: str = "SGLang"
     extra_args: str | list[str] = ""
-    model_path: str | RunOutput = ""
+    model_path: str | RunOutput | ArtifactValue = ""
     model_hf_path: str = ""
     model_id: str = ""
     stream_model: bool = True

--- a/plugins/vllm/src/flyteplugins/vllm/_app_environment.py
+++ b/plugins/vllm/src/flyteplugins/vllm/_app_environment.py
@@ -7,7 +7,7 @@ from typing import Any, Literal, Optional, Union
 import flyte.app
 import rich.repr
 from flyte import Environment, Image, Resources, SecretRequest
-from flyte.app import Parameter, RunOutput
+from flyte.app import ArtifactValue, Parameter, RunOutput
 from flyte.app._types import Port
 from flyte.models import SerializationContext
 
@@ -49,7 +49,8 @@ class VLLMAppEnvironment(flyte.app.AppEnvironment):
         extra_args: Extra args to pass to `vllm serve`. See
             https://docs.vllm.ai/en/stable/configuration/engine_args
             or run `vllm serve --help` for details.
-        model_path: Remote path to model (e.g., s3://bucket/path/to/model).
+        model_path: Remote path to model (e.g., s3://bucket/path/to/model), or a
+            `RunOutput`/`ArtifactValue` resolved at deploy time.
         model_hf_path: Hugging Face path to model (e.g., Qwen/Qwen3-0.6B).
         model_id: Model id that is exposed by vllm.
         stream_model: When `model_path` is set, use True to stream weights from object
@@ -61,7 +62,7 @@ class VLLMAppEnvironment(flyte.app.AppEnvironment):
     port: int | Port = 8080
     type: str = "vLLM"
     extra_args: str | list[str] = ""
-    model_path: str | RunOutput = ""
+    model_path: str | RunOutput | ArtifactValue = ""
     model_hf_path: str = ""
     model_id: str = ""
     stream_model: bool = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,20 @@ include = ["flyte*"]
 
 [tool.setuptools_scm]
 write_to = "src/flyte/_version.py"
+# Only Python releases are tagged "v<semver>". Other tags live in this repo too
+# (e.g. "rs-v0.1.0" for the Rust crates), and without these two settings a plain
+# `git describe` picks the nearest tag of any kind, producing a bogus version
+# like 0.1.1.dev4 that the backend rejects as older than the minimum SDK.
+tag_regex = '^v(?P<version>\d+\.\d+\.\d+.*)$'
+git_describe_command = [
+    "git",
+    "describe",
+    "--dirty",
+    "--tags",
+    "--long",
+    "--match",
+    "v[0-9]*",
+]
 
 [tool.pytest.ini_options]
 markers = [

--- a/src/flyte/prefetch/_deployable.py
+++ b/src/flyte/prefetch/_deployable.py
@@ -1,0 +1,100 @@
+"""
+A prefetch task that can be registered once and launched by anything.
+
+`hf_model` builds its environment at call time and ships the task as a
+cloudpickle bundle, which means only a Python process holding the SDK can start
+a prefetch. That is the right shape for a notebook or a CLI, and the wrong shape
+for a control plane: a console button has no Python to run.
+
+So this module declares the same work as an ordinary registered task. Deployed
+once into a system project, it is addressable by name and version like any other
+task, and a backend can bind it to a run in the user's own project -- which is
+how the remote image builder's `build-image` task already works.
+
+Both paths converge on `store_hf_model_task`, so there is one implementation of
+prefetching and two ways to reach it.
+
+Not imported from `flyte.prefetch`'s `__init__`: importing prefetch eagerly at
+the `flyte` level has been a problem before, and this module is only ever
+imported by the deploy driver.
+"""
+
+from __future__ import annotations
+
+import os
+
+import flyte
+from flyte.io import Dir
+
+from ._hf_model import HF_DOWNLOAD_IMAGE_PACKAGES, HuggingFaceModelInfo, store_hf_model_task
+
+#: Pin the serving image at deploy time rather than rebuilding it, mirroring how
+#: the image-builder task takes UNION_IMAGE_NAME_PREFIX / UNION_IMAGE_TAG from
+#: the environment. Set to a fully-qualified image to skip the image build
+#: entirely -- which is also the only practical way to deploy this against a
+#: locally-built SDK, since the default base installs the *published* flyte.
+_IMAGE_OVERRIDE = os.environ.get("FLYTE_PREFETCH_IMAGE")
+
+#: Name of the secret holding a HuggingFace token, attached to every run of this
+#: task. Empty by default, and deliberately so: public repos need no token, and
+#: naming a secret that does not exist wedges the pod in
+#: CreateContainerConfigError with no HuggingFace error to read -- an opaque
+#: failure in exactly the first-run case. Callers that need a gated repo supply
+#: the secret per run instead.
+_HF_TOKEN_KEY = os.environ.get("FLYTE_PREFETCH_HF_TOKEN_KEY", "")
+
+#: Unsharded only. Sharding pulls in vLLM and a CUDA toolchain, and needs GPUs
+#: at prefetch time to run the engine that writes the per-rank files; that
+#: belongs in a separate environment with its own resources, not behind a flag
+#: on this one.
+image = _IMAGE_OVERRIDE or flyte.Image.from_debian_base(name="prefetch-hf-model-image").with_pip_packages(
+    *HF_DOWNLOAD_IMAGE_PACKAGES
+)
+
+prefetch_env = flyte.TaskEnvironment(
+    name="prefetch",
+    image=image,
+    # The unsharded path streams HuggingFace straight to object storage in
+    # chunks and never lands the weights on disk, so the disk request covers the
+    # snapshot-download fallback rather than the happy path.
+    resources=flyte.Resources(cpu="2", memory="8Gi", disk="50Gi"),
+    secrets=[flyte.Secret(key=_HF_TOKEN_KEY, as_env_var="HF_TOKEN")] if _HF_TOKEN_KEY else None,
+)
+
+
+@prefetch_env.task(report=True, produces_artifacts=True)
+def hf_model(repo: str, artifact_name: str = "", short_description: str = "") -> Dir:
+    """
+    Prefetch a HuggingFace model into a model artifact.
+
+    Registered as ``prefetch.hf_model`` -- ``TaskEnvironment`` prefixes task
+    names with the environment's name.
+
+    Flat strings with ``""`` for unset, rather than ``str | None``: an optional
+    becomes a union literal, which is awkward to construct from a non-Python
+    caller, and every input has to be sent explicitly anyway because CreateRun
+    does not apply a task's declared defaults. Neither field can legitimately be
+    empty, so ``""`` is unambiguous.
+
+    The remaining fields of ``HuggingFaceModelInfo`` are intentionally absent:
+    architecture, model type, task and modality are all read from the model's
+    own config, so asking a caller for them invites a wrong answer.
+
+    Args:
+        repo: HuggingFace repository id, e.g. ``Qwen/Qwen3-0.6B``.
+        artifact_name: Name to publish under. Empty derives it from the repo's
+            last path segment with ``.`` replaced by ``-``.
+        short_description: Free-text description for the artifact.
+
+    Returns:
+        The directory holding the model, published as a model artifact whose
+        version is the HuggingFace commit.
+    """
+    info = HuggingFaceModelInfo(
+        repo=repo,
+        artifact_name=artifact_name or None,
+        short_description=short_description or None,
+    )
+    # Called as a plain function, not launched as a task: this already *is* the
+    # task, and running it as one would nest a run inside a run for no gain.
+    return store_hf_model_task(info.model_dump_json())

--- a/src/flyte/prefetch/_deployable.py
+++ b/src/flyte/prefetch/_deployable.py
@@ -67,23 +67,23 @@ def hf_model(repo: str, artifact_name: str = "", short_description: str = "") ->
     """
     Prefetch a HuggingFace model into a model artifact.
 
-    Registered as ``prefetch.hf_model`` -- ``TaskEnvironment`` prefixes task
+    Registered as `prefetch.hf_model` -- `TaskEnvironment` prefixes task
     names with the environment's name.
 
-    Flat strings with ``""`` for unset, rather than ``str | None``: an optional
+    Flat strings with `""` for unset, rather than `str | None`: an optional
     becomes a union literal, which is awkward to construct from a non-Python
     caller, and every input has to be sent explicitly anyway because CreateRun
     does not apply a task's declared defaults. Neither field can legitimately be
-    empty, so ``""`` is unambiguous.
+    empty, so `""` is unambiguous.
 
-    The remaining fields of ``HuggingFaceModelInfo`` are intentionally absent:
+    The remaining fields of `HuggingFaceModelInfo` are intentionally absent:
     architecture, model type, task and modality are all read from the model's
     own config, so asking a caller for them invites a wrong answer.
 
     Args:
-        repo: HuggingFace repository id, e.g. ``Qwen/Qwen3-0.6B``.
+        repo: HuggingFace repository id, e.g. `Qwen/Qwen3-0.6B`.
         artifact_name: Name to publish under. Empty derives it from the repo's
-            last path segment with ``.`` replaced by ``-``.
+            last path segment with `.` replaced by `-`.
         short_description: Free-text description for the artifact.
 
     Returns:

--- a/src/flyte/prefetch/_hf_model.py
+++ b/src/flyte/prefetch/_hf_model.py
@@ -152,6 +152,54 @@ VLLM_SHARDING_IMAGE_PACKAGES = [
     "vllm>=0.11.0",
 ]
 
+#: Serving facts, as versioned JSON, under the same reserved `flyte.io/`
+#: namespace as `KIND_KEY` -- see the rationale there. Prefetch is the only
+#: producer: these are measurements of one specific checkpoint, and code that
+#: has not looked at the weights has no business claiming them.
+#:
+#: One nested blob rather than ~15 flat attrs, because `attrs` is
+#: map<string,string> and spreading the schema across the key set would freeze
+#: it. Consumers refuse a version they do not recognise rather than reading it
+#: partially: a half-understood model sizes wrong, and sizing wrong is worse
+#: than declining to size at all.
+SERVING_ATTR_KEY = "flyte.io/serving"
+SERVING_FACTS_VERSION = 1
+
+#: Legacy config spellings for the geometry fields, tried in order after the
+#: modern name. GPT-2-family configs still ship `n_layer`/`n_head`/`n_embd`, and
+#: transformers only reconciles them through each config class's `attribute_map`
+#: -- reading the raw JSON, as we do, sees the original names.
+#:
+#: Worth the table: a missed layer or head count silently zeroes the KV-cache
+#: term, and that under-estimates VRAM, which is the direction that OOMs a
+#: deploy rather than merely wasting a GPU.
+_CONFIG_ALIASES = {
+    "num_hidden_layers": ("n_layer", "num_layers", "n_layers"),
+    "num_attention_heads": ("n_head", "n_heads", "encoder_attention_heads"),
+    "hidden_size": ("n_embd", "d_model", "hidden_dim"),
+    "max_position_embeddings": ("n_positions", "n_ctx", "max_seq_len", "seq_length"),
+    "head_dim": ("d_kv", "attention_head_dim"),
+    "num_key_value_heads": ("num_kv_heads", "n_kv_heads"),
+}
+
+#: Bytes per element for the dtype names the Hub's safetensors scan reports.
+#: Unrecognised dtypes fall back to 2, which is what every current 16-bit
+#: checkpoint uses -- conservative rather than absent.
+_DTYPE_BYTES = {
+    "f64": 8,
+    "f32": 4,
+    "f16": 2,
+    "bf16": 2,
+    "f8_e4m3": 1,
+    "f8_e5m2": 1,
+    "i64": 8,
+    "i32": 4,
+    "i16": 2,
+    "i8": 1,
+    "u8": 1,
+    "bool": 1,
+}
+
 
 def _validate_artifact_name(name: str | None) -> None:
     """Validate that artifact name contains only allowed characters."""
@@ -159,7 +207,9 @@ def _validate_artifact_name(name: str | None) -> None:
         raise ValueError(f"Artifact name '{name}' must only contain alphanumeric characters, underscores, and hyphens")
 
 
-def _lookup_huggingface_model_info(model_repo: str, commit: str, token: str | None) -> tuple[str | None, str | None]:
+def _lookup_huggingface_model_info(
+    model_repo: str, commit: str, token: str | None
+) -> tuple[str | None, str | None, dict[str, Any]]:
     """
     Lookup HuggingFace model info from config.json.
 
@@ -169,7 +219,9 @@ def _lookup_huggingface_model_info(model_repo: str, commit: str, token: str | No
         token: HuggingFace token for private models.
 
     Returns:
-        Tuple of (model_type, architecture).
+        Tuple of (model_type, architecture, raw config). The raw config is
+        returned as well because the serving facts are derived almost entirely
+        from it, and it costs one ~2KB download to fetch.
     """
     import json
 
@@ -188,7 +240,143 @@ def _lookup_huggingface_model_info(model_repo: str, commit: str, token: str | No
             if arch:
                 arch = ",".join(arch)
         model_type = j.get("model_type", None)
-    return model_type, arch
+    return model_type, arch, j
+
+
+def _hf_weight_stats(repo_id: str, commit: str, token: str | None) -> tuple[int, int, bool, str]:
+    """
+    Parameter count, weight bytes, and whether the checkpoint can be streamed.
+
+    Read from the Hub's metadata rather than from the weights: every number here
+    is available before a single byte of the model is downloaded, which is what
+    lets a caller size a model it has not fetched yet.
+
+    Returns (params_total, weight_bytes, streamable, stream_blocked_reason).
+    """
+    import huggingface_hub
+
+    params_total = 0
+    weight_bytes = 0
+
+    # Prefer the Hub's own safetensors scan: it reports parameter counts per
+    # dtype, which converts to bytes exactly and sidesteps the file-selection
+    # traps that summing blobs runs into (repos shipping both .bin and
+    # .safetensors, or an extra fp8/ subdirectory, double-count).
+    try:
+        info = huggingface_hub.HfApi(token=token).model_info(repo_id, revision=commit)
+        scan = getattr(info, "safetensors", None)
+        if scan:
+            params_total = int(getattr(scan, "total", 0) or 0)
+            for dtype, count in (getattr(scan, "parameters", None) or {}).items():
+                weight_bytes += int(count) * _DTYPE_BYTES.get(str(dtype).lower(), 2)
+    except Exception as e:
+        logger.info(f"HuggingFace safetensors scan unavailable for {repo_id}: {e}")
+
+    # The listing is needed regardless, to decide streamability -- the serving
+    # loader reads safetensors and nothing else, so a repo without them cannot
+    # be served no matter how well it sizes.
+    safetensors_bytes = 0
+    has_safetensors = False
+    try:
+        hfs = huggingface_hub.HfFileSystem(token=token)
+        for file_info in hfs.ls(repo_id, revision=commit, detail=True):
+            if isinstance(file_info, str) or file_info.get("type") != "file":
+                continue
+            name = str(file_info.get("name", ""))
+            if name.endswith(".safetensors"):
+                has_safetensors = True
+                safetensors_bytes += int(file_info.get("size") or 0)
+    except Exception as e:
+        # Not fatal: without the listing we cannot prove the checkpoint is
+        # unstreamable, and refusing to publish over a failed metadata call
+        # would be a worse outcome than publishing without facts.
+        logger.warning(f"Could not list files for {repo_id}: {e}")
+        return params_total, weight_bytes, False, "the model's files could not be listed from HuggingFace"
+
+    if not weight_bytes:
+        weight_bytes = safetensors_bytes
+
+    if not has_safetensors:
+        return (
+            params_total,
+            weight_bytes,
+            False,
+            "this checkpoint has no safetensors weights, which the serving loader requires",
+        )
+    if not weight_bytes:
+        return params_total, weight_bytes, False, "the size of this checkpoint's weights could not be determined"
+
+    return params_total, weight_bytes, True, ""
+
+
+def _serving_facts(
+    config: dict[str, Any],
+    *,
+    params_total: int,
+    weight_bytes: int,
+    streamable: bool,
+    stream_blocked_reason: str,
+    modality: tuple[str, ...],
+    shard_config: ShardConfig | None,
+) -> dict[str, Any]:
+    """
+    The `flyte.io/serving` blob: everything a serving backend needs to decide
+    which GPUs this model fits on, and on which engines it can run at all.
+
+    Derived from config.json, whose field names are the de-facto transformers
+    schema. Consumers supply their own fallbacks for the two fields older
+    configs routinely omit (`head_dim`, `num_key_value_heads`), so absent is
+    represented as 0 rather than guessed at here -- a guess made in the producer
+    is indistinguishable from a measurement once it is written down.
+    """
+    # Multimodal configs nest the language model's geometry, and the language
+    # model is what dominates both the weights and the KV cache.
+    text = config.get("text_config") if isinstance(config.get("text_config"), dict) else {}
+
+    def num(key: str) -> int:
+        for candidate in (key, *_CONFIG_ALIASES.get(key, ())):
+            value = config.get(candidate, text.get(candidate))
+            if isinstance(value, (int, float)):
+                return int(value)
+        return 0
+
+    facts: dict[str, Any] = {
+        "v": SERVING_FACTS_VERSION,
+        "params_total": params_total,
+        "weight_bytes": weight_bytes,
+        # transformers renamed this to `dtype`; older checkpoints still carry
+        # `torch_dtype`, and plenty of live repos have only the old spelling.
+        "torch_dtype": str(config.get("torch_dtype") or config.get("dtype") or text.get("torch_dtype") or ""),
+        "num_hidden_layers": num("num_hidden_layers"),
+        "num_attention_heads": num("num_attention_heads"),
+        "num_key_value_heads": num("num_key_value_heads"),
+        "head_dim": num("head_dim"),
+        "hidden_size": num("hidden_size"),
+        "vocab_size": num("vocab_size"),
+        "max_position_embeddings": num("max_position_embeddings"),
+        "architectures": list(config.get("architectures") or text.get("architectures") or []),
+        "modality": list(modality),
+        "streamable": streamable,
+        "stream_blocked_reason": stream_blocked_reason,
+    }
+
+    quant = config.get("quantization_config")
+    if isinstance(quant, dict):
+        facts["quantization"] = {
+            "method": str(quant.get("quant_method") or ""),
+            "bits": int(quant.get("bits") or 0),
+        }
+
+    if shard_config is not None:
+        # Recorded because it is irreversible: the loader reads exactly the
+        # per-rank files sharding wrote, so this artifact is servable at this
+        # engine and this degree, and nothing else.
+        facts["sharding"] = {
+            "engine": shard_config.engine,
+            "tp": shard_config.args.tensor_parallel_size,
+        }
+
+    return facts
 
 
 def _stream_to_remote_dir(
@@ -373,6 +561,7 @@ def _wrap_as_model_artifact(
     artifact_name: str,
     commit: str,
     card_md: str | None,
+    serving_facts: dict[str, Any] | None = None,
 ) -> Dir:
     """
     Wrap the stored model Dir with artifact metadata so the platform records a
@@ -408,6 +597,12 @@ def _wrap_as_model_artifact(
     attrs = {"source_repo": info.repo, "source_commit": commit}
     if info.shard_config is not None:
         attrs["sharding"] = f"{info.shard_config.engine}-tp{info.shard_config.args.tensor_parallel_size}"
+    if serving_facts is not None:
+        import json
+
+        # Compact separators because this rides in a map<string,string> attr and
+        # nothing reads it by eye.
+        attrs[SERVING_ATTR_KEY] = json.dumps(serving_facts, separators=(",", ":"))
 
     metadata = artifacts.Metadata.create_model_metadata(
         name=artifact_name,
@@ -446,17 +641,41 @@ def store_hf_model_task(info: str, raw_data_path: str | None = None) -> Dir:
     commit = huggingface_hub.list_repo_commits(_info.repo, token=token)[0].commit_id
     logger.info(f"Latest commit: {commit}")
 
-    # Lookup model info if not provided
-    if not _info.model_type or not _info.architecture:
-        logger.info("Looking up HuggingFace model info...")
-        try:
-            _info.model_type, _info.architecture = _lookup_huggingface_model_info(_info.repo, commit, token)
-        except Exception as e:
-            logger.warning(f"Warning: Could not lookup model info: {e}")
-            _info.model_type = "custom"
-            _info.architecture = "custom"
+    # Fetched unconditionally, even when the caller supplied model_type and
+    # architecture: the serving facts are derived from the config regardless,
+    # and it is a single ~2KB download.
+    config: dict[str, Any] = {}
+    logger.info("Looking up HuggingFace model info...")
+    try:
+        _model_type, _architecture, config = _lookup_huggingface_model_info(_info.repo, commit, token)
+        _info.model_type = _info.model_type or _model_type
+        _info.architecture = _info.architecture or _architecture
+    except Exception as e:
+        logger.warning(f"Warning: Could not lookup model info: {e}")
+        _info.model_type = _info.model_type or "custom"
+        _info.architecture = _info.architecture or "custom"
 
     logger.info(f"Model type: {_info.model_type}, architecture: {_info.architecture}")
+
+    # Sizing metadata, read from the Hub's own records rather than from the
+    # weights. Best-effort on purpose: a model that cannot be measured is still
+    # a perfectly good artifact, so a failure here publishes without facts
+    # rather than failing a download that may have taken an hour.
+    serving_facts: dict[str, Any] | None = None
+    try:
+        params_total, weight_bytes, streamable, blocked_reason = _hf_weight_stats(_info.repo, commit, token)
+        serving_facts = _serving_facts(
+            config,
+            params_total=params_total,
+            weight_bytes=weight_bytes,
+            streamable=streamable,
+            stream_blocked_reason=blocked_reason,
+            modality=_info.modality,
+            shard_config=_info.shard_config,
+        )
+        logger.info(f"Serving facts: {weight_bytes} weight bytes, streamable={streamable}")
+    except Exception as e:
+        logger.warning(f"Could not derive serving facts for {_info.repo}: {e}")
 
     # Determine artifact name
     if _info.artifact_name is None:
@@ -519,7 +738,7 @@ def store_hf_model_task(info: str, raw_data_path: str | None = None) -> Dir:
         flyte.report.flush()
 
     logger.info(f"Model stored successfully at {result_dir.path}")
-    return _wrap_as_model_artifact(result_dir, _info, artifact_name, commit, card)
+    return _wrap_as_model_artifact(result_dir, _info, artifact_name, commit, card, serving_facts)
 
 
 def hf_model(

--- a/src/flyte/prefetch/_hf_model.py
+++ b/src/flyte/prefetch/_hf_model.py
@@ -331,7 +331,8 @@ def _serving_facts(
     """
     # Multimodal configs nest the language model's geometry, and the language
     # model is what dominates both the weights and the KV cache.
-    text = config.get("text_config") if isinstance(config.get("text_config"), dict) else {}
+    text_config = config.get("text_config")
+    text: dict[str, Any] = text_config if isinstance(text_config, dict) else {}
 
     def num(key: str) -> int:
         for candidate in (key, *_CONFIG_ALIASES.get(key, ())):

--- a/tests/flyte/prefetch/test_deployable.py
+++ b/tests/flyte/prefetch/test_deployable.py
@@ -1,0 +1,146 @@
+"""Tests for flyte.prefetch._deployable module."""
+
+import importlib
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def deployable():
+    """
+    Import the module fresh.
+
+    Its environment is built at import time from process environment variables,
+    so a test that changes them has to reimport to see the effect.
+    """
+    sys.modules.pop("flyte.prefetch._deployable", None)
+    return importlib.import_module("flyte.prefetch._deployable")
+
+
+def test_registers_under_the_prefetch_environment(deployable):
+    """
+    The registered name is the contract: a backend addresses this task by name
+    and version, so renaming it silently breaks every caller that is not Python.
+
+    TaskEnvironment prefixes task names with the environment's name, which is why
+    the bare `hf-model` that build-image gets is not available to a @env.task.
+    """
+    assert deployable.prefetch_env.name == "prefetch"
+    assert deployable.hf_model.name == "prefetch.hf_model"
+
+
+def test_no_secret_is_attached_by_default(deployable):
+    """
+    Naming a secret that does not exist wedges the pod in
+    CreateContainerConfigError with no HuggingFace error to read -- an opaque
+    failure in exactly the first-run case. Public repos need no token.
+    """
+    assert deployable.prefetch_env.secrets is None
+
+
+def test_hf_token_key_attaches_a_secret_when_set():
+    """A caller that needs a gated repo opts in through the environment."""
+    sys.modules.pop("flyte.prefetch._deployable", None)
+    with patch.dict("os.environ", {"FLYTE_PREFETCH_HF_TOKEN_KEY": "my-hf-token"}):
+        module = importlib.import_module("flyte.prefetch._deployable")
+
+    secrets = module.prefetch_env.secrets
+    assert secrets is not None
+    assert len(secrets) == 1
+    assert secrets[0].key == "my-hf-token"
+    assert secrets[0].as_env_var == "HF_TOKEN"
+
+    # Leave the module cache holding the default-environment build.
+    sys.modules.pop("flyte.prefetch._deployable", None)
+
+
+def test_image_override_skips_the_build():
+    """
+    A fully-qualified image is the only practical way to deploy this against a
+    locally-built SDK, since the default base installs the published flyte.
+    """
+    sys.modules.pop("flyte.prefetch._deployable", None)
+    with patch.dict("os.environ", {"FLYTE_PREFETCH_IMAGE": "ghcr.io/acme/prefetch:v3"}):
+        module = importlib.import_module("flyte.prefetch._deployable")
+
+    assert module.image == "ghcr.io/acme/prefetch:v3"
+
+    sys.modules.pop("flyte.prefetch._deployable", None)
+
+
+def test_requests_disk_for_the_snapshot_fallback(deployable):
+    """
+    The unsharded path streams to object storage and never lands the weights, so
+    the disk request covers the snapshot-download fallback, not the happy path.
+    """
+    resources = deployable.prefetch_env.resources
+    assert resources.disk == "50Gi"
+    # Unsharded only -- sharding needs vLLM, a CUDA toolchain and GPUs at
+    # prefetch time, which belongs in its own environment.
+    assert resources.gpu is None
+
+
+def test_not_imported_by_the_prefetch_package():
+    """
+    Importing prefetch eagerly at the `flyte` level has been a problem before;
+    this module is only ever imported by the deploy driver.
+
+    Runs in a subprocess because this test session has already imported the
+    module, so an in-process sys.modules check would always pass.
+    """
+    import subprocess
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; import flyte.prefetch; sys.exit(1 if 'flyte.prefetch._deployable' in sys.modules else 0)",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"importing flyte.prefetch pulled in _deployable\n{result.stderr}"
+
+
+def test_empty_optional_strings_become_none(deployable):
+    """
+    Flat strings with "" for unset: an optional becomes a union literal that is
+    awkward to build from a non-Python caller, and every input has to be sent
+    explicitly anyway because CreateRun does not apply declared defaults.
+    """
+    captured = {}
+
+    def fake_store(info_json, raw_data_path=None):
+        import json
+
+        captured.update(json.loads(info_json))
+        return "dir"
+
+    with patch.object(deployable, "store_hf_model_task", side_effect=fake_store):
+        result = deployable.hf_model.func("Qwen/Qwen3-0.6B", "", "")
+
+    assert result == "dir"
+    assert captured["repo"] == "Qwen/Qwen3-0.6B"
+    assert captured["artifact_name"] is None
+    assert captured["short_description"] is None
+
+
+def test_supplied_optional_strings_are_passed_through(deployable):
+    """Non-empty values reach HuggingFaceModelInfo unchanged."""
+    captured = {}
+
+    def fake_store(info_json, raw_data_path=None):
+        import json
+
+        captured.update(json.loads(info_json))
+        return "dir"
+
+    with patch.object(deployable, "store_hf_model_task", side_effect=fake_store):
+        deployable.hf_model.func("Qwen/Qwen3-0.6B", "my-model", "a small model")
+
+    assert captured["artifact_name"] == "my-model"
+    assert captured["short_description"] == "a small model"

--- a/tests/flyte/prefetch/test_hf_model.py
+++ b/tests/flyte/prefetch/test_hf_model.py
@@ -291,10 +291,11 @@ def test_lookup_huggingface_model_info_with_architectures_list(tmp_path):
     with patch.dict(sys.modules, {"huggingface_hub": mock_hf_hub}):
         from flyte.prefetch._hf_model import _lookup_huggingface_model_info
 
-        model_type, arch = _lookup_huggingface_model_info("meta-llama/Llama-2-7b-hf", "abc123", "token")
+        model_type, arch, config = _lookup_huggingface_model_info("meta-llama/Llama-2-7b-hf", "abc123", "token")
 
         assert model_type == "llama"
         assert arch == "LlamaForCausalLM"
+        assert config == config_data
         mock_hf_hub.hf_hub_download.assert_called_once_with(
             repo_id="meta-llama/Llama-2-7b-hf",
             filename="config.json",
@@ -318,10 +319,11 @@ def test_lookup_huggingface_model_info_with_single_architecture(tmp_path):
     with patch.dict(sys.modules, {"huggingface_hub": mock_hf_hub}):
         from flyte.prefetch._hf_model import _lookup_huggingface_model_info
 
-        model_type, arch = _lookup_huggingface_model_info("gpt2", "main", None)
+        model_type, arch, config = _lookup_huggingface_model_info("gpt2", "main", None)
 
         assert model_type == "gpt2"
         assert arch == "GPT2LMHeadModel"
+        assert config == config_data
 
 
 def test_lookup_huggingface_model_info_with_multiple_architectures(tmp_path):
@@ -339,10 +341,11 @@ def test_lookup_huggingface_model_info_with_multiple_architectures(tmp_path):
     with patch.dict(sys.modules, {"huggingface_hub": mock_hf_hub}):
         from flyte.prefetch._hf_model import _lookup_huggingface_model_info
 
-        model_type, arch = _lookup_huggingface_model_info("bert-base", "main", None)
+        model_type, arch, config = _lookup_huggingface_model_info("bert-base", "main", None)
 
         assert model_type == "bert"
         assert arch == "BertModel,BertForMaskedLM"
+        assert config == config_data
 
 
 def test_lookup_huggingface_model_info_with_missing_fields(tmp_path):
@@ -357,10 +360,13 @@ def test_lookup_huggingface_model_info_with_missing_fields(tmp_path):
     with patch.dict(sys.modules, {"huggingface_hub": mock_hf_hub}):
         from flyte.prefetch._hf_model import _lookup_huggingface_model_info
 
-        model_type, arch = _lookup_huggingface_model_info("custom-model", "main", None)
+        model_type, arch, config = _lookup_huggingface_model_info("custom-model", "main", None)
 
         assert model_type is None
         assert arch is None
+        # The raw config is returned even when the summary fields are absent --
+        # it is what the serving facts are derived from.
+        assert config == config_data
 
 
 # =============================================================================
@@ -654,3 +660,378 @@ def test_shard_model_invalid_engine():
                 model_path="/tmp/model",
                 output_dir="/tmp/output",
             )
+
+
+# =============================================================================
+# Serving facts Tests
+# =============================================================================
+
+
+def _facts(config, **overrides):
+    """Call _serving_facts with the boring arguments defaulted."""
+    from flyte.prefetch._hf_model import _serving_facts
+
+    kwargs = {
+        "params_total": 0,
+        "weight_bytes": 0,
+        "streamable": True,
+        "stream_blocked_reason": "",
+        "modality": ("text",),
+        "shard_config": None,
+    }
+    kwargs.update(overrides)
+    return _serving_facts(config, **kwargs)
+
+
+def test_serving_facts_modern_config():
+    """A current-generation config populates every geometry field."""
+    from flyte.prefetch._hf_model import SERVING_FACTS_VERSION
+
+    facts = _facts(
+        {
+            "architectures": ["Qwen3ForCausalLM"],
+            "model_type": "qwen3",
+            "torch_dtype": "bfloat16",
+            "num_hidden_layers": 64,
+            "num_attention_heads": 64,
+            "num_key_value_heads": 8,
+            "head_dim": 128,
+            "hidden_size": 5120,
+            "vocab_size": 151936,
+            "max_position_embeddings": 40960,
+        },
+        params_total=32_762_123_264,
+        weight_bytes=65_524_246_528,
+    )
+
+    assert facts["v"] == SERVING_FACTS_VERSION
+    assert facts["params_total"] == 32_762_123_264
+    assert facts["weight_bytes"] == 65_524_246_528
+    assert facts["torch_dtype"] == "bfloat16"
+    assert facts["num_hidden_layers"] == 64
+    assert facts["num_key_value_heads"] == 8
+    assert facts["head_dim"] == 128
+    assert facts["hidden_size"] == 5120
+    assert facts["max_position_embeddings"] == 40960
+    assert facts["streamable"] is True
+    assert facts["stream_blocked_reason"] == ""
+    assert facts["modality"] == ["text"]
+
+
+def test_serving_facts_architectures_stays_a_list():
+    """
+    architectures is a list, not a comma-joined scalar.
+
+    Joining it would deserialize as one bogus architecture name and fail every
+    engine-support lookup on the consumer side.
+    """
+    facts = _facts({"architectures": ["BertModel", "BertForMaskedLM"]})
+
+    assert facts["architectures"] == ["BertModel", "BertForMaskedLM"]
+
+
+def test_serving_facts_legacy_gpt2_aliases():
+    """
+    GPT-2-family configs spell their geometry n_layer/n_head/n_embd.
+
+    transformers reconciles these through each config class's attribute_map, but
+    we read the raw JSON and so see the original names. A missed alias silently
+    zeroes the KV-cache term, which under-estimates VRAM -- the direction that
+    OOMs a deploy.
+    """
+    facts = _facts(
+        {
+            "architectures": ["GPT2LMHeadModel"],
+            "model_type": "gpt2",
+            "n_layer": 12,
+            "n_head": 12,
+            "n_embd": 768,
+            "n_positions": 1024,
+            "vocab_size": 50257,
+        }
+    )
+
+    assert facts["num_hidden_layers"] == 12
+    assert facts["num_attention_heads"] == 12
+    assert facts["hidden_size"] == 768
+    assert facts["max_position_embeddings"] == 1024
+    assert facts["vocab_size"] == 50257
+
+
+def test_serving_facts_absent_fields_are_zero_not_guessed():
+    """
+    head_dim and num_key_value_heads are routinely omitted by older configs.
+
+    They are reported as 0 rather than derived here, because a guess made in the
+    producer is indistinguishable from a measurement once written down -- the
+    consumer supplies its own fallbacks.
+    """
+    facts = _facts({"num_hidden_layers": 12, "num_attention_heads": 12, "hidden_size": 768})
+
+    assert facts["head_dim"] == 0
+    assert facts["num_key_value_heads"] == 0
+
+
+def test_serving_facts_reads_nested_text_config():
+    """Multimodal configs nest the language model's geometry, which dominates."""
+    facts = _facts(
+        {
+            "architectures": ["Llama4ForConditionalGeneration"],
+            "text_config": {
+                "num_hidden_layers": 48,
+                "num_attention_heads": 40,
+                "hidden_size": 5120,
+                "torch_dtype": "bfloat16",
+            },
+        },
+        modality=("text", "image"),
+    )
+
+    assert facts["num_hidden_layers"] == 48
+    assert facts["num_attention_heads"] == 40
+    assert facts["hidden_size"] == 5120
+    assert facts["torch_dtype"] == "bfloat16"
+    assert facts["modality"] == ["text", "image"]
+
+
+def test_serving_facts_dtype_falls_back_to_new_spelling():
+    """transformers renamed torch_dtype to dtype; older repos have only the old one."""
+    assert _facts({"dtype": "float16"})["torch_dtype"] == "float16"
+    assert _facts({"torch_dtype": "bfloat16"})["torch_dtype"] == "bfloat16"
+    assert _facts({})["torch_dtype"] == ""
+
+
+def test_serving_facts_quantization_present_and_absent():
+    """The quantization sub-object appears only when the config declares one."""
+    facts = _facts({"quantization_config": {"quant_method": "fp8", "bits": 8}})
+    assert facts["quantization"] == {"method": "fp8", "bits": 8}
+
+    assert "quantization" not in _facts({})
+
+
+def test_serving_facts_records_sharding():
+    """
+    Sharding is recorded because it is irreversible: the loader reads exactly the
+    per-rank files sharding wrote, so the artifact is servable at this engine and
+    this degree and nothing else.
+    """
+    facts = _facts({}, shard_config=ShardConfig(args=VLLMShardArgs(tensor_parallel_size=8)))
+
+    assert facts["sharding"] == {"engine": "vllm", "tp": 8}
+    assert "sharding" not in _facts({})
+
+
+def test_serving_facts_carries_stream_blocked_reason():
+    """An unstreamable checkpoint carries the reason through to the consumer."""
+    facts = _facts({}, streamable=False, stream_blocked_reason="no safetensors")
+
+    assert facts["streamable"] is False
+    assert facts["stream_blocked_reason"] == "no safetensors"
+
+
+# =============================================================================
+# _hf_weight_stats Tests
+# =============================================================================
+
+
+def _hf_hub_mock(*, scan=None, files=None, ls_raises=None, model_info_raises=None):
+    """A huggingface_hub double exposing just model_info and HfFileSystem.ls."""
+    from types import SimpleNamespace
+
+    hub = MagicMock()
+    if model_info_raises is not None:
+        hub.HfApi.return_value.model_info.side_effect = model_info_raises
+    else:
+        hub.HfApi.return_value.model_info.return_value = SimpleNamespace(safetensors=scan)
+    if ls_raises is not None:
+        hub.HfFileSystem.return_value.ls.side_effect = ls_raises
+    else:
+        hub.HfFileSystem.return_value.ls.return_value = files or []
+    return hub
+
+
+def _file(name, size):
+    return {"type": "file", "name": name, "size": size}
+
+
+def test_hf_weight_stats_converts_scan_parameters_to_bytes():
+    """
+    The Hub's safetensors scan reports parameter counts per dtype, which converts
+    to bytes exactly and sidesteps the double-counting that summing blobs hits on
+    repos shipping both .bin and .safetensors.
+    """
+    from types import SimpleNamespace
+
+    from flyte.prefetch._hf_model import _hf_weight_stats
+
+    hub = _hf_hub_mock(
+        scan=SimpleNamespace(total=1000, parameters={"BF16": 1000}),
+        files=[_file("m/model.safetensors", 999)],
+    )
+    with patch.dict(sys.modules, {"huggingface_hub": hub}):
+        params, weight_bytes, streamable, reason = _hf_weight_stats("m", "abc", None)
+
+    assert params == 1000
+    # bf16 is 2 bytes/param, and the scan wins over the 999-byte file listing.
+    assert weight_bytes == 2000
+    assert streamable is True
+    assert reason == ""
+
+
+def test_hf_weight_stats_unknown_dtype_falls_back_to_two_bytes():
+    """Unrecognised dtypes assume 16-bit -- conservative rather than absent."""
+    from types import SimpleNamespace
+
+    from flyte.prefetch._hf_model import _hf_weight_stats
+
+    hub = _hf_hub_mock(
+        scan=SimpleNamespace(total=100, parameters={"some_future_dtype": 100}),
+        files=[_file("m/model.safetensors", 1)],
+    )
+    with patch.dict(sys.modules, {"huggingface_hub": hub}):
+        _, weight_bytes, _, _ = _hf_weight_stats("m", "abc", None)
+
+    assert weight_bytes == 200
+
+
+def test_hf_weight_stats_falls_back_to_file_sizes_without_a_scan():
+    """Without a scan, the summed .safetensors blob sizes stand in."""
+    from flyte.prefetch._hf_model import _hf_weight_stats
+
+    hub = _hf_hub_mock(
+        scan=None,
+        files=[
+            _file("m/model-00001-of-00002.safetensors", 500),
+            _file("m/model-00002-of-00002.safetensors", 300),
+            _file("m/README.md", 10),
+        ],
+    )
+    with patch.dict(sys.modules, {"huggingface_hub": hub}):
+        params, weight_bytes, streamable, reason = _hf_weight_stats("m", "abc", None)
+
+    assert params == 0
+    # Non-safetensors files do not count toward the weights.
+    assert weight_bytes == 800
+    assert streamable is True
+    assert reason == ""
+
+
+def test_hf_weight_stats_without_safetensors_is_not_streamable():
+    """The serving loader reads safetensors and nothing else."""
+    from flyte.prefetch._hf_model import _hf_weight_stats
+
+    hub = _hf_hub_mock(scan=None, files=[_file("m/pytorch_model.bin", 1000)])
+    with patch.dict(sys.modules, {"huggingface_hub": hub}):
+        _, _, streamable, reason = _hf_weight_stats("m", "abc", None)
+
+    assert streamable is False
+    assert "safetensors" in reason
+
+
+def test_hf_weight_stats_listing_failure_is_not_fatal():
+    """
+    A failed listing cannot prove the checkpoint unstreamable, but refusing to
+    publish over it would be worse than publishing without facts.
+    """
+    from flyte.prefetch._hf_model import _hf_weight_stats
+
+    hub = _hf_hub_mock(scan=None, ls_raises=RuntimeError("hub is down"))
+    with patch.dict(sys.modules, {"huggingface_hub": hub}):
+        _, _, streamable, reason = _hf_weight_stats("m", "abc", None)
+
+    assert streamable is False
+    assert "could not be listed" in reason
+
+
+def test_hf_weight_stats_survives_scan_failure():
+    """An unavailable scan degrades to the file listing rather than raising."""
+    from flyte.prefetch._hf_model import _hf_weight_stats
+
+    hub = _hf_hub_mock(
+        model_info_raises=RuntimeError("gated repo"),
+        files=[_file("m/model.safetensors", 750)],
+    )
+    with patch.dict(sys.modules, {"huggingface_hub": hub}):
+        params, weight_bytes, streamable, _ = _hf_weight_stats("m", "abc", None)
+
+    assert params == 0
+    assert weight_bytes == 750
+    assert streamable is True
+
+
+# =============================================================================
+# _wrap_as_model_artifact Tests
+# =============================================================================
+
+
+def test_wrap_as_model_artifact_writes_serving_facts_as_one_attr():
+    """
+    The facts ride as a single JSON value under one key, not as ~15 flat attrs.
+
+    attrs is a map<string,string>, so spreading the schema across the key set
+    would freeze it -- and it multiplies the index entries the control plane
+    keeps per artifact.
+    """
+    import flyte.artifacts as artifacts
+    from flyte.prefetch._hf_model import SERVING_ATTR_KEY, _wrap_as_model_artifact
+
+    captured = {}
+    facts = {"v": 1, "params_total": 751_632_384, "streamable": True}
+    info = HuggingFaceModelInfo(repo="Qwen/Qwen3-0.6B")
+
+    with (
+        patch.object(artifacts.Metadata, "create_model_metadata", side_effect=lambda **kw: captured.update(kw)),
+        patch.object(artifacts, "new", return_value="wrapped") as mock_new,
+    ):
+        result = _wrap_as_model_artifact(MagicMock(), info, "Qwen3-0-6B", "abc123", None, facts)
+
+    assert result == "wrapped"
+    assert mock_new.call_count == 1
+
+    attrs = captured["attrs"]
+    assert set(attrs) == {"source_repo", "source_commit", SERVING_ATTR_KEY}
+    assert attrs["source_repo"] == "Qwen/Qwen3-0.6B"
+    assert attrs["source_commit"] == "abc123"
+    assert json.loads(attrs[SERVING_ATTR_KEY]) == facts
+    # Compact separators: nothing reads this by eye.
+    assert ", " not in attrs[SERVING_ATTR_KEY]
+    assert ": " not in attrs[SERVING_ATTR_KEY]
+
+
+def test_wrap_as_model_artifact_without_facts_omits_the_key():
+    """A model that could not be measured is still a perfectly good artifact."""
+    import flyte.artifacts as artifacts
+    from flyte.prefetch._hf_model import SERVING_ATTR_KEY, _wrap_as_model_artifact
+
+    captured = {}
+    info = HuggingFaceModelInfo(repo="Qwen/Qwen3-0.6B")
+
+    with (
+        patch.object(artifacts.Metadata, "create_model_metadata", side_effect=lambda **kw: captured.update(kw)),
+        patch.object(artifacts, "new", return_value="wrapped"),
+    ):
+        _wrap_as_model_artifact(MagicMock(), info, "Qwen3-0-6B", "abc123", None, None)
+
+    assert SERVING_ATTR_KEY not in captured["attrs"]
+
+
+def test_wrap_as_model_artifact_sharded_carries_both_attrs():
+    """Sharding is recorded as its own flat attr as well as inside the facts."""
+    import flyte.artifacts as artifacts
+    from flyte.prefetch._hf_model import SERVING_ATTR_KEY, _wrap_as_model_artifact
+
+    captured = {}
+    info = HuggingFaceModelInfo(
+        repo="Qwen/Qwen3-32B",
+        shard_config=ShardConfig(args=VLLMShardArgs(tensor_parallel_size=8)),
+    )
+
+    with (
+        patch.object(artifacts.Metadata, "create_model_metadata", side_effect=lambda **kw: captured.update(kw)),
+        patch.object(artifacts, "new", return_value="wrapped"),
+    ):
+        _wrap_as_model_artifact(MagicMock(), info, "Qwen3-32B", "abc123", None, {"v": 1})
+
+    attrs = captured["attrs"]
+    assert attrs["sharding"] == "vllm-tp8"
+    assert set(attrs) == {"source_repo", "source_commit", "sharding", SERVING_ATTR_KEY}


### PR DESCRIPTION
## Why are the changes needed?

Union's deploy path reads a `flyte.io/serving` attr off a model artifact to decide which GPUs it fits on and which engines can load it. **Nothing wrote that key.** Searching every branch of this repo for it returns no producer at all, so every model published through the SDK arrived without it and could not be deployed — a consumer that has existed for a while, against a producer that never did.

Prefetch is the right place to fix that: it already downloads `config.json`, and it already receives per-file sizes from the Hub that it was throwing away.

Separately, `hf_model` builds its environment at call time and ships the task as a cloudpickle bundle. That is the right shape for a notebook and the wrong one for a control plane — a console button has no Python process to run — so there is no way to start a prefetch other than from Python.

## What changes were proposed in this pull request?

1. **Record serving facts at prefetch.** `_serving_facts` derives what sizing needs — weight bytes, dtype, layer and head geometry, context length, architectures, sharding — and `_wrap_as_model_artifact` stamps it as versioned JSON. Everything is read from the Hub's metadata rather than from the weights, so the same derivation works before a byte is downloaded.

2. **Add a registered prefetch task.** `flyte/prefetch/_deployable.py` declares the same work as an ordinary task, addressable by name and version, so a backend can bind it to a run in the user's own project — the shape the remote image builder's `build-image` task already uses. Both paths call `store_hf_model_task`, so there is one implementation with two ways to reach it.

### Three details worth reviewing

- **`architectures` is written as a list.** It was being comma-joined into a scalar, which deserializes as one bogus architecture name and fails every engine-support lookup.
- **GPT-2-family configs spell their geometry `n_layer`/`n_head`/`n_embd`**, which transformers reconciles through each config class's `attribute_map`. Reading the raw JSON sees the original names, so a missed alias silently zeroes the KV-cache term — and that *under*-estimates VRAM, the direction that OOMs a deploy rather than merely wasting a GPU.
- **The registered task is `prefetch.hf_model`, not `prefetch-hf-model`.** `TaskEnvironment` prefixes task names with the environment's name; `build-image` keeps its bare name only because it is a `ContainerTask`.

Deriving the facts is best-effort on purpose: a model that cannot be measured is still a perfectly good artifact, so a failure publishes without facts rather than failing a download that may have taken an hour.

No `HF_TOKEN` secret is attached to the registered environment. Public repos need none, and naming a secret that does not exist wedges the pod in `CreateContainerConfigError` with no HuggingFace error to read — an opaque failure in exactly the first-run case. Callers supply a token per run instead.

## How was this patch tested?

Against the live Hub: `Qwen3-0.6B` (751M params, 1.5 GB bf16, GQA at 8 KV heads), `Qwen3-32B` (65.5 GB across shards), `gpt2` (legacy config names, and ships both `.bin` and `.safetensors` without double-counting), and `bert-base` (no `head_dim` or `kv_heads`, absorbed by the consumer's fallbacks).

End to end on a local Union backend: the registered task imports `hf-internal-testing/tiny-random-LlamaForCausalLM`, publishes an artifact carrying `kind=model` and the facts blob, and the deploy service then reports it deployable with a populated recommendation.

Unit tests cover the derivations offline, against fixtures rather than the live Hub: the geometry fields including the GPT-2 aliases and the nested `text_config`, `architectures` staying a list, absent `head_dim`/`num_key_value_heads` reported as 0 rather than guessed, the dtype table and its 2-byte fallback, and both unstreamable verdicts (no safetensors, and a failed listing — which must degrade rather than raise). One test pins that the facts land as a single attr key holding compact JSON rather than ~15 flat attrs, which is what keeps the control plane's GIN index at one entry for the whole blob.

`_deployable` had no tests; its registered name — the entire contract for a non-Python caller — is now pinned, along with the empty-string-means-unset convention, the opt-in secret and the image override. Its "not imported at the `flyte` level" claim is checked in a subprocess, because this test session has already imported the module and an in-process check would always pass.

Adding the raw config to `_lookup_huggingface_model_info`'s return changed it from a 2-tuple to a 3-tuple, which broke the four existing tests that unpack it. They now assert on the config as well.

```
$ pytest tests/flyte/prefetch tests/cli
397 passed
```

`ruff check`, `ruff format --check`, `mypy src/flyte/prefetch/` and `check-docstrings` are all clean. Importing `flyte` pulls in no new modules — `_deployable` stays lazily imported.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Out of scope

Sharded prefetch through the registered task — it needs vLLM, a CUDA toolchain and GPUs at prefetch time, so it belongs in its own environment. Revision pinning also stays out: `hf_model` has no `revision` parameter and always resolves the latest commit, which becomes the artifact version.

