### PR TITLE
move the allow_missing_source_outputs argument from with_runcontext to rerun method

### DIFF
--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -263,7 +263,6 @@ class _Runner:
         debug: bool = False,
         tracked: bool = False,
         tracked_strict: bool = False,
-        allow_missing_source_outputs: bool = False,
         _tracker: Any = None,
         _bundle_relative_paths: tuple[str, ...] | None = None,
         _bundle_from_dir: pathlib.Path | None = None,
@@ -318,9 +317,6 @@ class _Runner:
         # Strict reporting (debugging): any reporting failure fails the run loudly instead of
         # being swallowed. Also enabled via the `local.tracked_strict` config key.
         self._tracked_strict = tracked_strict
-        # Opt-in for rerun/recover of a source run whose outputs were cleaned up from storage:
-        # proceed with its inputs URI instead of failing. See the fallback in rerun().
-        self._allow_missing_source_outputs = allow_missing_source_outputs
 
     def _resolve_spawn_parent(self) -> Any | None:
         """Resolve the implicit *spawn* provenance parent (`Relation.related_to`, `SPAWN`).
@@ -1316,6 +1312,7 @@ class _Runner:
         action_name: str = "a0",
         recover: bool = False,
         force_rerun_actions: Sequence[str] | None = None,
+        allow_missing_source_outputs: bool = False,
         **inputs: Any,
     ) -> Run:
         """Re-run a prior run, returning a new `Run`.
@@ -1352,6 +1349,9 @@ class _Runner:
                 they succeeded in the source run (escape hatch). A listed parent action re-enqueues
                 its children — list them too to force the whole subtree; a listed condition re-pauses
                 for a new signal. Unknown names are ignored.
+            allow_missing_source_outputs: Proceed when the source run's outputs were cleaned up
+                from storage, using its inputs URI directly. The client cannot verify the inputs
+                still exist — if they were deleted too, the new run fails at runtime.
             inputs: Optional native keyword inputs to change parameters; omit to reuse prior inputs.
 
         Returns:
@@ -1446,14 +1446,14 @@ class _Runner:
                         f"launch fresh local code with `flyte run ...` "
                         f"(inputs come from the CLI parameters).",
                     ) from e
