### PR TITLE
fix: treat a blank project/domain as unset (FLYTE-SDK-3A)

### DIFF
--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -924,6 +924,25 @@ def requires_initialization(func: T) -> T:
     return typing.cast(T, wrapper)
 
 
+def blank_to_none(value: str | None) -> str | None:
+    """
+    Normalize a user-supplied setting so that blank means "not provided".
+
+    An empty or whitespace-only string is what a shell hands us for an unset variable
+    (`flyte run --project "$PROJECT"`), so it must not be mistaken for a real value.
+
+    Args:
+        value: The raw setting, which may be None, blank, or a real value.
+
+    Returns:
+        The stripped value, or None if it was None or blank.
+    """
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
 def require_project_and_domain(func):
     """
     Decorator that ensures the current Flyte configuration defines
@@ -933,7 +952,7 @@ def require_project_and_domain(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         cfg = get_init_config()
-        if cfg.project is None:
+        if blank_to_none(cfg.project) is None:
             raise InitializationError(
                 "ProjectNotConfigured",
                 "user",
@@ -942,7 +961,7 @@ def require_project_and_domain(func):
                 "or pass it directly to flyte.init(project='your-project-name').",
             )
 
-        if cfg.domain is None:
+        if blank_to_none(cfg.domain) is None:
             raise InitializationError(
                 "DomainNotConfigured",
                 "user",
@@ -1007,14 +1026,15 @@ def current_domain() -> str:
             return domain
 
     cfg = _get_init_config()
-    if cfg is None or cfg.domain is None:
+    configured_domain = blank_to_none(cfg.domain) if cfg is not None else None
+    if configured_domain is None:
         raise InitializationError(
             "DomainNotInitializedError",
             "user",
             "Domain has not been initialized. Call flyte.init() with a valid domain before using this function"
             " or Call flyte.init_from_config() with a valid path to the config file",
         )
-    return cfg.domain
+    return configured_domain
 
 
 def current_project() -> str:
@@ -1037,11 +1057,12 @@ def current_project() -> str:
             return project
 
     cfg = _get_init_config()
-    if cfg is None or cfg.project is None:
+    configured_project = blank_to_none(cfg.project) if cfg is not None else None
+    if configured_project is None:
         raise InitializationError(
             "ProjectNotInitializedError",
             "user",
             "Project has not been initialized. Call flyte.init() with a valid project before using this function"
             " or Call flyte.init_from_config() with a valid path to the config file",
         )
-    return cfg.project
+    return configured_project

--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -981,6 +981,25 @@ def requires_initialization(func: T) -> T:
     return typing.cast(T, wrapper)
 
 
+def blank_to_none(value: str | None) -> str | None:
+    """
+    Normalize a user-supplied setting so that blank means "not provided".
+
+    An empty or whitespace-only string is what a shell hands us for an unset variable
+    (`flyte run --project "$PROJECT"`), so it must not be mistaken for a real value.
+
+    Args:
+        value: The raw setting, which may be None, blank, or a real value.
+
+    Returns:
+        The stripped value, or None if it was None or blank.
+    """
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
 def require_project_and_domain(func):
     """
     Decorator that ensures the current Flyte configuration defines
