### PR TITLE
Make action watch resilient to transient stream interruptions

### DIFF
--- a/src/flyte/remote/_action.py
+++ b/src/flyte/remote/_action.py
@@ -176,24 +176,36 @@ _WATCH_RECONNECT_INITIAL_BACKOFF_SECS = 0.5
 _WATCH_RECONNECT_MAX_BACKOFF_SECS = 10.0
 
 # CANCELED is what an intermediary's RST_STREAM surfaces as; UNAVAILABLE/DEADLINE_EXCEEDED are
-# the standard transient transport codes. INTERNAL/UNKNOWN stay fatal — they can be real bugs.
+# the standard transient transport codes. INTERNAL/UNKNOWN stay fatal here — they can be real
+# bugs — and are rescued only when _is_stream_reset proves a transport reset underneath.
 _TRANSIENT_CONNECT_CODES = (Code.UNAVAILABLE, Code.DEADLINE_EXCEEDED, Code.CANCELED)
+
+
+def _is_stream_reset(exc: BaseException) -> bool:
+    """Whether exc is (or wraps) a pyqwest HTTP/2 stream reset — "Error reading content".
+
+    connectrpc catches the transport's StreamError and re-raises it as a ConnectError
+    (`raise rst_err from e`), mapping most RST_STREAM codes — NO_ERROR, INTERNAL_ERROR,
+    PROTOCOL_ERROR, ... — onto Code.INTERNAL. Only the __cause__ distinguishes an
+    intermediary resetting an idle stream from a genuine server-side INTERNAL, which is
+    built from the response body and carries no StreamError cause.
+    """
+    # pyqwest is the HTTP transport under connectrpc; imported lazily as a transitive dependency.
+    try:
+        from pyqwest import StreamError
+    except ImportError:
+        return False
+    return isinstance(exc, StreamError) or isinstance(exc.__cause__, StreamError)
 
 
 def _is_transient_watch_error(exc: BaseException) -> bool:
     """Whether a watch-stream failure is a transient transport error worth re-subscribing after."""
     if isinstance(exc, ConnectError):
-        return exc.code in _TRANSIENT_CONNECT_CODES
+        return exc.code in _TRANSIENT_CONNECT_CODES or _is_stream_reset(exc)
     # OS-level connection drops and timeouts (ConnectionResetError, socket.timeout, ...).
     if isinstance(exc, (ConnectionError, TimeoutError)):
         return True
-    # pyqwest is the HTTP transport under connectrpc; StreamError ("Error reading content")
-    # is an HTTP/2 stream reset mid-body. Imported lazily since it is a transitive dependency.
-    try:
-        from pyqwest import StreamError
-    except ImportError:
-        return False
-    return isinstance(exc, StreamError)
+    return _is_stream_reset(exc)
 
 
 def _action_done_check(phase: phase_pb2.ActionPhase) -> bool:

