### PR TITLE
Add --devbox shortcut to 'flyte create config'

### DIFF
--- a/src/flyte/cli/_create.py
+++ b/src/flyte/cli/_create.py
@@ -398,7 +398,23 @@ def secret(
     Secret.create(name=name, value=value, type=type, cluster_pool=cluster_pool)
 
 
+_DEVBOX_ENDPOINT = "localhost:30080"
+_DEVBOX_PROJECT = "flytesnacks"
+_DEVBOX_DOMAIN = "development"
+
+
 @create.command(cls=common.CommandBase)
+@click.option(
+    "--devbox",
+    is_flag=True,
+    default=False,
+    help=(
+        "Configure for a local devbox cluster (see 'flyte start devbox'). Shortcut for "
+        f"'--endpoint {_DEVBOX_ENDPOINT} --insecure --project {_DEVBOX_PROJECT} "
+        f"--domain {_DEVBOX_DOMAIN} --builder local'. Explicit flags override these defaults."
+    ),
+    show_default=True,
+)
 @click.option("--endpoint", type=str, help="Endpoint of the Flyte backend.")
 @click.option("--insecure", is_flag=True, help="Use an insecure connection to the Flyte backend.")
 @click.option(
@@ -465,6 +481,7 @@ def secret(
 )
 def config(
     output: str,
+    devbox: bool = False,
     endpoint: str | None = None,
     insecure: bool = False,
     org: str | None = None,
@@ -481,10 +498,22 @@ def config(
     Creates a configuration file for Flyte CLI.
     If the `--output` option is not specified, it will create a file named `config.yaml` in the current directory.
     If the file already exists, it will raise an error unless the `--force` option is used.
+
+    To point the CLI at a local devbox cluster started with `flyte start devbox`, use the `--devbox` shortcut:
+
+    ```bash
+    $ flyte create config --devbox
+    ```
     """
     import yaml
 
     from flyte._utils import org_from_endpoint, sanitize_endpoint
+
+    if devbox:
+        endpoint = endpoint or _DEVBOX_ENDPOINT
+        insecure = True
+        project = project or _DEVBOX_PROJECT
+        domain = domain or _DEVBOX_DOMAIN
 
     output_path = Path(output)
 
@@ -520,7 +549,9 @@ def config(
     image: Dict[str, str] = {}
     if image_builder:
         image["builder"] = image_builder
-    if not registry and image_builder != "remote" and _is_interactive():
+    if not registry and not devbox and image_builder != "remote" and _is_interactive():
+        # The devbox resolves its own push registry (the in-cluster localhost registry), so we
+        # never propose a Docker-login registry for it.
         # No explicit --registry: try to infer a push registry from the user's Docker login and
         # offer it interactively. We only ever propose here (never at `flyte run` time), only in
         # an interactive terminal, and only write it on confirmation. The remote builder resolves

--- a/src/flyte/cli/_create.py
+++ b/src/flyte/cli/_create.py
@@ -411,7 +411,8 @@ _DEVBOX_DOMAIN = "development"
     help=(
         "Configure for a local devbox cluster (see 'flyte start devbox'). Shortcut for "
         f"'--endpoint {_DEVBOX_ENDPOINT} --insecure --project {_DEVBOX_PROJECT} "
-        f"--domain {_DEVBOX_DOMAIN} --builder local'. Explicit flags override these defaults."
+        f"--domain {_DEVBOX_DOMAIN} --builder local'. Mutually exclusive with --endpoint; "
+        "--project/--domain may still be overridden."
     ),
     show_default=True,
 )
@@ -510,7 +511,9 @@ def config(
     from flyte._utils import org_from_endpoint, sanitize_endpoint
 
     if devbox:
-        endpoint = endpoint or _DEVBOX_ENDPOINT
+        if endpoint:
+            raise click.UsageError(f"--devbox already implies --endpoint {_DEVBOX_ENDPOINT}; pass one or the other.")
+        endpoint = _DEVBOX_ENDPOINT
         insecure = True
         project = project or _DEVBOX_PROJECT
         domain = domain or _DEVBOX_DOMAIN

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -508,3 +508,46 @@ def test_create_config_with_local_tracked(runner: CliRunner, tmp_path):
     with open(outpath) as f:
         d = yaml.safe_load(f)
     assert d["local"]["tracked"] is True
+
+
+def test_create_config_devbox(runner: CliRunner, tmp_path):
+    """Test that --devbox writes the full devbox config (endpoint, insecure, project, domain, builder)."""
+    outpath = str(tmp_path / "config.yaml")
+    result = runner.invoke(main, ["create", "config", "--devbox", "-o", outpath, "--force"])
+    assert result.exit_code == 0, result.output
+    with open(outpath) as f:
+        d = yaml.safe_load(f)
+    assert d["admin"]["endpoint"] == "dns:///localhost:30080"
+    assert d["admin"]["insecure"] is True
+    assert d["task"]["project"] == "flytesnacks"
+    assert d["task"]["domain"] == "development"
+    assert d["image"]["builder"] == "local"
+    # The devbox resolves its own push registry; no registry should be written or prompted for.
+    assert "registry" not in d["image"]
+
+
+def test_create_config_devbox_explicit_flags_override(runner: CliRunner, tmp_path):
+    """Test that explicit flags override the --devbox defaults."""
+    outpath = str(tmp_path / "config.yaml")
+    result = runner.invoke(
+        main,
+        [
+            "create",
+            "config",
+            "--devbox",
+            "--project",
+            "my_project",
+            "--domain",
+            "staging",
+            "-o",
+            outpath,
+            "--force",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    with open(outpath) as f:
+        d = yaml.safe_load(f)
+    assert d["admin"]["endpoint"] == "dns:///localhost:30080"
+    assert d["admin"]["insecure"] is True
+    assert d["task"]["project"] == "my_project"
+    assert d["task"]["domain"] == "staging"

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -1,3 +1,4 @@
+import re
 from unittest.mock import Mock, patch
 
 import pytest
@@ -551,3 +552,16 @@ def test_create_config_devbox_explicit_flags_override(runner: CliRunner, tmp_pat
     assert d["admin"]["insecure"] is True
     assert d["task"]["project"] == "my_project"
     assert d["task"]["domain"] == "staging"
+
+
+def test_create_config_devbox_rejects_explicit_endpoint(runner: CliRunner, tmp_path):
+    """Test that --devbox and --endpoint are mutually exclusive."""
+    outpath = str(tmp_path / "config.yaml")
+    result = runner.invoke(
+        main,
+        ["create", "config", "--devbox", "--endpoint", "example.com", "-o", outpath, "--force"],
+    )
+    assert result.exit_code != 0
+    # rich_click wraps and colorizes the error panel; strip ANSI codes and newlines before matching.
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output).replace("\n", " ")
+    assert "--devbox already implies --endpoint" in re.sub(r"\s+", " ", plain)


### PR DESCRIPTION
## Why

The devbox docs ([Run locally on the devbox → Configure](https://www.union.ai/docs/v2/union/user-guide/get-started/run-modes/running-devbox/#configure)) tell users to run a five-flag command to point the CLI at a freshly started devbox:

```bash
flyte create config \
    --endpoint localhost:30080 \
    --project flytesnacks \
    --domain development \
    --builder local \
    --insecure
```

## What

`flyte create config --devbox` now produces the same config in one flag:

```yaml
admin:
  endpoint: dns:///localhost:30080
  insecure: true
image:
  builder: local
task:
  domain: development
  project: flytesnacks
```

- Explicit flags override the shortcut's defaults (e.g. `--devbox --project my_project`).
- The interactive "use your Docker login as the image registry?" proposal is skipped under `--devbox`, since the devbox resolves its own push registry (`localhost:30000`) from the localhost endpoint.

## Tests

- `test_create_config_devbox` — asserts the full YAML written by `--devbox`.
- `test_create_config_devbox_explicit_flags_override` — asserts explicit `--project/--domain` win over the defaults.

All 16 `create config` CLI tests pass; ruff check/format and pre-commit (mypy, ty) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)