### PR TITLE
fix: don't report to Sentry while a test is running (FLYTE-SDK-73)

### DIFF
--- a/src/flyte/_sentry.py
+++ b/src/flyte/_sentry.py
@@ -33,6 +33,26 @@ def _is_dev_mode() -> bool:
     return False
 
 
+def _is_test_run() -> bool:
+    """Skip Sentry while a pytest test is executing.
+
+    `_is_dev_mode` recognizes a working copy by the sibling `.git` directory and a
+    dev build by the version string. Neither survives a source tree copied into a
+    container without its `.git` and installed under a release version — and in
+    that setup the SDK's *own* test suite reports to the production DSN. That is
+    where FLYTE-SDK-73/74/75/76 came from: three runs of
+    tests/flyte/test_sentry.py, one issue per click exception it deliberately
+    raises (`Abort`, `Exit: 1`, `ClickException: docker daemon not running`), all
+    filed against release 2.2.3 — a version that predates the test file itself.
+
+    pytest sets PYTEST_CURRENT_TEST for the duration of each test's setup, call
+    and teardown, so this suppresses reports only while a test is actually
+    running. Synthetic exceptions raised by a test are never a crash worth
+    reporting, whether the suite is ours or a user's.
+    """
+    return bool(os.environ.get("PYTEST_CURRENT_TEST"))
+
+
 def _is_disabled() -> bool:
     return os.environ.get("FLYTE_DISABLE_SENTRY", "").lower() in ("true", "1", "yes")
 
@@ -43,7 +63,7 @@ def init() -> None:
         return
     _state["initialized"] = True
 
-    if _is_disabled() or _is_dev_mode():
+    if _is_disabled() or _is_dev_mode() or _is_test_run():
         return
 
     try:

--- a/src/flyte/_sentry.py
+++ b/src/flyte/_sentry.py
@@ -34,21 +34,8 @@ def _is_dev_mode() -> bool:
 
 
 def _is_test_run() -> bool:
-    """Skip Sentry while a pytest test is executing.
-
-    `_is_dev_mode` recognizes a working copy by the sibling `.git` directory and a
-    dev build by the version string. Neither survives a source tree copied into a
-    container without its `.git` and installed under a release version — and in
-    that setup the SDK's *own* test suite reports to the production DSN. That is
-    where FLYTE-SDK-73/74/75/76 came from: three runs of
-    tests/flyte/test_sentry.py, one issue per click exception it deliberately
-    raises (`Abort`, `Exit: 1`, `ClickException: docker daemon not running`), all
-    filed against release 2.2.3 — a version that predates the test file itself.
-
-    pytest sets PYTEST_CURRENT_TEST for the duration of each test's setup, call
-    and teardown, so this suppresses reports only while a test is actually
-    running. Synthetic exceptions raised by a test are never a crash worth
-    reporting, whether the suite is ours or a user's.
+    """
+    Skip Sentry while a pytest test is executing.
     """
     return bool(os.environ.get("PYTEST_CURRENT_TEST"))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ def _never_report_tests_to_sentry():
 
     flyte._sentry already skips a pytest run, but that relies on PYTEST_CURRENT_TEST,
     which is unset while modules are being imported/collected. Setting the opt-out
-    env var for the whole session closes that window too (FLYTE-SDK-73/74/75/76).
+    env var for the whole session closes that window too.
     """
     os.environ["FLYTE_DISABLE_SENTRY"] = "true"
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,18 @@ from flyte.models import ActionID, RawDataPath, SerializationContext, TaskContex
 from flyte.report import Report
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _never_report_tests_to_sentry():
+    """Belt-and-braces guard so the suite can never reach the production Sentry DSN.
+
+    flyte._sentry already skips a pytest run, but that relies on PYTEST_CURRENT_TEST,
+    which is unset while modules are being imported/collected. Setting the opt-out
+    env var for the whole session closes that window too (FLYTE-SDK-73/74/75/76).
+    """
+    os.environ["FLYTE_DISABLE_SENTRY"] = "true"
+    yield
+
+
 @pytest.fixture
 def ctx_with_test_raw_data_path():
     """Pytest fixture to set a RawDataPath in the internal_ctx."""

--- a/tests/flyte/test_sentry.py
+++ b/tests/flyte/test_sentry.py
@@ -608,3 +608,40 @@ def test_track_operation_tags_error_code_when_present():
             with _sentry.track_operation("create_run"):
                 raise RuntimeSystemError("RunCreationError", "Failed to create run")
     assert count_mock.call_args.kwargs["tags"]["error_code"] == "RunCreationError"
