### PR TITLE
fix: don't crash-report a non-Connect endpoint answering a Connect RPC (FLYTE-SDK-77, FLYTE-SDK-7A)

### DIFF
--- a/src/flyte/_sentry.py
+++ b/src/flyte/_sentry.py
@@ -9,6 +9,7 @@ import atexit
 import errno
 import logging
 import os
+import re
 import socket
 from contextlib import contextmanager
 from http import HTTPStatus
@@ -157,26 +158,45 @@ _NON_OK_SUCCESS_HTTP_PHRASES: frozenset[str] = frozenset(
 )
 
 
+# connectrpc rejects a response whose content-type it cannot decode with
+# `ConnectError(Code.UNKNOWN, f"invalid content-type: '{received}'; expecting '{wanted}'")`
+# (connectrpc/_protocol_connect.py). A `text/*` body — an HTML error page, a login
+# page, a plain-text banner — is never something a Connect handler produces.
+_INVALID_CONTENT_TYPE_RE = re.compile(r"^invalid content-type: '(?P<received>[^']*)'")
+
+
 def _is_non_connect_endpoint_response(exc: BaseException) -> bool:
-    """A Connect RPC answered with a 2xx that carried no Connect payload.
+    """A Connect RPC was answered by something that is not a Connect endpoint.
 
     A Connect endpoint replies to a unary POST with 200 and a Connect body, or
-    with an error status and a Connect JSON body. A *success* status that is not
-    200 (204 No Content, 202 Accepted, ...) means the request never reached a
-    Connect handler at all — a proxy, VPN appliance, captive portal, corporate TLS
-    interceptor or misrouted ingress absorbed it and answered on the backend's
-    behalf. That is endpoint/network configuration, never a Python-SDK logic bug,
-    and the SDK cannot recover from it (FLYTE-SDK-77 / FLYTE-SDK-78: `flyte run`
-    and `flyte deploy` from a Windows host got `ConnectError: No Content` out of
-    CreateUploadLocation and SelectCluster, surfaced as `RuntimeSystemError:
-    Upload failed for ...`).
+    with an error status and a Connect JSON body. Two response shapes prove the
+    request never reached a Connect handler at all — a proxy, VPN appliance,
+    captive portal, corporate TLS interceptor or misrouted ingress absorbed it and
+    answered on the backend's behalf:
 
