### PR TITLE
rs_controller: publish flyte_core to crates.io

### DIFF
--- a/.github/workflows/publish-rust-crate.yml
+++ b/.github/workflows/publish-rust-crate.yml
@@ -1,0 +1,91 @@
+# Publish the `flyte_core` Rust crate to crates.io.
+#
+# Separate from `publish.yml` on purpose. That workflow releases the Python
+# packages on `v*` tags, and its version comes from the Python release train --
+# tying the crate to it would force flyte_core's version to track flyte's and
+# publish a crate on every SDK release whether or not the Rust code changed.
+# The crate version lives in rs_controller/Cargo.toml and is checked against the
+# tag rather than rewritten from it.
+#
+#   git tag rs-v0.1.0 && git push origin rs-v0.1.0
+#
+# The pull_request trigger runs everything except the upload, so this workflow is
+# validated by the PR that adds it -- the same idiom publish.yml uses.
+name: Publish Rust crate
+
+on:
+  push:
+    tags: ["rs-v*"]
+  pull_request:
+    paths:
+      - ".github/workflows/publish-rust-crate.yml"
+      - "rs_controller/**"
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    name: Publish flyte_core to crates.io
+    runs-on: ubuntu-latest
+    # Hoisted to job level so the publish step can test it in an `if:` --
+    # secrets are not available in step-level conditions.
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - name: Fetch the code
+        uses: actions/checkout@v4
+
+      - name: Cache Cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            rs_controller/target
+          key: ${{ runner.os }}-cargo-publish-${{ hashFiles('rs_controller/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-publish-
+
+      - name: Install toolchain
+        run: rustup toolchain install
+
+      # The default feature set includes pyo3/auto-initialize, so the crates.io
+      # verification build links libpython when it compiles src/bin/*.
+      - name: Install libpython for the verification build
+        run: sudo apt-get update && sudo apt-get install -y python3-dev pkg-config
+
+      # A tag that disagrees with the manifest would publish a version nobody can
+      # reproduce from the tree. crates.io versions are immutable, so check first.
+      - name: Check tag matches the crate version
+        if: startsWith(github.ref, 'refs/tags/')
+        working-directory: rs_controller
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#rs-v}"
+          CRATE_VERSION=$(grep -m1 '^version = ' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+          echo "tag=$TAG_VERSION crate=$CRATE_VERSION"
+          if [ -z "$CRATE_VERSION" ]; then
+            echo "ERROR: could not read the version from rs_controller/Cargo.toml"
+            exit 1
+          fi
+          if [ "$TAG_VERSION" != "$CRATE_VERSION" ]; then
+            echo "ERROR: tag $GITHUB_REF_NAME implies version $TAG_VERSION but rs_controller/Cargo.toml says $CRATE_VERSION"
+            exit 1
+          fi
+
+      - name: Dry-run publish
+        run: make -C rs_controller publish-dry-run
+
+      # Skipped until CARGO_REGISTRY_TOKEN exists, so adding the workflow does not
+      # fail a release; mirrors the notify-docs job's handling in publish.yml.
+      - name: Publish to crates.io
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          if [ -z "${CARGO_REGISTRY_TOKEN}" ]; then
+            echo "::warning title=crates.io publish skipped::CARGO_REGISTRY_TOKEN is not set — skipping the upload. Add the secret to enable it."
+            exit 0
+          fi
+          make -C rs_controller publish

--- a/rs_controller/Cargo.toml
+++ b/rs_controller/Cargo.toml
@@ -2,6 +2,28 @@
 name = "flyte_core"
 version = "0.1.0"
 edition = "2021"
+description = "Core Flyte controller: action submission, a watch-backed informer cache, and ActionsService auth."
+license = "Apache-2.0"
+repository = "https://github.com/flyteorg/flyte-sdk"
+readme = "README.md"
+keywords = ["flyte", "workflow", "orchestration"]
+categories = ["api-bindings"]
+# The crate is published for Rust consumers; the maturin/Python packaging around
+# it is not. Without this the tarball also ships uv.lock (81 KB), the
+# wheel-builder Makefile and Dockerfile, and three hand-run Python test scripts.
+# `exclude` affects only the published tarball -- maturin still reads
+# pyproject.toml from the working tree.
+exclude = [
+    "pyproject.toml",
+    "Makefile",
+    "Dockerfile.maturinx",
+    "uv.lock",
+    "test_auth_direct.py",
+    "test_auth_simple.py",
+    "try_rust_controller.py",
+    "docker_cargo_cache/",
+    "dist/",
+]
 
 [lib]
 name = "flyte_controller_base"

--- a/rs_controller/Makefile
+++ b/rs_controller/Makefile
@@ -73,3 +73,16 @@ lint:
 .PHONY: lint-fix
 lint-fix:
 	cargo clippy --all-targets --fix
+
+# crates.io publishing. The crate version lives in Cargo.toml and is independent
+# of the Python SDK version; `rs-v<version>` tags drive the release workflow.
+# Note the verification build compiles src/bin/*, which link libpython because
+# the default feature set includes pyo3/auto-initialize -- python3-dev has to be
+# installed for these to work.
+.PHONY: publish-dry-run
+publish-dry-run:
+	cargo publish --dry-run
+
+.PHONY: publish
+publish:
+	cargo publish

--- a/rs_controller/README.md
+++ b/rs_controller/README.md
@@ -1,0 +1,67 @@
+# flyte_core
+
+The Flyte controller core: submit actions to the Flyte ActionsService, track them
+through a watch-backed informer cache, and authenticate against a Flyte
+deployment.
+
+This crate backs two consumers:
+
+- the **Python** `flyte_controller_base` extension module, built from this same
+  source with maturin and used by `flyte` when `_F_USE_RUST_CONTROLLER=1`;
+- the **Rust SDK** ([`flyte`](https://github.com/flyteorg/flyte-sdk-rs)), which
+  drives it directly.
+
+## Two things that will surprise you
+
+**The library is named `flyte_controller_base`, not `flyte_core`.** The crates.io
+package name and the library name differ, so imports read:
+
+```rust
+use flyte_controller_base::core::CoreBaseController;
+use flyte_controller_base::action::{Action, ActionType};
+```
+
+**Default features embed a Python interpreter.** `default = ["pyo3/auto-initialize"]`
+means a plain `cargo build` links `libpython`, and you need `python3-dev` (or
+equivalent) installed to build. That default exists because the crate's own
+binaries need it.
+
+`pyo3/auto-initialize` is mutually exclusive with `pyo3/extension-module`, so a
+downstream crate that also builds a Python extension module must not take this
+one with default features. Building the Python wheel does exactly that — see
+`pyproject.toml`, which sets `no-default-features = true` and
+`features = ["extension-module"]`.
+
+Note that turning pyo3 off entirely is not currently possible: `flyteidl2`, which
+supplies every protobuf type crossing this API, depends on pyo3 unconditionally
+and annotates its generated messages as `#[pyclass]`. Separating a pure-Rust core
+from the pyo3 bindings is planned, and it will be a breaking release.
+
+## Usage
+
+```toml
+[dependencies]
+flyte_core = "0.1"
+```
+
+```rust
+use flyte_controller_base::core::CoreBaseController;
+
+// Auth from _UNION_EAGER_API_KEY. Must be called off an async thread: the
+// constructor blocks on the shared runtime.
+let controller = CoreBaseController::new_with_auth(20)?;
+```
+
+For an unauthenticated endpoint (devbox or local backend), use
+`CoreBaseController::new_without_auth(endpoint, workers)`.
+
+## Releasing
+
+Tag `rs-v<version>` to publish to crates.io; see
+`.github/workflows/publish-rust-crate.yml`. The crate version lives in
+`Cargo.toml` and is independent of the Python SDK's version — the workflow checks
+the tag against the manifest rather than rewriting it.
+
+## License
+
+Apache-2.0


### PR DESCRIPTION
## Why are the changes needed?

The Rust SDK at [flyteorg/flyte-sdk-rs](https://github.com/flyteorg/flyte-sdk-rs) depends on this crate by git rev, and crates.io refuses to publish a crate whose dependencies are not on the registry:

```
all dependencies must have a version requirement specified when publishing.
dependency `flyte_core` does not specify a version
```

So the `flyte` crate cannot be released at all until `flyte_core` is. This unblocks that.

## What changes were proposed in this pull request?

**`rs_controller/Cargo.toml`**
- Adds `description` and `license`. Both are hard crates.io requirements — publishing fails outright without them. The repo `LICENSE` is Apache-2.0 but sits outside the crate directory and would not be packaged, so this uses the SPDX `license` key rather than `license-file`.
- Adds `repository`, `readme`, `keywords`, `categories`.
- Adds `exclude`, so the published tarball carries only the Rust crate. Without it, `uv.lock` (81 KB), the wheel-builder `Makefile` and `Dockerfile.maturinx`, and three hand-run Python test scripts all ship to crates.io. **This affects the published tarball only** — maturin still reads `pyproject.toml` from the working tree, so wheel builds are unchanged.

**`.github/workflows/publish-rust-crate.yml`** (new) — publishes on `rs-v*` tags.

Deliberately separate from `publish.yml`: that workflow releases the Python packages on `v*` tags and derives the version from the Python release train. Folding the crate in would force `flyte_core`'s version to track `flyte`'s, and publish a crate on every SDK release whether or not the Rust code changed. Here the crate version stays in `Cargo.toml` and is *checked against* the tag rather than rewritten from it.

It follows the conventions already in this repo: the `pull_request` trigger runs everything except the upload (the same dual-trigger idiom `publish.yml` uses to validate itself), work is delegated to `make -C rs_controller` targets like the existing `rs-fmt` / `rs-lint` jobs, and caching is keyed on `hashFiles('rs_controller/Cargo.lock')`. The upload step warns and skips while `CARGO_REGISTRY_TOKEN` is unset, mirroring the `notify-docs` job — so merging this cannot break a release.

**`rs_controller/README.md`** (new) — required by the `readme` key, and documents two things that will otherwise surprise consumers: the package is `flyte_core` but the library is `flyte_controller_base`, and default features embed a Python interpreter.

## What this PR deliberately does *not* do

Feature defaults are untouched. `default = ["pyo3/auto-initialize"]` is what flyte-sdk-rs wants today, so changing it now would only churn.

A pure-Rust core split out from the pyo3 bindings was considered and deferred: it is not achievable while `flyteidl2` depends on pyo3 unconditionally and annotates ~790 generated types with `#[pyclass]`. Making that optional upstream, then splitting this crate, is a future breaking release. The README records the constraint so the next person does not re-derive it.

Note for downstream: `rs_controller` pins `flyteidl2 = "=2.0.40"` while flyte-sdk-rs currently pins `=2.0.37`. Two `=` requirements cannot unify, so flyte-sdk-rs moves to `=2.0.40` in the PR that consumes this crate. Nothing changes in this repo.

## How was this patch tested?

- `cargo publish --dry-run` on a clean tree — **succeeds** (this is the command that fails on `main` today).
- `cargo package --list` — confirms the tarball contains only Rust sources, `Cargo.toml`, `Cargo.lock`, `build.rs`, `rustfmt.toml`, and `README.md`; no `pyproject.toml`, `Makefile`, `uv.lock`, or `.py` files.
- `make -C rs_controller lint` — clean, unchanged.
- Both new Makefile targets run as the workflow invokes them.
- The tag-vs-manifest check was exercised directly: accepts `rs-v0.1.0`, rejects `rs-v9.9.9`.

The `pull_request` trigger means this PR's own CI run exercises the workflow end to end, minus the upload.

### Labels

added

🤖 Generated with [Claude Code](https://claude.com/claude-code)