### PR TITLE
More verbose logging for keyring failures

### DIFF
--- a/src/flyte/remote/_client/auth/_keyring.py
+++ b/src/flyte/remote/_client/auth/_keyring.py
@@ -127,7 +127,13 @@ class KeyringStore:
         except NoKeyringError as e:
             logger.debug(f"KeyRing not available, tokens will not be cached. Error: {e}")
         except Exception as e:
-            logger.debug(f"Failed to store tokens in keyring. Error: {e}")
+            # Not debug: the call still succeeds, but the tokens just minted are lost.
+            # Refresh tokens rotate, so a silent miss here spends the stored refresh
+            # token and strands the user on the next call with an unexplained login.
+            logger.warning(
+                f"Failed to cache tokens in the system keyring, so the next command will "
+                f"have to authenticate again. Error: {e}"
+            )
         return credentials
 
     @staticmethod
@@ -161,7 +167,13 @@ class KeyringStore:
             logger.debug(f"KeyRing not available, tokens will not be cached. Error: {e}")
             return None
         except Exception as e:
-            logger.debug(f"Failed to retrieve tokens from keyring. Error: {e}")
+            # A locked keychain or denied access is not "nothing stored": the backend
+            # raises precisely so this does not masquerade as a cache miss and trigger
+            # a silent re-login, so say why the login is happening.
+            logger.warning(
+                f"Failed to read cached tokens from the system keyring, so a fresh login "
+                f"is required. Error: {e}"
+            )
             return None
 
         if not tokens_json:
@@ -228,7 +240,12 @@ class KeyringStore:
             except NotImplementedError as e:
                 logger.debug(f"Key {key} deletion not implemented in keyring backend. Error: {e}")
             except Exception as e:
-                logger.debug(f"Failed to delete key {key} from keyring. Error: {e}")
+                # Delete runs after a failed refresh, so a stale item left behind here
+                # keeps failing every subsequent command until it is removed by hand.
+                logger.warning(
+                    f"Failed to remove stale key {key} from the system keyring; "
+                    f"authentication may keep failing until it is deleted. Error: {e}"
+                )
 
         _delete_key(KeyringStore._tokens_key)
         # Clean up legacy per-token items from before tokens were combined.

--- a/src/flyte/remote/_client/auth/_keyring.py
+++ b/src/flyte/remote/_client/auth/_keyring.py
@@ -171,8 +171,7 @@ class KeyringStore:
             # raises precisely so this does not masquerade as a cache miss and trigger
             # a silent re-login, so say why the login is happening.
             logger.warning(
-                f"Failed to read cached tokens from the system keyring, so a fresh login "
-                f"is required. Error: {e}"
+                f"Failed to read cached tokens from the system keyring, so a fresh login is required. Error: {e}"
             )
             return None
 

--- a/tests/flyte/keyring/test_keyring_store.py
+++ b/tests/flyte/keyring/test_keyring_store.py
@@ -112,6 +112,56 @@ def test_store_swallows_no_keyring_error():
     assert result is creds
 
 
+def test_store_warns_when_caching_fails():
+    """A failed store spends the rotated refresh token, so it must not be silent."""
+    from keyring.errors import PasswordSetError
+
+    from flyte.remote._client.auth._keyring import Credentials, KeyringStore
+
+    creds = Credentials(access_token="tok", for_endpoint="foo", refresh_token="rtok")
+    with _mock_get_keyring_backend() as mock_backend:
+        mock_backend.return_value.set_password.side_effect = PasswordSetError(
+            "Can't store password on keychain: (-25244, 'Unknown Error')"
+        )
+        with patch("flyte.remote._client.auth._keyring.logger") as mock_logger:
+            result = KeyringStore.store(creds, disable=False)
+
+    assert result is creds
+    assert mock_logger.warning.call_count == 1
+    assert "-25244" in mock_logger.warning.call_args.args[0]
+
+
+def test_store_does_not_warn_when_keyring_is_simply_absent():
+    """No keyring in a cluster pod is expected, not a problem worth warning about."""
+    from keyring.errors import NoKeyringError
+
+    from flyte.remote._client.auth._keyring import Credentials, KeyringStore
+
+    creds = Credentials(access_token="tok", for_endpoint="foo")
+    with _mock_get_keyring_backend() as mock_backend:
+        mock_backend.return_value.set_password.side_effect = NoKeyringError("no backend")
+        with patch("flyte.remote._client.auth._keyring.logger") as mock_logger:
+            KeyringStore.store(creds, disable=False)
+
+    mock_logger.warning.assert_not_called()
+
+
+def test_retrieve_warns_when_keychain_read_fails():
+    """A denied or locked keychain must not masquerade as a silent cache miss."""
+    from keyring.errors import KeyringError
+
+    from flyte.remote._client.auth._keyring import KeyringStore
+
+    with _mock_get_keyring_backend() as mock_backend:
+        mock_backend.return_value.get_password.side_effect = KeyringError("keychain is locked")
+        with patch("flyte.remote._client.auth._keyring.logger") as mock_logger:
+            result = KeyringStore.retrieve("foo", disable=False)
+
+    assert result is None
+    assert mock_logger.warning.call_count == 1
+    assert "keychain is locked" in mock_logger.warning.call_args.args[0]
+
+
 def test_retrieve_skips_when_disabled():
     from flyte.remote._client.auth._keyring import KeyringStore
 


### PR DESCRIPTION
- `store()`Previously a failed write was invisible
- `retrieve()`gives a reason for a login attempt on not found rather than treating as a silent cache miss
-  `delete()` Runs after a failed refresh, so anything left behind here makes every command afterwards fail the same way     until someone manually removes it