### PR TITLE
fix: bundle code reached through a symlinked root (FLYTE-SDK-7E)

### DIFF
--- a/src/flyte/_code_bundle/_utils.py
+++ b/src/flyte/_code_bundle/_utils.py
@@ -115,6 +115,34 @@ def tar_strip_file_attributes(tar_info: tarfile.TarInfo) -> tarfile.TarInfo:
     return tar_info
 
 
+def _rebase_under_source(path: str, source_path: pathlib.Path, resolved_source: pathlib.Path) -> str:
+    """Rewrite `path` so it is spelled as a literal subpath of `source_path`.
+
+    File discovery can hand back a path that points inside the bundle root without being written
+    as a subpath of it. The common case is a symlinked root: on macOS `/tmp` is a symlink to
+    `/private/tmp`, so the bundle root resolves to `/private/tmp` while a loaded module's
+    `__file__` still reads `/tmp/task.py`. Everything downstream — the digest below,
+    `print_ls_tree`, and the tarball arcnames in `create_bundle` — takes the path relative to
+    `source_path`, so such an entry either raises or, worse, normalizes to a `../` path and gets
+    silently dropped from the bundle.
+
+    A path that is already a literal subpath is returned untouched. Resolving those would follow
+    symlinks that legitimately point outside the root (for example `.venv/bin/python`), which
+    `create_bundle` deliberately keeps unresolved. A path that cannot be rebased is also returned
+    untouched, so the caller reports it against the root the user actually passed.
+    """
+    p = pathlib.Path(path)
+    if p.is_relative_to(source_path):
+        return path
+
+    try:
+        rel = p.resolve().relative_to(resolved_source)
+    except (ValueError, OSError):
+        return path
+
+    return str(source_path / rel)
+
+
 def ls_files(
     source_path: pathlib.Path,
     copy_file_detection: CopyFiles,
@@ -158,8 +186,10 @@ def ls_files(
     else:
         all_files = list_all_files(source_path, deref_symlinks, ignore_group)
 
+    resolved_source = source_path.resolve()
+    all_files = [_rebase_under_source(f, source_path, resolved_source) for f in all_files]
+
     if additional_files:
-        resolved_source = source_path.resolve()
         extra_paths: list[str] = []
         for entry in additional_files:
             p = pathlib.Path(entry)
@@ -195,7 +225,18 @@ def ls_files(
     hasher = hashlib.md5()
     for abspath in all_files:
         # Use POSIX-style path for hashing to ensure consistent hashes across platforms
-        relpath = pathlib.Path(abspath).relative_to(source_path).as_posix()
+        try:
+            relpath = pathlib.Path(abspath).relative_to(source_path).as_posix()
+        except ValueError as exc:
+            from flyte.errors import CodeBundleError
+
+            # Reached only when a discovered file lies outside the bundle root even after
+            # resolving symlinks, which means the configured root does not contain the code.
+            # That is a user configuration problem, not an SDK bug (FLYTE-SDK-7E).
+            raise CodeBundleError(
+                f"{abspath!r} is outside the bundle root {source_path!s} and cannot be packaged. "
+                f"Pass --root-dir (or configure it) so that every file to bundle lives under the root."
+            ) from exc
         _filehash_update(abspath, hasher)
         _pathhash_update(relpath, hasher)
 

--- a/tests/flyte/code_bundle/test_code_bundle.py
+++ b/tests/flyte/code_bundle/test_code_bundle.py
@@ -885,3 +885,105 @@ async def test_build_code_bundle_does_not_warn_for_loaded_modules_copy_style(mon
 
         warnings = [call.args[0] for call in mock_warning.call_args_list]
         assert not any("home directory" in w for w in warnings)
+
+
+def _symlinked_root(tmpdir: str) -> tuple[pathlib.Path, pathlib.Path]:
+    """Build `real/` plus a `link -> real` symlink, mirroring macOS's /tmp -> /private/tmp."""
+    root = pathlib.Path(tmpdir).resolve()
+    real = root / "real"
+    real.mkdir()
+    link = root / "link"
+    link.symlink_to(real, target_is_directory=True)
+    return real, link
+
+
+def test_ls_files_rebases_module_reached_through_a_symlinked_root():
+    """A module whose __file__ points through a symlink to the bundle root must still bundle.
+
+    On macOS `/tmp` is a symlink to `/private/tmp`, so the root resolves to `/private/tmp` while
+    a loaded module's __file__ still reads `/tmp/task.py`. That path is not a literal subpath of
+    the root, so `relative_to` raised ValueError and aborted the deploy (FLYTE-SDK-7E).
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        real, link = _symlinked_root(tmpdir)
+        (real / "task.py").write_text("x = 1\n")
+
+        # The loader recorded the path as the user spelled it — through the symlink.
+        task_mod = ModuleType("task")
+        task_mod.__file__ = str(link / "task.py")
+
+        with patch.dict(sys.modules, {"task": task_mod}):
+            files, digest = ls_files(real, "loaded_modules")
+
+        assert files == [str(real / "task.py")]
+        assert digest
+
+
+def test_ls_files_symlinked_root_bundle_actually_contains_the_file():
+    """The rebased path must survive into the tarball, not just past the digest.
+
+    `create_bundle` derives arcnames with os.path.relpath, which is lexical: the un-rebased
+    path yields "../link/task.py", trips the outside-the-root guard, and the file is silently
+    dropped — an empty bundle rather than a crash.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        real, link = _symlinked_root(tmpdir)
+        (real / "task.py").write_text("x = 1\n")
+        output_dir = pathlib.Path(tmpdir) / "out"
+        output_dir.mkdir()
+
+        task_mod = ModuleType("task")
+        task_mod.__file__ = str(link / "task.py")
+
+        with patch.dict(sys.modules, {"task": task_mod}):
+            files, digest = ls_files(real, "loaded_modules")
+
+        tar_path, _, _ = create_bundle(real, output_dir, files, digest)
+        with tarfile.open(str(tar_path)) as tar:
+            assert tar.getnames() == ["task.py"]
+
+
+def test_ls_files_keeps_symlinks_inside_the_root_unresolved():
+    """A symlink under the root pointing outside it must keep its in-root spelling.
+
+    `.venv/bin/python -> /usr/bin/python3` is the canonical case: resolving it would push the
+    path outside the root and drop it. Only paths that are *not* already subpaths get rebased.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = pathlib.Path(tmpdir).resolve()
+        source = root / "src"
+        source.mkdir()
+        outside = root / "outside.txt"
+        outside.write_text("installed elsewhere")
+        (source / "linked.txt").symlink_to(outside)
+
+        files, _ = ls_files(source, "all", deref_symlinks=False)
+
+        assert str(source / "linked.txt") in files
+
+
+def test_ls_files_reports_a_file_outside_the_root_as_a_user_error():
+    """A file that is outside the root even after resolving is a misconfigured root, not a bug.
+
+    It must surface as CodeBundleError so it is filtered from crash reporting instead of
+    leaking as a raw ValueError out of pathlib.
+    """
+    from flyte.errors import CodeBundleError
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = pathlib.Path(tmpdir).resolve()
+        source = root / "src"
+        source.mkdir()
+        stray = root / "stray.py"
+        stray.write_text("x = 1\n")
+
+        stray_mod = ModuleType("stray")
+        stray_mod.__file__ = str(stray)
+
+        with patch(
+            "flyte._code_bundle._utils.list_imported_modules_as_files",
+            return_value=[str(stray)],
+        ):
+            with patch("flyte._code_bundle._utils._ruff_is_available", return_value=False):
+                with pytest.raises(CodeBundleError, match="outside the bundle root"):
+                    ls_files(source, "loaded_modules")


### PR DESCRIPTION
## What

`flyte deploy` aborts with a raw `ValueError` out of `pathlib` when the bundle root is reached through a symlink ([FLYTE-SDK-7E](https://unionai.sentry.io/issues/7671400252/), release 2.6.0):

```
ValueError: '/tmp/flyte2-smoke.py' is not in the subpath of '/private/tmp'
  flyte/_code_bundle/_utils.py:198 in ls_files
```

## Why

On macOS `/tmp` is a symlink to `/private/tmp`. The bundle root resolves to `/private/tmp`, but the loaded module's `__file__` still reads `/tmp/task.py`.

`_is_user_file` checks containment on **resolved** paths, so the file is correctly accepted — but discovery returns it with its *original* spelling, which is not a literal subpath of the root. `ls_files` then takes it relative to the root and raises.

**The crash is only the visible half.** `create_bundle` derives tar arcnames with `os.path.relpath`, which is purely lexical: the same path yields `../link/task.py`, trips the existing outside-the-root guard, and the file is **silently dropped**. A run that got past the `ValueError` would upload an empty bundle and fail on the cluster with `ModuleNotFoundError` instead. Verified both halves on `main` — the tarball comes back empty.

## How

Rebase discovered paths onto the root, so containment stays resolved-based while the returned path keeps the `source_path` prefix that everything downstream (`ls_files`'s digest, `print_ls_tree`, `create_bundle`'s arcnames) expects. This mirrors what the `additional_files` branch already does for include paths.

Two deliberate constraints:

- **Paths already spelled as literal subpaths are left untouched.** A symlink *inside* the root that legitimately points outside it (`.venv/bin/python -> /usr/bin/python3`) must keep its in-root spelling — `create_bundle` documents that it relies on this and avoids `resolve()` for exactly that reason. Pinned by a regression test.
- **A file still outside the root after resolving** means the configured root doesn't contain the code. That's user configuration, not an SDK bug, so it now raises `CodeBundleError` naming the root and pointing at `--root-dir`, instead of leaking a raw pathlib `ValueError` into crash reporting.

No digest change for setups that work today: the only paths whose spelling changes are the ones that previously crashed.

## Tests

4 tests in `tests/flyte/code_bundle/test_code_bundle.py`; 3 verified failing on `main`. The 4th is the `.venv/bin/python` guard, which passes on both sides by design — it exists to catch a regression this change could otherwise introduce.

Full `tests/flyte`: 3597 passed, 7 failed — all 7 fail identically on clean `main` in this environment.

fixes FLYTE-SDK-7E

## Update 2026-09-14 — this leak has now fired again, at the current release

`FLYTE-SDK-8H` (2026-09-14, release **2.7.2**) is this exact bug, reached through the *other* macOS
symlinked root:

```
ValueError: '/var/folders/2s/.../T/mission-partition-flyte2-.../app/mission_partition/publish_mission_partition.py'
  is not in the subpath of '/private/var/folders/2s/.../T/mission-partition-flyte2-.../...'
```

Frames are entirely SDK — `cli/_deploy.invoke` → `_deploy.apply` → `build_code_bundle` →
`list_files_to_bundle` → `_utils.ls_files` → `pathlib.relative_to` — i.e. the same
`relative_to(source_path)` this PR patches. `/var` is a symlink to `/private/var` on macOS just as
`/tmp` is to `/private/tmp`, so the bundle root resolves while the discovered module path does not.

That makes two distinct users hitting this on two different roots, the second one on a release cut
31 days after this PR was opened.

fixes FLYTE-SDK-8H
