### PR TITLE
fix(sentry): count triggers deployed through deploy_task

### DIFF
--- a/src/flyte/_deploy.py
+++ b/src/flyte/_deploy.py
@@ -20,7 +20,7 @@ from ._environment import Environment
 from ._image import Image
 from ._initialize import ensure_client, get_client, get_init_config, requires_initialization
 from ._logging import logger
-from ._sentry import track_operation
+from ._sentry import count, track_operation
 from ._status import status
 from ._task import TaskTemplate
 from ._task_environment import TaskEnvironment
@@ -296,6 +296,15 @@ async def _deploy_task(
                     )
                 )
                 status.success(f"Deployed task {task.name} (version {task_id.version})")
+                # Triggers ride along inside DeployTaskRequest, so TriggerService.DeployTrigger
+                # (the only other deploy_trigger emitter, in remote.Trigger.create) never sees
+                # them. Count them here or they go unmeasured.
+                if deployable_triggers:
+                    count(
+                        "flyte.operation",
+                        len(deployable_triggers),
+                        tags={"operation": "deploy_trigger", "status": "success"},
+                    )
             except ConnectError as e:
                 if e.code == Code.ALREADY_EXISTS:
                     status.info(f"Task {task.name} already exists, skipping")

--- a/src/flyte/_deploy.py
+++ b/src/flyte/_deploy.py
@@ -296,9 +296,6 @@ async def _deploy_task(
                     )
                 )
                 status.success(f"Deployed task {task.name} (version {task_id.version})")
-                # Triggers ride along inside DeployTaskRequest, so TriggerService.DeployTrigger
-                # (the only other deploy_trigger emitter, in remote.Trigger.create) never sees
-                # them. Count them here or they go unmeasured.
                 if deployable_triggers:
                     count(
                         "flyte.operation",

--- a/tests/flyte/test_deploy.py
+++ b/tests/flyte/test_deploy.py
@@ -605,3 +605,63 @@ async def test_apply_version_derivation_under_redirected_std_streams():
         deployment = await apply(plan, copy_style="loaded_modules", dryrun=True)
 
     assert "e" in deployment.envs
+
+
+@pytest.mark.asyncio
+async def test_deploy_task_counts_deployed_triggers(monkeypatch):
+    """Triggers ship inside DeployTaskRequest, so deploy_task is the only place they can be counted."""
+    from flyteidl2.task import task_definition_pb2
+
+    root_dir = pathlib.Path(__file__).parents[2].resolve()
+    monkeypatch.setattr(sys, "path", [str(root_dir / "src"), *sys.path])
+
+    env = flyte.TaskEnvironment(name="test_env", image="python:3.10")
+
+    @env.task()
+    async def task() -> None:
+        pass
+
+    task = replace(task, triggers=(Mock(), Mock()))
+    context = SerializationContext(version="v1", root_dir=root_dir)
+    config = Mock(sync_local_sys_paths=False)
+
+    with (
+        patch("flyte._deploy.ensure_client"),
+        patch("flyte._deploy.get_init_config", return_value=config),
+        patch("flyte._deploy.get_client", return_value=Mock(task_service=Mock(deploy_task=AsyncMock()))),
+        patch("flyte._internal.runtime.convert.convert_upload_default_inputs", AsyncMock(return_value=[])),
+        patch(
+            "flyte._internal.runtime.trigger_serde.to_task_trigger",
+            AsyncMock(return_value=task_definition_pb2.TaskTrigger(name="t")),
+        ),
+        patch("flyte._deploy.count") as count_mock,
+    ):
+        await _deploy_task(task, context, dryrun=False)
+
+    count_mock.assert_called_once_with("flyte.operation", 2, tags={"operation": "deploy_trigger", "status": "success"})
+
+
+@pytest.mark.asyncio
+async def test_deploy_task_without_triggers_emits_no_trigger_count(monkeypatch):
+    root_dir = pathlib.Path(__file__).parents[2].resolve()
+    monkeypatch.setattr(sys, "path", [str(root_dir / "src"), *sys.path])
+
+    env = flyte.TaskEnvironment(name="test_env", image="python:3.10")
+
+    @env.task()
+    async def task() -> None:
+        pass
+
+    context = SerializationContext(version="v1", root_dir=root_dir)
+    config = Mock(sync_local_sys_paths=False)
+
+    with (
+        patch("flyte._deploy.ensure_client"),
+        patch("flyte._deploy.get_init_config", return_value=config),
+        patch("flyte._deploy.get_client", return_value=Mock(task_service=Mock(deploy_task=AsyncMock()))),
+        patch("flyte._internal.runtime.convert.convert_upload_default_inputs", AsyncMock(return_value=[])),
+        patch("flyte._deploy.count") as count_mock,
+    ):
+        await _deploy_task(task, context, dryrun=False)
+
+    count_mock.assert_not_called()


### PR DESCRIPTION
## Why

The `deploy_trigger` counter added in #1295 has recorded **0 events in 90 days**, against 83K `deploy_task` events over the same window (Sentry project `4511135180128256`, metric `flyte.operation`). It is not that nobody deploys triggers — the counter is on a code path nobody takes.

`track_operation("deploy_trigger")` in `remote/_trigger.py` wraps `TriggerService.DeployTrigger`, which is only reachable from `flyte.remote.Trigger.create()`. Nothing in the SDK calls that; it is a standalone public API.

The path everyone actually uses is `flyte deploy`: `_deploy.py` builds `deployable_triggers` and passes them **inside** `DeployTaskRequest`, so every trigger deployed in practice is counted as a `deploy_task` and never as a `deploy_trigger`.

## What

Emit the counter where triggers actually get deployed — after a successful `deploy_task`, one count per trigger in the request. The `remote/_trigger.py` emitter is left alone; it still covers the standalone `Trigger.create()` API.

The `ALREADY_EXISTS` branch deliberately does not count: the server skipped the deploy, so nothing was deployed.

## Test Plan

Two tests in `tests/flyte/test_deploy.py`:

- `test_deploy_task_counts_deployed_triggers` — a task with 2 triggers emits `count("flyte.operation", 2, tags={"operation": "deploy_trigger", "status": "success"})` exactly once. Verified it fails without the fix.
- `test_deploy_task_without_triggers_emits_no_trigger_count` — a task with no triggers emits nothing.

```
uv run pytest tests/flyte/test_deploy.py -q
26 passed
```

## Rollout Plan

Ships with the next SDK release. Purely additive telemetry — no behavior change to deployment itself. After it rolls out, the "Triggers deployed" panel on the [Flyte Sentry Metrics dashboard](https://unionai.grafana.net/d/nar4d2t/flyte-sentry-metrics) should start reporting instead of sitting at 0.

## Rollback Plan

Revert this commit. `flyte._sentry.count` already swallows every exception, so the worst case is the counter going quiet again.
