### PR TITLE
fix(recovery): resolve confirmed action-name instabilities (ENG26-831)

### DIFF
--- a/src/flyte/_internal/controllers/__init__.py
+++ b/src/flyte/_internal/controllers/__init__.py
@@ -21,11 +21,12 @@ class TaskCallSequencer:
     deterministic, unique sub-action IDs when the same task is invoked
     multiple times within a single parent action.
 
-    `call_key` should combine the task identity with the inputs hash so that
-    concurrent calls with different inputs never share a counter — sequence
-    assignment (and therefore action names) then stays independent of
-    event-loop scheduling order. Calls that do share a counter are
-    byte-identical and interchangeable.
+    `call_key` should combine the task identity, the inputs hash, and the group
+    (every component that is folded into the action name) so that concurrent
+    calls producing different names never share a counter — sequence assignment
+    (and therefore action names) then stays independent of event-loop scheduling
+    order. Calls that do share a counter are byte-identical, same-group, and
+    interchangeable.
     """
 
     def __init__(self) -> None:

--- a/src/flyte/_internal/controllers/_local_controller.py
+++ b/src/flyte/_internal/controllers/_local_controller.py
@@ -139,7 +139,8 @@ class LocalController(ControllerProtocol):
         inputs_hash = convert.generate_inputs_hash_from_proto(inputs.proto_inputs)
         task_interface = cast(interface_pb2.TypedInterface, transform_native_to_typed_interface(_task.interface))
 
-        task_call_seq = self._sequencer.next_seq(f"{_task.name}:{inputs_hash}", tctx.action.name)
+        group = tctx.group_data.name if tctx.group_data else ""
+        task_call_seq = self._sequencer.next_seq(f"{_task.name}:{inputs_hash}:{group}", tctx.action.name)
         sub_action_id, sub_action_output_path = convert.generate_sub_action_id_and_output_path(
             tctx, _task.name, inputs_hash, task_call_seq
         )
@@ -350,7 +351,8 @@ class LocalController(ControllerProtocol):
 
         func_name = cast(FunctionType, _func).__name__
         inputs_hash = convert.generate_inputs_hash_from_proto(converted_inputs.proto_inputs)
-        invoke_seq_num = self._sequencer.next_seq(f"{func_name}:{inputs_hash}", tctx.action.name)
+        group = tctx.group_data.name if tctx.group_data else ""
+        invoke_seq_num = self._sequencer.next_seq(f"{func_name}:{inputs_hash}:{group}", tctx.action.name)
         action_id, action_output_path = convert.generate_sub_action_id_and_output_path(
             tctx,
             func_name,

--- a/src/flyte/_internal/controllers/remote/_controller.py
+++ b/src/flyte/_internal/controllers/remote/_controller.py
@@ -154,13 +154,18 @@ class RemoteController(Controller):
         self._submit_init_lock = threading.Lock()
         self._pending_conditions: dict[str, Action] = {}
 
-    def generate_task_call_sequence(self, call_key: str, action_id: ActionID) -> int:
+    def generate_task_call_sequence(self, call_key: str, action_id: ActionID, group: str | None = None) -> int:
         """
         Generate a task call sequence for the given call identity (task identity + inputs hash)
         and action ID. This is used to track the number of times an identical call is made
         within an action; keying by inputs keeps sequence assignment independent of async
