### PR TITLE
fix: reconnect action watch stream when an idle proxy drops it

### DIFF
--- a/src/flyte/remote/_action.py
+++ b/src/flyte/remote/_action.py
@@ -44,6 +44,10 @@ from flyte.syncify import syncify
 
 WaitFor = Literal["terminal", "running", "logs-ready"]
 
+# Delay before re-establishing a watch stream that ended before the action reached a terminal phase.
+_WATCH_RECONNECT_BACKOFF_SECS = 1.0
+_WATCH_RECONNECT_MAX_SECS = 30.0
+
 # ACTION_PHASE_RECOVERED landed in flyteidl2 2.0.28; tolerate older bindings (the wire value
 # is stable) — never crash on an enum value the local bindings don't know.
 _ACTION_PHASE_RECOVERED: int = getattr(phase_pb2, "ACTION_PHASE_RECOVERED", 10)
@@ -781,31 +785,45 @@ class ActionDetails(ToJSONMixin):
     @classmethod
     async def watch(cls, action_id: identifier_pb2.ActionIdentifier) -> AsyncIterator[ActionDetails]:
         """
-        Watch the action for updates. This is a placeholder for watching the action.
+        Watch the action for updates until it reaches a terminal phase.
+
+        The underlying stream is re-established if it ends before the action is done: a quiet
+        watch (e.g. a long image build with no phase change) can be dropped by an idle proxy such
+        as an ALB, whose default idle timeout is 60s and which TCP keepalive does not hold open.
         """
         ensure_client()
         if not action_id:
             raise ValueError("Action ID is required")
 
-        call = cast(
-            AsyncIterator[WatchActionDetailsResponse],
-            get_client().run_service.watch_action_details(
-                request=run_service_pb2.WatchActionDetailsRequest(
-                    action_id=action_id,
-                )
-            ),
-        )
-        try:
-            async for resp in call:
-                v = cls(resp.details)
-                yield v
-                if v.done():
+        backoff = _WATCH_RECONNECT_BACKOFF_SECS
+        while True:
+            got_update = False
+            call = cast(
+                AsyncIterator[WatchActionDetailsResponse],
+                get_client().run_service.watch_action_details(
+                    request=run_service_pb2.WatchActionDetailsRequest(
+                        action_id=action_id,
+                    )
+                ),
+            )
+            try:
+                async for resp in call:
+                    got_update = True
+                    v = cls(resp.details)
+                    yield v
+                    if v.done():
+                        return
+            except ConnectError as e:
+                if e.code == Code.CANCELED:
                     return
-        except ConnectError as e:
-            if e.code == Code.CANCELED:
-                pass
-            else:
                 raise e
