### PR TITLE
Publish flyteplugins-otel to PyPI on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -254,6 +254,7 @@ jobs:
           - "plugins/hydra"
           - "plugins/omegaconf"
           - "plugins/huggingface"
+          - "plugins/otel"
           - "plugins/agents/core"
           - "plugins/agents/openai"
           - "plugins/agents/claude"


### PR DESCRIPTION
Publish the new flyteplugins-otel plugin (added in #1355) to PyPI on release