### PR TITLE
fix(io): fix 0-byte directory placeholder download

### DIFF
--- a/src/flyte/storage/_parallel_reader.py
+++ b/src/flyte/storage/_parallel_reader.py
@@ -326,9 +326,15 @@ class ObstoreParallelReader:
             async for obj in _list_downloadable():
                 path = pathlib.Path(obj["path"])  # e.g. Path(prefix/file.txt), needs to be changed to str.
                 size = obj["size"]
-                source = Source(id=path, path=path, length=size)
-                # Strip src_prefix from path for destination
+
+                # Skip directory placeholder objects (0-byte folder markers)
+                # These are typically used by cloud storage (e.g., GCS) to represent empty directories
+                # and end with "/" or have a relative path of "."
                 rel_path = path.relative_to(src_prefix)  # doesn't work on windows
+                if rel_path == pathlib.Path(".") or obj["path"].endswith("/"):
+                    continue
+
+                source = Source(id=path, path=path, length=size)
                 # Emit a single empty chunk for zero-byte objects so the file is still materialized locally
                 chunk_ranges = self._chunks(size) if size else [(0, 0)]
                 for offset, length in chunk_ranges:

--- a/src/flyte/storage/_parallel_reader.py
+++ b/src/flyte/storage/_parallel_reader.py
@@ -323,15 +323,23 @@ class ObstoreParallelReader:
                     yield obj
 
         async def _gen(tmp_dir: str) -> typing.AsyncGenerator[DownloadTask, None]:
-            async for obj in _list_downloadable():
+            # Materialize all objects to detect directory placeholders via parent relationships
+            objs = [obj async for obj in _list_downloadable()]
+
+            # Build a set of all parent directory paths from the objects
+            # This identifies which paths are parent directories of actual files
+            dir_paths = {str(parent) for o in objs for parent in pathlib.Path(o["path"]).parents}
+
+            for obj in objs:
                 path = pathlib.Path(obj["path"])  # e.g. Path(prefix/file.txt), needs to be changed to str.
                 size = obj["size"]
-
-                # Skip directory placeholder objects (0-byte folder markers)
-                # These are typically used by cloud storage (e.g., GCS) to represent empty directories
-                # and end with "/" or have a relative path of "."
+                # Strip src_prefix from path for destination
                 rel_path = path.relative_to(src_prefix)  # doesn't work on windows
-                if rel_path == pathlib.Path(".") or obj["path"].endswith("/"):
+
+                # Skip directory placeholder objects. These are identified by:
+                # 1. Root-level entry (rel_path == ".") — represents the prefix itself
+                # 2. 0-byte object that is a parent of other files in the listing
+                if rel_path == pathlib.Path(".") or (size == 0 and str(path) in dir_paths):
                     continue
 
                 source = Source(id=path, path=path, length=size)

--- a/tests/flyte/storage/test_parallel_reader.py
+++ b/tests/flyte/storage/test_parallel_reader.py
@@ -494,10 +494,13 @@ async def test_download_files_skips_directory_placeholders(tmp_path):
     Regression test for directory placeholder objects causing download failures.
 
     When downloading a directory from GCS/S3, obstore.list() may return 0-byte
