### PR TITLE
fix: don't crash printing emoji on a legacy Windows code page (FLYTE-SDK-7M)

### DIFF
--- a/src/flyte/cli/_common.py
+++ b/src/flyte/cli/_common.py
@@ -476,6 +476,7 @@ def print_url(console: Console, url: str, prefix: str = "➡️  ", of: OutputFo
     """
     Print a URL on a line of its own, soft-wrapped so it stays clickable and copyable.
     """
+    prefix = safe_text(prefix)
     if of in ["table-simple", "json", "json-raw"]:
         console.print(f"{prefix}{url}", highlight=False, soft_wrap=True)
         return
@@ -489,6 +490,25 @@ def get_console() -> Console:
     return Console(color_system="auto", force_terminal=True)
 
 
+def _stdout_can_encode(probe: str) -> bool:
+    """
+    Report whether stdout's encoding can represent `probe`.
+
+    Anything it can't represent raises UnicodeEncodeError at write time, deep inside
+    Rich's renderer, which crashes the command rather than degrading the output.
+    """
+    import sys
+
+    encoding = getattr(sys.stdout, "encoding", None) or ""
+    if encoding.lower().replace("-", "") in ("utf8", "utf16", "utf32"):
+        return True
+    try:
+        probe.encode(encoding)
+    except (UnicodeEncodeError, LookupError):
+        return False
+    return True
+
+
 def safe_spinner(spinner: str = "dots") -> str:
     """
     Pick an ASCII-safe spinner when stdout encoding can't represent the requested
@@ -496,17 +516,48 @@ def safe_spinner(spinner: str = "dots") -> str:
     braille characters used by Rich's default "dots" spinner, which crashes
     mid-render with UnicodeEncodeError).
     """
+    # Probe with a representative non-ASCII char from the "dots" spinner.
+    return spinner if _stdout_can_encode("⠙") else "line"
+
+
+# Plain-ASCII stand-ins for the decorative glyphs the CLI prints. Purely ornamental
+# ones map to the empty string; ones that carry meaning keep an ASCII equivalent.
+_ASCII_FALLBACKS = {
+    "\U0001f680": "",  # rocket
+    "\U0001f433": "",  # whale
+    "\u27a1": "->",  # right arrow
+    "\u26a0": "!",  # warning sign
+    "\u274c": "x",  # cross mark
+    "\u2705": "v",  # check mark button
+    "\u2714": "v",  # heavy check mark
+    "\ufe0f": "",  # variation selector-16, trails several of the above
+}
+
+
+def safe_text(text: str) -> str:
+    """
+    Rewrite `text` so every character survives stdout's encoding.
+
+    Legacy Windows consoles run on a regional code page (cp936, cp1252, ...) that has no
+    room for emoji, so printing one raises UnicodeEncodeError from inside Rich's renderer
+    and takes the whole command down. Known decorative glyphs become their ASCII stand-ins
+    and anything else that still won't encode becomes "?", the same substitution Python's
+    own `errors="replace"` would make.
+
+    Returns `text` unchanged whenever stdout can already encode it, which is every UTF-8
+    terminal, so this only ever degrades output that would otherwise have crashed.
+    """
     import sys
 
-    encoding = getattr(sys.stdout, "encoding", None) or ""
-    if encoding.lower().replace("-", "") in ("utf8", "utf16", "utf32"):
-        return spinner
+    if _stdout_can_encode(text):
+        return text
+    for glyph, replacement in _ASCII_FALLBACKS.items():
+        text = text.replace(glyph, replacement)
+    encoding = getattr(sys.stdout, "encoding", None) or "ascii"
     try:
-        # Probe with a representative non-ASCII char from the "dots" spinner.
-        "⠙".encode(encoding)
-    except (UnicodeEncodeError, LookupError):
-        return "line"
-    return spinner
+        return text.encode(encoding, "replace").decode(encoding, "replace")
+    except LookupError:
+        return text.encode("ascii", "replace").decode("ascii")
 
 
 class _StaticStatus:

--- a/src/flyte/cli/_devbox.py
+++ b/src/flyte/cli/_devbox.py
@@ -20,6 +20,8 @@ from rich.table import Table
 
 from flyte import _sentry
 
+from ._common import safe_spinner, safe_text
+
 _CONTAINER_NAME = "flyte-devbox"
 _VOLUME_NAME = "flyte-devbox"
 _KUBE_DIR = Path(
@@ -359,7 +361,7 @@ def _launch_devbox_plain(image_name: str, is_dev_mode: bool, steps: list[tuple[s
 
 def _launch_devbox_rich(image_name: str, is_dev_mode: bool, steps: list[tuple[str, str]], gpu: bool = False) -> None:
     with Progress(
-        SpinnerColumn(),
+        SpinnerColumn(spinner_name=safe_spinner()),
         TextColumn("[progress.description]{task.description}"),
         BarColumn(),
         TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
@@ -378,9 +380,11 @@ def _launch_devbox_rich(image_name: str, is_dev_mode: bool, steps: list[tuple[st
     else:
         console.print(
             Panel(
-                "[green bold]Flyte devbox cluster is ready![/green bold]\n\n"
-                "  🚀 UI:             [link=http://localhost:30080/v2]http://localhost:30080/v2[/link]\n"
-                "  🐳 Image Registry: localhost:30000",
+                safe_text(
+                    "[green bold]Flyte devbox cluster is ready![/green bold]\n\n"
+                    "  🚀 UI:             [link=http://localhost:30080/v2]http://localhost:30080/v2[/link]\n"
+                    "  🐳 Image Registry: localhost:30000"
+                ),
                 title="[bold]Flyte Devbox[/bold]",
                 border_style="green",
             )

--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -529,7 +529,7 @@ Missing required parameter(s): {", ".join(f"--{p[0]} (type: {p[1]})" for p in mi
         if not self.run_args.local and self.run_args.copy_style == "all":
             effective_root_dir = Path(self.run_args.root_dir).resolve() if self.run_args.root_dir else Path.cwd()
             if is_home_directory(effective_root_dir):
-                warning = HOME_DIRECTORY_WARNING.format(path=effective_root_dir)
+                warning = common.safe_text(HOME_DIRECTORY_WARNING.format(path=effective_root_dir))
                 common.get_console().print(f"[yellow]Warning: {warning}[/yellow]")
         self._validate_required_params(ctx)
         if self.run_args.tui:

--- a/tests/flyte/cli/test_safe_text.py
+++ b/tests/flyte/cli/test_safe_text.py
@@ -1,0 +1,115 @@
+"""Tests for ASCII-safe console text on non-UTF stdout encodings.
+
+Legacy Windows consoles run on a regional code page with no room for emoji, so a
+decorative glyph reaches Rich's renderer and raises UnicodeEncodeError there, taking
+the command down (FLYTE-SDK-7M, a `flyte start devbox` on a cp936 console).
+"""
+
+import io
+from unittest import mock
+
+import pytest
+from rich.console import Console
+from rich.panel import Panel
+
+from flyte._code_bundle._utils import HOME_DIRECTORY_WARNING
+from flyte.cli._common import print_url, safe_text
+
+DEVBOX_READY_PANEL = (
+    "[green bold]Flyte devbox cluster is ready![/green bold]\n\n"
+    "  \U0001f680 UI:             [link=http://localhost:30080/v2]http://localhost:30080/v2[/link]\n"
+    "  \U0001f433 Image Registry: localhost:30000"
+)
+
+
+def _stdout_with_encoding(encoding: str) -> io.TextIOWrapper:
+    return io.TextIOWrapper(io.BytesIO(), encoding=encoding)
+
+
+def _console_on(encoding: str) -> tuple[Console, io.TextIOWrapper]:
+    """A Console writing to a strict stream on `encoding`, like a legacy Windows console."""
+    stream = io.TextIOWrapper(io.BytesIO(), encoding=encoding, errors="strict")
+    return Console(file=stream, width=100, color_system=None), stream
+
+
+def test_utf8_stdout_is_left_alone():
+    with mock.patch("sys.stdout", _stdout_with_encoding("utf-8")):
+        assert safe_text(DEVBOX_READY_PANEL) == DEVBOX_READY_PANEL
+
+
+def test_ascii_only_text_is_left_alone():
+    with mock.patch("sys.stdout", _stdout_with_encoding("cp936")):
+        assert safe_text("Flyte devbox cluster is ready!") == "Flyte devbox cluster is ready!"
+
+
+@pytest.mark.parametrize("encoding", ["cp936", "cp1252", "ascii"])
+def test_emoji_dropped_on_legacy_code_pages(encoding: str):
+    with mock.patch("sys.stdout", _stdout_with_encoding(encoding)):
+        out = safe_text(DEVBOX_READY_PANEL)
+    assert "\U0001f680" not in out
+    assert "\U0001f433" not in out
+    # Only the ornament goes; the message and its Rich markup survive intact.
+    assert "Flyte devbox cluster is ready!" in out
+    assert "[link=http://localhost:30080/v2]" in out
+    assert "Image Registry: localhost:30000" in out
+    out.encode(encoding)  # would raise if anything unencodable were left
+
+
+def test_meaningful_glyphs_keep_an_ascii_stand_in():
+    with mock.patch("sys.stdout", _stdout_with_encoding("cp936")):
+        assert safe_text("➡️  ") == "->  "
+        assert safe_text("⚠️ warning").startswith("! ")
+
+
+def test_unmapped_unencodable_character_becomes_a_question_mark():
+    # Not in the fallback table: it must still not reach the stream unencoded.
+    with mock.patch("sys.stdout", _stdout_with_encoding("cp1252")):
+        assert safe_text("run 中文 done") == "run ?? done"
+
+
+def test_unknown_encoding_name_degrades_to_ascii():
+    class _BogusEncoding:
+        encoding = "not-a-real-codec"
+
+    with mock.patch("sys.stdout", _BogusEncoding()):
+        assert safe_text("\U0001f680 UI") == " UI"
+
+
+def test_missing_encoding_attribute_degrades_to_ascii():
+    class _NoEncoding:
+        encoding = None
+
+    with mock.patch("sys.stdout", _NoEncoding()):
+        assert safe_text("\U0001f680 UI") == " UI"
+
+
+def test_devbox_ready_panel_renders_on_a_cp936_console():
+    """The FLYTE-SDK-7M crash, end to end: Rich writing the panel to a cp936 stream."""
+    console, stream = _console_on("cp936")
+    with mock.patch("sys.stdout", _stdout_with_encoding("cp936")):
+        body = safe_text(DEVBOX_READY_PANEL)
+    console.print(Panel(body, title="[bold]Flyte Devbox[/bold]", border_style="green"))
+    stream.flush()
+    rendered = stream.buffer.getvalue().decode("cp936")
+    assert "Flyte devbox cluster is ready!" in rendered
+
+
+def test_print_url_prefix_renders_on_a_cp936_console():
+    """`flyte run` prints the run URL behind a default arrow-emoji prefix."""
+    console, stream = _console_on("cp936")
+    with mock.patch("sys.stdout", _stdout_with_encoding("cp936")):
+        print_url(console, "https://example.com/run/abc")
+    stream.flush()
+    rendered = stream.buffer.getvalue().decode("cp936")
+    assert "https://example.com/run/abc" in rendered
+    assert rendered.startswith("->")
+
+
+def test_home_directory_warning_renders_on_a_cp936_console():
+    console, stream = _console_on("cp936")
+    with mock.patch("sys.stdout", _stdout_with_encoding("cp936")):
+        warning = safe_text(HOME_DIRECTORY_WARNING.format(path="/home/u"))
+    console.print(f"[yellow]Warning: {warning}[/yellow]")
+    stream.flush()
+    rendered = stream.buffer.getvalue().decode("cp936")
+    assert "Running from your home directory" in rendered


### PR DESCRIPTION
Sentry: [FLYTE-SDK-7M](https://unionai.sentry.io/issues/7682040267/) — `UnicodeEncodeError: 'gbk' codec can't encode character '\U0001f680'`, release 2.6.2.
Sentry: [FLYTE-SDK-7S](https://unionai.sentry.io/issues/7691901326/) — the same crash on **cp1252**, release 2.6.5.

## What happens

`flyte start devbox` finishes bringing the cluster up, prints its success panel, and then dies:

```
flyte/cli/_devbox.py   launch_devbox
flyte/cli/_devbox.py   _launch_devbox_rich
rich/console.py        print
rich/_windows_renderer.py  legacy_windows_render
rich/_win32_console.py     write_text
UnicodeEncodeError: 'gbk' codec can't encode character '\U0001f680' in position 2
```

The panel prints 🚀 and 🐳. A Windows console on a regional code page (cp936 here, cp1252 in western locales) has no room for either, so the encode raises inside Rich's renderer — after the work succeeded. The user sees a crash instead of their cluster URL.

## The fix

The repo already solves this for spinners: `safe_spinner()` (#1058) probes `sys.stdout.encoding` and falls back to `"line"` when the braille glyphs won't fit. This generalises that probe to arbitrary output.

`safe_text()` returns its input unchanged whenever stdout can already encode it — every UTF-8 terminal, so nothing changes for almost everyone. Otherwise it swaps the decorative glyphs the CLI actually emits for ASCII stand-ins (🚀/🐳 → dropped, ➡️ → `->`, ⚠️ → `!`, ❌ → `x`) and replaces anything left over with `?`, the same substitution `errors="replace"` would make. Rich markup is untouched, so links and colours survive.

Applied at the three sites that emit non-ASCII decoration:

| site | reached by |
|---|---|
| devbox ready panel | `flyte start devbox` — the crash in Sentry |
| `print_url()` default `➡️  ` prefix | `flyte run`, `flyte rerun` |
| home-directory warning | `flyte run --copy-style all` from `$HOME` |

`print_url` is worth calling out: it is on the mainstream `flyte run` path, so the same console would have crashed there next. The reporting user also has [FLYTE-SDK-7P](https://unionai.sentry.io/issues/7682250607/) — their uploads fail behind a proxy — which is the only reason they had not reached it yet.

Also passes `safe_spinner()` to the devbox `SpinnerColumn`, which was the last spinner under `flyte/cli` still asking for Rich's braille default; cp936 cannot encode those either.

## Verification

The new tests import `safe_text`, so on main they fail at *collection* and prove nothing on their own. Instead I ran a repro that renders each of the four sites to a strict cp936 stream, against clean `origin/main` and against this branch:

```
### clean origin/main ###
devbox panel   : CRASH -> UnicodeEncodeError: 'gbk' codec can't encode character '\U0001f680'   <- the Sentry signature
print_url      : CRASH -> UnicodeEncodeError: 'gbk' codec can't encode character '➡'
home warning   : CRASH -> UnicodeEncodeError: 'gbk' codec can't encode character '⚠'
devbox spinner : CRASH -> UnicodeEncodeError: 'gbk' codec can't encode character '⠋'

### this branch ###
all four: OK
```

12 new tests in `tests/flyte/cli/test_safe_text.py`, including three that drive a real `rich.Console` over a strict cp936 stream. `tests/flyte/cli` + `tests/cli`: 447 passed. ruff, mypy and `check-docstrings` clean.

## Left alone deliberately

`flyte/remote/_action.py:648` builds a `SpinnerColumn()` with the same braille default and would crash the same way. Fixing it means `flyte.remote` importing `flyte.cli._common`, which inverts the layering; it has no Sentry evidence yet, so it is called out here rather than bundled in.

## Update: the cp1252 case arrived

This PR predicted "cp936 here, cp1252 in western locales". [FLYTE-SDK-7S](https://unionai.sentry.io/issues/7691901326/) is exactly that, reported on release 2.6.5 from a different host: same `_launch_devbox_rich` panel, same `\U0001f680`, same `rich/_win32_console.write_text` frame — only the code page differs, which is why Sentry grouped it separately (the codec name is part of the message). No code change needed; it is the same defect and the same fix, so it is listed here so both close together.

fixes FLYTE-SDK-7M
fixes FLYTE-SDK-7S