+
+            # Stream ended without a terminal phase: reconnect. The server re-sends current state,
+            # so reconnecting is safe. Back off only while streams keep ending empty, so a server
+            # that closes immediately is not hammered.
+            # ponytail: no cap on total reconnects -- the caller owns the timeout.
+            backoff = _WATCH_RECONNECT_BACKOFF_SECS if got_update else min(backoff * 2, _WATCH_RECONNECT_MAX_SECS)
+            await asyncio.sleep(backoff)
 
     async def watch_updates(self, cache_data_on_done: bool = False) -> AsyncGenerator[ActionDetails, None]:
         """

--- a/tests/flyte/remote/test_action_watch_reconnect.py
+++ b/tests/flyte/remote/test_action_watch_reconnect.py
@@ -1,0 +1,121 @@
+"""ActionDetails.watch reconnects when the stream ends before a terminal phase.
+
+A quiet watch stream (long image build, no phase change) can be dropped by an idle proxy such as
+an ALB. Without a reconnect the caller sees the stream end, treats the action as finished, and
+reads a still-running phase as a failure.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from connectrpc.code import Code
+from connectrpc.errors import ConnectError
+from flyteidl2.common import identifier_pb2, phase_pb2
+from flyteidl2.workflow import run_definition_pb2, run_service_pb2
+
+from flyte.remote._action import ActionDetails
+
+
+def _action_id() -> identifier_pb2.ActionIdentifier:
+    return identifier_pb2.ActionIdentifier(
+        run=identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="r"),
+        name="a0",
+    )
+
+
+def _resp(phase: phase_pb2.ActionPhase) -> run_service_pb2.WatchActionDetailsResponse:
+    return run_service_pb2.WatchActionDetailsResponse(
+        details=run_definition_pb2.ActionDetails(
+            id=_action_id(),
+            status=run_definition_pb2.ActionStatus(phase=phase),
+        )
+    )
+
+
+def _stream(*items):
+    """Build an async iterator that yields `items`; a ConnectError item is raised instead."""
+
+    async def _gen():
+        for item in items:
+            if isinstance(item, ConnectError):
+                raise item
+            yield item
+
+    return _gen()
+
+
+def _client_yielding(*streams):
+    """A mock client whose watch_action_details returns each stream in turn."""
+    client = MagicMock()
+    client.run_service.watch_action_details = MagicMock(side_effect=list(streams))
+    return client
+
+
+async def _collect(action_id):
+    return [d.pb2.status.phase async for d in ActionDetails.watch.aio(action_id=action_id)]
+
+
+RUNNING = phase_pb2.ACTION_PHASE_RUNNING
+SUCCEEDED = phase_pb2.ACTION_PHASE_SUCCEEDED
+
+
+@pytest.mark.asyncio
+@patch("flyte.remote._action.asyncio.sleep")
+@patch("flyte.remote._action.ensure_client", MagicMock())
+async def test_reconnects_when_stream_ends_before_terminal(mock_sleep):
+    """Stream 1 ends mid-build (the ALB drop); the watch must reconnect and see the terminal phase."""
+    client = _client_yielding(
+        _stream(_resp(RUNNING)),  # dropped without a terminal phase
+        _stream(_resp(RUNNING), _resp(SUCCEEDED)),
+    )
+    with patch("flyte.remote._action.get_client", return_value=client):
+        phases = await _collect(_action_id())
+
+    assert phases == [RUNNING, RUNNING, SUCCEEDED]
+    assert client.run_service.watch_action_details.call_count == 2
+    mock_sleep.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("flyte.remote._action.ensure_client", MagicMock())
+async def test_no_reconnect_after_terminal_phase():
+    client = _client_yielding(_stream(_resp(SUCCEEDED)))
+    with patch("flyte.remote._action.get_client", return_value=client):
+        phases = await _collect(_action_id())
+
+    assert phases == [SUCCEEDED]
+    assert client.run_service.watch_action_details.call_count == 1
+
+
+@pytest.mark.asyncio
+@patch("flyte.remote._action.ensure_client", MagicMock())
+async def test_cancelled_stream_stops_without_reconnect():
+    client = _client_yielding(_stream(ConnectError(Code.CANCELED, "cancelled")))
+    with patch("flyte.remote._action.get_client", return_value=client):
+        phases = await _collect(_action_id())
+
+    assert phases == []
+    assert client.run_service.watch_action_details.call_count == 1
+
+
+@pytest.mark.asyncio
+@patch("flyte.remote._action.ensure_client", MagicMock())
+async def test_other_errors_still_raise():
+    client = _client_yielding(_stream(ConnectError(Code.PERMISSION_DENIED, "nope")))
+    with patch("flyte.remote._action.get_client", return_value=client):
+        with pytest.raises(ConnectError):
+            await _collect(_action_id())
+
+
+@pytest.mark.asyncio
+@patch("flyte.remote._action.asyncio.sleep")
+@patch("flyte.remote._action.ensure_client", MagicMock())
+async def test_backoff_grows_while_streams_end_empty(mock_sleep):
+    client = _client_yielding(_stream(), _stream(), _stream(_resp(SUCCEEDED)))
+    with patch("flyte.remote._action.get_client", return_value=client):
+        await _collect(_action_id())
+
+    delays = [call.args[0] for call in mock_sleep.await_args_list]
+    assert delays == [2.0, 4.0]


### PR DESCRIPTION
## Why

`ActionDetails.watch` iterated the `watch_action_details` server stream exactly once. If that stream ended **before** the action reached a terminal phase, the generator simply returned — `Action.watch` exited its loop, `run.wait` returned early, and the caller read a still-running phase as a finished one. In `remote_builder.py` that surfaces as a false `ImageBuildError("❌ Build failed")` on a build that is still happily running.

A quiet watch is exactly the case that gets dropped: an image build can sit for minutes with no phase change, and an ALB closes idle connections at its 60s default.

Keepalive doesn't save us here. The transport sets only `tcp_keepalive_interval=30.0` (`_session.py:215`, marked `# was grpc.keepalive_time_ms = 30000`). The old gRPC setting sent HTTP/2 PING frames, which are real frames on the wire and reset a proxy's idle timer; TCP keepalive probes carry no data and generally do not. `pyqwest.HTTPTransport` exposes no `http2_keep_alive_interval`, so restoring PINGs needs an upstream change.

`RetryServerStreamInterceptor` doesn't cover it either — it retries only a `ConnectError` with a retryable code, and a proxy-side close arrives as a clean EOF.

## What

Reconnect on the client. The watch stream is idempotent (the server re-sends current state), so `ActionDetails.watch` now re-establishes it until the action is done:

- Backoff resets to 1s whenever a stream delivered at least one update, so a mid-build drop reconnects promptly.
- Backoff doubles to a 30s ceiling only while streams keep ending empty, so a server closing immediately isn't hammered.
- No cap on total reconnects — the caller owns the timeout.
- `CANCELED` and non-retryable errors behave exactly as before.

Everything downstream inherits the fix: `Action.watch`, `wait`, `_wait_rich`/`_wait_plain`, the CLI, and the remote image builder.

## Test plan

New `tests/flyte/remote/test_action_watch_reconnect.py` covers: reconnect when a stream ends before terminal, no reconnect after a terminal phase, `CANCELED` stops quietly, non-retryable errors still raise, and backoff growth across empty streams.

- [x] `uv run pytest tests/flyte/remote/test_action_watch_reconnect.py` — 5 passed
- [x] `uv run pytest tests/flyte/remote` — 573 passed
- [x] `uv run ruff check` / `ruff format --check` — clean

## Notes / follow-ups

- A server-side heartbeat on the watch stream would be the better fix — it holds the connection open instead of re-dialing it. Out of scope for this repo.
- Same for raising the ALB's `idle_timeout.timeout_seconds`.
- No overall watch deadline was added.

https://claude.ai/code/session_01GnSjdUY4zbspszGCRPkXGq