@@ -990,7 +1009,7 @@ def require_project_and_domain(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         cfg = get_init_config()
-        if cfg.project is None:
+        if blank_to_none(cfg.project) is None:
             raise InitializationError(
                 "ProjectNotConfigured",
                 "user",
@@ -999,7 +1018,7 @@ def require_project_and_domain(func):
                 "or pass it directly to flyte.init(project='your-project-name').",
             )
 
-        if cfg.domain is None:
+        if blank_to_none(cfg.domain) is None:
             raise InitializationError(
                 "DomainNotConfigured",
                 "user",
@@ -1064,14 +1083,15 @@ def current_domain() -> str:
             return domain
 
     cfg = _get_init_config()
-    if cfg is None or cfg.domain is None:
+    configured_domain = blank_to_none(cfg.domain) if cfg is not None else None
+    if configured_domain is None:
         raise InitializationError(
             "DomainNotInitializedError",
             "user",
             "Domain has not been initialized. Call flyte.init() with a valid domain before using this function"
             " or Call flyte.init_from_config() with a valid path to the config file",
         )
-    return cfg.domain
+    return configured_domain
 
 
 def current_project() -> str:
@@ -1094,11 +1114,12 @@ def current_project() -> str:
             return project
 
     cfg = _get_init_config()
-    if cfg is None or cfg.project is None:
+    configured_project = blank_to_none(cfg.project) if cfg is not None else None
+    if configured_project is None:
         raise InitializationError(
             "ProjectNotInitializedError",
             "user",
             "Project has not been initialized. Call flyte.init() with a valid project before using this function"
             " or Call flyte.init_from_config() with a valid path to the config file",
         )
-    return cfg.project
+    return configured_project

--- a/src/flyte/cli/_common.py
+++ b/src/flyte/cli/_common.py
@@ -138,9 +138,16 @@ class CLIConfig:
         images: tuple[str, ...] | None = None,
         sync_local_sys_paths: bool = True,
     ):
+        from flyte._initialize import blank_to_none
         from flyte.config._config import TaskConfig
 
         api_key = os.getenv("FLYTE_API_KEY")
+
+        # A blank --project/--domain is what the shell substitutes for an unset variable
+        # (`flyte run --project "$PROJECT"`), so treat it as "not provided" and fall back to
+        # the config file, matching what init_from_config already does with `project or ...`.
+        project = blank_to_none(project)
+        domain = blank_to_none(domain)
 
         task_cfg = TaskConfig(
             org=self.org or self.config.task.org,

--- a/src/flyte/cli/_common.py
+++ b/src/flyte/cli/_common.py
@@ -41,11 +41,39 @@ HEADER_STYLE = f"{PREFERRED_ACCENT_COLOR} on black"
 #: rather than in either module because both spell the same command.
 HELLO_CMD = "hello"
 
+
+def blank_option_to_none(_ctx: click.Context, _param: click.Parameter, value: str | None) -> str | None:
+    """
+    Normalize a blank command-line value to None, i.e. "the flag was not given".
+
+    `flyte run --project "$PROJECT"` with `PROJECT` unset hands click an empty string. Without
+    this the blank counts as an explicit value, overrides the config file, and travels to the
+    backend as `id is required` (FLYTE-SDK-3A).
+
+    This deliberately lives on the click option rather than in `CLIConfig.init`: only a value
+    typed on the command line is ambiguous. A caller that passes `project=""` in Python means it
+    -- `flyte get/create/delete secret` use the empty string as the org-level scope sentinel --
+    and must not have it rewritten.
+
+    Args:
+        _ctx: The click context, unused.
+        _param: The parameter being processed, unused.
+        value: The raw command-line value.
+
+    Returns:
+        The stripped value, or None if it was absent or blank.
+    """
+    from flyte._initialize import blank_to_none
+
+    return blank_to_none(value)
+
+
 PROJECT_OPTION = click.Option(
     param_decls=["-p", "--project"],
     required=False,
     type=str,
     default=None,
+    callback=blank_option_to_none,
     help="Project to which this command applies.",
     show_default=True,
 )
@@ -55,6 +83,7 @@ DOMAIN_OPTION = click.Option(
     required=False,
     type=str,
     default=None,
+    callback=blank_option_to_none,
     help="Domain to which this command applies.",
     show_default=True,
 )
@@ -138,17 +167,15 @@ class CLIConfig:
         images: tuple[str, ...] | None = None,
         sync_local_sys_paths: bool = True,
     ):
-        from flyte._initialize import blank_to_none
         from flyte.config._config import TaskConfig
 
         api_key = os.getenv("FLYTE_API_KEY")
 
-        # A blank --project/--domain is what the shell substitutes for an unset variable
-        # (`flyte run --project "$PROJECT"`), so treat it as "not provided" and fall back to
-        # the config file, matching what init_from_config already does with `project or ...`.
-        project = blank_to_none(project)
-        domain = blank_to_none(domain)
-
+        # NOTE: a blank project/domain is *not* normalized here. A blank typed on the command line
+        # is already turned into None by `blank_option_to_none`; what reaches this point as ""
+        # came from a caller that meant it -- `flyte get/create/delete secret` pass the empty
+        # string to select the org-level scope -- so rewriting it here would silently rescope
+        # those commands to the config file's project/domain.
         task_cfg = TaskConfig(
             org=self.org or self.config.task.org,
             project=project if project is not None else self.config.task.project,

--- a/src/flyte/cli/_common.py
+++ b/src/flyte/cli/_common.py
@@ -37,11 +37,39 @@ PREFERRED_BORDER_COLOR = "dim cyan"
 PREFERRED_ACCENT_COLOR = "bold #FFD700"
 HEADER_STYLE = f"{PREFERRED_ACCENT_COLOR} on black"
 
+
+def blank_option_to_none(_ctx: click.Context, _param: click.Parameter, value: str | None) -> str | None:
+    """
+    Normalize a blank command-line value to None, i.e. "the flag was not given".
+
+    `flyte run --project "$PROJECT"` with `PROJECT` unset hands click an empty string. Without
+    this the blank counts as an explicit value, overrides the config file, and travels to the
+    backend as `id is required` (FLYTE-SDK-3A).
+
+    This deliberately lives on the click option rather than in `CLIConfig.init`: only a value
+    typed on the command line is ambiguous. A caller that passes `project=""` in Python means it
+    -- `flyte get/create/delete secret` use the empty string as the org-level scope sentinel --
+    and must not have it rewritten.
+
+    Args:
+        _ctx: The click context, unused.
+        _param: The parameter being processed, unused.
+        value: The raw command-line value.
+
+    Returns:
+        The stripped value, or None if it was absent or blank.
+    """
+    from flyte._initialize import blank_to_none
+
+    return blank_to_none(value)
+
+
 PROJECT_OPTION = click.Option(
     param_decls=["-p", "--project"],
     required=False,
     type=str,
     default=None,
+    callback=blank_option_to_none,
     help="Project to which this command applies.",
     show_default=True,
 )
@@ -51,6 +79,7 @@ DOMAIN_OPTION = click.Option(
     required=False,
     type=str,
     default=None,
+    callback=blank_option_to_none,
     help="Domain to which this command applies.",
     show_default=True,
 )
@@ -134,17 +163,15 @@ class CLIConfig:
         images: tuple[str, ...] | None = None,
         sync_local_sys_paths: bool = True,
     ):
-        from flyte._initialize import blank_to_none
         from flyte.config._config import TaskConfig
 
         api_key = os.getenv("FLYTE_API_KEY")
 
-        # A blank --project/--domain is what the shell substitutes for an unset variable
-        # (`flyte run --project "$PROJECT"`), so treat it as "not provided" and fall back to
-        # the config file, matching what init_from_config already does with `project or ...`.
-        project = blank_to_none(project)
-        domain = blank_to_none(domain)
-
+        # NOTE: a blank project/domain is *not* normalized here. A blank typed on the command line
+        # is already turned into None by `blank_option_to_none`; what reaches this point as ""
+        # came from a caller that meant it -- `flyte get/create/delete secret` pass the empty
+        # string to select the org-level scope -- so rewriting it here would silently rescope
+        # those commands to the config file's project/domain.
         task_cfg = TaskConfig(
             org=self.org or self.config.task.org,
             project=project if project is not None else self.config.task.project,

--- a/src/flyte/cli/_common.py
+++ b/src/flyte/cli/_common.py
@@ -134,9 +134,16 @@ class CLIConfig:
         images: tuple[str, ...] | None = None,
         sync_local_sys_paths: bool = True,
     ):
+        from flyte._initialize import blank_to_none
         from flyte.config._config import TaskConfig
 
         api_key = os.getenv("FLYTE_API_KEY")
+
+        # A blank --project/--domain is what the shell substitutes for an unset variable
+        # (`flyte run --project "$PROJECT"`), so treat it as "not provided" and fall back to
+        # the config file, matching what init_from_config already does with `project or ...`.
+        project = blank_to_none(project)
+        domain = blank_to_none(domain)
 
         task_cfg = TaskConfig(
             org=self.org or self.config.task.org,

--- a/src/flyte/cli/_rerun.py
+++ b/src/flyte/cli/_rerun.py
@@ -189,8 +189,20 @@ class RerunCommand(click.RichCommand):
 
 @click.command("rerun", cls=RerunCommand)
 @click.argument("run_name", required=True)
-@click.option("-p", "--project", default=None, help="Project for the new run (defaults to config).")
-@click.option("-d", "--domain", default=None, help="Domain for the new run (defaults to config).")
+@click.option(
+    "-p",
+    "--project",
+    default=None,
+    callback=common.blank_option_to_none,
+    help="Project for the new run (defaults to config).",
+)
+@click.option(
+    "-d",
+    "--domain",
+    default=None,
+    callback=common.blank_option_to_none,
+    help="Domain for the new run (defaults to config).",
+)
 @click.option("--name", default=None, help="Name for the new run (a random name is generated if unset).")
 @click.option("-e", "--env", "env", multiple=True, help="Env var KEY=VALUE for the new run. Repeatable.")
 @click.option("--label", "label", multiple=True, help="Label KEY=VALUE for the new run. Repeatable.")

--- a/src/flyte/cli/_rerun.py
+++ b/src/flyte/cli/_rerun.py
@@ -37,8 +37,20 @@ def _parse_kv(items: Tuple[str, ...], flag: str) -> Optional[Dict[str, str]]:
 
 @click.command("rerun", cls=click.RichCommand)
 @click.argument("run_name", required=True)
-@click.option("-p", "--project", default=None, help="Project for the new run (defaults to config).")
-@click.option("-d", "--domain", default=None, help="Domain for the new run (defaults to config).")
+@click.option(
+    "-p",
+    "--project",
+    default=None,
+    callback=common.blank_option_to_none,
+    help="Project for the new run (defaults to config).",
+)
+@click.option(
+    "-d",
+    "--domain",
+    default=None,
+    callback=common.blank_option_to_none,
+    help="Domain for the new run (defaults to config).",
+)
 @click.option("--name", default=None, help="Name for the new run (a random name is generated if unset).")
 @click.option("-e", "--env", "env", multiple=True, help="Env var KEY=VALUE for the new run. Repeatable.")
 @click.option("--label", "label", multiple=True, help="Label KEY=VALUE for the new run. Repeatable.")

--- a/tests/cli/test_blank_project_domain.py
+++ b/tests/cli/test_blank_project_domain.py
@@ -1,0 +1,72 @@
+"""Regression tests for FLYTE-SDK-3A: a blank --project/--domain must not override config.
+
+`flyte run --project "$PROJECT" --domain "$DOMAIN"` with unset shell variables hands the
+CLI empty strings. Those used to be treated as explicit values, overriding the config file
+and travelling all the way to CreateUploadLocation, where the backend answered
+"failed to validate project: invalid_argument: id is required". That surfaced as a
+RuntimeSystemError and was reported to Sentry as an SDK crash rather than as the user's
+missing configuration.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+
+from flyte.cli._common import CLIConfig
+from flyte.config._config import Config, TaskConfig
+
+
+def _make_cli_config(config: Config | None = None) -> CLIConfig:
+    ctx = MagicMock(spec=click.Context)
+    return CLIConfig(config=config or Config(), ctx=ctx)
+
+
+CONFIGURED = Config(task=TaskConfig(project="from-config", domain="from-config-domain"))
+
+
+class TestBlankProjectDomain:
+    @pytest.mark.parametrize("blank", ["", "   ", "\t"])
+    @patch("flyte.cli._common.flyte")
+    def test_blank_cli_values_fall_back_to_config(self, mock_flyte, blank):
+        cli = _make_cli_config(config=CONFIGURED)
+        cli.init(project=blank, domain=blank)
+
+        call_cfg = mock_flyte.init_from_config.call_args[0][0]
+        assert call_cfg.task.project == "from-config"
+        assert call_cfg.task.domain == "from-config-domain"
+
+    @patch("flyte.cli._common.flyte")
+    def test_explicit_values_still_override_config(self, mock_flyte):
+        cli = _make_cli_config(config=CONFIGURED)
+        cli.init(project="explicit", domain="explicit-domain")
+
+        call_cfg = mock_flyte.init_from_config.call_args[0][0]
+        assert call_cfg.task.project == "explicit"
+        assert call_cfg.task.domain == "explicit-domain"
+
+    @patch("flyte.cli._common.flyte")
+    def test_padded_values_are_stripped(self, mock_flyte):
+        cli = _make_cli_config(config=CONFIGURED)
+        cli.init(project="  explicit  ", domain="  explicit-domain  ")
+
+        call_cfg = mock_flyte.init_from_config.call_args[0][0]
+        assert call_cfg.task.project == "explicit"
+        assert call_cfg.task.domain == "explicit-domain"
+
+    @pytest.mark.parametrize("blank", ["", "   "])
+    @patch("flyte.cli._common.flyte")
+    def test_blank_on_both_sides_leaves_project_unset(self, mock_flyte, blank):
+        """With nothing configured either, project stays None so the guard can raise.
+
+        None is what `require_project_and_domain` reports as "Project must be provided",
+        a user-kind InitializationError that is filtered out of Sentry.
+        """
+        cli = _make_cli_config()
+        cli.init(project=blank, domain=blank)
+
+        call_cfg = mock_flyte.init_from_config.call_args[0][0]
+        assert call_cfg.task.project is None
+        assert call_cfg.task.domain is None

--- a/tests/cli/test_blank_project_domain.py
+++ b/tests/cli/test_blank_project_domain.py
@@ -6,6 +6,11 @@ and travelling all the way to CreateUploadLocation, where the backend answered
 "failed to validate project: invalid_argument: id is required". That surfaced as a
 RuntimeSystemError and was reported to Sentry as an SDK crash rather than as the user's
 missing configuration.
+
+The normalization lives on the click option, not in `CLIConfig.init`, because only a value
+typed on the command line is ambiguous. `flyte get/create/delete secret` call `init` with a
+literal `""` to select the org-level scope, and that has to survive -- the second class below
+pins it.
 """
 
 from __future__ import annotations
@@ -15,7 +20,7 @@ from unittest.mock import MagicMock, patch
 import click
 import pytest
 
-from flyte.cli._common import CLIConfig
+from flyte.cli._common import CLIConfig, CommandBase, blank_option_to_none
 from flyte.config._config import Config, TaskConfig
 
 
@@ -27,46 +32,98 @@ def _make_cli_config(config: Config | None = None) -> CLIConfig:
 CONFIGURED = Config(task=TaskConfig(project="from-config", domain="from-config-domain"))
 
 
-class TestBlankProjectDomain:
+def _invoke(args: list[str], config: Config) -> Config:
+    """Run a `CommandBase` command with `args` and return the Config handed to init_from_config.
+
+    Goes through click so the option callback runs, which is where the blank is normalized.
+    """
+    captured = {}
+
+    @click.command(cls=CommandBase)
+    @click.pass_context
+    def cmd(ctx, project=None, domain=None):
+        CLIConfig(config=config, ctx=ctx).init(project=project, domain=domain)
+
+    with patch("flyte.cli._common.flyte") as mock_flyte:
+        cmd.main(args=args, standalone_mode=False)
+        captured["cfg"] = mock_flyte.init_from_config.call_args[0][0]
+    return captured["cfg"]
+
+
+class TestBlankProjectDomainOnTheCommandLine:
     @pytest.mark.parametrize("blank", ["", "   ", "\t"])
+    def test_blank_cli_values_fall_back_to_config(self, blank):
+        cfg = _invoke(["--project", blank, "--domain", blank], CONFIGURED)
+        assert cfg.task.project == "from-config"
+        assert cfg.task.domain == "from-config-domain"
+
+    def test_explicit_values_still_override_config(self):
+        cfg = _invoke(["--project", "explicit", "--domain", "explicit-domain"], CONFIGURED)
+        assert cfg.task.project == "explicit"
+        assert cfg.task.domain == "explicit-domain"
+
+    def test_padded_values_are_stripped(self):
+        cfg = _invoke(["--project", "  explicit  ", "--domain", "  explicit-domain  "], CONFIGURED)
+        assert cfg.task.project == "explicit"
+        assert cfg.task.domain == "explicit-domain"
+
+    @pytest.mark.parametrize("blank", ["", "   "])
+    def test_blank_on_both_sides_leaves_project_unset(self, blank):
+        """With nothing configured either, project stays None so the guard can raise.
+
+        None is what `require_project_and_domain` reports as "Project must be provided",
+        a user-kind InitializationError that is filtered out of Sentry.
+        """
+        cfg = _invoke(["--project", blank, "--domain", blank], Config())
+        assert cfg.task.project is None
+        assert cfg.task.domain is None
+
+    def test_omitting_the_flags_entirely_falls_back_to_config(self):
+        cfg = _invoke([], CONFIGURED)
+        assert cfg.task.project == "from-config"
+        assert cfg.task.domain == "from-config-domain"
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [(None, None), ("", None), ("   ", None), ("\t", None), ("proj", "proj"), ("  proj  ", "proj")],
+    )
+    def test_callback_normalization(self, value, expected):
+        assert blank_option_to_none(MagicMock(spec=click.Context), MagicMock(spec=click.Parameter), value) == expected
+
+
+class TestOrgLevelSecretScopeIsPreserved:
+    """`flyte get/create/delete secret` pass project="" to mean "org level", not "unset".
+
+    Normalizing that blank away inside `CLIConfig.init` would make those three commands fall
+    back to the config file's project/domain: the listing would silently change scope, and
+    `--cluster-pool` would start failing outright, since `Secret._resolve_scope` rejects a
+    request that carries both a cluster pool and a project/domain.
+    """
+
     @patch("flyte.cli._common.flyte")
-    def test_blank_cli_values_fall_back_to_config(self, mock_flyte, blank):
+    def test_programmatic_blank_stays_blank(self, mock_flyte):
         cli = _make_cli_config(config=CONFIGURED)
-        cli.init(project=blank, domain=blank)
+        cli.init(project="", domain="")
 
         call_cfg = mock_flyte.init_from_config.call_args[0][0]
-        assert call_cfg.task.project == "from-config"
-        assert call_cfg.task.domain == "from-config-domain"
+        assert call_cfg.task.project == ""
+        assert call_cfg.task.domain == ""
 
     @patch("flyte.cli._common.flyte")
-    def test_explicit_values_still_override_config(self, mock_flyte):
+    def test_cluster_pool_scope_check_still_sees_an_empty_scope(self, mock_flyte):
+        """The empty scope is what keeps the `--cluster-pool` guard from rejecting the request."""
+        cli = _make_cli_config(config=CONFIGURED)
+        cli.init(project="", domain="")
+
+        call_cfg = mock_flyte.init_from_config.call_args[0][0]
+        assert not call_cfg.task.project
+        assert not call_cfg.task.domain
+
+    @patch("flyte.cli._common.flyte")
+    def test_programmatic_real_values_still_pass_through(self, mock_flyte):
         cli = _make_cli_config(config=CONFIGURED)
         cli.init(project="explicit", domain="explicit-domain")
 
         call_cfg = mock_flyte.init_from_config.call_args[0][0]
         assert call_cfg.task.project == "explicit"
         assert call_cfg.task.domain == "explicit-domain"
-
-    @patch("flyte.cli._common.flyte")
-    def test_padded_values_are_stripped(self, mock_flyte):
-        cli = _make_cli_config(config=CONFIGURED)
-        cli.init(project="  explicit  ", domain="  explicit-domain  ")
-
-        call_cfg = mock_flyte.init_from_config.call_args[0][0]
-        assert call_cfg.task.project == "explicit"
-        assert call_cfg.task.domain == "explicit-domain"
-
-    @pytest.mark.parametrize("blank", ["", "   "])
-    @patch("flyte.cli._common.flyte")
-    def test_blank_on_both_sides_leaves_project_unset(self, mock_flyte, blank):
-        """With nothing configured either, project stays None so the guard can raise.
-
-        None is what `require_project_and_domain` reports as "Project must be provided",
-        a user-kind InitializationError that is filtered out of Sentry.
-        """
-        cli = _make_cli_config()
-        cli.init(project=blank, domain=blank)
-
-        call_cfg = mock_flyte.init_from_config.call_args[0][0]
-        assert call_cfg.task.project is None
-        assert call_cfg.task.domain is None

--- a/tests/user_api/test_current_project_domain.py
+++ b/tests/user_api/test_current_project_domain.py
@@ -31,6 +31,13 @@ class TestCurrentProject:
         with pytest.raises(InitializationError):
             current_project()
 
+    @pytest.mark.parametrize("blank", ["", "   ", "\t"])
+    def test_current_project_raises_when_project_blank(self, blank):
+        """Regression for FLYTE-SDK-3A: a blank project is not a project."""
+        init_module._init_config = _InitConfig(root_dir=Path("/test"), project=blank)
+        with pytest.raises(InitializationError):
+            current_project()
+
 
 class TestCurrentDomain:
     @pytest.fixture(autouse=True)
@@ -49,5 +56,12 @@ class TestCurrentDomain:
 
     def test_current_domain_raises_when_domain_none(self):
         init_module._init_config = _InitConfig(root_dir=Path("/test"), domain=None)
+        with pytest.raises(InitializationError):
+            current_domain()
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\t"])
+    def test_current_domain_raises_when_domain_blank(self, blank):
+        """Regression for FLYTE-SDK-3A: a blank domain is not a domain."""
+        init_module._init_config = _InitConfig(root_dir=Path("/test"), domain=blank)
         with pytest.raises(InitializationError):
             current_domain()

--- a/tests/user_api/test_initialize.py
+++ b/tests/user_api/test_initialize.py
@@ -564,6 +564,56 @@ class TestDecorators:
         assert exc_info.value.code == "DomainNotConfigured"
         assert exc_info.value.kind == "user"
 
+    @pytest.mark.parametrize("blank", ["", "   ", "\t", "\n"])
+    def test_require_project_and_domain_rejects_blank_project(self, blank):
+        """Regression for FLYTE-SDK-3A: a blank project must not pass the guard.
+
+        `flyte run --project "$PROJECT"` with an unset shell variable hands the CLI an
+        empty string, which the old `is None` check let through. The blank project then
+        reached CreateUploadLocation, where the backend answered "failed to validate
+        project: invalid_argument: id is required" -- surfaced as a RuntimeSystemError and
+        reported to Sentry as an SDK crash instead of as the user's missing config.
+        """
+        test_config = _InitConfig(root_dir=Path("/test"), project=blank, domain="dev")
+        init_module._init_config = test_config
+
+        @require_project_and_domain
+        def test_func():
+            return "success"
+
+        with pytest.raises(InitializationError) as exc_info:
+            test_func()
+
+        assert exc_info.value.code == "ProjectNotConfigured"
+        assert exc_info.value.kind == "user"
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\t", "\n"])
+    def test_require_project_and_domain_rejects_blank_domain(self, blank):
+        """A blank domain must be rejected for the same reason as a blank project."""
+        test_config = _InitConfig(root_dir=Path("/test"), project="my-project", domain=blank)
+        init_module._init_config = test_config
+
+        @require_project_and_domain
+        def test_func():
+            return "success"
+
+        with pytest.raises(InitializationError) as exc_info:
+            test_func()
+
+        assert exc_info.value.code == "DomainNotConfigured"
+        assert exc_info.value.kind == "user"
+
+    def test_require_project_and_domain_allows_padded_values(self):
+        """Surrounding whitespace must not make an otherwise valid setting fail."""
+        test_config = _InitConfig(root_dir=Path("/test"), project=" my-project ", domain=" dev ")
+        init_module._init_config = test_config
+
+        @require_project_and_domain
+        def test_func():
+            return "success"
+
+        assert test_func() == "success"
+
 
 class TestInitFunction:
     """Test cases for the main init function"""


### PR DESCRIPTION
## What

`flyte run --project "$PROJECT" --domain "$DOMAIN"` with unset shell variables hands the CLI empty strings. Two things then went wrong:

1. `CLIConfig.init` used `project if project is not None else self.config.task.project`, so a blank value **overrode** the config file instead of falling back to it.
2. `require_project_and_domain` — the guard that exists precisely to catch a missing project — checked `cfg.project is None`, so the blank sailed straight through.

The blank project then reached `CreateUploadLocation`, where the backend answered `failed to validate project: invalid_argument: id is required`. That came back as a `RuntimeSystemError` and was reported to Sentry as an SDK crash rather than as the user's missing configuration.

The Sentry event shows the shape exactly — note both project **and** domain are empty, which is what you get from `-p "$P" -d "$D"` with both unset:

```
RuntimeSystemError: Upload failed for /var/folders/.../fast9b7b178a....tar.gz
  (org='flyte', project='', domain=''): failed to validate project: invalid_argument: id is required
```

## The fix

Both halves, because either alone leaves a bad outcome:

- **`CLIConfig.init`** treats a blank `--project`/`--domain` as *not provided* and falls back to the config file. This matches what `init_from_config` already does (`project or cfg.task.project`) and what the config layer's `set_if_exists` already does (it filters empty strings out of `TaskConfig.auto`). Without this half, the common case — a CI script with an unset variable — still fails when it should have just used the config file.
- **`require_project_and_domain`, `current_project`, `current_domain`** reject blank as well as `None`. Without this half, a user with nothing configured anywhere still gets the opaque backend error. With it they get the existing `InitializationError("ProjectNotConfigured", "user", ...)`, which is on `_is_user_error`'s allow-list and so is filtered out of Sentry.

The shared `blank_to_none` helper also strips surrounding whitespace, so ` my-project ` keeps working rather than becoming a new failure mode.

I deliberately left the in-cluster `tctx.action.project` path in `current_project` alone — it is populated by the backend, there is no Sentry evidence for it, and widening the change there would mask rather than surface a backend problem.

## Verification

20 of the new tests fail on `origin/main` and pass here (the remainder are regression guards for behavior that must *not* change — explicit values still override the config file).

Full `tests/flyte` is identical to the clean-`origin/main` baseline in this sandbox: **3597 passed, 7 failed** on both sides, the 7 being the known pre-existing local failures (`test_ls_files_loaded_modules_*`, `test_image_with_secrets`, `test_retrieve_degrades_when_keyring_not_installed`, the two `test_launch_remote_*`, `test_real_build`). `tests/cli` + `tests/user_api` + `tests/flyte/config`: 999 passed. `ruff format`/`check`, `check_docstring_style.py` (491 files clean) and `mypy` all clean.

fixes FLYTE-SDK-3A

Sentry: https://unionai.sentry.io/issues/7491437173/

### Note on the Sentry grouping

`FLYTE-SDK-3A` is a **mixed group**: Sentry buckets everything that crashes at the same `_upload_single_file` else-branch, so its 9 events are four unrelated root causes:

| when | release | shape | owner |
|---|---|---|---|
| 08-13, 08-14 | 2.5.18 | `failed to validate project: invalid_argument: id is required` | **this PR** |
| 07-10 | 2.4.4 | nginx `302 Found` HTML page | backend |
| 05-29 | 2.3.6 | `permission denied` (org/identity) | user config |
| 05-19 | 2.3.2 | `cross org calls are not allowed` | user config |

This PR fixes only the first, which is the only shape still firing and the only one on a current release. The other three are aged out and are not SDK bugs. I've kept `fixes FLYTE-SDK-3A` so the group gets marked resolved-in-next-release; if one of the other shapes recurs, Sentry's regression detection will reopen it.
