### PR TITLE
feat(sentry): count create_run from the SDK

### DIFF
--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -35,6 +35,7 @@ from flyte.syncify import syncify
 # ``flyte.storage.join`` is imported lazily inside the one method that needs it so
 # ``import flyte`` does not eagerly pull fsspec/obstore/etc. into the startup path.
 from ._constants import FLYTE_SYS_PATH
+from ._sentry import track_operation
 
 if TYPE_CHECKING:
     from flyteidl2.core import artifact_id_pb2
@@ -750,7 +751,8 @@ class _Runner:
             else:
                 create_req.task_spec.CopyFrom(task_spec)
 
-            resp = await get_client().run_service.create_run(create_req)
+            with track_operation("create_run"):
+                resp = await get_client().run_service.create_run(create_req)
             return Run(pb2=resp.run, _preserve_original_types=self._preserve_original_types)
         except ConnectError as e:
             if e.code == Code.UNAVAILABLE:

--- a/tests/flyte/test_run_sentry.py
+++ b/tests/flyte/test_run_sentry.py
@@ -1,0 +1,84 @@
+"""The SDK counts create_run so it can be compared against the same operation
+counted server-side by the Flyte backend."""
+
+import mock
+import pytest
+from connectrpc.code import Code
+from connectrpc.errors import ConnectError
+from flyteidl2.common import run_pb2 as common_run_pb2
+from flyteidl2.dataproxy import dataproxy_service_pb2
+from mock.mock import AsyncMock, MagicMock
+
+import flyte
+import flyte.errors
+from flyte._initialize import _init_for_testing
+from flyte.models import CodeBundle
+
+env = flyte.TaskEnvironment(name="test")
+
+
+@env.task
+async def task1(v: str) -> str:
+    return f"Hello, world {v}!"
+
+
+def _make_mock_client():
+    mock_client = MagicMock()
+    mock_client.run_service = AsyncMock()
+
+    mock_dataproxy_service = AsyncMock()
+    mock_dataproxy_service.upload_inputs.return_value = dataproxy_service_pb2.UploadInputsResponse(
+        offloaded_input_data=common_run_pb2.OffloadedInputData(uri="s3://bucket/inputs", inputs_hash="abc123"),
+    )
+    mock_client.dataproxy_service = mock_dataproxy_service
+    return mock_client
+
+
+def _patch_build(fn):
+    fn = mock.patch("flyte._code_bundle.build_code_bundle", new_callable=AsyncMock)(fn)
+    fn = mock.patch("flyte._deploy._build_image_bg", new_callable=AsyncMock)(fn)
+    return fn
+
+
+async def _run_remote(mock_build_image_bg, mock_code_bundler, mock_client):
+    mock_code_bundler.return_value = CodeBundle(computed_version="v1", tgz="test.tgz")
+    mock_build_image_bg.return_value = (env.name, "image_name", None)
+    await _init_for_testing(client=mock_client, project="test", domain="test")
+    return await flyte.with_runcontext(mode="remote").run.aio(task1, "hello")
+
+
+def _operation_calls(count_mock):
+    """The (key, tags) of every flyte.operation counter emitted."""
+    return [
+        (call.args[0], call.kwargs.get("tags"))
+        for call in count_mock.call_args_list
+        if call.args and call.args[0] == "flyte.operation"
+    ]
+
+
+@pytest.mark.asyncio
+@_patch_build
+async def test_create_run_counts_success(mock_code_bundler, mock_build_image_bg):
+    with mock.patch("flyte._sentry.count") as count_mock:
+        await _run_remote(mock_build_image_bg, mock_code_bundler, _make_mock_client())
+
+    assert _operation_calls(count_mock) == [("flyte.operation", {"operation": "create_run", "status": "success"})]
+
+
+@pytest.mark.asyncio
+@_patch_build
+async def test_create_run_counts_failure(mock_code_bundler, mock_build_image_bg):
+    mock_client = _make_mock_client()
+    mock_client.run_service.create_run.side_effect = ConnectError(Code.INVALID_ARGUMENT, "bad inputs")
+
+    with mock.patch("flyte._sentry.count") as count_mock:
+        with pytest.raises(flyte.errors.RuntimeUserError):
+            await _run_remote(mock_build_image_bg, mock_code_bundler, mock_client)
+
+    calls = _operation_calls(count_mock)
+    assert len(calls) == 1
+    tags = calls[0][1]
+    assert tags["operation"] == "create_run"
+    assert tags["status"] == "error"
+    # An invalid argument is the caller's fault, not a backend bug.
+    assert tags["error_kind"] == "user"


### PR DESCRIPTION
## Why

`flyte.operation` is emitted from two places: this SDK and the Flyte backend's Connect interceptor. The SDK counts `deploy_task`, `deploy_app` and `deploy_trigger`; the backend counts `create_run`. Runs are therefore the one operation with no SDK-side counter, so the two sides can never be compared for them — over the last 90 days Sentry shows `create_run` exclusively from `sdk.name:sentry.go`, never from `sentry.python`.

This adds the missing half.

## What

Wrap the `RunService.CreateRun` call in `_run.py` with `track_operation("create_run")`.

Two scoping choices worth calling out:

- **Only the RPC is wrapped.** The inputs-offload (`dataproxy_service.upload_inputs`) that precedes it stays outside the block, so the SDK counter covers exactly what the backend interceptor covers. An offload failure is not a failed `create_run`.
- **`TrackedRunService.CreateRun` in `_persistence/_remote_reporter.py` is left alone.** It is a different RPC, the backend does not count it, and folding it in would inflate the SDK side of the comparison.

## How was this patch tested?

New `tests/flyte/test_run_sentry.py`, driving the real remote run path with a mocked client (same scaffolding as `test_run_runspec_chars.py`):

- `test_create_run_counts_success` — a successful remote run emits exactly one `flyte.operation` counter, tagged `{"operation": "create_run", "status": "success"}`.
- `test_create_run_counts_failure` — an `INVALID_ARGUMENT` from the backend emits one counter tagged `status=error` with `error_kind=user` (the caller's fault, not a backend bug), and still surfaces as `RuntimeUserError`.

Both verified to fail without the change.

```
uv run pytest tests/flyte/test_run_sentry.py tests/flyte/test_run_runspec_chars.py -q
26 passed
```

## Related PRs

- flyteorg/flyte-sdk#1436 — fixes the `deploy_trigger` undercount
- flyteorg/flyte#7855 — adds `deploy_task` / `deploy_app` / `deploy_trigger` counters to the backend

With all three, every operation on `flyte.operation` is emitted by both the SDK and the backend.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