-    directory placeholder objects (e.g., "prefix/folder/"). These should be
-    skipped during download to avoid:
-    1. Creating files in the temp directory that would collide
-    2. Failing to replace the staging temp directory onto its parent
+    directory placeholder objects. These are detected as directory markers by checking:
+    1. Root-level entries (rel_path == ".") — the prefix itself
+    2. 0-byte objects that are parents of other files in the listing
+
+    This ensures:
+    1. No file creation in temp directory that would collide
+    2. No failures replacing the staging temp directory onto its parent
 
     See: https://github.com/flyteorg/flyte/issues/XXXX
     """
@@ -509,7 +512,7 @@ async def test_download_files_skips_directory_placeholders(tmp_path):
         yield [
             {"path": "s3://bucket/dataset", "size": 0},  # Root-level placeholder
             {"path": "s3://bucket/dataset/data.parquet", "size": 100},  # Real file
-            {"path": "s3://bucket/dataset/subdir/", "size": 0},  # Subdir placeholder
+            {"path": "s3://bucket/dataset/subdir", "size": 0},  # Subdir placeholder (0-byte, parent of subdir/file.parquet)
             {"path": "s3://bucket/dataset/subdir/file.parquet", "size": 50},  # File in subdir
         ]
 

--- a/tests/flyte/storage/test_parallel_reader.py
+++ b/tests/flyte/storage/test_parallel_reader.py
@@ -512,7 +512,10 @@ async def test_download_files_skips_directory_placeholders(tmp_path):
         yield [
             {"path": "s3://bucket/dataset", "size": 0},  # Root-level placeholder
             {"path": "s3://bucket/dataset/data.parquet", "size": 100},  # Real file
-            {"path": "s3://bucket/dataset/subdir", "size": 0},  # Subdir placeholder (0-byte, parent of subdir/file.parquet)
+            {
+                "path": "s3://bucket/dataset/subdir",
+                "size": 0,
+            },  # Subdir placeholder (0-byte, parent of subdir/file.parquet)
             {"path": "s3://bucket/dataset/subdir/file.parquet", "size": 50},  # File in subdir
         ]
 

--- a/tests/flyte/storage/test_parallel_reader.py
+++ b/tests/flyte/storage/test_parallel_reader.py
@@ -486,3 +486,51 @@ async def test_download_files_no_cross_device_error(tmp_path):
     result = target_prefix / file_rel
     assert result.exists(), "downloaded file must exist after cross-device-safe move"
     assert result.read_bytes() == content
+
+
+@pytest.mark.asyncio
+async def test_download_files_skips_directory_placeholders(tmp_path):
+    """
+    Regression test for directory placeholder objects causing download failures.
+
+    When downloading a directory from GCS/S3, obstore.list() may return 0-byte
+    directory placeholder objects (e.g., "prefix/folder/"). These should be
+    skipped during download to avoid:
+    1. Creating files in the temp directory that would collide
+    2. Failing to replace the staging temp directory onto its parent
+
+    See: https://github.com/flyteorg/flyte/issues/XXXX
+    """
+    src_prefix = pathlib.Path("s3://bucket/dataset")
+    target_prefix = tmp_path / "output"
+
+    # Mock obstore to return both real files and directory placeholders
+    async def _mock_list(store, prefix=None):
+        yield [
+            {"path": "s3://bucket/dataset", "size": 0},  # Root-level placeholder
+            {"path": "s3://bucket/dataset/data.parquet", "size": 100},  # Real file
+            {"path": "s3://bucket/dataset/subdir/", "size": 0},  # Subdir placeholder
+            {"path": "s3://bucket/dataset/subdir/file.parquet", "size": 50},  # File in subdir
+        ]
+
+    async def _mock_get_range(store, path, *, start, end):
+        if "subdir/file" in path:
+            return b"y" * (end - start)
+        return b"x" * (end - start)
+
+    store = MagicMock()
+    with (
+        patch("flyte.storage._parallel_reader.obstore.list", side_effect=_mock_list),
+        patch(
+            "flyte.storage._parallel_reader.obstore.get_range_async",
+            side_effect=_mock_get_range,
+        ),
+    ):
+        reader = ObstoreParallelReader(store, chunk_size=100)
+        await reader.download_files(src_prefix, target_prefix)
+
+    # Verify only real files were downloaded, not directory placeholders
+    downloaded_files = sorted(p.name for p in target_prefix.rglob("*") if p.is_file())
+    assert downloaded_files == ["data.parquet", "file.parquet"]
+    assert (target_prefix / "data.parquet").read_bytes() == b"x" * 100
+    assert (target_prefix / "subdir" / "file.parquet").read_bytes() == b"y" * 50


### PR DESCRIPTION
## Problem

When downloading a directory, let's say `bucket`, of type `flyte.io.Dir` from GCS using `bucket.download_sync()`, the operation fails with:
```
OSError: [Errno 39] Directory not empty: '/tmp/.../run_dir/.flyte-download-u3nhf4r3' -> '/tmp/.../run_dir'
```

This occurs when the directory contains 0-byte directory placeholder objects (folder markers), which GCS uses to represent empty directories.

## Root Cause

GCS and other cloud storage systems store 0-byte directory placeholder objects to explicitly represent empty directories. When `obstore.list()` is called to enumerate objects under a prefix, it returns these placeholders alongside actual data files.

In `flyte/storage/_parallel_reader.py`, the `_gen()` function processes all objects from `obstore.list()` without filtering:

1. For a directory placeholder at the root level (e.g., `prefix/`), computing `rel_path = path.relative_to(src_prefix)` yields `Path(".")`
2. This causes the download target to be calculated as `tmp_dir / Path(".")`, which resolves to the temp directory itself
3. A file buffer is created at the temp directory location instead of a child path
4. Later, when the transformer attempts to move the staging directory with `aiofiles.os.replace(staging_dir, target_dir)`, it fails because:
   - `staging_dir` is still the temp directory (non-empty)
   - `target_dir` is the parent directory
   - POSIX `os.replace()` requires the destination to be empty

This issue was introduced in #1366, which added support for preserving zero-byte files in Dir/File downloads.

## Fix

The fix uses metadata-based directory detection to identify and skip directory placeholders:

1. **Materialize the object list** to enable analysis of parent-child relationships:
   ```python
   objs = [obj async for obj in _list_downloadable()]
   ```

2. **Build a set of parent directories** by extracting all parent paths from the objects:
   ```python
   dir_paths = {str(parent) for o in objs for parent in pathlib.Path(o["path"]).parents}
   ```

3. **Skip directory placeholders** identified by two conditions:
   - `rel_path == pathlib.Path(".")` — root-level entry representing the prefix itself
   - `size == 0 and str(path) in dir_paths` — 0-byte object that is a parent of other files

```python
   if rel_path == pathlib.Path(".") or (size == 0 and str(path) in dir_paths):
       continue
```

This approach uses actual metadata relationships (parent-child file structure) rather than relying on naming conventions. It correctly identifies directory markers across different cloud storage systems regardless of how they represent directories.

## Testing

Added a comprehensive regression test `test_download_files_skips_directory_placeholders()` that verifies:
- Root-level directory placeholders are correctly skipped using metadata (parent detection)
- Subdirectory placeholders (0-byte objects that are parents of other files) are correctly skipped
- Real data files in the directory are downloaded correctly
- Directory structure is preserved in the output

All existing unit tests pass without modification, confirming backward compatibility:
- `test_download_preserves_zero_byte_files` — verifies 0-byte files are still materialized
- `test_download_files_single_file` — verifies single file downloads work
- `test_download_files_multipart` — verifies multipart downloads work
- `test_download_files_no_cross_device_error` — verifies cross-device move safety
- Plus 6 additional unit tests (10/10 passing, 3 sandbox tests skipped)