--- a/src/flyte/remote/_action.py
+++ b/src/flyte/remote/_action.py
@@ -168,6 +168,34 @@ def _action_details_rich_repr(
     yield "related to", _relation_repr(action.metadata)
 
 
+# Reconnect policy for streaming watches. Only *consecutive* failed subscriptions count —
+# any delivered update resets the budget — so long-lived watches survive periodic proxy
+# resets indefinitely while a genuinely unreachable backend still fails fast.
+_WATCH_RECONNECT_MAX_ATTEMPTS = 5
+_WATCH_RECONNECT_INITIAL_BACKOFF_SECS = 0.5
+_WATCH_RECONNECT_MAX_BACKOFF_SECS = 10.0
+
+# CANCELED is what an intermediary's RST_STREAM surfaces as; UNAVAILABLE/DEADLINE_EXCEEDED are
+# the standard transient transport codes. INTERNAL/UNKNOWN stay fatal — they can be real bugs.
+_TRANSIENT_CONNECT_CODES = (Code.UNAVAILABLE, Code.DEADLINE_EXCEEDED, Code.CANCELED)
+
+
+def _is_transient_watch_error(exc: BaseException) -> bool:
+    """Whether a watch-stream failure is a transient transport error worth re-subscribing after."""
+    if isinstance(exc, ConnectError):
+        return exc.code in _TRANSIENT_CONNECT_CODES
+    # OS-level connection drops and timeouts (ConnectionResetError, socket.timeout, ...).
+    if isinstance(exc, (ConnectionError, TimeoutError)):
+        return True
+    # pyqwest is the HTTP transport under connectrpc; StreamError ("Error reading content")
+    # is an HTTP/2 stream reset mid-body. Imported lazily since it is a transitive dependency.
+    try:
+        from pyqwest import StreamError
+    except ImportError:
+        return False
+    return isinstance(exc, StreamError)
+
+
 def _action_done_check(phase: phase_pb2.ActionPhase) -> bool:
     """
     Check if the action is done.
@@ -781,31 +809,61 @@ class ActionDetails(ToJSONMixin):
     @classmethod
     async def watch(cls, action_id: identifier_pb2.ActionIdentifier) -> AsyncIterator[ActionDetails]:
         """
-        Watch the action for updates. This is a placeholder for watching the action.
+        Watch the action for updates, yielding details until the action reaches a terminal phase.
+
+        The underlying server stream rides a single HTTP/2 stream that proxies and load balancers
+        are free to reset at any time (idle timeouts, connection churn), long before a slow action
+        finishes. Those interruptions — including streams that end cleanly before a terminal
+        phase — are re-subscribed transparently, so this generator only ends at a terminal phase
+        or raises on a non-transient error / persistent reconnect failure.
         """
+        from flyte._logging import logger
+
         ensure_client()
         if not action_id:
             raise ValueError("Action ID is required")
 
-        call = cast(
-            AsyncIterator[WatchActionDetailsResponse],
-            get_client().run_service.watch_action_details(
-                request=run_service_pb2.WatchActionDetailsRequest(
-                    action_id=action_id,
+        consecutive_failures = 0
+        while True:
+            call = cast(
+                AsyncIterator[WatchActionDetailsResponse],
+                get_client().run_service.watch_action_details(
+                    request=run_service_pb2.WatchActionDetailsRequest(
+                        action_id=action_id,
+                    )
+                ),
+            )
+            try:
+                async for resp in call:
+                    # Any delivered update proves the connection works; only *consecutive*
+                    # failed subscriptions should count toward the reconnect budget.
+                    consecutive_failures = 0
+                    v = cls(resp.details)
+                    yield v
+                    if v.done():
+                        return
+            except Exception as e:
+                if not _is_transient_watch_error(e):
+                    raise
+                consecutive_failures += 1
+                if consecutive_failures > _WATCH_RECONNECT_MAX_ATTEMPTS:
+                    raise
+                backoff = min(
+                    _WATCH_RECONNECT_INITIAL_BACKOFF_SECS * 2 ** (consecutive_failures - 1),
+                    _WATCH_RECONNECT_MAX_BACKOFF_SECS,
                 )
-            ),
-        )
-        try:
-            async for resp in call:
-                v = cls(resp.details)
-                yield v
-                if v.done():
-                    return
-        except ConnectError as e:
-            if e.code == Code.CANCELED:
-                pass
-            else:
-                raise e
+                logger.warning(
+                    f"Watch stream for action {action_id.name} interrupted ({type(e).__name__}: {e}); "
+                    f"reconnecting in {backoff:.1f}s "
+                    f"(attempt {consecutive_failures}/{_WATCH_RECONNECT_MAX_ATTEMPTS})"
+                )
+                await asyncio.sleep(backoff)
+                continue
+            # Stream ended cleanly before a terminal phase (idle/stream-duration limit on a
+            # proxy). Re-subscribe after a short pause; the pause bounds the reconnect rate
+            # if a proxy closes each stream immediately after the initial snapshot.
+            logger.debug(f"Watch stream for action {action_id.name} ended before a terminal phase; re-subscribing")
+            await asyncio.sleep(_WATCH_RECONNECT_INITIAL_BACKOFF_SECS)
 
     async def watch_updates(self, cache_data_on_done: bool = False) -> AsyncGenerator[ActionDetails, None]:
         """

--- a/tests/flyte/remote/test_action_watch_reconnect.py
+++ b/tests/flyte/remote/test_action_watch_reconnect.py
@@ -146,9 +146,7 @@ def test_wrapped_stream_reset_is_transient():
     import pyqwest
 
     try:
-        raise ConnectError(Code.INTERNAL, "Error reading content") from pyqwest.StreamError(
-            "Error reading content", 1
-        )
+        raise ConnectError(Code.INTERNAL, "Error reading content") from pyqwest.StreamError("Error reading content", 1)
     except ConnectError as e:
         assert _is_transient_watch_error(e)
 

--- a/tests/flyte/remote/test_action_watch_reconnect.py
+++ b/tests/flyte/remote/test_action_watch_reconnect.py
@@ -133,3 +133,27 @@ def test_transient_classifier():
     assert _is_transient_watch_error(TimeoutError("timed out"))
     assert not _is_transient_watch_error(ValueError("nope"))
     assert _is_transient_watch_error(pyqwest.StreamError("Error reading content", 1))
+
+
+def test_wrapped_stream_reset_is_transient():
+    """The shape connectrpc actually raises: an RST_STREAM mapped onto ConnectError.
+
+    `_client_async._send_request_bidi_stream` does `raise rst_err from e`, and
+    `maybe_map_stream_reset` sends NO_ERROR/INTERNAL_ERROR/PROTOCOL_ERROR resets to
+    Code.INTERNAL. Only the __cause__ separates an ALB resetting an idle stream from a
+    real server-side INTERNAL, which is built from the response body and has no cause.
+    """
+    import pyqwest
+
+    try:
+        raise ConnectError(Code.INTERNAL, "Error reading content") from pyqwest.StreamError(
+            "Error reading content", 1
+        )
+    except ConnectError as e:
+        assert _is_transient_watch_error(e)
+
+    # A server-side INTERNAL with no transport cause stays fatal.
+    try:
+        raise ConnectError(Code.INTERNAL, "boom") from ValueError("server bug")
+    except ConnectError as e:
+        assert not _is_transient_watch_error(e)

--- a/tests/flyte/remote/test_action_watch_reconnect.py
+++ b/tests/flyte/remote/test_action_watch_reconnect.py
@@ -1,0 +1,135 @@
+"""Tests for ActionDetails.watch resilience to transient stream interruptions."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from connectrpc.code import Code
+from connectrpc.errors import ConnectError
+from flyteidl2.common import identifier_pb2, phase_pb2
+from flyteidl2.workflow import run_service_pb2
+
+from flyte.remote._action import ActionDetails, _is_transient_watch_error
+
+ACTION_ID = identifier_pb2.ActionIdentifier(name="a0")
+
+
+def _resp(phase: int) -> run_service_pb2.WatchActionDetailsResponse:
+    r = run_service_pb2.WatchActionDetailsResponse()
+    r.details.status.phase = phase
+    return r
+
+
+RUNNING = _resp(phase_pb2.ACTION_PHASE_RUNNING)
+SUCCEEDED = _resp(phase_pb2.ACTION_PHASE_SUCCEEDED)
+
+
+def _stream(items):
+    """An async iterator that yields responses and raises any exception it encounters."""
+
+    async def gen():
+        for item in items:
+            if isinstance(item, BaseException):
+                raise item
+            yield item
+
+    return gen()
+
+
+def _client_with_streams(streams):
+    """A fake client whose watch_action_details returns each stream in order."""
+    it = iter(streams)
+    client = MagicMock()
+    client.run_service.watch_action_details = MagicMock(side_effect=lambda request: _stream(next(it)))
+    return client
+
+
+async def _collect():
+    phases = []
+    async for ad in ActionDetails.watch.aio(ACTION_ID):
+        phases.append(ad.raw_phase)
+    return phases
+
+
+@pytest.fixture(autouse=True)
+def fast_backoff(monkeypatch):
+    monkeypatch.setattr("flyte.remote._action._WATCH_RECONNECT_INITIAL_BACKOFF_SECS", 0.001)
+    monkeypatch.setattr("flyte.remote._action._WATCH_RECONNECT_MAX_BACKOFF_SECS", 0.002)
+
+
+@pytest.mark.asyncio
+async def test_reconnects_after_transient_error(fast_backoff):
+    client = _client_with_streams(
+        [
+            [RUNNING, ConnectError(Code.CANCELED, "stream reset")],
+            [SUCCEEDED],
+        ]
+    )
+    with patch("flyte.remote._action.get_client", return_value=client), patch("flyte.remote._action.ensure_client"):
+        phases = await _collect()
+    assert phases == [phase_pb2.ACTION_PHASE_RUNNING, phase_pb2.ACTION_PHASE_SUCCEEDED]
+    assert client.run_service.watch_action_details.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_reconnects_after_clean_close_before_terminal(fast_backoff):
+    client = _client_with_streams(
+        [
+            [RUNNING],  # stream ends cleanly while still running
+            [SUCCEEDED],
+        ]
+    )
+    with patch("flyte.remote._action.get_client", return_value=client), patch("flyte.remote._action.ensure_client"):
+        phases = await _collect()
+    assert phases == [phase_pb2.ACTION_PHASE_RUNNING, phase_pb2.ACTION_PHASE_SUCCEEDED]
+    assert client.run_service.watch_action_details.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_non_transient_error_raises(fast_backoff):
+    client = _client_with_streams([[RUNNING, ConnectError(Code.INTERNAL, "boom")]])
+    with patch("flyte.remote._action.get_client", return_value=client), patch("flyte.remote._action.ensure_client"):
+        with pytest.raises(ConnectError):
+            await _collect()
+
+
+@pytest.mark.asyncio
+async def test_gives_up_after_max_consecutive_failures(fast_backoff):
+    from flyte.remote._action import _WATCH_RECONNECT_MAX_ATTEMPTS
+
+    err = ConnectError(Code.UNAVAILABLE, "down")
+    client = _client_with_streams([[err]] * (_WATCH_RECONNECT_MAX_ATTEMPTS + 1))
+    with patch("flyte.remote._action.get_client", return_value=client), patch("flyte.remote._action.ensure_client"):
+        with pytest.raises(ConnectError):
+            await _collect()
+    assert client.run_service.watch_action_details.call_count == _WATCH_RECONNECT_MAX_ATTEMPTS + 1
+
+
+@pytest.mark.asyncio
+async def test_delivered_update_resets_failure_budget(fast_backoff):
+    from flyte.remote._action import _WATCH_RECONNECT_MAX_ATTEMPTS
+
+    # More total interruptions than the budget, but every subscription delivers an update
+    # before dying — so the consecutive-failure counter keeps resetting and the watch survives.
+    streams = [[RUNNING, ConnectError(Code.UNAVAILABLE, "blip")] for _ in range(_WATCH_RECONNECT_MAX_ATTEMPTS + 3)]
+    streams.append([SUCCEEDED])
+    client = _client_with_streams(streams)
+    with patch("flyte.remote._action.get_client", return_value=client), patch("flyte.remote._action.ensure_client"):
+        phases = await _collect()
+    assert phases[-1] == phase_pb2.ACTION_PHASE_SUCCEEDED
+    assert len(phases) == _WATCH_RECONNECT_MAX_ATTEMPTS + 4
+
+
+def test_transient_classifier():
+    import pyqwest
+
+    assert _is_transient_watch_error(ConnectError(Code.UNAVAILABLE, "x"))
+    assert _is_transient_watch_error(ConnectError(Code.DEADLINE_EXCEEDED, "x"))
+    assert _is_transient_watch_error(ConnectError(Code.CANCELED, "x"))
+    assert not _is_transient_watch_error(ConnectError(Code.INTERNAL, "x"))
+    assert not _is_transient_watch_error(ConnectError(Code.PERMISSION_DENIED, "x"))
+    assert _is_transient_watch_error(ConnectionResetError("reset"))
+    assert _is_transient_watch_error(TimeoutError("timed out"))
+    assert not _is_transient_watch_error(ValueError("nope"))
+    assert _is_transient_watch_error(pyqwest.StreamError("Error reading content", 1))


### PR DESCRIPTION
## What

Fixes run/action watching (`run.wait`, `Action.wait`, the remote image builder's build wait, CLI monitoring) crashing or silently mis-terminating when the underlying watch stream is interrupted — e.g. `ConnectError: Error reading content` (FLYTE-SDK-6H).

## Why

`ActionDetails.watch` rode a single server stream and treated any end of that stream as authoritative:

- `ConnectError(CANCELED)` — what an intermediary's RST_STREAM surfaces as — was swallowed, ending the generator silently.
- A clean stream close before a terminal phase was indistinguishable from completion.
- Transport-level stream resets weren't caught at all and killed the wait.

Proxies and LBs reset long-lived HTTP/2 streams routinely (idle timeouts, connection churn), so waiting on a slow action — a remote image build, a long task — could crash mid-wait, or worse: `run.wait` returned early, the caller read a non-terminal phase, and the image builder reported `❌ Build failed` for a build that was still running (and often later succeeded).

## How

`ActionDetails.watch` now re-subscribes with exponential backoff (0.5s → 10s cap) on transient failures — `CANCELED`/`UNAVAILABLE`/`DEADLINE_EXCEEDED`, OS-level connection drops/timeouts, and HTTP/2 stream resets — and on clean closes before a terminal phase. Key property: only **consecutive** failed subscriptions count against the reconnect budget (5); any delivered update resets it. So a watch lasting hours survives periodic proxy resets indefinitely, while a genuinely unreachable backend still fails fast.

Classifying the stream reset is the subtle part. You never see the transport's `pyqwest.StreamError` — connectrpc catches it and re-raises it as a `ConnectError` (`_client_async._send_request_bidi_stream`, `raise rst_err from e`), and `maybe_map_stream_reset` sends the `NO_ERROR` / `INTERNAL_ERROR` / `PROTOCOL_ERROR` reset codes onto `Code.INTERNAL`. Retrying every `INTERNAL` would paper over real server bugs, so `_is_transient_watch_error` checks `__cause__` instead: a `ConnectError` is transient if its code is in the transient set **or** a `StreamError` sits underneath it. A genuine server-side `INTERNAL` is built from the response body and carries no such cause, so it stays fatal — as do `PERMISSION_DENIED` and friends.

Concretely, this is what an AWS ALB at its default 60s idle timeout does to a quiet watch stream; before the `__cause__` check it surfaced as a fatal `ConnectError: Error reading content` and the reconnect loop never ran.

The generator now only ends at a terminal phase or raises, which fixes every caller of `run.wait`/`Action.wait` without touching them.

## Testing

New `tests/flyte/remote/test_action_watch_reconnect.py`: reconnect after transient error, reconnect after clean close, non-transient raises, reconnect budget exhaustion, budget reset on delivered updates, the transient-error classifier, and the wrapped-`StreamError` shape connectrpc actually raises (plus its negative case, a causeless server-side `INTERNAL`). Full `tests/flyte/remote` suite passes (575 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
