### PR TITLE
ci: bump actions to node24 majors, silence Node 20 deprecation warnings

### DIFF
--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -17,12 +17,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v10.0.0
       id: setup-uv
       with:
         version: ${{ inputs.uv-version }}

--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -17,12 +17,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v7
       id: setup-uv
       with:
         version: ${{ inputs.uv-version }}

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -18,6 +18,6 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Codespell
         uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -18,6 +18,6 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Codespell
         uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -27,13 +27,13 @@ jobs:
         shell: bash
     steps:
       - name: Check out
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache uv packages
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-${{ matrix.python-version }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -27,13 +27,13 @@ jobs:
         shell: bash
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache uv packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-${{ matrix.python-version }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Python 3.12
         uses: ./.github/actions/setup-python-env
         with:
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Check flyteidl2 version consistency
         run: |
           # Extract flyteidl2 version from root pyproject.toml
@@ -61,9 +61,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cache Cargo registry and build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -84,9 +84,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cache Cargo registry and build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Python 3.12
         uses: ./.github/actions/setup-python-env
         with:
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Python 3.12
         uses: ./.github/actions/setup-python-env
         with:
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Python 3.12
         uses: ./.github/actions/setup-python-env
         with:
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Python 3.12
         uses: ./.github/actions/setup-python-env
         with:
@@ -158,7 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Python 3.12
         uses: ./.github/actions/setup-python-env
       - name: Check root uv.lock
@@ -177,9 +177,9 @@ jobs:
 #    runs-on: ubuntu-latest
 #    steps:
 #      - name: Fetch the code
-#        uses: actions/checkout@v4
+#        uses: actions/checkout@v5
 #      - name: Set up Python 3.13
-#        uses: actions/setup-python@v4
+#        uses: actions/setup-python@v6
 #        with:
 #          python-version: 3.13
 #      - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Set up Python 3.12
         uses: ./.github/actions/setup-python-env
         with:
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Check flyteidl2 version consistency
         run: |
           # Extract flyteidl2 version from root pyproject.toml
@@ -61,9 +61,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Cache Cargo registry and build
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -84,9 +84,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Cache Cargo registry and build
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Set up Python 3.12
         uses: ./.github/actions/setup-python-env
         with:
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Set up Python 3.12
         uses: ./.github/actions/setup-python-env
         with:
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Set up Python 3.12
         uses: ./.github/actions/setup-python-env
         with:
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Set up Python 3.12
         uses: ./.github/actions/setup-python-env
         with:
@@ -158,7 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Set up Python 3.12
         uses: ./.github/actions/setup-python-env
       - name: Check root uv.lock
@@ -177,9 +177,9 @@ jobs:
 #    runs-on: ubuntu-latest
 #    steps:
 #      - name: Fetch the code
-#        uses: actions/checkout@v5
+#        uses: actions/checkout@v7
 #      - name: Set up Python 3.13
-#        uses: actions/setup-python@v6
+#        uses: actions/setup-python@v7
 #        with:
 #          python-version: 3.13
 #      - name: Install dependencies

--- a/.github/workflows/publish-rust-crate.yml
+++ b/.github/workflows/publish-rust-crate.yml
@@ -37,10 +37,10 @@ jobs:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
       - name: Fetch the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cache Cargo registry and build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/publish-rust-crate.yml
+++ b/.github/workflows/publish-rust-crate.yml
@@ -37,10 +37,10 @@ jobs:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
       - name: Fetch the code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Cache Cargo registry and build
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: "0"
           ref: ${{ inputs.tag || github.ref }}
@@ -56,7 +56,7 @@ jobs:
           args: --release --out dist -m rs_controller/Cargo.toml
           sccache: true
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: rs-controller-wheel-${{ matrix.target }}
           path: dist/*.whl
@@ -68,7 +68,7 @@ jobs:
     if: github.event_name == 'release'
     steps:
       - name: Download all wheel artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: rs-controller-wheel-*
           merge-multiple: true
@@ -104,16 +104,16 @@ jobs:
     if: always() && (needs.rs-controller-publish.result == 'success' || needs.rs-controller-publish.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: "0"
           ref: ${{ inputs.tag || github.ref }}
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         id: setup-uv
       - name: Install dependencies
         run: |
@@ -177,12 +177,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: "0"
           ref: ${{ inputs.tag || github.ref }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.9.21"
       - name: Export constraints from uv.lock
@@ -212,7 +212,7 @@ jobs:
           cat "constraints-${VERSION}.txt"
           echo "::endgroup::"
       - name: Upload constraints as a workflow artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: flyte-constraints
           path: constraints*.txt
@@ -272,16 +272,16 @@ jobs:
           - workdir: "plugins/vllm"
             image-type: vllm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: "0"
           ref: ${{ inputs.tag || github.ref }}
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         id: setup-uv
       - name: Set version from tag (release only)
         if: github.event_name == 'release'
@@ -331,17 +331,17 @@ jobs:
           - "3.13"
           - "3.14"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: "0"
           ref: ${{ inputs.tag || github.ref }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io/flyteorg
           username: "${{ secrets.FLYTE_BOT_USERNAME }}"
@@ -359,7 +359,7 @@ jobs:
         run: |
           make dist
       - name: Download rs-controller wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: rs-controller-wheel-*
           merge-multiple: true
@@ -397,7 +397,7 @@ jobs:
       - name: Mint docsy-bot App token for unionai-docs
         id: app-token
         if: ${{ env.DOCSY_BOT_APP_ID != '' }}
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.DOCSY_BOT_APP_ID }}
           private-key: ${{ secrets.DOCSY_BOT_PRIVATE_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: "0"
           ref: ${{ inputs.tag || github.ref }}
@@ -56,7 +56,7 @@ jobs:
           args: --release --out dist -m rs_controller/Cargo.toml
           sccache: true
       - name: Upload wheels
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: rs-controller-wheel-${{ matrix.target }}
           path: dist/*.whl
@@ -68,7 +68,7 @@ jobs:
     if: github.event_name == 'release'
     steps:
       - name: Download all wheel artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: rs-controller-wheel-*
           merge-multiple: true
@@ -104,16 +104,16 @@ jobs:
     if: always() && (needs.rs-controller-publish.result == 'success' || needs.rs-controller-publish.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: "0"
           ref: ${{ inputs.tag || github.ref }}
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.0
         id: setup-uv
       - name: Install dependencies
         run: |
@@ -177,12 +177,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: "0"
           ref: ${{ inputs.tag || github.ref }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.0
         with:
           version: "0.9.21"
       - name: Export constraints from uv.lock
@@ -212,7 +212,7 @@ jobs:
           cat "constraints-${VERSION}.txt"
           echo "::endgroup::"
       - name: Upload constraints as a workflow artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: flyte-constraints
           path: constraints*.txt
@@ -272,16 +272,16 @@ jobs:
           - workdir: "plugins/vllm"
             image-type: vllm
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: "0"
           ref: ${{ inputs.tag || github.ref }}
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.0
         id: setup-uv
       - name: Set version from tag (release only)
         if: github.event_name == 'release'
@@ -331,7 +331,7 @@ jobs:
           - "3.13"
           - "3.14"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: "0"
           ref: ${{ inputs.tag || github.ref }}
@@ -359,7 +359,7 @@ jobs:
         run: |
           make dist
       - name: Download rs-controller wheels
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: rs-controller-wheel-*
           merge-multiple: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         shell: bash
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env
@@ -30,7 +30,7 @@ jobs:
         run: make unit_test
 
       - name: Upload coverage reports to Codecov with GitHub Action on Python 3.11
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         if: ${{ matrix.python-version == '3.11' }}
 
   discover-plugins:
@@ -39,7 +39,7 @@ jobs:
       plugins: ${{ steps.find.outputs.plugins }}
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Find plugins with tests
         id: find
@@ -63,7 +63,7 @@ jobs:
         shell: bash
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env
@@ -87,7 +87,7 @@ jobs:
         shell: bash
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         shell: bash
     steps:
       - name: Check out
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env
@@ -30,7 +30,7 @@ jobs:
         run: make unit_test
 
       - name: Upload coverage reports to Codecov with GitHub Action on Python 3.11
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         if: ${{ matrix.python-version == '3.11' }}
 
   discover-plugins:
@@ -39,7 +39,7 @@ jobs:
       plugins: ${{ steps.find.outputs.plugins }}
     steps:
       - name: Check out
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Find plugins with tests
         id: find
@@ -63,7 +63,7 @@ jobs:
         shell: bash
     steps:
       - name: Check out
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env
@@ -87,7 +87,7 @@ jobs:
         shell: bash
     steps:
       - name: Check out
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env

--- a/.github/workflows/validate-codecov-config.yml
+++ b/.github/workflows/validate-codecov-config.yml
@@ -10,6 +10,6 @@ jobs:
   validate-codecov-config:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Validate codecov configuration
         run: curl -sSL --fail-with-body --data-binary @codecov.yaml https://codecov.io/validate

--- a/.github/workflows/validate-codecov-config.yml
+++ b/.github/workflows/validate-codecov-config.yml
@@ -10,6 +10,6 @@ jobs:
   validate-codecov-config:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Validate codecov configuration
         run: curl -sSL --fail-with-body --data-binary @codecov.yaml https://codecov.io/validate


### PR DESCRIPTION
GitHub Actions runs are full of "Node.js 20 is deprecated" annotations (e.g. every PyPI-package job in the Publish workflow) because several pinned action majors still target node20, which runners now force onto node24 and will eventually drop.

Bumps every action in the repo to its latest major (all node24): checkout v7, setup-python v7 (was v1/v4/v5), setup-uv v10.0.0 (exact pin — the action stopped publishing moving major tags after v7), cache v6, upload-artifact v7, download-artifact v8, docker login/buildx/qemu v4, codecov v7, create-github-app-token v3.

Verified against each action's release notes: no removed inputs are used (setup-uv dropped `server-url`, setup-python dropped `pip-install`), no `pull_request_target`/`workflow_run` triggers exist (checkout v7 blocks fork-PR checkout there), and download-artifact v8's digest-mismatch=error default only affects corrupted downloads. setup-uv v9/v10 cache-default changes don't apply since no sensitive events are used.

Also renames `validate-codecov-config.yml ` to drop a trailing space in the filename that was hiding it from tooling globs.