### PR TITLE
Make the release publish workflow rerunnable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,16 +3,27 @@ name: Publish
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to rebuild, e.g. v2.6.0. Rebuilds and pushes the images for an already-published release; every PyPI upload step is release-gated, so nothing is re-published."
+        required: true
   pull_request:
     paths:
       - ".github/workflows/publish.yml"
       - "maint_tools/build_default_image.py"
+
+env:
+  # Release runs use the tag they fired on; manual reruns use the tag input.
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
   rs-controller-wheels:
     name: Build RS controller wheel (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     strategy:
+      # one flaky target shouldn't cancel the wheels that already built
+      fail-fast: false
       matrix:
         include:
           - target: x86_64
@@ -25,10 +36,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: "0"
+          ref: ${{ inputs.tag || github.ref }}
       - name: Set version from tag
         run: |
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            VERSION=$(echo "$GITHUB_REF" | sed 's|refs/tags/v||')
+          if [[ "$RELEASE_TAG" == v* ]]; then
+            VERSION="${RELEASE_TAG#v}"
           else
             VERSION="0.0.0.dev0"
           fi
@@ -68,7 +80,7 @@ jobs:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          twine upload --verbose dist/*
+          twine upload --verbose --skip-existing dist/*
       - name: Wait for PyPI availability
         run: |
           VERSION=$(echo "$GITHUB_REF" | sed 's|refs/tags/v||')
@@ -95,6 +107,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: "0"
+          ref: ${{ inputs.tag || github.ref }}
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
@@ -127,7 +140,7 @@ jobs:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          uvx twine upload --verbose dist/*
+          uvx twine upload --verbose --skip-existing dist/*
       - name: Sleep until pypi is available
         if: ${{ github.event_name == 'release' }}
         id: pypiwait
@@ -167,6 +180,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: "0"
+          ref: ${{ inputs.tag || github.ref }}
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
@@ -261,6 +275,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: "0"
+          ref: ${{ inputs.tag || github.ref }}
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
@@ -296,7 +311,7 @@ jobs:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          uvx twine upload --verbose dist/*
+          uvx twine upload --verbose --skip-existing dist/*
 
   build-and-push-flyte-docker-images:
     needs: [flyte-pypi, rs-controller-wheels]
@@ -319,6 +334,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: "0"
+          ref: ${{ inputs.tag || github.ref }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx


### PR DESCRIPTION
## Why

The [v2.6.0 release run](https://github.com/flyteorg/flyte-sdk/actions/runs/31641590766) failed on a network flake, and recovering from it was worse than the flake itself:

1. `PyO3/maturin-action` failed downloading its own tarball inside the manylinux container — `curl: (52) Empty reply from server` → `tar: Error is not recoverable`. The Rust build never started.
2. Matrix fail-fast then **cancelled** the two `aarch64` wheel jobs, which were perfectly healthy.
3. Rerunning the failed jobs made the wheels green, but the core `PyPI package` job now failed with `400 File already exists ('flyte-2.6.0-py3-none-any.whl')` — the *first* attempt had already uploaded it.
4. That non-zero exit skipped every downstream job: the docker images, the dependency constraints, and the docs regen signal.

Net result: `flyte==2.6.0` is live on PyPI, but `ghcr.io/flyteorg/flyte:py3.x-v2.6.0` does not exist. Since the SDK derives its default image tag from the installed version, anyone on 2.6.0 resolves an image that isn't there. Rerunning can't fix it either — a rerun replays the workflow file as it existed at the tag.

## What

- **`fail-fast: false`** on the wheel matrix — one flaky target no longer cancels wheels that already built.
- **`--skip-existing`** on all three `twine upload` calls — a rerun treats an already-uploaded file as a no-op rather than a hard failure. This is the difference between "rerun the release" working and not.
- **`workflow_dispatch` with a `tag` input** — lets us rebuild and push images for an already-published release. Every PyPI upload step is *already* gated on `github.event_name == 'release'`, so a manual run builds and pushes images without re-publishing anything to PyPI. Checkouts and the rs-controller version derivation follow the tag input.

## Testing

- `actionlint` is clean on this file apart from pre-existing warnings (`SC2086`/`SC2001` style, `actions/setup-python@v1` age) that this PR doesn't touch.
- The `pull_request` trigger already covers `.github/workflows/publish.yml`, so this PR exercises the workflow itself — with all publish steps release-gated, as on any PR.
- Follow-up once merged: dispatch with `tag: v2.6.0` to backfill the missing 2.6.0 images.

https://claude.ai/code/session_01AyWfEZ3tzCQ5kBawRQVSoy