### PR TITLE
feat: install ms-python.debugpy and bump code-server/extensions

### DIFF
--- a/examples/plugins/spark_example.py
+++ b/examples/plugins/spark_example.py
@@ -1,4 +1,3 @@
-# # Spark Example
 import random
 from copy import deepcopy
 from operator import add
@@ -16,11 +15,13 @@ image = (
         extendable=True,
         platform=("linux/amd64", "linux/arm64"),
     )
-    .with_pip_packages("flyteplugins-spark>=2.5.0")
+    .with_pip_packages("flyteplugins-spark>=2.5.18")
 )
 
 task_env = flyte.TaskEnvironment(
-    name="get_pi", resources=flyte.Resources(cpu=(1, 2), memory=("400Mi", "1000Mi")), image=image
+    name="get_pi",
+    resources=flyte.Resources(cpu=(1, 2), memory=("400Mi", "1000Mi")),
+    image=image,
 )
 
 spark_conf = Spark(
@@ -29,7 +30,7 @@ spark_conf = Spark(
         "spark.executor.memory": "1000M",
         "spark.executor.cores": "1",
         "spark.executor.instances": "2",
-        "spark.driver.cores": "1",
+        "spark.driver.cores": "3",
         "spark.kubernetes.file.upload.path": "/opt/spark/work-dir",
         "spark.jars": "https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop3-latest.jar,https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.2.2/hadoop-aws-3.2.2.jar,https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar",
     },
@@ -37,9 +38,10 @@ spark_conf = Spark(
 
 spark_env = flyte.TaskEnvironment(
     name="spark_env",
-    resources=flyte.Resources(cpu=(1, 2), memory=("3000Mi", "5000Mi")),
+    resources=flyte.Resources(cpu=(3, 5), memory=("3000Mi", "5000Mi")),
     plugin_config=spark_conf,
     image=image,
+    env_vars={"HOME": "/opt/spark/work-dir"},
     depends_on=[task_env],
 )
 

--- a/src/flyte/_debug/constants.py
+++ b/src/flyte/_debug/constants.py
@@ -7,12 +7,20 @@ DOWNLOAD_DIR = Path.cwd() / ".code-server"
 HOURS_TO_SECONDS = 60 * 60
 DEFAULT_UP_SECONDS = 10 * HOURS_TO_SECONDS  # 10 hours
 DEFAULT_CODE_SERVER_REMOTE_PATHS = {
-    "amd64": "https://github.com/coder/code-server/releases/download/v4.106.3/code-server-4.106.3-linux-amd64.tar.gz",
-    "arm64": "https://github.com/coder/code-server/releases/download/v4.106.3/code-server-4.106.3-linux-arm64.tar.gz",
+    "amd64": "https://github.com/coder/code-server/releases/download/v4.132.0/code-server-4.132.0-linux-amd64.tar.gz",
+    "arm64": "https://github.com/coder/code-server/releases/download/v4.132.0/code-server-4.132.0-linux-arm64.tar.gz",
 }
 DEFAULT_CODE_SERVER_EXTENSIONS = [
-    "https://raw.githubusercontent.com/flyteorg/flytetools/master/flytekitplugins/flyin/ms-python.python-2023.20.0.vsix",
+    "https://open-vsx.org/api/ms-python/python/2026.4.0/file/ms-python.python-2026.4.0.vsix",
 ]
+
+# ms-python.debugpy ships the "debugpy" debug type that the generated launch.json uses; without it
+# the debug configs are unusable. Its vsix is platform-specific, so it is resolved per-arch at runtime.
+DEBUGPY_EXTENSION_VERSION = "2026.6.0"
+DEBUGPY_EXTENSION_URL = (
+    "https://open-vsx.org/api/ms-python/debugpy/{target}/{version}/file/ms-python.debugpy-{version}@{target}.vsix"
+)
+DEBUGPY_TARGET_PLATFORMS = {"x86_64": "linux-x64", "aarch64": "linux-arm64"}
 
 # Duration to pause the checking of the heartbeat file until the next one
 HEARTBEAT_CHECK_SECONDS = 60

--- a/src/flyte/_debug/vscode.py
+++ b/src/flyte/_debug/vscode.py
@@ -17,6 +17,9 @@ import httpx
 
 from flyte import storage
 from flyte._debug.constants import (
+    DEBUGPY_EXTENSION_URL,
+    DEBUGPY_EXTENSION_VERSION,
+    DEBUGPY_TARGET_PLATFORMS,
     DEFAULT_CODE_SERVER_EXTENSIONS,
     DEFAULT_CODE_SERVER_REMOTE_PATHS,
     DOWNLOAD_DIR,
@@ -63,11 +66,23 @@ async def download_file(url: str, target_dir: str) -> str:
         raise RuntimeError(f"An unexpected error occurred: {e}")
 
 
+def get_debugpy_extension() -> List[str]:
+    """
+    Returns the ms-python.debugpy vsix url for this machine's architecture, or an empty list if the
+    architecture has no published build (the vsix is platform-specific).
+    """
+    target = DEBUGPY_TARGET_PLATFORMS.get(platform.machine())
+    if target is None:
+        logger.warning(f"No ms-python.debugpy build for machine type {platform.machine()}, skipping it.")
+        return []
+    return [DEBUGPY_EXTENSION_URL.format(target=target, version=DEBUGPY_EXTENSION_VERSION)]
+
+
 def get_default_extensions() -> List[str]:
     extensions = os.getenv("_F_CS_E")
     if extensions is not None:
         return extensions.split(",")
-    return DEFAULT_CODE_SERVER_EXTENSIONS
+    return [*DEFAULT_CODE_SERVER_EXTENSIONS, *get_debugpy_extension()]
 
 
 def get_code_server_info() -> str:

--- a/tests/flyte/test_debug.py
+++ b/tests/flyte/test_debug.py
@@ -278,3 +278,33 @@ async def test_start_vscode_server_pins_port_env_with_picklable_target():
     assert f"--bind-addr 0.0.0.0:{VSCODE_PORT}" in kwargs["kwargs"]["cmd"]
     # The target must be picklable (lambdas are not) so the spawn/forkserver start methods work.
     pickle.dumps(kwargs["target"])
+
+
+# ---------------------------------------------------------------------------
+# Default extensions include the debugpy extension the launch.json depends on
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultExtensions:
+    def test_debugpy_included_per_arch(self, monkeypatch):
+        from flyte._debug import vscode
+
+        monkeypatch.delenv("_F_CS_E", raising=False)
+        for machine, target in (("x86_64", "linux-x64"), ("aarch64", "linux-arm64")):
+            monkeypatch.setattr(vscode.platform, "machine", lambda m=machine: m)
+            extensions = vscode.get_default_extensions()
+            assert any("ms-python.python" in e for e in extensions)
+            assert any("ms-python.debugpy" in e and target in e for e in extensions)
+
+    def test_debugpy_skipped_on_unsupported_arch(self, monkeypatch):
+        from flyte._debug import vscode
+
+        monkeypatch.delenv("_F_CS_E", raising=False)
+        monkeypatch.setattr(vscode.platform, "machine", lambda: "riscv64")
+        assert vscode.get_default_extensions() == list(vscode.DEFAULT_CODE_SERVER_EXTENSIONS)
+
+    def test_env_var_overrides_defaults(self, monkeypatch):
+        from flyte._debug import vscode
+
+        monkeypatch.setenv("_F_CS_E", "a.vsix,b.vsix")
+        assert vscode.get_default_extensions() == ["a.vsix", "b.vsix"]


### PR DESCRIPTION
The `launch.json` generated for interactive debugging uses `"type": "debugpy"`, which is provided by the separate **ms-python.debugpy** extension. That extension was never in the default list, so the generated debug configurations were unusable.

## Changes

- **Install `ms-python.debugpy`** alongside `ms-python.python` before the vscode server starts. Its vsix is platform-specific, so the URL is resolved per-arch (`linux-x64` / `linux-arm64`); an unsupported arch logs a warning and skips it rather than failing the task. `_F_CS_E` still overrides the whole list.
- **code-server** `4.106.3` → `4.132.0` (Code 1.132.0).
- **ms-python.python** `2023.20.0` → `2026.4.0`, sourced from open-vsx instead of the `flyteorg/flytetools` mirror — both extensions now come from the same place, so bumping is a version-string edit.
- **spark example**: set `HOME` to the spark work dir. The spark image runs as a uid with no home directory, so `~` resolves to `/` and code-server dies with `EACCES: permission denied, mkdir '/.config'` while installing extensions. Also includes minor driver/executor resource tweaks from testing.

Engine check: code-server 4.132.0 = Code 1.132.0, above both `^1.95.0` (python) and `^1.92.0` (debugpy). All pinned vsix/tarball URLs were confirmed to resolve.

## Tests

`TestDefaultExtensions` in `tests/flyte/test_debug.py` covers the per-arch URL, the unsupported-arch skip, and the `_F_CS_E` override. `uv run pytest tests/flyte/test_debug.py` — 26 passed.

Not yet exercised end-to-end on a cluster; worth one manual debug session before merge.

https://claude.ai/code/session_01Sbi3ptp7Siz8FR73SNFUzP