### PR TITLE
fix: make flyte start devbox work on Windows (FLYTE-SDK-79, FLYTE-SDK-7B)

### DIFF
--- a/src/flyte/cli/_devbox.py
+++ b/src/flyte/cli/_devbox.py
@@ -5,6 +5,7 @@ import json
 import os
 import shutil
 import subprocess
+import tempfile
 import time
 import urllib.error
 import urllib.request
@@ -22,9 +23,10 @@ from flyte import _sentry
 
 _CONTAINER_NAME = "flyte-devbox"
 _VOLUME_NAME = "flyte-devbox"
-_KUBE_DIR = Path(
-    "/tmp/.kube"
-)  # This path is used to store k3s kubeconfig file, we later merge it with the default kubeconfig
+# This path is used to store the k3s kubeconfig file, we later merge it with the default kubeconfig.
+# Use the platform temp directory rather than a hardcoded "/tmp": on Windows there is no /tmp, and
+# Path("/tmp/.kube") becomes the drive-relative "\tmp\.kube", which mkdir rejects outright.
+_KUBE_DIR = Path(tempfile.gettempdir()) / ".kube"
 _KUBECONFIG_PATH = _KUBE_DIR / "kubeconfig"
 _FLYTE_DEVBOX_CONFIG_DIR = Path.home() / ".flyte" / "devbox"
 _PORTS = ["6443:6443", "30000:30000", "30001:30001", "30002:30002", "30003:30003", "30080:30080", "30081:30081"]
@@ -216,7 +218,9 @@ def _switch_k8s_context(context: str = "flyte-devbox", namespace: str = "flyte")
 def _flatten_kubeconfig(default_kubeconfig: Path, kubeconfig_path: Path) -> subprocess.CompletedProcess:
     env = os.environ.copy()
     if default_kubeconfig.exists():
-        env["KUBECONFIG"] = f"{kubeconfig_path}:{default_kubeconfig}"
+        # kubectl splits KUBECONFIG on the platform path separator -- ";" on Windows, where a
+        # hardcoded ":" would instead split "C:\..." on its drive letter and fail to load either file.
+        env["KUBECONFIG"] = os.pathsep.join([str(kubeconfig_path), str(default_kubeconfig)])
     else:
         env["KUBECONFIG"] = str(kubeconfig_path)
     return subprocess.run(
@@ -228,9 +232,21 @@ def _flatten_kubeconfig(default_kubeconfig: Path, kubeconfig_path: Path) -> subp
     )
 
 
-def _merge_kubeconfig(kubeconfig_path: Path, container_name: str) -> None:
-    import tempfile
+def _kubeconfig_merge_error(exc: BaseException) -> click.ClickException:
+    """Translate a failure to read/flatten the kubeconfig into a user-facing message."""
+    if isinstance(exc, subprocess.CalledProcessError):
+        details = (exc.stderr or exc.stdout or "").strip()
+    else:
+        details = str(exc).strip()
+    message = (
+        "Failed to merge the devbox kubeconfig into your default kubeconfig "
+        "(`kubectl config view --flatten`). The devbox cluster is running; "
+        "re-run `flyte start devbox` once kubectl can read both files."
+    )
+    return click.ClickException(f"{message}\n{details}" if details else message)
 
