### PR TITLE
fix: omit empty main tab from report

### DIFF
--- a/src/flyte/report/_report.py
+++ b/src/flyte/report/_report.py
@@ -97,7 +97,8 @@ class Report:
         Returns:
             The final report.
         """
-        tabs = {n: t.get_html() for n, t in self.tabs.items()}
+        # "main" is always created in __post_init__; don't render a nav entry for it if nothing was logged there.
+        tabs = {n: t.get_html() for n, t in self.tabs.items() if t.content or n != _MAIN_TAB_NAME}
         nav_htmls = []
         body_htmls = []
 

--- a/tests/flyte/report/test_report.py
+++ b/tests/flyte/report/test_report.py
@@ -71,6 +71,13 @@ def test_get_final_report(report):
     assert "New tab content" in final_report
 
 
+def test_empty_main_tab_is_omitted(report):
+    get_tab("new_tab").log("New tab content")
+    final_report = report.get_final_report()
+    assert "New tab content" in final_report
+    assert ">main<" not in final_report
+
+
 @patch("flyte._internal.runtime.io.report_path")
 @patch("flyte.storage.put_stream", new_callable=AsyncMock)
 def test_flush_saves_report(mock_put_stream, mock_report_path, report):


### PR DESCRIPTION
## Why

`Report.__post_init__` always creates the `main` tab, so a report that only logs to named tabs still rendered an empty `main` nav entry in the UI.

<img width="1304" height="682" alt="Screenshot 2026-08-11 at 10 08 52 PM" src="https://github.com/user-attachments/assets/159aae40-0f5b-4f48-be0a-e733a8ae988b" />



## What

`get_final_report` now skips the `main` tab when nothing was logged to it. Other (user-created) tabs are rendered as before, even if empty.

## Test

Added `test_empty_main_tab_is_omitted`; `tests/flyte/report/test_report.py` passes (12 tests).

https://claude.ai/code/session_01Sbi3ptp7Siz8FR73SNFUzP