### PR TITLE
fix(auth): fail fast instead of interactive PKCE inside task pods

### DIFF
--- a/src/flyte/_internal/controllers/remote/_core.py
+++ b/src/flyte/_internal/controllers/remote/_core.py
@@ -570,7 +570,10 @@ class Controller:
                     logger.warning(f"[{worker_id}] Retrying action {action.name} after backoff")
                     await self._shared_queue.put(action)
             except Exception as e:
-                logger.error(f"[{worker_id}] Error in controller loop for {action.name}: {e}")
+                # exc_info: the wrapped cause (e.g. an OSError from deep inside the launch
+                # path) is not serialized into the action error event, so the traceback
+                # logged here is the only place the true origin is recorded.
+                logger.error(f"[{worker_id}] Error in controller loop for {action.name}: {e}", exc_info=True)
                 if isinstance(e, flyte.errors.SlowDownError):
                     reason = f"retries {action.retries} / {self._max_retries} exhausted"
                 else:

--- a/src/flyte/remote/_client/auth/_authenticators/pkce.py
+++ b/src/flyte/remote/_client/auth/_authenticators/pkce.py
@@ -22,7 +22,7 @@ from flyte._logging import logger
 from flyte.remote._client.auth._authenticators.base import Authenticator
 from flyte.remote._client.auth._default_html import get_default_success_html
 from flyte.remote._client.auth._keyring import Credentials
-from flyte.remote._client.auth.errors import AccessTokenNotFoundError
+from flyte.remote._client.auth.errors import AccessTokenNotFoundError, AuthenticationError
 
 _utf_8 = "utf-8"
 _code_verifier_length = 64
@@ -334,6 +334,20 @@ class AuthorizationClient(object):
         Raises:
             Exception: Authentication-related exceptions if the flow fails.
         """
+        # Interactive browser auth is impossible inside a task pod: there is no browser to
+        # complete the redirect, and the callback server binds the platform-wide fixed
+        # redirect-URI port on localhost — concurrent attempts (e.g. several controller
+        # workers, or Ray drivers sharing a node) collide with EADDRINUSE. Fail fast with an
+        # actionable message instead (historically this surfaced as
+        # "OSError: [Errno 98] address already in use" on the redirect port).
+        if os.getenv("ACTION_NAME") or os.getenv("RUN_NAME"):
+            raise AuthenticationError(
+                "No API credentials available inside the task environment: interactive "
+                "browser (PKCE) authentication cannot run in a cluster pod. This usually "
+                "means the platform API key (_UNION_EAGER_API_KEY) was not injected into "
+                "this pod's environment."
+            )
+
         # In the absence of globally-set token values, initiate the token request flow
         with self._lock:
             # Clear cache if it's been more than 60 seconds since the last check

--- a/tests/flyte/internal/test_pkce_in_cluster_guard.py
+++ b/tests/flyte/internal/test_pkce_in_cluster_guard.py
@@ -1,0 +1,13 @@
+import pytest
+
+from flyte.remote._client.auth._authenticators.pkce import AuthorizationClient
+from flyte.remote._client.auth.errors import AuthenticationError
+
+
+@pytest.mark.asyncio
+async def test_pkce_refuses_to_run_in_cluster(monkeypatch):
+    """In-cluster task pods must fail fast instead of binding the OAuth callback port."""
+    monkeypatch.setenv("ACTION_NAME", "a0")
+    client = AuthorizationClient.__new__(AuthorizationClient)  # skip __init__: the guard fires first
+    with pytest.raises(AuthenticationError, match="cannot run in a cluster pod"):
+        await client.get_creds_from_remote()


### PR DESCRIPTION
## Why

Root-caused from Ray runs failing with `Controller failed for action … (non-retryable OSError): [Errno 98] address already in use` on port 53593: a keyless task pod (missing `_UNION_EAGER_API_KEY`) falls back to **interactive PKCE browser auth**, whose callback server binds the platform-wide fixed redirect-URI port (`http://localhost:53593/callback`). In a pod that can never succeed — no browser will complete the redirect — and when several controller workers (or Ray drivers sharing a node) attempt it concurrently, all but the first crash on the port bind. The credential-injection gap itself is fixed platform-side (unionai/cloud#17605); this PR makes the SDK fail loud and clear if it ever recurs.

## Changes

- `AuthorizationClient.get_creds_from_remote`: raise `AuthenticationError` ("No API credentials available inside the task environment … cannot run in a cluster pod") when task-pod env markers (`ACTION_NAME`/`RUN_NAME`) are present, before any port is bound.
- Controller worker loop: log failures with `exc_info` — the action error event doesn't serialize the cause chain, so the pod log is the only place the true origin (e.g. the PKCE bind) is recorded.
- Unit test for the in-cluster guard.