-        scheduling order across calls with different inputs.
+        scheduling order across calls with different inputs. The group is folded into the
+        call key because it is folded into the action name: identical calls made from
+        different groups must not share a counter, or which group gets which sequence
+        number would depend on scheduling order and the names would flip run-to-run.
         """
+        if group:
+            call_key = f"{call_key}:{group}"
         action_key = unique_action_name(action_id)
         seq = self._sequencer.next_seq(call_key, action_key)
         logger.info(f"For action {action_key}, task call sequence is {seq}")
@@ -224,7 +229,11 @@ class RemoteController(Controller):
             if ignored_input_vars
             else inputs_hash
         )
-        task_call_seq = self.generate_task_call_sequence(f"{task_identity}:{name_inputs_hash}", current_action_id)
+        task_call_seq = self.generate_task_call_sequence(
+            f"{task_identity}:{name_inputs_hash}",
+            current_action_id,
+            tctx.group_data.name if tctx.group_data else None,
+        )
         sub_action_id, sub_action_output_path = convert.generate_sub_action_id_and_output_path(
             tctx, task_identity, name_inputs_hash, task_call_seq
         )
@@ -431,7 +440,11 @@ class RemoteController(Controller):
             inputs = await convert.convert_from_native_to_inputs(_interface, *args, **kwargs)
         serialized_inputs = inputs.proto_inputs.SerializeToString(deterministic=True)
         inputs_hash = convert.generate_inputs_hash_from_proto(inputs.proto_inputs)
-        invoke_seq_num = self.generate_task_call_sequence(f"{trace_identity}:{inputs_hash}", current_action_id)
+        invoke_seq_num = self.generate_task_call_sequence(
+            f"{trace_identity}:{inputs_hash}",
+            current_action_id,
+            tctx.group_data.name if tctx.group_data else None,
+        )
 
         sub_action_id, sub_action_output_path = convert.generate_sub_action_id_and_output_path(
             tctx, trace_identity, inputs_hash, invoke_seq_num
@@ -595,7 +608,11 @@ class RemoteController(Controller):
             if ignored_input_vars
             else inputs_hash
         )
-        invoke_seq_num = self.generate_task_call_sequence(f"{task_identity}:{name_inputs_hash}", current_action_id)
+        invoke_seq_num = self.generate_task_call_sequence(
+            f"{task_identity}:{name_inputs_hash}",
+            current_action_id,
+            tctx.group_data.name if tctx.group_data else None,
+        )
         sub_action_id, sub_action_output_path = convert.generate_sub_action_id_and_output_path(
             tctx, task_identity, name_inputs_hash, invoke_seq_num
         )
@@ -701,7 +718,9 @@ class RemoteController(Controller):
         # Condition actions nest under the real running task (task_action), so conditions fired inside a
         # @trace still parent to the task rather than the trace pseudo-action.
         task_action = tctx.task_action
-        invoke_seq = self.generate_task_call_sequence(condition.name, current_action_id)
+        invoke_seq = self.generate_task_call_sequence(
+            condition.name, current_action_id, tctx.group_data.name if tctx.group_data else None
+        )
 
         # Generate a deterministic action name from condition name + sequence
         sub_action_id, sub_action_output_path = convert.generate_sub_action_id_and_output_path(

--- a/src/flyte/_internal/controllers/remote/_r_controller.py
+++ b/src/flyte/_internal/controllers/remote/_r_controller.py
@@ -157,13 +157,18 @@ class RemoteController(BaseController):
         self._submit_loop: asyncio.AbstractEventLoop | None = None
         self._submit_thread: threading.Thread | None = None
 
-    def generate_task_call_sequence(self, call_key: str, action_id: ActionID) -> int:
+    def generate_task_call_sequence(self, call_key: str, action_id: ActionID, group: str | None = None) -> int:
         """
         Generate a task call sequence for the given call identity (task identity + inputs hash)
         and action ID. This is used to track the number of times an identical call is made
         within an action; keying by inputs keeps sequence assignment independent of async