-    Deliberately narrow. connectrpc synthesizes the same shape of error — Code.UNKNOWN,
-    no details, message == a bare HTTP reason phrase — for *any* unmapped status,
-    including 500 ("Internal Server Error"). Those stay reported: a 500 means
-    something genuinely broke and is worth tracking (FLYTE-SDK-64 and friends are
-    exactly that, and are real backend signal). Only the 2xx class is unambiguously
-    "an intermediary answered instead of the backend", so only it is filtered.
+    1. A *success* status that is not 200 (204 No Content, 202 Accepted, ...).
+       FLYTE-SDK-77 / FLYTE-SDK-78: `flyte run` and `flyte deploy` from a Windows
+       host got `ConnectError: No Content` out of CreateUploadLocation and
+       SelectCluster, surfaced as `RuntimeSystemError: Upload failed for ...`.
+    2. A `text/*` content-type. FLYTE-SDK-7A / FLYTE-SDK-6P:
+       `invalid content-type: 'text/html'; expecting 'application/proto'` — an HTML
+       page where a protobuf body belongs. `_client_config.py` already treats this
+       exact signature as a misconfigured endpoint (#1235) when it comes back from
+       the auth metadata fetch; these are the same thing arriving on a data-plane
+       call instead.
+
+    Either way it is endpoint/network configuration, never a Python-SDK logic bug,
+    and the SDK cannot recover from it.
+
+    Deliberately narrow on both counts. connectrpc synthesizes the same shape of
+    error — Code.UNKNOWN, no details, message == a bare HTTP reason phrase — for
+    *any* unmapped status, including 500 ("Internal Server Error"). Those stay
+    reported: a 500 means something genuinely broke and is worth tracking
+    (FLYTE-SDK-64 and friends are exactly that, and are real backend signal). Only
+    the 2xx class is unambiguously "an intermediary answered instead of the
+    backend". Likewise only `text/*` is filtered on content-type, so an
+    `application/*` mismatch — which would point at a codec bug on our side —
+    keeps reporting.
     """
     try:
         from connectrpc.code import Code
@@ -186,12 +206,16 @@ def _is_non_connect_endpoint_response(exc: BaseException) -> bool:
     if not isinstance(exc, ConnectError):
         return False
     # A Connect JSON error body always yields either an explicit code or details;
-    # from_http_status yields UNKNOWN with neither.
+    # from_http_status and the content-type check both yield UNKNOWN with neither.
     if getattr(exc, "code", None) is not Code.UNKNOWN:
         return False
     if getattr(exc, "details", ()):
         return False
-    return (getattr(exc, "message", "") or "").strip() in _NON_OK_SUCCESS_HTTP_PHRASES
+    message = (getattr(exc, "message", "") or "").strip()
+    if message in _NON_OK_SUCCESS_HTTP_PHRASES:
+        return True
+    content_type = _INVALID_CONTENT_TYPE_RE.match(message)
+    return bool(content_type and content_type.group("received").strip().lower().startswith("text/"))
 
 
 _USER_ENVIRONMENT_OSERROR_ERRNOS: frozenset[int] = frozenset({errno.ENOSPC})

--- a/src/flyte/_sentry.py
+++ b/src/flyte/_sentry.py
@@ -11,6 +11,7 @@ import logging
 import os
 import socket
 from contextlib import contextmanager
+from http import HTTPStatus
 
 from flyte._logging import logger
 
@@ -145,6 +146,54 @@ def _is_user_actionable_connect_error(exc: BaseException) -> bool:
     return getattr(code, "name", None) in _USER_ACTIONABLE_CONNECT_CODES
 
 
+# Reason phrases of the 2xx statuses other than 200 OK ("Created", "Accepted",
+# "No Content", ...). connectrpc only maps a handful of HTTP statuses onto Connect
+# codes (401/403/404/429/502/503/504); everything else falls through to
+# `ConnectWireError.from_http_status`, which produces Code.UNKNOWN and keeps the
+# stdlib reason phrase as the whole message. The numeric status is dropped on the
+# floor, so matching the phrase is the only way back to the status class.
+_NON_OK_SUCCESS_HTTP_PHRASES: frozenset[str] = frozenset(
+    status.phrase for status in HTTPStatus if 200 < status.value < 300
+)
+
+
+def _is_non_connect_endpoint_response(exc: BaseException) -> bool:
+    """A Connect RPC answered with a 2xx that carried no Connect payload.
+
+    A Connect endpoint replies to a unary POST with 200 and a Connect body, or
+    with an error status and a Connect JSON body. A *success* status that is not
+    200 (204 No Content, 202 Accepted, ...) means the request never reached a
+    Connect handler at all — a proxy, VPN appliance, captive portal, corporate TLS
+    interceptor or misrouted ingress absorbed it and answered on the backend's
+    behalf. That is endpoint/network configuration, never a Python-SDK logic bug,
+    and the SDK cannot recover from it (FLYTE-SDK-77 / FLYTE-SDK-78: `flyte run`
+    and `flyte deploy` from a Windows host got `ConnectError: No Content` out of
+    CreateUploadLocation and SelectCluster, surfaced as `RuntimeSystemError:
+    Upload failed for ...`).
+
+    Deliberately narrow. connectrpc synthesizes the same shape of error — Code.UNKNOWN,
+    no details, message == a bare HTTP reason phrase — for *any* unmapped status,
+    including 500 ("Internal Server Error"). Those stay reported: a 500 means
+    something genuinely broke and is worth tracking (FLYTE-SDK-64 and friends are
+    exactly that, and are real backend signal). Only the 2xx class is unambiguously
+    "an intermediary answered instead of the backend", so only it is filtered.
+    """
+    try:
+        from connectrpc.code import Code
+        from connectrpc.errors import ConnectError
+    except ImportError:
+        return False
+    if not isinstance(exc, ConnectError):
+        return False
+    # A Connect JSON error body always yields either an explicit code or details;
+    # from_http_status yields UNKNOWN with neither.
+    if getattr(exc, "code", None) is not Code.UNKNOWN:
+        return False
+    if getattr(exc, "details", ()):
+        return False
+    return (getattr(exc, "message", "") or "").strip() in _NON_OK_SUCCESS_HTTP_PHRASES
+
+
 _USER_ENVIRONMENT_OSERROR_ERRNOS: frozenset[int] = frozenset({errno.ENOSPC})
 
 
@@ -272,6 +321,8 @@ def _is_user_error(exc: BaseException) -> bool:
         if user_excs and isinstance(cause, user_excs):
             return True
         if _is_user_actionable_connect_error(cause):
+            return True
+        if _is_non_connect_endpoint_response(cause):
             return True
         if _is_user_environment_oserror(cause):
             return True

--- a/tests/flyte/test_sentry.py
+++ b/tests/flyte/test_sentry.py
@@ -724,3 +724,60 @@ def test_non_connect_endpoint_response_ignores_errors_carrying_details():
 
     err = ConnectError(Code.UNKNOWN, "No Content", details=[identity_pb2.Identity()])
     assert not _sentry._is_non_connect_endpoint_response(err)
+
+
+# --- FLYTE-SDK-7A / FLYTE-SDK-6P: an HTML page where a protobuf body belongs ---
+
+
+def _content_type_error(received: str, wanted: str = "application/proto"):
+    """The ConnectError connectrpc raises for an undecodable content-type."""
+    from connectrpc.code import Code
+    from connectrpc.errors import ConnectError
+
+    return ConnectError(Code.UNKNOWN, f"invalid content-type: '{received}'; expecting '{wanted}'")
+
+
+@pytest.mark.parametrize("received", ["text/html", "text/html; charset=utf-8", "text/plain", "TEXT/HTML"])
+def test_capture_exception_skips_text_content_type(received):
+    """A text/* body means a proxy/login page answered, not a Connect handler."""
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(_content_type_error(received))
+    init_mock.assert_not_called()
+
+
+def test_capture_exception_skips_html_wrapped_in_runtime_system_error():
+    """The real FLYTE-SDK-7A shape: the ConnectError arrives as the __cause__ chain of an upload failure."""
+    from flyte.errors import RuntimeSystemError
+
+    try:
+        raise _content_type_error("text/html")
+    except Exception as inner:
+        err = RuntimeSystemError("UploadError", "Upload failed for /tmp/fast.tar.gz")
+        err.__cause__ = inner
+
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()
+
+
+@pytest.mark.parametrize("received", ["application/json", "application/grpc", "application/octet-stream", ""])
+def test_non_connect_endpoint_response_still_reports_application_content_types(received):
+    """An application/* mismatch would point at a codec bug on our side -- keep reporting it."""
+    assert not _sentry._is_non_connect_endpoint_response(_content_type_error(received))
+
+
+def test_non_connect_endpoint_response_ignores_message_merely_mentioning_html():
+    """The filter matches connectrpc's own message shape, not any mention of a content type.
+
+    FLYTE-SDK-3A and FLYTE-SDK-4K carry an nginx HTML page inside a *backend* error
+    message; those are real signal and must keep reporting.
+    """
+    from connectrpc.code import Code
+    from connectrpc.errors import ConnectError
+
+    err = ConnectError(
+        Code.UNKNOWN,
+        "rpc error: code = Internal desc = request failed with status code 502. "
+        "Body: <html>\r\n<head><title>502 Bad Gateway</title></head>\r\n",
+    )
+    assert not _sentry._is_non_connect_endpoint_response(err)

--- a/tests/flyte/test_sentry.py
+++ b/tests/flyte/test_sentry.py
@@ -642,3 +642,85 @@ def test_init_still_reports_outside_a_test_run(monkeypatch):
     ):
         _sentry.init()
     sdk_init.assert_called_once()
+
+
+# --- FLYTE-SDK-77 / FLYTE-SDK-78: an intermediary answered instead of the backend ---
+
+
+def _wire_error_for_status(status: int):
+    """Build the ConnectError connectrpc raises for a response it can't parse as Connect."""
+    from connectrpc._protocol import ConnectWireError
+
+    return ConnectWireError.from_http_status(status).to_exception()
+
+
+@pytest.mark.parametrize("status", [201, 202, 203, 204, 205, 206])
+def test_capture_exception_skips_non_200_success_from_proxy(status):
+    """A 2xx that isn't 200 means the request never reached a Connect handler."""
+    err = _wire_error_for_status(status)
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()
+
+
+def test_capture_exception_skips_no_content_wrapped_in_runtime_system_error():
+    """The real FLYTE-SDK-78 shape: ConnectError(204) wrapped as RuntimeSystemError."""
+    from flyte.errors import RuntimeSystemError
+
+    try:
+        raise _wire_error_for_status(204)
+    except Exception as inner:
+        err = RuntimeSystemError("UploadError", "Upload failed for C:\\Temp\\fast.tar.gz")
+        err.__cause__ = inner
+
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()
+
+
+def test_capture_exception_still_reports_bare_http_500():
+    """500 produces the same UNKNOWN/bare-phrase shape but is real signal (FLYTE-SDK-64)."""
+    err = _wire_error_for_status(500)
+    with (
+        mock.patch.object(_sentry, "init"),
+        mock.patch("sentry_sdk.is_initialized", return_value=True),
+        mock.patch("sentry_sdk.capture_exception") as capture_mock,
+        mock.patch("sentry_sdk.flush"),
+    ):
+        _sentry.capture_exception(err)
+    capture_mock.assert_called_once_with(err)
+
+
+def test_capture_exception_still_reports_backend_unknown_with_message():
+    """The backend collapsing a code into UNKNOWN must keep reaching Sentry."""
+    from connectrpc.code import Code
+    from connectrpc.errors import ConnectError
+
+    err = ConnectError(
+        Code.UNKNOWN,
+        "failed to get data proxy client. Error: rpc error: code = Unavailable desc = no healthy cluster",
+    )
+    with (
+        mock.patch.object(_sentry, "init"),
+        mock.patch("sentry_sdk.is_initialized", return_value=True),
+        mock.patch("sentry_sdk.capture_exception") as capture_mock,
+        mock.patch("sentry_sdk.flush"),
+    ):
+        _sentry.capture_exception(err)
+    capture_mock.assert_called_once_with(err)
+
+
+def test_non_connect_endpoint_response_ignores_200_and_redirects():
+    """Only the 2xx-not-200 class is filtered; 200 and 3xx keep their existing handling."""
+    assert not _sentry._is_non_connect_endpoint_response(_wire_error_for_status(200))
+    assert not _sentry._is_non_connect_endpoint_response(_wire_error_for_status(302))
+
+
+def test_non_connect_endpoint_response_ignores_errors_carrying_details():
+    """A Connect JSON error body yields details; from_http_status never does."""
+    from connectrpc.code import Code
+    from connectrpc.errors import ConnectError
+    from flyteidl2.common import identity_pb2
+
+    err = ConnectError(Code.UNKNOWN, "No Content", details=[identity_pb2.Identity()])
+    assert not _sentry._is_non_connect_endpoint_response(err)


### PR DESCRIPTION
## What

`flyte run` and `flyte deploy` from a Windows host failed with `RuntimeSystemError: Upload failed for C:\Users\...\fast….tar.gz`, whose cause was a bare `ConnectError: No Content` — raised out of both `CreateUploadLocation` (`_data.py`) and `SelectCluster` (`controlplane.py`). Both were reported to Sentry as SDK crashes.

A Connect endpoint answers a unary POST with **200 + a Connect body**, or with an **error status + a Connect JSON body**. HTTP **204 is neither**. A *success* status that isn't 200 means the request never reached a Connect handler at all — a proxy, VPN appliance, captive portal, corporate TLS interceptor or misrouted ingress absorbed it and answered on the backend's behalf. That's endpoint/network configuration, not a Python-SDK logic bug, and the SDK can't recover from it.

This is the same rationale already applied to `UNIMPLEMENTED` in `_USER_ACTIONABLE_CONNECT_CODES` ("a raw HTTP 404 from the ingress … the endpoint config is wrong").

## Why the check looks the way it does

connectrpc maps only a handful of HTTP statuses onto Connect codes (401/403/404/429/502/503/504). Everything else falls through to `ConnectWireError.from_http_status`, which produces `Code.UNKNOWN`, **no details**, and the stdlib reason phrase as the *entire* message. The numeric status is dropped on the floor, so matching the phrase is the only way back to the status class.

## Deliberately narrow — and why that matters

HTTP 500 produces an **identically shaped** error: `Code.UNKNOWN`, no details, message `"Internal Server Error"`. Filtering on "message is a bare HTTP phrase" would therefore have silenced real backend signal, including **FLYTE-SDK-64 (276 events)**, 6S and 43. Only the 2xx class is unambiguously "an intermediary answered instead of the backend", so only it is filtered.

I checked this against the live corpus before writing the fix — every `ConnectError` across all 67 unresolved issues, and the only ones carrying a *2xx* phrase are 77 and 78. Genuine backend errors all carry verbose Go-style messages (`rpc error: code = … desc = …`), and the backend-collapses-code-into-UNKNOWN family (67/4T) is untouched.

Verified behaviour:

| response | code | message | filtered |
|---|---|---|---|
| 204 / 202 | UNKNOWN | `No Content` / `Accepted` | ✅ yes |
| 500 | UNKNOWN | `Internal Server Error` | ❌ no (real signal) |
| 302 | UNKNOWN | `Found` | ❌ no |
| 404 / 401 / 502 | UNIMPLEMENTED / UNAUTHENTICATED / UNAVAILABLE | — | ❌ no (already handled) |
| backend UNKNOWN + verbose msg | UNKNOWN | `rpc error: code = Unavailable desc = …` | ❌ no |

## Tests

10 new tests. 7 fail without the `_sentry.py` change; the two **regression guards** (500 and backend-UNKNOWN still reach Sentry) pass both before and after — that's the point of them. Full file: 55 passed.

## Follow-up not included here

Filtering stops the false crash report but the user still sees `ConnectError: No Content`, which is opaque. A clearer message ("the endpoint returned HTTP 204 with no Connect payload — something between this machine and `<endpoint>` intercepted the request") would need a chokepoint at the RPC boundary; kept out of this PR to keep it reviewable.

---

## Update: the same root cause via connectrpc's other rejection path (FLYTE-SDK-7A)

Added in a follow-up commit on this branch. connectrpc has a second way of saying "this is not a Connect response" — when the body's content-type cannot be decoded by the codec:

```
ConnectError(Code.UNKNOWN, "invalid content-type: 'text/html'; expecting 'application/proto'")
```

An HTML page where a protobuf body belongs means the same thing a 204 does: a proxy, login page or misrouted ingress answered instead of the backend. `_client_config.py` already draws exactly this conclusion for this exact signature when it comes back from the auth metadata fetch (#1235) — [FLYTE-SDK-7A](https://unionai.sentry.io/issues/?query=FLYTE-SDK-7A) and [FLYTE-SDK-6P](https://unionai.sentry.io/issues/?query=FLYTE-SDK-6P) are the same thing arriving on a data-plane call.

Kept as narrow as the status-class check: only `text/*` matches, so an `application/*` mismatch — which would point at a codec bug on our side — keeps reporting.

**Corpus check.** Following the same discipline as the 2xx discriminator, the predicate was tested against `events/latest` for *every* unresolved issue in the project. Exactly two match — 7A and 6P — and no backend-owned issue does. Worth calling out explicitly: FLYTE-SDK-3A and FLYTE-SDK-4K embed an **nginx HTML error page inside the message** and do *not* match, because the filter keys on connectrpc's own message shape rather than on any mention of HTML. There is a regression test pinning that.

Note 6P is nominally tracked by #1340; its latest event has since drifted to this content-type shape, so this is what would actually stop it firing. Left the `fixes` line to #1340 rather than claiming it from two PRs.

fixes FLYTE-SDK-77
fixes FLYTE-SDK-78
fixes FLYTE-SDK-7A
