### PR TITLE
Publish flyteplugins-otel to PyPI on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -254,6 +254,7 @@ jobs:
           - "plugins/hydra"
           - "plugins/omegaconf"
           - "plugins/huggingface"
+          - "plugins/otel"
           - "plugins/agents/core"
           - "plugins/agents/openai"
           - "plugins/agents/claude"


### PR DESCRIPTION
## Why

`flyteplugins-otel` is not in the `plugin-pypi` matrix in `publish.yml`, so unlike the other plugins it never reaches PyPI and is only installable as a git dependency:

```
flyteplugins-otel @ git+https://github.com/flyteorg/flyte-sdk@<sha>#subdirectory=plugins/otel
```

That works for leaf projects, but any package that depends on it and is itself published to an index ends up with a direct URL in its `Requires-Dist`, which uv rejects for registry packages and which forces git + GitHub egress on every consumer at install time.

## What

Adds `plugins/otel` to the matrix. The plugin builds cleanly with the job's existing steps — verified locally with `SETUPTOOLS_SCM_PRETEND_VERSION` set, and the built wheel's metadata carries a plain `flyte` requirement (the `[tool.uv.sources]` workspace path does not leak into the wheel).