-        scheduling order across calls with different inputs.
+        scheduling order across calls with different inputs. The group is folded into the
+        call key because it is folded into the action name: identical calls made from
+        different groups must not share a counter, or which group gets which sequence
+        number would depend on scheduling order and the names would flip run-to-run.
         """
+        if group:
+            call_key = f"{call_key}:{group}"
         action_key = unique_action_name(action_id)
         seq = self._sequencer.next_seq(call_key, action_key)
         logger.info(f"For action {action_key}, task call sequence is {seq}")
@@ -220,7 +225,11 @@ class RemoteController(BaseController):
             if ignored_input_vars
             else inputs_hash
         )
-        task_call_seq = self.generate_task_call_sequence(f"{task_identity}:{name_inputs_hash}", current_action_id)
+        task_call_seq = self.generate_task_call_sequence(
+            f"{task_identity}:{name_inputs_hash}",
+            current_action_id,
+            tctx.group_data.name if tctx.group_data else None,
+        )
         sub_action_id, sub_action_output_path = convert.generate_sub_action_id_and_output_path(
             tctx, task_identity, name_inputs_hash, task_call_seq
         )
@@ -440,7 +449,11 @@ class RemoteController(BaseController):
         inputs = await convert.convert_from_native_to_inputs(_interface, *args, **kwargs)
         serialized_inputs = inputs.proto_inputs.SerializeToString(deterministic=True)
         inputs_hash = convert.generate_inputs_hash_from_proto(inputs.proto_inputs)
-        invoke_seq_num = self.generate_task_call_sequence(f"{trace_identity}:{inputs_hash}", current_action_id)
+        invoke_seq_num = self.generate_task_call_sequence(
+            f"{trace_identity}:{inputs_hash}",
+            current_action_id,
+            tctx.group_data.name if tctx.group_data else None,
+        )
 
         sub_action_id, sub_action_output_path = convert.generate_sub_action_id_and_output_path(
             tctx, trace_identity, inputs_hash, invoke_seq_num
@@ -592,7 +605,11 @@ class RemoteController(BaseController):
             if ignored_input_vars
             else inputs_hash
         )
-        invoke_seq_num = self.generate_task_call_sequence(f"{task_identity}:{name_inputs_hash}", current_action_id)
+        invoke_seq_num = self.generate_task_call_sequence(
+            f"{task_identity}:{name_inputs_hash}",
+            current_action_id,
+            tctx.group_data.name if tctx.group_data else None,
+        )
         sub_action_id, sub_action_output_path = convert.generate_sub_action_id_and_output_path(
             tctx, task_identity, name_inputs_hash, invoke_seq_num
         )

--- a/src/flyte/_internal/runtime/convert.py
+++ b/src/flyte/_internal/runtime/convert.py
@@ -585,6 +585,34 @@ def generate_inputs_hash(serialized_inputs: str | bytes) -> str:
     return hash_data(serialized_inputs)
 
 
+_MSGPACK_TAG = "msgpack"
+
+
+def _canonical_msgpack_bytes(data: bytes) -> bytes:
+    """
+    Re-encode msgpack bytes with map keys recursively sorted. Msgpack maps preserve dict
+    insertion order, so semantically-equal untyped-dict inputs built in different key
+    orders serialize to different bytes — and would otherwise produce different input
+    hashes (and action names) run-to-run. Re-encoding already-sorted data is
+    byte-identical, so canonical inputs keep their existing hashes.
+
+    Returns the original bytes unchanged if they cannot be decoded.
+    """
+    import msgpack
+
+    def canonicalize(obj: Any) -> Any:
+        if isinstance(obj, dict):
+            return {k: canonicalize(obj[k]) for k in sorted(obj, key=msgpack.packb)}
+        if isinstance(obj, (list, tuple)):
+            return [canonicalize(v) for v in obj]
+        return obj
+
+    try:
+        return cast(bytes, msgpack.packb(canonicalize(msgpack.unpackb(data, strict_map_key=False))))
+    except Exception:
+        return data
+
+
 def generate_inputs_repr_for_literal(literal: literals_pb2.Literal) -> bytes:
     """
     Generate a byte representation for a single literal that is meant to be hashed as part of the cache key
@@ -626,6 +654,15 @@ def generate_inputs_repr_for_literal(literal: literals_pb2.Literal) -> bytes:
 
         b = bytes(buf)
         return b
+
+    elif literal.HasField("scalar") and literal.scalar.HasField("binary") and literal.scalar.binary.tag == _MSGPACK_TAG:
+        canonical = _canonical_msgpack_bytes(literal.scalar.binary.value)
+        if canonical != literal.scalar.binary.value:
+            lit = literals_pb2.Literal()
+            lit.CopyFrom(literal)
+            lit.scalar.binary.value = canonical
+            return lit.SerializeToString(deterministic=True)
+        return literal.SerializeToString(deterministic=True)
 
     # For all other cases (scalars, etc.), just serialize the literal normally
     return literal.SerializeToString(deterministic=True)

--- a/src/flyte/types/_pickle.py
+++ b/src/flyte/types/_pickle.py
@@ -67,6 +67,23 @@ class FlytePickle(typing.Generic[T]):
         return data
 
 
+def _canonical_content_hash(python_val: typing.Any) -> str | None:
+    """
+    Content hash for pickled values whose serialized bytes are not stable across
+    processes. Sets iterate in hash order, which varies with PYTHONHASHSEED, so pickling
+    the same set in two runs produces different bytes — input hashing (action names,
+    cache keys) must use a canonical hash instead. Returns None when no canonical form
+    is available (e.g. unsortable elements); those values remain unstable and are a
+    documented recovery limitation.
+    """
+    if isinstance(python_val, (set, frozenset)):
+        try:
+            return hashlib.md5(cloudpickle.dumps(sorted(python_val))).hexdigest()
+        except Exception:
+            return None
+    return None
+
+
 class FlytePickleTransformer(TypeTransformer[FlytePickle]):
     PYTHON_PICKLE_FORMAT = "PythonPickle"
 