+
+def _merge_kubeconfig(kubeconfig_path: Path, container_name: str) -> None:
     if not _is_kubectl_installed():
         console.print(
             "[red]Warning: kubectl is not installed or not on PATH. Skipping kubeconfig merge. "
@@ -243,16 +259,25 @@ def _merge_kubeconfig(kubeconfig_path: Path, container_name: str) -> None:
 
     try:
         result = _flatten_kubeconfig(default_kubeconfig, kubeconfig_path)
-    except (PermissionError, subprocess.CalledProcessError):
+    except (PermissionError, subprocess.CalledProcessError) as e:
         # On Linux bind mounts, the in-container kubeconfig lands root-owned on
         # the host; kubectl then exits non-zero (CalledProcessError) rather than
-        # Python raising PermissionError on open.
+        # Python raising PermissionError on open. Re-owning it to the calling user
+        # only means something where POSIX uids exist -- os.getuid is absent on
+        # Windows, so surface the original kubectl failure instead of crashing on it.
+        if not hasattr(os, "getuid"):
+            raise _kubeconfig_merge_error(e) from e
         uid, gid = os.getuid(), os.getgid()
-        subprocess.run(
-            ["docker", "exec", container_name, "chown", f"{uid}:{gid}", "/.kube/kubeconfig"],
-            check=True,
-        )
-        result = _flatten_kubeconfig(default_kubeconfig, kubeconfig_path)
+        try:
+            subprocess.run(
+                ["docker", "exec", container_name, "chown", f"{uid}:{gid}", "/.kube/kubeconfig"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            result = _flatten_kubeconfig(default_kubeconfig, kubeconfig_path)
+        except (PermissionError, subprocess.CalledProcessError) as retry_err:
+            raise _kubeconfig_merge_error(retry_err) from retry_err
 
     with tempfile.NamedTemporaryFile("w", delete=False, suffix=".yaml") as tmp:
         tmp.write(result.stdout)

--- a/tests/cli/test_devbox.py
+++ b/tests/cli/test_devbox.py
@@ -3,17 +3,24 @@ Unit tests for flyte.cli._devbox.
 
 Covers the `--gpu` plumbing on `flyte start devbox`, the kubeconfig chown-retry
 fallback when kubectl fails to read a root-owned kubeconfig on Linux bind mounts,
-and the status snapshot behind `flyte get devbox`.
+the status snapshot behind `flyte get devbox`, and the platform assumptions
+(POSIX temp dir, path separator, uids) that broke `flyte start devbox` on Windows.
 """
 
+import os
 import subprocess
+import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import click
 import pytest
 from click.testing import CliRunner
 
 from flyte.cli._devbox import (
+    _KUBE_DIR,
+    _KUBECONFIG_PATH,
+    _flatten_kubeconfig,
     _is_kubectl_installed,
     _merge_kubeconfig,
     _run_container,
@@ -143,8 +150,9 @@ class TestMergeKubeconfigRetry:
             assert mock_flatten.call_count == 2
             assert mock_run.call_count == 1
 
-    def test_second_flatten_failure_propagates(self, tmp_path):
-        """If kubectl still fails after the chown, we should not swallow the error."""
+    def test_second_flatten_failure_surfaces_as_click_exception(self, tmp_path):
+        """If kubectl still fails after the chown, the user gets a readable CLI error
+        rather than a raw CalledProcessError traceback."""
         kubeconfig = tmp_path / "kubeconfig"
         kubeconfig.write_text("")
 
@@ -153,11 +161,106 @@ class TestMergeKubeconfigRetry:
             patch("flyte.cli._devbox.subprocess.run"),
             patch("flyte.cli._devbox.Path.home", return_value=tmp_path),
         ):
-            err = subprocess.CalledProcessError(1, ["kubectl"])
+            err = subprocess.CalledProcessError(1, ["kubectl"], stderr="error loading config file")
             mock_flatten.side_effect = [err, err]
 
-            with pytest.raises(subprocess.CalledProcessError):
+            with pytest.raises(click.ClickException) as exc_info:
                 _merge_kubeconfig(kubeconfig, "flyte-devbox")
+
+            assert "error loading config file" in str(exc_info.value)
+
+    def test_chown_failure_surfaces_as_click_exception(self, tmp_path):
+        """A failing `docker exec ... chown` must not escape as a raw CalledProcessError."""
+        kubeconfig = tmp_path / "kubeconfig"
+        kubeconfig.write_text("")
+
+        with (
+            patch("flyte.cli._devbox._flatten_kubeconfig") as mock_flatten,
+            patch("flyte.cli._devbox.subprocess.run") as mock_run,
+            patch("flyte.cli._devbox.Path.home", return_value=tmp_path),
+        ):
+            mock_flatten.side_effect = subprocess.CalledProcessError(1, ["kubectl"])
+            mock_run.side_effect = subprocess.CalledProcessError(
+                1, ["docker", "exec"], stderr="No such container: flyte-devbox"
+            )
+
+            with pytest.raises(click.ClickException) as exc_info:
+                _merge_kubeconfig(kubeconfig, "flyte-devbox")
+
+            assert "No such container" in str(exc_info.value)
+
+
+class TestMergeKubeconfigWindows:
+    """`os.getuid`/`os.getgid` do not exist on Windows. The chown fallback must not be
+    attempted there -- reaching for them turned a kubectl failure into an
+    `AttributeError: module 'os' has no attribute 'getuid'`."""
+
+    def test_missing_getuid_reports_original_kubectl_failure(self, tmp_path, monkeypatch):
+        kubeconfig = tmp_path / "kubeconfig"
+        kubeconfig.write_text("")
+
+        monkeypatch.delattr(os, "getuid", raising=False)
+
+        with (
+            patch("flyte.cli._devbox._flatten_kubeconfig") as mock_flatten,
+            patch("flyte.cli._devbox.subprocess.run") as mock_run,
+            patch("flyte.cli._devbox.Path.home", return_value=tmp_path),
+        ):
+            mock_flatten.side_effect = subprocess.CalledProcessError(1, ["kubectl"], stderr="error loading config file")
+
+            with pytest.raises(click.ClickException) as exc_info:
+                _merge_kubeconfig(kubeconfig, "flyte-devbox")
+
+            # The original kubectl error is what the user needs to see.
+            assert "error loading config file" in str(exc_info.value)
+            # No chown is attempted, and no second flatten.
+            mock_run.assert_not_called()
+            assert mock_flatten.call_count == 1
+
+
+class TestFlattenKubeconfigEnv:
+    """KUBECONFIG is a path *list*; kubectl splits it on the platform separator."""
+
+    def test_kubeconfig_list_uses_platform_path_separator(self, tmp_path, monkeypatch):
+        devbox_kubeconfig = tmp_path / "devbox" / "kubeconfig"
+        devbox_kubeconfig.parent.mkdir()
+        devbox_kubeconfig.write_text("")
+        default_kubeconfig = tmp_path / "config"
+        default_kubeconfig.write_text("")
+
+        # Emulate Windows, where the separator is ";" -- the hardcoded ":" produced a
+        # KUBECONFIG that kubectl split on the drive letter of "C:\...".
+        monkeypatch.setattr(os, "pathsep", ";")
+
+        with patch("flyte.cli._devbox.subprocess.run") as mock_run:
+            _flatten_kubeconfig(default_kubeconfig, devbox_kubeconfig)
+
+        env = mock_run.call_args.kwargs["env"]
+        assert env["KUBECONFIG"] == f"{devbox_kubeconfig};{default_kubeconfig}"
+        assert env["KUBECONFIG"].split(";") == [str(devbox_kubeconfig), str(default_kubeconfig)]
+
+    def test_single_kubeconfig_has_no_separator(self, tmp_path):
+        devbox_kubeconfig = tmp_path / "kubeconfig"
+        devbox_kubeconfig.write_text("")
+        default_kubeconfig = tmp_path / "does-not-exist"
+
+        with patch("flyte.cli._devbox.subprocess.run") as mock_run:
+            _flatten_kubeconfig(default_kubeconfig, devbox_kubeconfig)
+
+        assert mock_run.call_args.kwargs["env"]["KUBECONFIG"] == str(devbox_kubeconfig)
+
+
+class TestKubeDirLocation:
+    """The devbox kubeconfig directory must be a real path on every platform.
+    A hardcoded "/tmp/.kube" becomes the drive-relative "\\tmp\\.kube" on Windows,
+    which `mkdir` rejects with WinError 123."""
+
+    def test_kube_dir_is_under_the_platform_temp_dir(self):
+        assert _KUBE_DIR.parent == Path(tempfile.gettempdir())
+        assert _KUBE_DIR.name == ".kube"
+
+    def test_kubeconfig_path_is_inside_kube_dir(self):
+        assert _KUBECONFIG_PATH.parent == _KUBE_DIR
 
 
 class TestIsKubectlInstalled:


### PR DESCRIPTION
## What

`flyte start devbox` carried three POSIX-only assumptions. On Windows each one crashes the CLI with an exception that reads like an SDK bug, and both Sentry issues below came from the same Windows user in the same session.

### 1. `/tmp` is not a path on Windows — [FLYTE-SDK-79](https://unionai.sentry.io/issues/?query=FLYTE-SDK-79)

`_KUBE_DIR = Path("/tmp/.kube")` resolves to the drive-relative `\tmp\.kube`, and `launch_devbox` fails at `mkdir`:

```
OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect: '\tmp\\.kube'
```

Derived from `tempfile.gettempdir()` instead. Side benefit on POSIX: each user gets their own directory on shared Linux hosts, where a single root-or-other-user-owned `/tmp/.kube` is exactly the situation the chown fallback below exists to work around.

### 2. `KUBECONFIG` is a path *list*

kubectl splits `KUBECONFIG` on the platform separator — `;` on Windows. Joining with a hardcoded `:` makes kubectl split `C:\Users\...` on its drive letter, so neither file loads and `kubectl config view --flatten` exits 1. Now uses `os.pathsep`.

### 3. `os.getuid` does not exist on Windows — [FLYTE-SDK-7B](https://unionai.sentry.io/issues/?query=FLYTE-SDK-7B)

Recovering from that kubectl failure reached straight for `os.getuid()`/`os.getgid()`, so the recovery attempt itself raised:

```
AttributeError: module 'os' has no attribute 'getuid'
```

...which is what got reported, burying the real kubectl error underneath it. The chown only means something where POSIX uids exist; elsewhere we now surface the original kubectl failure.

While here: the two `subprocess.CalledProcessError`s that could escape `_merge_kubeconfig` — from `docker exec ... chown` and from the retried flatten — are now `click.ClickException`s carrying kubectl's own stderr, so users get the reason instead of a traceback (and these stop reaching Sentry as SDK crashes).

## Testing

`tests/cli/test_devbox.py`: 26 passed. 5 of them fail on `main` (verified by stashing the source change):

- `test_kube_dir_is_under_the_platform_temp_dir`
- `test_kubeconfig_list_uses_platform_path_separator` (monkeypatches `os.pathsep` to `;` so it discriminates on any host, not only Windows)
- `test_missing_getuid_reports_original_kubectl_failure` (deletes `os.getuid` via monkeypatch)
- `test_second_flatten_failure_surfaces_as_click_exception`
- `test_chown_failure_surfaces_as_click_exception`

fixes FLYTE-SDK-79
fixes FLYTE-SDK-7B