+
+
+# --- FLYTE-SDK-73/74/75/76: the SDK's own test suite reported to production Sentry ---
+
+
+def test_is_test_run_detects_pytest():
+    assert _sentry._is_test_run()
+
+
+def test_is_test_run_false_without_pytest_env(monkeypatch):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    assert not _sentry._is_test_run()
+
+
+def test_init_skips_while_running_under_pytest():
+    """A source copy with no .git and a release version must still not report."""
+    with (
+        mock.patch.dict(_sentry._state, {"initialized": False}),
+        mock.patch.object(_sentry, "_is_dev_mode", return_value=False),
+        mock.patch.object(_sentry, "_is_disabled", return_value=False),
+        mock.patch("sentry_sdk.init") as sdk_init,
+    ):
+        _sentry.init()
+    sdk_init.assert_not_called()
+
+
+def test_init_still_reports_outside_a_test_run(monkeypatch):
+    """Guard: the skip is scoped to test execution, not a blanket disable."""
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    with (
+        mock.patch.dict(_sentry._state, {"initialized": False}),
+        mock.patch.object(_sentry, "_is_dev_mode", return_value=False),
+        mock.patch.object(_sentry, "_is_disabled", return_value=False),
+        mock.patch("sentry_sdk.init") as sdk_init,
+    ):
+        _sentry.init()
+    sdk_init.assert_called_once()

--- a/tests/flyte/test_sentry.py
+++ b/tests/flyte/test_sentry.py
@@ -610,8 +610,6 @@ def test_track_operation_tags_error_code_when_present():
     assert count_mock.call_args.kwargs["tags"]["error_code"] == "RunCreationError"
 
 
-# --- FLYTE-SDK-73/74/75/76: the SDK's own test suite reported to production Sentry ---
-
 
 def test_is_test_run_detects_pytest():
     assert _sentry._is_test_run()

--- a/tests/flyte/test_sentry.py
+++ b/tests/flyte/test_sentry.py
@@ -610,7 +610,6 @@ def test_track_operation_tags_error_code_when_present():
     assert count_mock.call_args.kwargs["tags"]["error_code"] == "RunCreationError"
 
 
-
 def test_is_test_run_detects_pytest():
     assert _sentry._is_test_run()
 


### PR DESCRIPTION
## What

Four issues filed today — **FLYTE-SDK-73** (`ClickException: docker daemon not running`), **74** and **75** (`Abort`), **76** (`Exit: 1`) — are not user crashes. They are **our own test suite**.

One issue per click exception that `tests/flyte/test_sentry.py` deliberately raises, three events each from three runs, and 74's stack is literally `_sentry.py:wrapper` ← `tests/flyte/test_sentry.py:fn`.

## How they escaped

They were filed against **release 2.2.3 — a version that predates the test file itself** (it arrived with #1039). That mismatch is the tell: the reporting environment is a source tree copied **without its `.git`** and installed under a release version string.

`_is_dev_mode()` recognizes a working copy only by the sibling `.git` directory, and a dev build only by `"dev"` in the version. In that setup neither guard fires, so the suite reports to the **production DSN**. Nothing else stood in the way — there was no opt-out in `tests/conftest.py` either (I grepped; there is no `FLYTE_DISABLE_SENTRY` anywhere in the repo outside `_sentry.py`).

Reproduced on main: with `_is_dev_mode` forced False, `sentry_sdk.init` is called mid-test with the real DSN.

## Fix — two layers

1. **`_is_test_run()`** skips initialization while `PYTEST_CURRENT_TEST` is set. pytest sets it for each test's setup/call/teardown, so this is scoped to test *execution* rather than a blanket disable. A synthetic exception raised by a test is never a crash worth reporting — ours or a user's.
2. **A session-scoped autouse fixture** in `tests/conftest.py` sets `FLYTE_DISABLE_SENTRY`, closing the import/collection window where `PYTEST_CURRENT_TEST` is not yet set.

Layer 2 alone would fix our suite; layer 1 also covers a source copy run any other way, which is what actually happened here.

## Tests

`test_init_skips_while_running_under_pytest` fails on main (init called with the production DSN). `test_init_still_reports_outside_a_test_run` is a guard pinning that the skip stays scoped and doesn't silently disable reporting generally.

Full suite: `tests/flyte` → 3513 passed. The 10 failures are pre-existing — I re-ran them on clean `origin/main` and got the identical 10 (roundtrip/int_image_builder/keyring/code_bundle, all environment-dependent in my sandbox).

fixes FLYTE-SDK-73
fixes FLYTE-SDK-74
fixes FLYTE-SDK-75
fixes FLYTE-SDK-76