-                if not self._allow_missing_source_outputs:
+                if not allow_missing_source_outputs:
                     raise flyte.errors.RuntimeUserError(
                         "SourceRunOutputsUnavailableError",
                         f"Source run {run_name}'s outputs are no longer in storage. Rerun/recover "
                         f"only needs its inputs, but whether those still exist cannot be verified "
                         f"from the client. If you know the inputs are intact, retry with "
                         f"--allow-missing-outputs "
-                        f"(with_runcontext(allow_missing_source_outputs=True)); if they were "
+                        f"(rerun(..., allow_missing_source_outputs=True)); if they were "
                         f"deleted too, the new run would fail at runtime — pass new inputs "
                         f"explicitly instead (rerun('{run_name}', x=..., y=...) or "
                         f"`flyte run ...`).",
@@ -1533,7 +1533,6 @@ def with_runcontext(
     debug: bool = False,
     tracked: bool = False,
     tracked_strict: bool = False,
-    allow_missing_source_outputs: bool = False,
     _tracker: Any = None,
 ) -> _Runner:
     """
@@ -1617,10 +1616,6 @@ def with_runcontext(
             explicitly by this parameter.
         debug: Optional If true, the task will be run as a VSCode debug task, starting a code-server in the
             container so users can connect via the UI to interactively debug/run the task.
-        allow_missing_source_outputs: Opt-in for `rerun`/recover when the source run's
-            outputs were cleaned up from storage: proceed using the source inputs URI instead of
-            failing. The client cannot verify the inputs still exist — if they were deleted too,
-            the new run fails at runtime.
         tracked: Local-only. If true, report tracked run state (actions, attempts, outputs, reports)
             to the Flyte control plane via TrackedRunService so the run shows up in the console. Requires
             an initialized client and a configured project/domain. Can also be enabled globally with the
@@ -1681,7 +1676,6 @@ def with_runcontext(
         debug=debug,
         tracked=tracked,
         tracked_strict=tracked_strict,
-        allow_missing_source_outputs=allow_missing_source_outputs,
         _tracker=_tracker,
     )
 
@@ -1709,6 +1703,7 @@ async def rerun(
     action_name: str = "a0",
     recover: bool = False,
     force_rerun_actions: Sequence[str] | None = None,
+    allow_missing_source_outputs: bool = False,
     **inputs: Any,
 ) -> Run:
     """Re-run a prior run, returning a new `Run`.
@@ -1731,6 +1726,9 @@ async def rerun(
         force_rerun_actions: With `recover`, names of actions that must re-execute even though they
             succeeded in the source run (escape hatch). A listed parent action re-enqueues its
             children — list them too to force the whole subtree. Unknown names are ignored.
+        allow_missing_source_outputs: Proceed when the source run's outputs were cleaned up from
+            storage, using its inputs URI directly. The client cannot verify the inputs still
+            exist — if they were deleted too, the new run fails at runtime.
         inputs: Optional native keyword inputs to change parameters; omit to reuse prior inputs.
 
     Returns:
@@ -1741,5 +1739,6 @@ async def rerun(
         action_name,
         recover=recover,
         force_rerun_actions=force_rerun_actions,
+        allow_missing_source_outputs=allow_missing_source_outputs,
         **inputs,
     )

--- a/src/flyte/cli/_rerun.py
+++ b/src/flyte/cli/_rerun.py
@@ -153,13 +153,13 @@ async def _execute(
             name=name,
             env_vars=_parse_kv(env, "--env"),
             labels=_parse_kv(label, "--label"),
-            allow_missing_source_outputs=allow_missing_outputs,
         )
         result = await runner.rerun.aio(
             run_name,
             action_name=action_name or "a0",
             recover=recover,
             force_rerun_actions=force_rerun_action or None,
+            allow_missing_source_outputs=allow_missing_outputs,
         )
     except Exception as e:
         console.print(f"[red]✕ {'Recovery' if recover else 'Re-run'} failed:[/red] {e}")

--- a/tests/cli/test_rerun.py
+++ b/tests/cli/test_rerun.py
@@ -58,7 +58,13 @@ def test_rerun_delegates_to_runner_rerun():
     assert kwargs["mode"] == "remote"
     assert "recover" not in kwargs
     assert "recover_force_rerun_actions" not in kwargs
-    runner_obj.rerun.aio.assert_awaited_once_with("my-run", action_name="a0", recover=False, force_rerun_actions=None)
+    runner_obj.rerun.aio.assert_awaited_once_with(
+        "my-run",
+        action_name="a0",
+        recover=False,
+        force_rerun_actions=None,
+        allow_missing_source_outputs=False,
+    )
 
 
 def test_rerun_recover_flag_passed_to_rerun():
@@ -102,7 +108,7 @@ def test_rerun_force_rerun_action_passed_through():
     assert kwargs["force_rerun_actions"] == ("a3", "a7")
 
 
-def test_rerun_allow_missing_outputs_stays_on_run_context():
+def test_rerun_allow_missing_outputs_goes_to_rerun_not_run_context():
     runner_obj = _mock_runner()
 
     with (
@@ -113,8 +119,10 @@ def test_rerun_allow_missing_outputs_stays_on_run_context():
         result = CliRunner().invoke(rerun, ["my-run", "--label", "team=ml", "--allow-missing-outputs"])
 
     assert result.exit_code == 0, result.output
+    # Run-context options stay on with_runcontext; this one rides on rerun() now.
     assert wrc.call_args.kwargs["labels"] == {"team": "ml"}
-    assert wrc.call_args.kwargs["allow_missing_source_outputs"] is True
+    assert "allow_missing_source_outputs" not in wrc.call_args.kwargs
+    assert runner_obj.rerun.aio.call_args.kwargs["allow_missing_source_outputs"] is True
 
 
 def test_rerun_has_action_name_option():

--- a/tests/flyte/test_rerun.py
+++ b/tests/flyte/test_rerun.py
@@ -231,7 +231,7 @@ async def test_rerun_missing_source_outputs_opt_in_falls_back_to_inputs_uri():
 
     with mock.patch("flyte.remote._run.RunDetails") as RD:
         RD.get.aio = AsyncMock(return_value=_fake_prior_run())
-        run = await flyte.with_runcontext(mode="remote", allow_missing_source_outputs=True).rerun.aio("r1")
+        run = await flyte.with_runcontext(mode="remote").rerun.aio("r1", allow_missing_source_outputs=True)
 
     assert run
     mock_run_service.get_action_data_u_r_is.assert_called_once()

--- a/tests/flyte/test_run_runspec_chars.py
+++ b/tests/flyte/test_run_runspec_chars.py
@@ -360,8 +360,8 @@ async def test_apply_overrides_recover_stamps_relation():
     assert out.relation.relation_type == common_run_pb2.RELATION_TYPE_RECOVER
 
 
-def test_run_context_has_no_recover_options():
-    """Recovery moved onto rerun(); with_runcontext no longer carries it (SDK-16)."""
+def test_run_context_has_no_rerun_only_options():
+    """Every rerun-only option lives on rerun(), not on the run context (SDK-16)."""
     import inspect
 
     from flyte._run import _Runner, with_runcontext
@@ -370,7 +370,15 @@ def test_run_context_has_no_recover_options():
         params = inspect.signature(fn).parameters
         assert "recover" not in params
         assert "recover_force_rerun_actions" not in params
+        assert "allow_missing_source_outputs" not in params
     assert not hasattr(_Runner, "_resolve_recover_ref")
+    assert not hasattr(_Runner(), "_allow_missing_source_outputs")
+
+    # ... and rerun() is where they actually are.
+    rerun_params = inspect.signature(_Runner.rerun.__wrapped__).parameters
+    assert "recover" in rerun_params
+    assert "force_rerun_actions" in rerun_params
+    assert "allow_missing_source_outputs" in rerun_params
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR moves the rerun/recover-specific argument from `with_runcontext` to `rerun` for clarity