### PR TITLE
Install code-server extensions in one invocation to avoid EEXIST race

### DIFF
--- a/src/flyte/_debug/vscode.py
+++ b/src/flyte/_debug/vscode.py
@@ -179,12 +179,24 @@ async def download_vscode():
             coros.append(download_file(extension, str(DOWNLOAD_DIR)))
     extension_paths = await asyncio.gather(*coros)
 
-    coros = []
-    for p in extension_paths:
-        logger.info(f"Execute extension installation command to install extension {p}")
-        coros.append(execute_command(f"code-server --install-extension {p}"))
+    await install_extensions(extension_paths)
 
-    await asyncio.gather(*coros)
+
+async def install_extensions(extension_paths: List[str]) -> None:
+    """
+    Install all downloaded extensions with a single code-server invocation.
+
+    Installs must not run as concurrent code-server processes: extensions that share a
+    dependency (e.g. ms-python.python and ms-python.debugpy both depend on
+    ms-python.vscode-python-envs) each download and extract it into the shared extensions
+    directory, and the losing process dies on the EEXIST rename of the dependency's final
+    directory.
+    """
+    if not extension_paths:
+        return
+    args = " ".join(f"--install-extension {p}" for p in extension_paths)
+    logger.info(f"Execute extension installation command to install extensions {extension_paths}")
+    await execute_command(f"code-server {args}")
 
 
 def prepare_launch_json(ctx: click.Context, pid: int):

--- a/tests/flyte/test_debug.py
+++ b/tests/flyte/test_debug.py
@@ -308,3 +308,31 @@ class TestDefaultExtensions:
 
         monkeypatch.setenv("_F_CS_E", "a.vsix,b.vsix")
         assert vscode.get_default_extensions() == ["a.vsix", "b.vsix"]
+
+
+# ---------------------------------------------------------------------------
+# Extension installs run as a single code-server invocation (no concurrent
+# processes racing on shared-dependency extraction)
+# ---------------------------------------------------------------------------
+
+
+class TestInstallExtensions:
+    @pytest.mark.asyncio
+    async def test_single_invocation_for_all_extensions(self):
+        from flyte._debug import vscode
+
+        with patch.object(vscode, "execute_command", AsyncMock()) as mock_exec:
+            await vscode.install_extensions(["/tmp/a.vsix", "/tmp/b.vsix"])
+
+        mock_exec.assert_awaited_once_with(
+            "code-server --install-extension /tmp/a.vsix --install-extension /tmp/b.vsix"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_extensions_no_invocation(self):
+        from flyte._debug import vscode
+
+        with patch.object(vscode, "execute_command", AsyncMock()) as mock_exec:
+            await vscode.install_extensions([])
+
+        mock_exec.assert_not_awaited()


### PR DESCRIPTION
## What

Fixes a flaky debug-mode startup failure where `code-server --install-extension` dies with:

```
EEXIST: file already exists, rename '.../.<uuid>' -> '.../ms-python.vscode-python-envs-1.36.0-universal'
```

aborting the vscode debug server before it comes up.

## Why

`download_vscode()` installed each downloaded extension in a **concurrent** `code-server --install-extension` process via `asyncio.gather`. Both `ms-python.python` and `ms-python.debugpy` depend on `ms-python.vscode-python-envs`, so each process independently downloads and extracts that dependency into the shared extensions directory; whichever process loses the rename of its temp dir onto the dependency's final directory exits non-zero, and `execute_command` raises, killing debug-mode startup.

## How

Extension **downloads** stay parallel. The **install** step now goes through a new `install_extensions()` helper that passes every vsix to a single invocation (`code-server --install-extension a.vsix --install-extension b.vsix`), so one process handles dependency extraction exactly once.

## Testing

New tests assert all extensions are installed via one `execute_command` call and that an empty extension list makes no invocation. Full `test_debug.py` + `test_ssh_debug.py` suites pass (46 tests); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)