@@ -101,13 +118,17 @@ class FlytePickleTransformer(TypeTransformer[FlytePickle]):
         )
         if sys.getsizeof(python_val) > DEFAULT_PICKLE_BYTES_LIMIT:
             remote_path = await FlytePickle.to_pickle(python_val)
-            return literals_pb2.Literal(
+            lit = literals_pb2.Literal(
                 scalar=literals_pb2.Scalar(blob=literals_pb2.Blob(metadata=meta, uri=remote_path))
             )
         else:
-            return literals_pb2.Literal(
+            lit = literals_pb2.Literal(
                 scalar=literals_pb2.Scalar(binary=literals_pb2.Binary(value=cloudpickle.dumps(python_val)))
             )
+        content_hash = _canonical_content_hash(python_val)
+        if content_hash is not None:
+            lit.hash = content_hash
+        return lit
 
     def guess_python_type(self, literal_type: types_pb2.LiteralType) -> typing.Type[FlytePickle[typing.Any]]:
         if (

--- a/tests/flyte/internal/runtime/test_action_name_stability_gaps.py
+++ b/tests/flyte/internal/runtime/test_action_name_stability_gaps.py
@@ -2,25 +2,19 @@
 Action-name stability — remaining validation scope (ENG26-831).
 
 Every test here asserts the behavior recovery REQUIRES: running the same workflow twice
-must produce the identical set of action names. Tests that FAIL confirm a live
-instability that breaks recovery matching; tests that pass close out their row of the
-stability matrix.
+must produce the identical set of action names. The three instabilities this file
+originally confirmed (as strict xfails) are now fixed and their tests assert the fix:
 
-Confirmed instabilities are marked ``xfail(strict=True)`` so the suite stays green until
-each fix lands — the strict marker then forces its removal:
-
-* ``TestGroupSequencerInteraction`` — the sequencer call key (task identity + inputs
-  hash) does not include the group, but the group IS folded into the action name. Two
-  byte-identical calls made from different groups share one counter, so which group gets
-  seq 1 vs 2 depends on event-loop scheduling order — and because the group differs, the
-  resulting names are NOT interchangeable. The whole name set flips run-to-run.
-* ``TestUnorderedInputs::test_untyped_dict_*`` — untyped ``dict`` inputs serialize via
-  msgpack, which preserves insertion order; semantically-equal dicts built in different
-  key orders produce different input hashes.
-* ``TestUnorderedInputs::test_set_inputs_stable_across_processes`` — ``Set[str]`` falls
-  back to pickle, which serializes in set iteration order; iteration order of str sets
-  depends on PYTHONHASHSEED, so the hash differs across interpreter processes (i.e.
-  across any two real runs).
+* ``TestGroupSequencerInteraction`` — the group is folded into the sequencer call key
+  (as it is into the action name), so identical calls made from different groups never
+  share a counter and sequence assignment is independent of scheduling order.
+* ``TestUnorderedInputs::test_untyped_dict_*`` — msgpack binary literals are
+  re-encoded with recursively sorted map keys at hash time, so semantically-equal
+  untyped dicts hash identically regardless of insertion order.
+* ``TestUnorderedInputs::test_set_inputs_stable_across_processes`` — pickled
+  set/frozenset literals carry a canonical content hash (pickle of the sorted
+  elements), so the PYTHONHASHSEED-dependent pickle bytes no longer feed input hashing.
+  Sets of unsortable elements remain unstable (documented recovery limitation).
 """
 
 from __future__ import annotations
@@ -63,8 +57,11 @@ def _submit_name(
     group: str | None = None,
 ) -> str:
     """Replica of the remote controller's naming path (_controller.py::_submit):
-    call_key = task identity + inputs hash (group NOT included), name folds in group."""
-    seq = sequencer.next_seq(f"{task_identity}:{inputs_hash}", tctx.action.name)
+    call_key folds in every name component — task identity, inputs hash, and group."""
+    call_key = f"{task_identity}:{inputs_hash}"
+    if group:
+        call_key = f"{call_key}:{group}"
+    seq = sequencer.next_seq(call_key, tctx.action.name)
     call_tctx = tctx.replace(group_data=GroupData(group)) if group else tctx
     sub_id, _ = convert.generate_sub_action_id_and_output_path(call_tctx, task_identity, inputs_hash, seq)
     return sub_id.name
@@ -79,12 +76,9 @@ def _simulate_run(calls: list[tuple[str, str, str | None]]) -> set[str]:
 
 
 class TestGroupSequencerInteraction:
-    """Groups are folded into the name but not into the sequencer key, so identical
-    calls made from different groups race for sequence numbers."""
+    """The group is folded into both the name and the sequencer call key, so identical
+    calls made from different groups never race for sequence numbers."""
 
-    @pytest.mark.xfail(
-        strict=True, reason="ENG26-831: group is folded into the name but not into the sequencer call key"
-    )
     def test_same_call_in_two_groups_scheduling_order_insensitive(self):
         """Same task + same inputs invoked from two different groups (independent async
         branches): the name set must not depend on which branch reaches the controller
@@ -93,18 +87,12 @@ class TestGroupSequencerInteraction:
         run2 = _simulate_run([(TASK_IDENTITY, INPUTS_HASH, "group_b"), (TASK_IDENTITY, INPUTS_HASH, "group_a")])
         assert run1 == run2
 
-    @pytest.mark.xfail(
-        strict=True, reason="ENG26-831: group is folded into the name but not into the sequencer call key"
-    )
     def test_grouped_and_ungrouped_call_scheduling_order_insensitive(self):
         """Same task + same inputs invoked once inside a group and once outside."""
         run1 = _simulate_run([(TASK_IDENTITY, INPUTS_HASH, "group_a"), (TASK_IDENTITY, INPUTS_HASH, None)])
         run2 = _simulate_run([(TASK_IDENTITY, INPUTS_HASH, None), (TASK_IDENTITY, INPUTS_HASH, "group_a")])
         assert run1 == run2
 
-    @pytest.mark.xfail(
-        strict=True, reason="ENG26-831: group is folded into the name but not into the sequencer call key"
-    )
     def test_two_named_maps_over_same_items_scheduling_order_insensitive(self):
         """Two concurrent flyte.map calls (distinct group_name) mapping the same task
         over the same items: per-shard names must not depend on how the two maps
@@ -194,7 +182,6 @@ class TestStructuralChanges:
 class TestUnorderedInputs:
     """Input hashing must be insensitive to semantically-irrelevant ordering."""
 
-    @pytest.mark.xfail(strict=True, reason="ENG26-831: untyped dicts serialize via insertion-ordered msgpack")
     @pytest.mark.asyncio
     async def test_untyped_dict_insertion_order_stable(self):
         """Untyped dicts serialize via msgpack (insertion-ordered): two equal dicts
@@ -213,7 +200,6 @@ class TestUnorderedInputs:
         lit_ba = await TypeEngine.to_literal({"b": 2, "a": 1}, t, lt)
         assert convert.generate_inputs_repr_for_literal(lit_ab) == convert.generate_inputs_repr_for_literal(lit_ba)
 
-    @pytest.mark.xfail(strict=True, reason="ENG26-831: set inputs pickle in PYTHONHASHSEED-dependent iteration order")
     def test_set_inputs_stable_across_processes(self):
         """Set[str] inputs fall back to pickle in set iteration order, which depends on
         PYTHONHASHSEED — two runs (two interpreter processes) of the same workflow must


### PR DESCRIPTION
Fixes the three instabilities confirmed by the stability-matrix tests from #1406, and removes their `xfail` markers so the tests now assert the fixed behavior.

- **Group/sequencer race**: the group is now folded into the sequencer call key in all three controllers (remote, rust, local), matching the action name it feeds. Identical calls made from different groups no longer share a counter, so sequence assignment — and therefore the action-name set — is independent of event-loop scheduling order. Applies to task submits, trace actions, task refs, and condition actions.
- **Untyped `dict` inputs**: msgpack binary literals are re-encoded with recursively sorted map keys at input-hash time, so semantically-equal dicts built in different insertion orders hash identically. Re-encoding already-sorted data is byte-identical, so canonical inputs keep their existing hashes.
- **`set` inputs**: pickled `set`/`frozenset` literals now carry a canonical content hash (pickle of the sorted elements) in the literal's `hash` field, which input hashing prefers over the raw bytes — so PYTHONHASHSEED-dependent pickle ordering no longer affects action names. Sets of unsortable elements remain a documented limitation.

Naming note: names only change for workloads that were already unstable (out-of-order dicts, set inputs, multi-group races); stable workloads keep their existing names.

Full matrix: https://linear.app/unionai/issue/ENG26-831/recovery-validate-action-name-stability-across-runs