### PR TITLE
feat(vllm,sglang): speculative decoding, cache-aware routing, and current engine pins

### DIFF
--- a/examples/genai/nemotron_omni_voice/README.md
+++ b/examples/genai/nemotron_omni_voice/README.md
@@ -104,8 +104,10 @@ print(r.json()["choices"][0]["message"]["content"])
 ## Notes / knobs
 
 - **Version pins are deliberate.** The Omni checkpoint needs **vLLM ≥ 0.20** and
-  `--trust-remote-code`; both are set in `serve.py`. Bump `VLLM_VERSION` there if
-  NVIDIA's recipe moves.
+  `--trust-remote-code`. The vLLM pin comes from the plugin's `DEFAULT_VLLM_IMAGE`
+  (which is well past that floor) and `--trust-remote-code` is set in `serve.py`.
+  If NVIDIA's recipe moves to a newer vLLM, append a `.with_pip_packages("vllm==<version>")`
+  layer to the image there.
 - **Want lower cost over lower latency?** Set `Scaling(replicas=(0, 1), scaledown_after=300)`
   to scale to zero when idle — at the cost of a cold start (multi-GB load) on the next request.
 - **BF16 instead of FP8** needs ~64 GB → switch `MODEL_REPO` to the BF16 variant

--- a/examples/genai/nemotron_omni_voice/serve.py
+++ b/examples/genai/nemotron_omni_voice/serve.py
@@ -40,7 +40,7 @@ Deploy
        python examples/genai/nemotron_omni_voice/voice_client.py --endpoint <app-url>
 """
 
-from flyteplugins.vllm import VLLMAppEnvironment
+from flyteplugins.vllm import DEFAULT_VLLM_IMAGE, VLLMAppEnvironment
 
 import flyte
 import flyte.app
@@ -60,21 +60,17 @@ MODEL_ID = "nemotron-omni"  # the name clients pass as `model=...`
 # ---------------------------------------------------------------------------
 # Image
 #
-# The Omni model needs vLLM >= 0.20 and trust-remote-code. We mirror the
-# plugin's default image (flashinfer for fast FP8 attention on Ada/L40S) but
-# pin a newer vLLM and add the audio decoding libraries vLLM uses to read the
-# incoming wav/mp3 payloads.
+# The Omni model needs vLLM >= 0.20 and trust-remote-code. The plugin's default
+# image already satisfies the version floor (and carries a flashinfer build
+# matching that vLLM, for fast FP8 attention on Ada/L40S), so this only adds the
+# audio decoding libraries vLLM uses to read the incoming wav/mp3 payloads.
+#
+# To follow a newer vLLM than the plugin pins, append your own layer:
+#   .with_pip_packages("vllm==<version>")
 # ---------------------------------------------------------------------------
 
-VLLM_VERSION = "0.20.0"
-
 image = (
-    flyte.Image.from_debian_base(name="nemotron-omni-vllm", install_flyte=False)
-    .with_pip_packages("flashinfer-python", "flashinfer-cubin")
-    .with_pip_packages("flashinfer-jit-cache", index_url="https://flashinfer.ai/whl/cu129")
-    .with_pip_packages("flyteplugins-vllm", pre=True)
-    # vLLM goes in its own layer (dependency conflict with flyte on protovalidate).
-    .with_pip_packages(f"vllm=={VLLM_VERSION}", "transformers>=4.57.0")
+    DEFAULT_VLLM_IMAGE.clone(name="nemotron-omni-vllm")
     # Audio decoding for the multimodal input pipeline.
     .with_pip_packages("librosa", "soundfile")
 )

--- a/examples/genai/sglang/sglang_app.py
+++ b/examples/genai/sglang/sglang_app.py
@@ -39,29 +39,15 @@ print(response.choices[0].message.content)
 ```
 """
 
-from flyteplugins.sglang import SGLangAppEnvironment
+from flyteplugins.sglang import DEFAULT_SGLANG_IMAGE, SGLangAppEnvironment
 
 import flyte
 import flyte.app
 
-image = (
-    flyte.Image.from_debian_base(name="sglang-app-image", install_flyte=False)
-    .with_apt_packages("libnuma-dev", "wget", "curl", "openssl", "pkg-config", "libssl-dev", "build-essential")
-    .with_commands(
-        [
-            "wget https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/cuda-keyring_1.1-1_all.deb",
-            "dpkg -i cuda-keyring_1.1-1_all.deb",
-            "apt-get update",
-            "apt-get install -y cuda-toolkit-12-8",
-        ]
-    )
-    .with_commands(["curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && . $HOME/.cargo/env"])
-    .with_env_vars({"CUDA_HOME": "/usr/local/cuda-12.8", "PATH": "/root/.cargo/bin:/usr/local/cuda-12.8/bin:$PATH"})
-    .with_pip_packages("flashinfer-python", "flashinfer-cubin")
-    .with_pip_packages("flashinfer-jit-cache", index_url="https://flashinfer.ai/whl/cu128")
-    .with_pip_packages("sglang==0.5.7")
-    .with_pip_packages("flyteplugins-sglang")
-)
+# The plugin's default image: an SGLang the model loader supports, plus the CUDA toolkit
+# matching the CUDA major that SGLang's own wheels pin. Extend it with
+# `.clone(name=...).with_pip_packages(...)` when an app needs extra dependencies.
+image = DEFAULT_SGLANG_IMAGE
 
 # Define the SGLang app environment for the smallest Qwen3 model
 sglang_app = SGLangAppEnvironment(

--- a/examples/genai/sglang/sglang_app_artifact.py
+++ b/examples/genai/sglang/sglang_app_artifact.py
@@ -73,7 +73,7 @@ print(response.choices[0].message.content)
 ```
 """
 
-from flyteplugins.sglang import SGLangAppEnvironment
+from flyteplugins.sglang import DEFAULT_SGLANG_IMAGE, SGLangAppEnvironment
 
 import flyte
 import flyte.app
@@ -84,24 +84,10 @@ MODEL_REPO = "HuggingFaceTB/SmolLM2-135M-Instruct"
 # tail, with '.' replaced by '-'. Pass `artifact_name=` to hf_model to override it.
 ARTIFACT_NAME = "SmolLM2-135M-Instruct"
 
-image = (
-    flyte.Image.from_debian_base(name="sglang-app-image", install_flyte=False)
-    .with_apt_packages("libnuma-dev", "wget", "curl", "openssl", "pkg-config", "libssl-dev", "build-essential")
-    .with_commands(
-        [
-            "wget https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/cuda-keyring_1.1-1_all.deb",
-            "dpkg -i cuda-keyring_1.1-1_all.deb",
-            "apt-get update",
-            "apt-get install -y cuda-toolkit-12-8",
-        ]
-    )
-    .with_commands(["curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && . $HOME/.cargo/env"])
-    .with_env_vars({"CUDA_HOME": "/usr/local/cuda-12.8", "PATH": "/root/.cargo/bin:/usr/local/cuda-12.8/bin:$PATH"})
-    .with_pip_packages("flashinfer-python", "flashinfer-cubin")
-    .with_pip_packages("flashinfer-jit-cache", index_url="https://flashinfer.ai/whl/cu128")
-    .with_pip_packages("sglang==0.5.7")
-    .with_pip_packages("flyteplugins-sglang")
-)
+# The plugin's default image: an SGLang the model loader supports, plus the CUDA toolkit
+# matching the CUDA major that SGLang's own wheels pin. Extend it with
+# `.clone(name=...).with_pip_packages(...)` when an app needs extra dependencies.
+image = DEFAULT_SGLANG_IMAGE
 
 smollm2_app = SGLangAppEnvironment(
     name="smollm2-135m-sglang",

--- a/examples/genai/sglang/sglang_app_sharded.py
+++ b/examples/genai/sglang/sglang_app_sharded.py
@@ -39,29 +39,15 @@ print(response.choices[0].message.content)
 ```
 """
 
-from flyteplugins.sglang import SGLangAppEnvironment
+from flyteplugins.sglang import DEFAULT_SGLANG_IMAGE, SGLangAppEnvironment
 
 import flyte
 import flyte.app
 
-image = (
-    flyte.Image.from_debian_base(name="sglang-app-image", install_flyte=False)
-    .with_apt_packages("libnuma-dev", "wget", "curl", "openssl", "pkg-config", "libssl-dev", "build-essential")
-    .with_commands(
-        [
-            "wget https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/cuda-keyring_1.1-1_all.deb",
-            "dpkg -i cuda-keyring_1.1-1_all.deb",
-            "apt-get update",
-            "apt-get install -y cuda-toolkit-12-8",
-        ]
-    )
-    .with_commands(["curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && . $HOME/.cargo/env"])
-    .with_env_vars({"CUDA_HOME": "/usr/local/cuda-12.8", "PATH": "/root/.cargo/bin:/usr/local/cuda-12.8/bin:$PATH"})
-    .with_pip_packages("flashinfer-python", "flashinfer-cubin")
-    .with_pip_packages("flashinfer-jit-cache", index_url="https://flashinfer.ai/whl/cu128")
-    .with_pip_packages("sglang==0.5.7")
-    .with_pip_packages("flyteplugins-sglang")
-)
+# The plugin's default image: an SGLang the model loader supports, plus the CUDA toolkit
+# matching the CUDA major that SGLang's own wheels pin. Extend it with
+# `.clone(name=...).with_pip_packages(...)` when an app needs extra dependencies.
+image = DEFAULT_SGLANG_IMAGE
 
 # Define the SGLang app environment for the smallest Qwen3 model
 sglang_app = SGLangAppEnvironment(

--- a/examples/genai/vllm/vllm_app.py
+++ b/examples/genai/vllm/vllm_app.py
@@ -39,7 +39,7 @@ print(response.choices[0].message.content)
 ```
 """
 
-from flyteplugins.vllm import VLLMAppEnvironment
+from flyteplugins.vllm import DEFAULT_VLLM_IMAGE, VLLMAppEnvironment
 
 import flyte
 import flyte.app
@@ -50,16 +50,11 @@ vllm_app = VLLMAppEnvironment(
     model_hf_path="Qwen/Qwen3-0.6B",
     model_id="qwen3-0.6b",
     resources=flyte.Resources(cpu="4", memory="16Gi", gpu="L40s:1", disk="10Gi"),
-    image=(
-        flyte.Image.from_debian_base(
-            name="vllm-app-image",
-            install_flyte=False,
-        )
-        .with_pip_packages("flashinfer-python", "flashinfer-cubin")
-        .with_pip_packages("flashinfer-jit-cache", index_url="https://flashinfer.ai/whl/cu129")
-        .with_pip_packages("vllm==0.11.0", "transformers==4.57.6")
-        .with_pip_packages("flyteplugins-vllm")
-    ),
+    # `image` defaults to DEFAULT_VLLM_IMAGE, which pins a vLLM the plugin's model loader
+    # supports along with a matching flashinfer build. It is named here only to make that
+    # explicit; extend it with `.clone(name=...).with_pip_packages(...)` when an app needs
+    # extra dependencies.
+    image=DEFAULT_VLLM_IMAGE,
     stream_model=True,  # Stream model directly from blob store to GPU
     scaling=flyte.app.Scaling(
         replicas=(0, 1),  # (min_replicas, max_replicas)

--- a/examples/genai/vllm/vllm_app_artifact.py
+++ b/examples/genai/vllm/vllm_app_artifact.py
@@ -68,7 +68,7 @@ print(response.choices[0].message.content)
 ```
 """
 
-from flyteplugins.vllm import VLLMAppEnvironment
+from flyteplugins.vllm import DEFAULT_VLLM_IMAGE, VLLMAppEnvironment
 
 import flyte
 import flyte.app
@@ -79,18 +79,9 @@ MODEL_REPO = "HuggingFaceTB/SmolLM2-135M-Instruct"
 # tail, with '.' replaced by '-'. Pass `artifact_name=` to hf_model to override it.
 ARTIFACT_NAME = "SmolLM2-135M-Instruct"
 
-image = (
-    flyte.Image.from_debian_base(
-        name="vllm-app-image",
-        install_flyte=False,
-    )
-    .with_pip_packages("flashinfer-python", "flashinfer-cubin")
-    .with_pip_packages("flashinfer-jit-cache", index_url="https://flashinfer.ai/whl/cu129")
-    # transformers is pinned deliberately: newer releases break the tokenizer load
-    # path used by the plugin's fserve entrypoint.
-    .with_pip_packages("vllm==0.11.0", "transformers==4.57.6")
-    .with_pip_packages("flyteplugins-vllm")
-)
+# The plugin's default image: a vLLM the model loader supports, a flashinfer build matching
+# that vLLM's CUDA major, and transformers left to vLLM's own floor (it pins one).
+image = DEFAULT_VLLM_IMAGE
 
 smollm2_app = VLLMAppEnvironment(
     name="smollm2-135m-vllm",

--- a/examples/genai/vllm/vllm_app_sharded.py
+++ b/examples/genai/vllm/vllm_app_sharded.py
@@ -39,7 +39,7 @@ print(response.choices[0].message.content)
 ```
 """
 
-from flyteplugins.vllm import VLLMAppEnvironment
+from flyteplugins.vllm import DEFAULT_VLLM_IMAGE, VLLMAppEnvironment
 
 import flyte
 import flyte.app
@@ -50,13 +50,9 @@ vllm_app = VLLMAppEnvironment(
     model_hf_path="Qwen/Qwen3-14B",
     model_id="qwen3-14b",
     resources=flyte.Resources(cpu="36", memory="300Gi", gpu="L40s:4", disk="300Gi", shm="auto"),
-    image=(
-        flyte.Image.from_debian_base(name="vllm-app-image", install_flyte=False)
-        .with_pip_packages("flashinfer-python", "flashinfer-cubin")
-        .with_pip_packages("flashinfer-jit-cache", index_url="https://flashinfer.ai/whl/cu129")
-        .with_pip_packages("vllm==0.11.0")
-        .with_pip_packages("flyteplugins-vllm")
-    ),
+    # The plugin's default image already carries a vLLM its sharded loader supports, plus a
+    # matching flashinfer build, so there is nothing to add for tensor-parallel serving.
+    image=DEFAULT_VLLM_IMAGE,
     stream_model=True,  # Stream model directly from blob store to GPU
     scaling=flyte.app.Scaling(
         replicas=(0, 1),  # (min_replicas, max_replicas)

--- a/examples/genai/vllm/vllm_app_triattention.py
+++ b/examples/genai/vllm/vllm_app_triattention.py
@@ -38,7 +38,7 @@ print(response.choices[0].message.content)
 ```
 """
 
-from flyteplugins.vllm import VLLMAppEnvironment
+from flyteplugins.vllm import DEFAULT_VLLM_IMAGE, VLLMAppEnvironment
 
 import flyte
 import flyte.app
@@ -49,15 +49,12 @@ vllm_app = VLLMAppEnvironment(
     model_hf_path="Qwen/Qwen3-32B-AWQ",
     model_id="qwen3-32b-int4",
     resources=flyte.Resources(cpu="4", memory="24Gi", gpu="A10G:1", disk="50Gi"),
+    # Build on the plugin's default image so the vLLM pin and its matching flashinfer build
+    # stay in one place; TriAttention is the only thing this app adds on top.
     image=(
-        flyte.Image.from_debian_base(
-            name="vllm-triattention-image",
-            install_flyte=False,
-        )
-        .with_pip_packages("vllm==0.19.0", "transformers==4.57.6")
+        DEFAULT_VLLM_IMAGE.clone(name="vllm-triattention-image")
         .with_apt_packages("git")
         .with_pip_packages("triattention @ git+https://github.com/WeianMao/triattention.git")
-        .with_pip_packages("flyteplugins-vllm")
     ),
     stream_model=True,
     scaling=flyte.app.Scaling(

--- a/examples/genai/vllm/vllm_gpt_oss_claude.py
+++ b/examples/genai/vllm/vllm_gpt_oss_claude.py
@@ -80,7 +80,7 @@ Notes
   A100, and H100 all work.
 """
 
-from flyteplugins.vllm import VLLMAppEnvironment
+from flyteplugins.vllm import DEFAULT_VLLM_IMAGE, VLLMAppEnvironment
 
 import flyte.app
 
@@ -89,16 +89,9 @@ vllm_app = VLLMAppEnvironment(
     model_hf_path="openai/gpt-oss-20b",
     model_id="gpt-oss-20b",
     resources=flyte.Resources(cpu="6", memory="24Gi", gpu="A10G:1", disk="200Gi"),
-    image=(
-        flyte.Image.from_debian_base(
-            name="vllm-claude-image",
-            install_flyte=False,
-        )
-        .with_pip_packages("flashinfer-python", "flashinfer-cubin")
-        .with_pip_packages("flashinfer-jit-cache", index_url="https://flashinfer.ai/whl/cu129")
-        .with_pip_packages("vllm==0.11.0", "transformers==4.57.6")
-        .with_pip_packages("flyteplugins-vllm")
-    ),
+    # The plugin's default image, renamed so this app's builds are cached separately from
+    # the other vLLM examples'. Nothing extra is needed to serve gpt-oss.
+    image=DEFAULT_VLLM_IMAGE.clone(name="vllm-claude-image"),
     stream_model=True,
     scaling=flyte.app.Scaling(
         replicas=(0, 1),

--- a/plugins/sglang/README.md
+++ b/plugins/sglang/README.md
@@ -39,13 +39,78 @@ if __name__ == "__main__":
 ## Features
 
 - **Streaming Model Loading**: Stream model weights directly from object storage to GPU memory, reducing startup time and disk requirements.
+- **Speculative Decoding**: Serve a target model alongside a draft model (speculator) to shorten decode.
+- **Cache-Aware Routing**: Run data-parallel workers behind SGLang's router so requests land on the worker that already holds their prefix.
 - **OpenAI-Compatible API**: The deployed app exposes an OpenAI-compatible API for chat completions.
 - **Auto-scaling**: Configure scaling policies to scale up/down based on traffic.
 - **Tensor Parallelism**: Support for distributed inference across multiple GPUs.
 
-## Extra Arguments
+## Speculative decoding
 
-You can pass additional arguments to the SGLang server using the `extra_args` parameter:
+Set `speculative_config` to turn on
+[speculative decoding](https://docs.sglang.io/advanced_features/speculative_decoding.html). Each
+key becomes a `--speculative-<key>` server argument. When the speculator has its own weights,
+point `draft_model_path` (object storage, `RunOutput` or `ArtifactValue`) or `draft_model_hf_path`
+at them and the plugin mounts them next to the target model and fills in
+`--speculative-draft-model-path`:
+
+```python
+sglang_app = SGLangAppEnvironment(
+    name="qwen3-8b-spec",
+    model_path="s3://your-bucket/models/qwen3-8b",
+    model_id="qwen3-8b",
+    draft_model_path="s3://your-bucket/models/qwen3-8b-eagle3",
+    speculative_config={"algorithm": "EAGLE3"},
+    extra_args=["--mem-fraction-static", "0.75", "--trust-remote-code", "--enable-metrics"],
+    resources=flyte.Resources(cpu="8", memory="64Gi", gpu="L40s:1", disk="120Gi"),
+)
+```
+
+Supported algorithms include `EAGLE3`, `EAGLE`, `DFLASH`, `STANDALONE` (an independent small
+model as the drafter) and `NGRAM` (no draft model at all).
+
+Three caveats worth knowing up front:
+
+- **Let SGLang pick `num_steps`, `eagle_topk` and `num_draft_tokens` unless you have measured
+  otherwise.** Its defaults are model-family dependent — Llama/Grok want `topk=4`, everything else
+  `topk=1` — so a triple copied from a Llama example can make a Qwen target *slower* than no
+  speculation at all.
+- **Streaming is disabled whenever a draft model is configured.** The Flyte loader integration is
+  installed process-wide for a single set of weights, so both models are downloaded to the
+  container instead. Size `disk` for target + draft + a margin.
+- **Measure acceptance length, not just tokens/sec.** Add `--enable-metrics` and read acceptance
+  off `/metrics`; a value near 1 means the draft model is wrong for your target.
+
+## Cache-aware routing
+
+`router=True` serves the app through
+[SGLang's router](https://docs.sglang.io/advanced_features/router.html), which runs data-parallel
+workers in one process and sends each request to the worker most likely to already hold its
+prefix. Worker count and policy are ordinary server arguments:
+
+```python
+sglang_app = SGLangAppEnvironment(
+    name="my-llm-app",
+    model_path="s3://your-bucket/models/your-model",
+    model_id="your-model-id",
+    router=True,
+    extra_args=["--dp-size", "4", "--tp-size", "1", "--router-policy", "cache_aware"],
+    resources=flyte.Resources(cpu="32", memory="200Gi", gpu="L40s:4", disk="120Gi", shm="auto"),
+    scaling=flyte.app.Scaling(replicas=(1, 1)),
+)
+```
+
+Keeping routing inside the pod is what makes prefix affinity expressible at all: Flyte apps have
+no session affinity and no per-replica address, so the router has to sit in front of its own
+workers rather than in front of replicas. Note that the KV cache is per replica and dies with it,
+so scaling to zero throws away exactly what the router is building — prefer `replicas=(1, 1)`.
+
+Streaming is disabled in router mode: the router launches its workers as separate processes that
+never load the Flyte model loader.
+
+## Extra arguments
+
+`extra_args` is appended to the SGLang server command, as either a string or a list:
 
 ```python
 sglang_app = SGLangAppEnvironment(
@@ -56,5 +121,8 @@ sglang_app = SGLangAppEnvironment(
 )
 ```
 
-See the [SGLang server arguments documentation](https://docs.sglang.ai/backend/server_arguments.html) for available options.
+Arguments are quoted before they reach the server, so values containing spaces or JSON survive
+intact. Arguments of the form `$MY_VAR` are left unquoted so that Flyte still expands them from
+the app's environment. The server binds `0.0.0.0` unless you pass your own `--host`.
 
+See the [SGLang server arguments documentation](https://docs.sglang.ai/backend/server_arguments.html) for available options.

--- a/plugins/sglang/src/flyteplugins/sglang/_app_environment.py
+++ b/plugins/sglang/src/flyteplugins/sglang/_app_environment.py
@@ -54,12 +54,12 @@ DEFAULT_SGLANG_IMAGE = (
 def _shell_safe(args: list[str]) -> list[str]:
     """Quote args that have to survive a trip through a shell.
 
-    ``fserve`` runs the app with ``Popen(" ".join(args), shell=True)`` (flyte/_bin/serve.py), so
+    `fserve` runs the app with `Popen(" ".join(args), shell=True)` (flyte/_bin/serve.py), so
     any token carrying spaces or quotes reaches the engine mangled unless it is quoted here.
-    ``shlex.quote`` is the identity function for ordinary tokens, so this is a no-op for
+    `shlex.quote` is the identity function for ordinary tokens, so this is a no-op for
     everything else.
 
-    Tokens starting with ``$`` are left alone: ``fserve`` expands those against the container
+    Tokens starting with `$` are left alone: `fserve` expands those against the container
     environment *before* joining, and quoting would turn the marker into a literal.
     """
     return [arg if arg.startswith("$") else shlex.quote(arg) for arg in args]
@@ -262,7 +262,7 @@ class SGLangAppEnvironment(flyte.app.AppEnvironment):
         return bool(self.draft_model_path or self.draft_model_hf_path)
 
     def _speculative_args(self) -> list[str]:
-        """Render the flat ``--speculative-*`` flags, pointing at the draft model when there is one."""
+        """Render the flat `--speculative-*` flags, pointing at the draft model when there is one."""
         if self._has_draft_model and self.speculative_config is None:
             raise ValueError(
                 "speculative_config must be defined when a draft model is set. It selects the "

--- a/plugins/sglang/src/flyteplugins/sglang/_app_environment.py
+++ b/plugins/sglang/src/flyteplugins/sglang/_app_environment.py
@@ -7,11 +7,17 @@ from typing import Any, Literal, Optional, Union
 import flyte.app
 import rich.repr
 from flyte import Environment, Image, Resources, SecretRequest
+from flyte._logging import logger
 from flyte.app import ArtifactValue, Parameter, RunOutput
 from flyte.app._types import Port
 from flyte.models import SerializationContext
 
-from flyteplugins.sglang._constants import SGLANG_MIN_VERSION_STR
+from flyteplugins.sglang._constants import (
+    CUDA_HOME,
+    CUDA_TOOLKIT_PACKAGE,
+    SGLANG_MIN_VERSION_STR,
+    SGLANG_ROUTER_VERSION,
+)
 
 DEFAULT_SGLANG_IMAGE = (
     flyte.Image.from_debian_base(name="sglang-app-image")
@@ -23,18 +29,40 @@ DEFAULT_SGLANG_IMAGE = (
             "wget https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/cuda-keyring_1.1-1_all.deb",
             "dpkg -i cuda-keyring_1.1-1_all.deb",
             "apt-get update",
-            "apt-get install -y cuda-toolkit-12-8",
+            f"apt-get install -y {CUDA_TOOLKIT_PACKAGE}",
         ]
     )
     .with_commands(["curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && . $HOME/.cargo/env"])
-    .with_env_vars({"CUDA_HOME": "/usr/local/cuda-12.8", "PATH": "/root/.cargo/bin:/usr/local/cuda-12.8/bin:$PATH"})
-    # install flash-infer
-    .with_pip_packages("flashinfer-python", "flashinfer-cubin")
-    .with_pip_packages("flashinfer-jit-cache", index_url="https://flashinfer.ai/whl/cu128")
+    .with_env_vars({"CUDA_HOME": CUDA_HOME, "PATH": f"/root/.cargo/bin:{CUDA_HOME}/bin:$PATH"})
     .with_pip_packages("flyteplugins-sglang", pre=True)
-    .with_pip_packages(f"sglang=={SGLANG_MIN_VERSION_STR}")
-    .with_env_vars({"CUDA_HOME": "/usr/local/cuda-12.8"})
+    # No hand-pinned flashinfer layer: SGLang pins an exact flashinfer version with an exact
+    # CUDA extra (0.5.16 -> flashinfer_python[cu13]), so installing our own first only gives it
+    # something to fight, and a jit-cache built for a different CUDA major is actively wrong.
+    # The toolkit installed above covers whatever JIT remains -- a slower first start, but
+    # correct, and no index URL to keep in sync by hand.
+    #
+    # ``pre=True`` is required rather than cosmetic: SGLang depends on flash-attn-4>=4.0.0b18,
+    # itself a pre-release, and uv refuses pre-releases by default. Without it the resolver
+    # reports the package as simply unsatisfiable.
+    .with_pip_packages(f"sglang=={SGLANG_MIN_VERSION_STR}", pre=True)
+    # The cache-aware router, used when ``router=True``. Also pre=True: this layer re-resolves
+    # against the pre-release deps SGLang just installed and needs the same policy.
+    .with_pip_packages(f"sglang-router=={SGLANG_ROUTER_VERSION}", pre=True)
 )
+
+
+def _shell_safe(args: list[str]) -> list[str]:
+    """Quote args that have to survive a trip through a shell.
+
+    ``fserve`` runs the app with ``Popen(" ".join(args), shell=True)`` (flyte/_bin/serve.py), so
+    any token carrying spaces or quotes reaches the engine mangled unless it is quoted here.
+    ``shlex.quote`` is the identity function for ordinary tokens, so this is a no-op for
+    everything else.
+
+    Tokens starting with ``$`` are left alone: ``fserve`` expands those against the container
+    environment *before* joining, and quoting would turn the marker into a literal.
+    """
+    return [arg if arg.startswith("$") else shlex.quote(arg) for arg in args]
 
 
 @rich.repr.auto
@@ -67,7 +95,26 @@ class SGLangAppEnvironment(flyte.app.AppEnvironment):
         stream_model: When `model_path` is set, use True to stream weights from object
             storage to the GPU (Flyte loader integration). Ignored for `model_hf_path`-only apps,
             which use SGLang's normal Hugging Face download path. If False with `model_path`,
-            the model is downloaded to the local filesystem first, then loaded.
+            the model is downloaded to the local filesystem first, then loaded. Also ignored when
+            a draft model is configured, or when `router` is True -- see below.
+        draft_model_path: Remote path to the draft model (speculator) used for speculative
+            decoding, or a `RunOutput`/`ArtifactValue` resolved at deploy time. The weights are
+            downloaded alongside the target model and passed as `--speculative-draft-model-path`.
+            Requires `speculative_config`.
+        draft_model_hf_path: Hugging Face path to the draft model, as an alternative to
+            `draft_model_path` (e.g., Qwen/Qwen3-0.6B).
+        speculative_config: SGLang speculative decoding configuration. Each key becomes a
+            `--speculative-<key>` server arg, so `{"algorithm": "EAGLE3", "num_draft_tokens": 16}`
+            renders as `--speculative-algorithm EAGLE3 --speculative-num-draft-tokens 16`. The
+            draft model path is filled in from `draft_model_path`/`draft_model_hf_path` and must
+            not be set here. Note that SGLang auto-selects `num_steps`, `eagle_topk` and
+            `num_draft_tokens` per model family; override them only after reading acceptance
+            length off `/metrics`. See
+            https://docs.sglang.io/advanced_features/speculative_decoding.html.
+        router: Serve behind SGLang's cache-aware router (`sglang_router.launch_server`), which
+            runs data-parallel workers in one process and routes each request to the worker most
+            likely to already hold its prefix. Worker counts and routing policy are ordinary
+            server args, e.g. `extra_args=["--dp-size", "4", "--router-policy", "cache_aware"]`.
     """
 
     port: int | Port = 8080
@@ -77,8 +124,19 @@ class SGLangAppEnvironment(flyte.app.AppEnvironment):
     model_hf_path: str = ""
     model_id: str = ""
     stream_model: bool = True
+    draft_model_path: str | RunOutput | ArtifactValue = ""
+    draft_model_hf_path: str = ""
+    speculative_config: Optional[dict[str, Any]] = None
+    router: bool = False
     image: str | Image | Literal["auto"] = DEFAULT_SGLANG_IMAGE
-    _model_mount_path: str = field(default="/root/flyte", init=False)
+    # Under /tmp, and that is not cosmetic: ``fserve`` materializes each mounted Parameter
+    # through ``_ensure_dest_writable``, which needs the *image's* user to be able to create the
+    # parent directory. The released Flyte base image runs non-root, so a mount at the
+    # filesystem root -- or under /root -- fails with "Permission denied" before the engine ever
+    # starts. /tmp is writable for any user and lives on the same overlay filesystem the weights
+    # are already budgeted against by ``disk=``.
+    _model_mount_path: str = field(default="/tmp/flyte/model", init=False)
+    _draft_model_mount_path: str = field(default="/tmp/flyte/draft-model", init=False)
 
     def __post_init__(self):
         if self.env_vars is None:
@@ -101,6 +159,9 @@ class SGLangAppEnvironment(flyte.app.AppEnvironment):
         if self.model_path != "" and self.model_hf_path != "":
             raise ValueError("model_path and model_hf_path cannot be set at the same time")
 
+        if self.draft_model_path != "" and self.draft_model_hf_path != "":
+            raise ValueError("draft_model_path and draft_model_hf_path cannot be set at the same time")
+
         if self.model_hf_path:
             self._model_mount_path = self.model_hf_path
 
@@ -110,25 +171,58 @@ class SGLangAppEnvironment(flyte.app.AppEnvironment):
         if isinstance(self.extra_args, str):
             extra_args = shlex.split(self.extra_args)
         else:
-            extra_args = self.extra_args
+            extra_args = list(self.extra_args)
 
-        self.args = [
-            "sglang-fserve",
-            "--model-path",
-            self._model_mount_path,
-            "--served-model-name",
-            self.model_id,
-            "--port",
-            str(self.get_port().port),
-            *extra_args,
-        ]
-
-        if self.parameters:
-            raise ValueError("parameters cannot be set for SGLangAppEnvironment")
+        speculative_args = self._speculative_args()
 
         # Flyte blob streaming requires ``model_path`` (remote / RunOutput). HF-only apps use
         # SGLang's default loading regardless of ``stream_model``.
-        use_flyte_blob_streaming = bool(self.stream_model and self.model_path)
+        #
+        # Two other configurations rule streaming out:
+        #   * A draft model. The loader monkeypatch is process-wide and
+        #     ``FLYTE_MODEL_LOADER_REMOTE_MODEL_PATH``/``..._LOCAL_MODEL_PATH`` are a single global
+        #     pair, so it can only ever describe one set of weights -- with two models loaded it
+        #     would feed the target's tensors to the draft model.
+        #   * ``router=True``. The router launches its workers as separate processes that never go
+        #     through ``sglang-fserve``, so the patched loader is simply not installed in the
+        #     processes that load weights.
+        streaming_blocked_by = ""
+        if self._has_draft_model:
+            streaming_blocked_by = "a draft model"
+        elif self.router:
+            streaming_blocked_by = "router=True"
+
+        use_flyte_blob_streaming = bool(self.stream_model and self.model_path and not streaming_blocked_by)
+        if self.stream_model and self.model_path and streaming_blocked_by:
+            logger.warning(
+                "stream_model is not supported alongside %s: the Flyte streaming loader is installed "
+                "process-wide for a single set of weights. Falling back to downloading the model(s) to "
+                "the container filesystem.",
+                streaming_blocked_by,
+            )
+
+        entrypoint = ["python", "-m", "sglang_router.launch_server"] if self.router else ["sglang-fserve"]
+
+        # SGLang binds 127.0.0.1 by default, which is unreachable from outside the container.
+        host_args = [] if "--host" in extra_args else ["--host", "0.0.0.0"]
+
+        self.args = _shell_safe(
+            [
+                *entrypoint,
+                "--model-path",
+                self._model_mount_path,
+                "--served-model-name",
+                self.model_id,
+                *host_args,
+                "--port",
+                str(self.get_port().port),
+                *speculative_args,
+                *extra_args,
+            ]
+        )
+
+        if self.parameters:
+            raise ValueError("parameters cannot be set for SGLangAppEnvironment")
 
         input_kwargs: dict[str, Any] = {}
         if use_flyte_blob_streaming:
@@ -140,8 +234,20 @@ class SGLangAppEnvironment(flyte.app.AppEnvironment):
             input_kwargs["download"] = True
             input_kwargs["mount"] = self._model_mount_path
 
+        parameters: list[Parameter] = []
         if self.model_path:
-            self.parameters = [Parameter(name="model_path", value=self.model_path, **input_kwargs)]
+            parameters.append(Parameter(name="model_path", value=self.model_path, **input_kwargs))
+        if self.draft_model_path:
+            parameters.append(
+                Parameter(
+                    name="draft_model_path",
+                    value=self.draft_model_path,
+                    download=True,
+                    mount=self._draft_model_mount_path,
+                )
+            )
+        if parameters:
+            self.parameters = parameters
 
         self.env_vars["FLYTE_MODEL_LOADER_LOCAL_MODEL_PATH"] = self._model_mount_path
         self.links = [flyte.app.Link(path="/docs", title="SGLang OpenAPI Docs", is_relative=True), *self.links]
@@ -150,6 +256,43 @@ class SGLangAppEnvironment(flyte.app.AppEnvironment):
             self.image = DEFAULT_SGLANG_IMAGE
 
         super().__post_init__()
+
+    @property
+    def _has_draft_model(self) -> bool:
+        return bool(self.draft_model_path or self.draft_model_hf_path)
+
+    def _speculative_args(self) -> list[str]:
+        """Render the flat ``--speculative-*`` flags, pointing at the draft model when there is one."""
+        if self._has_draft_model and self.speculative_config is None:
+            raise ValueError(
+                "speculative_config must be defined when a draft model is set. It selects the "
+                'speculative decoding algorithm and its knobs, e.g. {"algorithm": "EAGLE3"}.'
+            )
+
+        if self.speculative_config is None:
+            return []
+
+        config = dict(self.speculative_config)
+        if "draft_model_path" in config or "draft-model-path" in config:
+            raise ValueError(
+                "speculative_config cannot set 'draft_model_path'. Use the draft_model_path or "
+                "draft_model_hf_path field instead, so that the weights are mounted into the container."
+            )
+        if self._has_draft_model:
+            config["draft_model_path"] = self.draft_model_hf_path or self._draft_model_mount_path
+
+        args: list[str] = []
+        for key, value in config.items():
+            # Both "algorithm" and the fully spelled out "speculative_algorithm" are accepted.
+            name = key.replace("_", "-").removeprefix("speculative-")
+            flag = f"--speculative-{name}"
+            if isinstance(value, bool):
+                # Flag-style options carry no value; a False one is simply left out.
+                if value:
+                    args.append(flag)
+            else:
+                args.extend([flag, str(value)])
+        return args
 
     def container_args(self, serialization_context: SerializationContext) -> list[str]:
         """Return the container arguments for SGLang."""
@@ -183,8 +326,23 @@ class SGLangAppEnvironment(flyte.app.AppEnvironment):
         else:
             set_model_hf_path = False
             model_hf_path = self.model_hf_path
+        if "draft_model_path" in kwargs:
+            set_draft_model_path = True
+            draft_model_path = kwargs.pop("draft_model_path", "") or ""
+        else:
+            set_draft_model_path = False
+            draft_model_path = self.draft_model_path
+        if "draft_model_hf_path" in kwargs:
+            set_draft_model_hf_path = True
+            draft_model_hf_path = kwargs.pop("draft_model_hf_path", "") or ""
+        else:
+            set_draft_model_hf_path = False
+            draft_model_hf_path = self.draft_model_hf_path
+        set_speculative_config = "speculative_config" in kwargs
+        speculative_config = kwargs.pop("speculative_config", None)
         model_id = kwargs.pop("model_id", None)
         stream_model = kwargs.pop("stream_model", None)
+        router = kwargs.pop("router", None)
 
         if kwargs:
             raise TypeError(f"Unexpected keyword arguments: {list(kwargs.keys())}")
@@ -215,8 +373,16 @@ class SGLangAppEnvironment(flyte.app.AppEnvironment):
             kwargs["model_path"] = model_path
         if set_model_hf_path:
             kwargs["model_hf_path"] = model_hf_path
+        if set_draft_model_path:
+            kwargs["draft_model_path"] = draft_model_path
+        if set_draft_model_hf_path:
+            kwargs["draft_model_hf_path"] = draft_model_hf_path
+        if set_speculative_config:
+            kwargs["speculative_config"] = speculative_config
         if model_id is not None:
             kwargs["model_id"] = model_id
         if stream_model is not None:
             kwargs["stream_model"] = stream_model
+        if router is not None:
+            kwargs["router"] = router
         return replace(self, **kwargs)

--- a/plugins/sglang/src/flyteplugins/sglang/_constants.py
+++ b/plugins/sglang/src/flyteplugins/sglang/_constants.py
@@ -1,2 +1,16 @@
-SGLANG_MIN_VERSION = (0, 5, 2)
+# DFLASH landed in SGLang on 2026-04-07 (PR #22077) and the Spec V2 engine it rides on became
+# the default in the 2026-06 release line. 0.5.2 predates both, as well as the EAGLE3 support
+# `speculative_config` on SGLangAppEnvironment depends on.
+SGLANG_MIN_VERSION = (0, 5, 16)
 SGLANG_MIN_VERSION_STR = ".".join(map(str, SGLANG_MIN_VERSION))
+
+# The cache-aware router ships as its own package on its own release cadence, so this pin
+# tracks SGLANG_MIN_VERSION by hand. A router/server mismatch shows up as workers failing to
+# register rather than as an install error, so re-check it whenever SGLang is bumped.
+SGLANG_ROUTER_VERSION = "0.3.2"
+
+# CUDA 13, matching the wheels SGLang itself pins: 0.5.16 requires flashinfer_python[cu13] and
+# nvidia-cutlass-dsl[cu13]. A toolkit from a different CUDA major leaves flashinfer half-loaded
+# until something explodes deep inside an import.
+CUDA_TOOLKIT_PACKAGE = "cuda-toolkit-13-0"
+CUDA_HOME = "/usr/local/cuda-13.0"

--- a/plugins/sglang/tests/test_app_environment.py
+++ b/plugins/sglang/tests/test_app_environment.py
@@ -1,5 +1,7 @@
 """Unit tests for SGLangAppEnvironment."""
 
+import shlex
+
 import flyte
 import flyte.app
 import pytest
@@ -144,7 +146,7 @@ def test_stream_model_true_with_model_path():
 
     # Check env vars
     assert app.env_vars["FLYTE_MODEL_LOADER_STREAM_SAFETENSORS"] == "true"
-    assert app.env_vars["FLYTE_MODEL_LOADER_LOCAL_MODEL_PATH"] == "/root/flyte"
+    assert app.env_vars["FLYTE_MODEL_LOADER_LOCAL_MODEL_PATH"] == "/tmp/flyte/model"
 
     # Check parameters
     assert len(app.parameters) == 1
@@ -171,7 +173,7 @@ def test_stream_model_false_with_model_path():
     assert len(app.parameters) == 1
     model_input = app.parameters[0]
     assert model_input.download is True
-    assert model_input.mount == "/root/flyte"
+    assert model_input.mount == "/tmp/flyte/model"
 
 
 def test_model_hf_path_no_inputs():
@@ -345,7 +347,7 @@ def _create_sglang_app_with_lifecycle_field(field_name, field_value):
     app.extra_args = ""
     app.stream_model = True
     app.image = DEFAULT_SGLANG_IMAGE
-    app._model_mount_path = "/root/flyte"
+    app._model_mount_path = "/tmp/flyte/model"
     setattr(app, field_name, field_value)
     return app
 
@@ -369,3 +371,258 @@ def test_on_shutdown_decorator_raises_error():
     app = _create_sglang_app_with_lifecycle_field("_on_shutdown", lambda: None)
     with pytest.raises(ValueError, match="on_shutdown function cannot be set for SGLangAppEnvironment"):
         SGLangAppEnvironment.__post_init__(app)
+
+
+# Tests for host binding
+
+
+def test_host_defaults_to_all_interfaces():
+    """SGLang binds 127.0.0.1 by default, which is unreachable from outside the container."""
+    app = SGLangAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+    )
+    assert app.args[app.args.index("--host") + 1] == "0.0.0.0"
+
+
+def test_explicit_host_is_not_overridden():
+    app = SGLangAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+        extra_args=["--host", "127.0.0.1"],
+    )
+    assert app.args.count("--host") == 1
+    assert app.args[app.args.index("--host") + 1] == "127.0.0.1"
+
+
+# Tests for speculative decoding / draft models
+
+
+def test_draft_model_path_mounts_second_model():
+    """A draft model is mounted alongside the target and passed as --speculative-draft-model-path."""
+    app = SGLangAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+        draft_model_path="s3://bucket/eagle3-head",
+        speculative_config={"algorithm": "EAGLE3"},
+    )
+
+    assert len(app.parameters) == 2
+    target, draft = app.parameters
+    assert target.name == "model_path"
+    assert target.mount == "/tmp/flyte/model"
+    assert draft.name == "draft_model_path"
+    assert draft.value == "s3://bucket/eagle3-head"
+    assert draft.download is True
+    assert draft.mount == "/tmp/flyte/draft-model"
+
+    assert app.args[app.args.index("--speculative-algorithm") + 1] == "EAGLE3"
+    assert app.args[app.args.index("--speculative-draft-model-path") + 1] == "/tmp/flyte/draft-model"
+
+
+def test_speculative_config_renders_flat_flags():
+    app = SGLangAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+        draft_model_path="s3://bucket/dflash",
+        speculative_config={"algorithm": "DFLASH", "num_draft_tokens": 16},
+    )
+    assert app.args[app.args.index("--speculative-num-draft-tokens") + 1] == "16"
+
+
+def test_speculative_config_accepts_fully_spelled_keys():
+    """Both "algorithm" and "speculative_algorithm" name the same flag."""
+    app = SGLangAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+        speculative_config={"speculative_algorithm": "NGRAM", "speculative_num_steps": 5},
+    )
+    assert app.args[app.args.index("--speculative-algorithm") + 1] == "NGRAM"
+    assert app.args[app.args.index("--speculative-num-steps") + 1] == "5"
+
+
+def test_speculative_config_boolean_flags():
+    app = SGLangAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+        speculative_config={"algorithm": "EAGLE3", "attention_mode": True, "disabled_thing": False},
+    )
+    assert "--speculative-attention-mode" in app.args
+    assert "--speculative-disabled-thing" not in app.args
+
+
+def test_draft_model_disables_streaming():
+    """The Flyte loader monkeypatch is single-model, so a draft model forces download mode."""
+    app = SGLangAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+        stream_model=True,
+        draft_model_path="s3://bucket/eagle3-head",
+        speculative_config={"algorithm": "EAGLE3"},
+    )
+    assert app.env_vars["FLYTE_MODEL_LOADER_STREAM_SAFETENSORS"] == "false"
+    assert app.parameters[0].download is True
+    assert app.parameters[0].mount == "/tmp/flyte/model"
+
+
+def test_draft_model_hf_path_creates_no_parameter():
+    app = SGLangAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+        draft_model_hf_path="Qwen/Qwen3-0.6B",
+        speculative_config={"algorithm": "STANDALONE"},
+    )
+    assert [p.name for p in app.parameters] == ["model_path"]
+    assert app.args[app.args.index("--speculative-draft-model-path") + 1] == "Qwen/Qwen3-0.6B"
+
+
+def test_speculative_config_without_draft_model():
+    """NGRAM speculation uses no draft model at all."""
+    app = SGLangAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+        speculative_config={"algorithm": "NGRAM", "num_draft_tokens": 8},
+    )
+    assert len(app.parameters) == 1
+    assert "--speculative-draft-model-path" not in app.args
+    # Streaming is unaffected: there is only one set of weights.
+    assert app.env_vars["FLYTE_MODEL_LOADER_STREAM_SAFETENSORS"] == "true"
+
+
+def test_draft_model_without_speculative_config_raises_error():
+    with pytest.raises(ValueError, match="speculative_config must be defined when a draft model is set"):
+        SGLangAppEnvironment(
+            name="test-app",
+            model_path="s3://bucket/model",
+            model_id="test-model",
+            draft_model_path="s3://bucket/eagle3-head",
+        )
+
+
+def test_speculative_config_draft_model_path_key_raises_error():
+    with pytest.raises(ValueError, match="speculative_config cannot set 'draft_model_path'"):
+        SGLangAppEnvironment(
+            name="test-app",
+            model_path="s3://bucket/model",
+            model_id="test-model",
+            speculative_config={"algorithm": "EAGLE3", "draft_model_path": "/somewhere/else"},
+        )
+
+
+def test_both_draft_model_path_and_hf_path_raises_error():
+    with pytest.raises(ValueError, match="draft_model_path and draft_model_hf_path cannot be set at the same time"):
+        SGLangAppEnvironment(
+            name="test-app",
+            model_path="s3://bucket/model",
+            model_id="test-model",
+            draft_model_path="s3://bucket/eagle3-head",
+            draft_model_hf_path="Qwen/Qwen3-0.6B",
+            speculative_config={"algorithm": "EAGLE3"},
+        )
+
+
+# Tests for the cache-aware router
+
+
+def test_router_uses_router_entrypoint():
+    app = SGLangAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+        router=True,
+        extra_args=["--dp-size", "4", "--router-policy", "cache_aware"],
+    )
+    assert app.args[:3] == ["python", "-m", "sglang_router.launch_server"]
+    assert "--dp-size" in app.args
+    assert "--router-policy" in app.args
+
+
+def test_router_disables_streaming():
+    """Router workers are separate processes that never load the patched loader."""
+    app = SGLangAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+        stream_model=True,
+        router=True,
+    )
+    assert app.env_vars["FLYTE_MODEL_LOADER_STREAM_SAFETENSORS"] == "false"
+    assert app.parameters[0].download is True
+
+
+def test_default_entrypoint_is_the_fserve_shim():
+    app = SGLangAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+    )
+    assert app.args[0] == "sglang-fserve"
+
+
+# Tests for shell-safe args
+
+
+def test_extra_args_with_spaces_are_shell_quoted():
+    app = SGLangAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+        extra_args=["--json-model-override-args", '{"rope_scaling": {"factor": 2.0}}'],
+    )
+    assert shlex.split(" ".join(app.args))[-1] == '{"rope_scaling": {"factor": 2.0}}'
+
+
+def test_env_var_args_are_left_unquoted():
+    """fserve expands $VARS before joining; quoting would turn the marker into a literal."""
+    app = SGLangAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+        extra_args=["--api-key", "$SGLANG_API_KEY"],
+    )
+    assert "$SGLANG_API_KEY" in app.args
+
+
+# Tests for clone_with with speculative decoding and routing
+
+
+def test_clone_with_draft_model_and_router():
+    app = SGLangAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+    )
+    cloned = app.clone_with(
+        name="spec-app",
+        draft_model_path="s3://bucket/eagle3-head",
+        speculative_config={"algorithm": "EAGLE3"},
+        router=True,
+    )
+    assert cloned.router is True
+    assert [p.name for p in cloned.parameters] == ["model_path", "draft_model_path"]
+    # The original is untouched.
+    assert app.router is False
+    assert app.draft_model_path == ""
+
+
+def test_clone_with_drops_draft_model():
+    app = SGLangAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+        draft_model_path="s3://bucket/eagle3-head",
+        speculative_config={"algorithm": "EAGLE3"},
+    )
+    baseline = app.clone_with(name="baseline-app", draft_model_path=None, speculative_config=None)
+    assert baseline.draft_model_path == ""
+    assert [p.name for p in baseline.parameters] == ["model_path"]
+    assert "--speculative-algorithm" not in baseline.args

--- a/plugins/vllm/README.md
+++ b/plugins/vllm/README.md
@@ -20,7 +20,7 @@ from flyteplugins.vllm import VLLMAppEnvironment
 # Define the vLLM app environment
 vllm_app = VLLMAppEnvironment(
     name="my-llm-app",
-    model="s3://your-bucket/models/your-model",
+    model_path="s3://your-bucket/models/your-model",
     model_id="your-model-id",
     resources=flyte.Resources(cpu="4", memory="16Gi", gpu="L40s:1"),
     stream_model=True,  # Stream model directly from blob store to GPU
@@ -39,7 +39,63 @@ if __name__ == "__main__":
 ## Features
 
 - **Streaming Model Loading**: Stream model weights directly from object storage to GPU memory, reducing startup time and disk requirements.
+- **Speculative Decoding**: Serve a target model alongside a draft model (speculator) to shorten decode.
 - **OpenAI-Compatible API**: The deployed app exposes an OpenAI-compatible API for chat completions.
 - **Auto-scaling**: Configure scaling policies to scale up/down based on traffic.
 - **Tensor Parallelism**: Support for distributed inference across multiple GPUs.
 
+## Speculative decoding
+
+Set `speculative_config` to turn on [speculative decoding](https://docs.vllm.ai/en/stable/features/spec_decode/).
+It is rendered into vLLM's `--speculative-config` JSON blob. When the speculator has its own
+weights, point `draft_model_path` (object storage, `RunOutput` or `ArtifactValue`) or
+`draft_model_hf_path` at them and the plugin mounts them next to the target model and fills in
+the config's `model` key:
+
+```python
+vllm_app = VLLMAppEnvironment(
+    name="qwen3-8b-spec",
+    model_path="s3://your-bucket/models/qwen3-8b",
+    model_id="qwen3-8b",
+    draft_model_path="s3://your-bucket/models/qwen3-8b-eagle3",
+    speculative_config={"method": "eagle3", "num_speculative_tokens": 3},
+    resources=flyte.Resources(cpu="8", memory="64Gi", gpu="L40s:1", disk="120Gi"),
+)
+```
+
+Methods that need no separate weights work the same way, without a draft model — n-gram is a
+useful floor to measure a real speculator against:
+
+```python
+speculative_config={"method": "ngram", "num_speculative_tokens": 5, "prompt_lookup_max": 4}
+```
+
+Two caveats worth knowing up front:
+
+- **Streaming is disabled whenever a draft model is configured.** The Flyte streaming loader is
+  process-wide and describes a single set of weights, so both models are downloaded to the
+  container instead. Size `disk` for target + draft + a margin.
+- **Measure acceptance length, not just tokens/sec.** A speculator that produces no speedup is
+  indistinguishable from a mis-tuned one until you read
+  `vllm:spec_decode_num_accepted_tokens_total` / `..._num_drafts_total`. Acceptance ≈ 1 means the
+  draft model is wrong for your target.
+
+## Extra arguments
+
+`extra_args` is appended to `vllm serve`, as either a string or a list:
+
+```python
+vllm_app = VLLMAppEnvironment(
+    name="my-llm-app",
+    model_path="s3://your-bucket/models/your-model",
+    model_id="your-model-id",
+    extra_args="--max-model-len 8192 --quantization fp8",
+)
+```
+
+Arguments are quoted before they reach the server, so values containing spaces or JSON survive
+intact. Arguments of the form `$MY_VAR` are left unquoted so that Flyte still expands them from
+the app's environment.
+
+See the [vLLM engine arguments documentation](https://docs.vllm.ai/en/stable/configuration/engine_args)
+for available options.

--- a/plugins/vllm/src/flyteplugins/vllm/_app_environment.py
+++ b/plugins/vllm/src/flyteplugins/vllm/_app_environment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import shlex
 from dataclasses import dataclass, field, replace
 from typing import Any, Literal, Optional, Union
@@ -7,22 +8,53 @@ from typing import Any, Literal, Optional, Union
 import flyte.app
 import rich.repr
 from flyte import Environment, Image, Resources, SecretRequest
+from flyte._logging import logger
 from flyte.app import ArtifactValue, Parameter, RunOutput
 from flyte.app._types import Port
 from flyte.models import SerializationContext
 
-from flyteplugins.vllm._constants import VLLM_MIN_VERSION_STR
+from flyteplugins.vllm._constants import (
+    FLASHINFER_JIT_CACHE_INDEX_URL,
+    FLASHINFER_VERSION,
+    VLLM_MIN_VERSION_STR,
+)
 
 DEFAULT_VLLM_IMAGE = (
     flyte.Image.from_debian_base(name="vllm-app-image")
-    # install flashinfer and vllm
-    .with_pip_packages("flashinfer-python", "flashinfer-cubin")
-    .with_pip_packages("flashinfer-jit-cache", index_url="https://flashinfer.ai/whl/cu129")
     # install the vllm flyte plugin
     .with_pip_packages("flyteplugins-vllm", pre=True)
     # install vllm in a separate layer due to dependency conflict with flyte (protovalidate)
     .with_pip_packages(f"vllm=={VLLM_MIN_VERSION_STR}")
+    # FlashInfer's prebuilt kernels. This image ships the CUDA *runtime* (via the torch/vLLM
+    # wheels) but no toolkit, so anything that JIT-compiles a kernel at startup dies with
+    # "Could not find nvcc and default cuda_home='/usr/local/cuda' doesn't exist". vLLM's
+    # top-k/top-p sampler is exactly such a path -- it builds its sampling module during
+    # warmup, after the weights load, so the failure looks like a late crash rather than a
+    # missing dependency. Shipping the jit-cache means nothing has to compile at runtime.
+    #
+    # Deliberately after the vLLM layer and pinned to vLLM's own flashinfer version: layers
+    # resolve independently, so an earlier unpinned layer would just be overwritten by vLLM's
+    # exact pin and leave the cache mismatched. ``flashinfer-cubin`` is absent because it
+    # publishes no release matching FLASHINFER_VERSION.
+    .with_pip_packages(
+        f"flashinfer-jit-cache=={FLASHINFER_VERSION}",
+        index_url=FLASHINFER_JIT_CACHE_INDEX_URL,
+    )
 )
+
+
+def _shell_safe(args: list[str]) -> list[str]:
+    """Quote args that have to survive a trip through a shell.
+
+    ``fserve`` runs the app with ``Popen(" ".join(args), shell=True)`` (flyte/_bin/serve.py),
+    so any token carrying spaces or quotes -- vLLM's ``--speculative-config`` JSON blob being
+    the obvious one -- reaches the engine mangled unless it is quoted here. ``shlex.quote`` is
+    the identity function for ordinary tokens, so this is a no-op for everything else.
+
+    Tokens starting with ``$`` are left alone: ``fserve`` expands those against the container
+    environment *before* joining, and quoting would turn the marker into a literal.
+    """
+    return [arg if arg.startswith("$") else shlex.quote(arg) for arg in args]
 
 
 @rich.repr.auto
@@ -56,7 +88,19 @@ class VLLMAppEnvironment(flyte.app.AppEnvironment):
         stream_model: When `model_path` is set, use True to stream weights from object
             storage to the GPU (Flyte custom loader). Ignored for `model_hf_path`-only apps,
             which always use vLLM's normal Hugging Face download path. If False with `model_path`,
-            the model is downloaded to the local filesystem first, then loaded.
+            the model is downloaded to the local filesystem first, then loaded. Also ignored when
+            a draft model is configured -- see `draft_model_path`.
+        draft_model_path: Remote path to the draft model (speculator) used for speculative
+            decoding, or a `RunOutput`/`ArtifactValue` resolved at deploy time. The weights are
+            downloaded alongside the target model and passed to vLLM as the `model` key of
+            `--speculative-config`. Requires `speculative_config`.
+        draft_model_hf_path: Hugging Face path to the draft model, as an alternative to
+            `draft_model_path` (e.g., Qwen/Qwen3-0.6B).
+        speculative_config: vLLM speculative decoding configuration, serialized into the
+            `--speculative-config` JSON blob. The `model` key is filled in from
+            `draft_model_path`/`draft_model_hf_path` and must not be set here. Draft-model-free
+            methods (e.g. `{"method": "ngram", "num_speculative_tokens": 5}`) need no draft model.
+            See https://docs.vllm.ai/en/stable/features/spec_decode/.
     """
 
     port: int | Port = 8080
@@ -66,8 +110,18 @@ class VLLMAppEnvironment(flyte.app.AppEnvironment):
     model_hf_path: str = ""
     model_id: str = ""
     stream_model: bool = True
+    draft_model_path: str | RunOutput | ArtifactValue = ""
+    draft_model_hf_path: str = ""
+    speculative_config: Optional[dict[str, Any]] = None
     image: str | Image | Literal["auto"] = DEFAULT_VLLM_IMAGE
-    _model_mount_path: str = field(default="/root/flyte", init=False)
+    # Under /tmp, and that is not cosmetic: ``fserve`` materializes each mounted Parameter
+    # through ``_ensure_dest_writable``, which needs the *image's* user to be able to create the
+    # parent directory. The released Flyte base image runs non-root, so a mount at the
+    # filesystem root -- or under /root -- fails with "Permission denied" before the engine ever
+    # starts. /tmp is writable for any user and lives on the same overlay filesystem the weights
+    # are already budgeted against by ``disk=``.
+    _model_mount_path: str = field(default="/tmp/flyte/model", init=False)
+    _draft_model_mount_path: str = field(default="/tmp/flyte/draft-model", init=False)
 
     def __post_init__(self):
         if self.env_vars is None:
@@ -90,6 +144,9 @@ class VLLMAppEnvironment(flyte.app.AppEnvironment):
         if self.model_path != "" and self.model_hf_path != "":
             raise ValueError("model_path and model_hf_path cannot be set at the same time")
 
+        if self.draft_model_path != "" and self.draft_model_hf_path != "":
+            raise ValueError("draft_model_path and draft_model_hf_path cannot be set at the same time")
+
         if self.model_hf_path:
             self._model_mount_path = self.model_hf_path
 
@@ -99,27 +156,43 @@ class VLLMAppEnvironment(flyte.app.AppEnvironment):
         if isinstance(self.extra_args, str):
             extra_args = shlex.split(self.extra_args)
         else:
-            extra_args = self.extra_args
+            extra_args = list(self.extra_args)
+
+        speculative_args = self._speculative_args()
 
         # Flyte streaming requires a remote ``model_path`` (and the model-loader env). HF-only
         # apps must use vLLM's default loaders regardless of ``stream_model``.
-        use_flyte_blob_streaming = bool(self.stream_model and self.model_path)
+        #
+        # A draft model rules streaming out entirely: ``--load-format flyte-vllm-streaming`` is
+        # process-wide and ``FLYTE_MODEL_LOADER_REMOTE_MODEL_PATH``/``..._LOCAL_MODEL_PATH`` are a
+        # single global pair, so the loader can only ever describe one set of weights. With two
+        # models in one process it would feed the target's tensors to the draft model.
+        use_flyte_blob_streaming = bool(self.stream_model and self.model_path and not self._has_draft_model)
+        if self.stream_model and self.model_path and self._has_draft_model:
+            logger.warning(
+                "stream_model is not supported alongside a draft model: the Flyte streaming loader is "
+                "process-wide and describes a single set of weights. Falling back to downloading both "
+                "the target and the draft model to the container filesystem."
+            )
 
         stream_model_args: list[str] = []
         if use_flyte_blob_streaming:
             stream_model_args.extend(["--load-format", "flyte-vllm-streaming"])
 
-        self.args = [
-            "vllm-fserve",
-            "serve",
-            self._model_mount_path,
-            "--served-model-name",
-            self.model_id,
-            "--port",
-            str(self.get_port().port),
-            *stream_model_args,
-            *extra_args,
-        ]
+        self.args = _shell_safe(
+            [
+                "vllm-fserve",
+                "serve",
+                self._model_mount_path,
+                "--served-model-name",
+                self.model_id,
+                "--port",
+                str(self.get_port().port),
+                *stream_model_args,
+                *speculative_args,
+                *extra_args,
+            ]
+        )
 
         if self.parameters:
             raise ValueError("parameters cannot be set for VLLMAppEnvironment")
@@ -134,8 +207,20 @@ class VLLMAppEnvironment(flyte.app.AppEnvironment):
             input_kwargs["download"] = True
             input_kwargs["mount"] = self._model_mount_path
 
+        parameters: list[Parameter] = []
         if self.model_path:
-            self.parameters = [Parameter(name="model_path", value=self.model_path, **input_kwargs)]
+            parameters.append(Parameter(name="model_path", value=self.model_path, **input_kwargs))
+        if self.draft_model_path:
+            parameters.append(
+                Parameter(
+                    name="draft_model_path",
+                    value=self.draft_model_path,
+                    download=True,
+                    mount=self._draft_model_mount_path,
+                )
+            )
+        if parameters:
+            self.parameters = parameters
 
         self.env_vars["FLYTE_MODEL_LOADER_LOCAL_MODEL_PATH"] = self._model_mount_path
         self.links = [flyte.app.Link(path="/docs", title="vLLM OpenAPI Docs", is_relative=True), *self.links]
@@ -144,6 +229,33 @@ class VLLMAppEnvironment(flyte.app.AppEnvironment):
             self.image = DEFAULT_VLLM_IMAGE
 
         super().__post_init__()
+
+    @property
+    def _has_draft_model(self) -> bool:
+        return bool(self.draft_model_path or self.draft_model_hf_path)
+
+    def _speculative_args(self) -> list[str]:
+        """Render ``--speculative-config``, pointing it at the draft model when there is one."""
+        if self._has_draft_model and self.speculative_config is None:
+            raise ValueError(
+                "speculative_config must be defined when a draft model is set. It selects the "
+                'speculative decoding method and its knobs, e.g. {"method": "eagle3", '
+                '"num_speculative_tokens": 3}.'
+            )
+
+        if self.speculative_config is None:
+            return []
+
+        config = dict(self.speculative_config)
+        if self._has_draft_model:
+            if "model" in config:
+                raise ValueError(
+                    "speculative_config cannot set 'model'. Use draft_model_path or "
+                    "draft_model_hf_path instead, so that the weights are mounted into the container."
+                )
+            config["model"] = self.draft_model_hf_path or self._draft_model_mount_path
+
+        return ["--speculative-config", json.dumps(config)]
 
     def container_args(self, serialization_context: SerializationContext) -> list[str]:
         """Return the container arguments for vLLM."""
@@ -177,6 +289,20 @@ class VLLMAppEnvironment(flyte.app.AppEnvironment):
         else:
             set_model_hf_path = False
             model_hf_path = self.model_hf_path
+        if "draft_model_path" in kwargs:
+            set_draft_model_path = True
+            draft_model_path = kwargs.pop("draft_model_path", "") or ""
+        else:
+            set_draft_model_path = False
+            draft_model_path = self.draft_model_path
+        if "draft_model_hf_path" in kwargs:
+            set_draft_model_hf_path = True
+            draft_model_hf_path = kwargs.pop("draft_model_hf_path", "") or ""
+        else:
+            set_draft_model_hf_path = False
+            draft_model_hf_path = self.draft_model_hf_path
+        set_speculative_config = "speculative_config" in kwargs
+        speculative_config = kwargs.pop("speculative_config", None)
         model_id = kwargs.pop("model_id", None)
         stream_model = kwargs.pop("stream_model", None)
 
@@ -209,6 +335,12 @@ class VLLMAppEnvironment(flyte.app.AppEnvironment):
             kwargs["model_path"] = model_path
         if set_model_hf_path:
             kwargs["model_hf_path"] = model_hf_path
+        if set_draft_model_path:
+            kwargs["draft_model_path"] = draft_model_path
+        if set_draft_model_hf_path:
+            kwargs["draft_model_hf_path"] = draft_model_hf_path
+        if set_speculative_config:
+            kwargs["speculative_config"] = speculative_config
         if model_id is not None:
             kwargs["model_id"] = model_id
         if stream_model is not None:

--- a/plugins/vllm/src/flyteplugins/vllm/_app_environment.py
+++ b/plugins/vllm/src/flyteplugins/vllm/_app_environment.py
@@ -46,12 +46,12 @@ DEFAULT_VLLM_IMAGE = (
 def _shell_safe(args: list[str]) -> list[str]:
     """Quote args that have to survive a trip through a shell.
 
-    ``fserve`` runs the app with ``Popen(" ".join(args), shell=True)`` (flyte/_bin/serve.py),
-    so any token carrying spaces or quotes -- vLLM's ``--speculative-config`` JSON blob being
-    the obvious one -- reaches the engine mangled unless it is quoted here. ``shlex.quote`` is
+    `fserve` runs the app with `Popen(" ".join(args), shell=True)` (flyte/_bin/serve.py),
+    so any token carrying spaces or quotes -- vLLM's `--speculative-config` JSON blob being
+    the obvious one -- reaches the engine mangled unless it is quoted here. `shlex.quote` is
     the identity function for ordinary tokens, so this is a no-op for everything else.
 
-    Tokens starting with ``$`` are left alone: ``fserve`` expands those against the container
+    Tokens starting with `$` are left alone: `fserve` expands those against the container
     environment *before* joining, and quoting would turn the marker into a literal.
     """
     return [arg if arg.startswith("$") else shlex.quote(arg) for arg in args]
@@ -235,7 +235,7 @@ class VLLMAppEnvironment(flyte.app.AppEnvironment):
         return bool(self.draft_model_path or self.draft_model_hf_path)
 
     def _speculative_args(self) -> list[str]:
-        """Render ``--speculative-config``, pointing it at the draft model when there is one."""
+        """Render `--speculative-config`, pointing it at the draft model when there is one."""
         if self._has_draft_model and self.speculative_config is None:
             raise ValueError(
                 "speculative_config must be defined when a draft model is set. It selects the "

--- a/plugins/vllm/src/flyteplugins/vllm/_constants.py
+++ b/plugins/vllm/src/flyteplugins/vllm/_constants.py
@@ -1,2 +1,15 @@
-VLLM_MIN_VERSION = (0, 11, 0)
+# vLLM 0.20.1+ is required for the DFlash speculator, and the whole 0.2x line takes every
+# speculative knob as a single ``--speculative-config`` JSON blob. Older pins (0.11.x) predate
+# both, so `speculative_config` on VLLMAppEnvironment would have nothing to talk to.
+VLLM_MIN_VERSION = (0, 26, 0)
 VLLM_MIN_VERSION_STR = ".".join(map(str, VLLM_MIN_VERSION))
+
+# Must equal the ``flashinfer-python`` pin of VLLM_MIN_VERSION -- vLLM pins it exactly, so a
+# different version here is silently overwritten by the vLLM layer and leaves the prebuilt
+# kernels below mismatched against the installed flashinfer.
+FLASHINFER_VERSION = "0.6.14"
+
+# The index has to match the CUDA major that vLLM's own wheels pin (0.26.0 ->
+# nvidia-cutlass-dsl[cu13], i.e. CUDA 13). This is a hand-maintained pair: bump
+# VLLM_MIN_VERSION and both of the above have to be re-checked together.
+FLASHINFER_JIT_CACHE_INDEX_URL = "https://flashinfer.ai/whl/cu130"

--- a/plugins/vllm/tests/test_app_environment.py
+++ b/plugins/vllm/tests/test_app_environment.py
@@ -1,5 +1,8 @@
 """Unit tests for VLLMAppEnvironment."""
 
+import json
+import shlex
+
 import flyte
 import flyte.app
 import pytest
@@ -148,7 +151,7 @@ def test_stream_model_true_with_model_path():
 
     # Check env vars
     assert app.env_vars["FLYTE_MODEL_LOADER_STREAM_SAFETENSORS"] == "true"
-    assert app.env_vars["FLYTE_MODEL_LOADER_LOCAL_MODEL_PATH"] == "/root/flyte"
+    assert app.env_vars["FLYTE_MODEL_LOADER_LOCAL_MODEL_PATH"] == "/tmp/flyte/model"
 
     # Check parameters
     assert len(app.parameters) == 1
@@ -178,7 +181,7 @@ def test_stream_model_false_with_model_path():
     assert len(app.parameters) == 1
     model_input = app.parameters[0]
     assert model_input.download is True
-    assert model_input.mount == "/root/flyte"
+    assert model_input.mount == "/tmp/flyte/model"
 
 
 def test_model_hf_path_no_inputs():
@@ -349,7 +352,7 @@ def _create_vllm_app_with_lifecycle_field(field_name, field_value):
     app.extra_args = ""
     app.stream_model = True
     app.image = DEFAULT_VLLM_IMAGE
-    app._model_mount_path = "/root/flyte"
+    app._model_mount_path = "/tmp/flyte/model"
     setattr(app, field_name, field_value)
     return app
 
@@ -373,3 +376,198 @@ def test_on_shutdown_decorator_raises_error():
     app = _create_vllm_app_with_lifecycle_field("_on_shutdown", lambda: None)
     with pytest.raises(ValueError, match="on_shutdown function cannot be set for VLLMAppEnvironment"):
         VLLMAppEnvironment.__post_init__(app)
+
+
+# Tests for speculative decoding / draft models
+
+
+def test_draft_model_path_mounts_second_model():
+    """A draft model is mounted alongside the target and referenced by --speculative-config."""
+    app = VLLMAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+        draft_model_path="s3://bucket/eagle3-head",
+        speculative_config={"method": "eagle3", "num_speculative_tokens": 3},
+    )
+
+    assert len(app.parameters) == 2
+    target, draft = app.parameters
+    assert target.name == "model_path"
+    assert target.mount == "/tmp/flyte/model"
+    assert draft.name == "draft_model_path"
+    assert draft.value == "s3://bucket/eagle3-head"
+    assert draft.download is True
+    assert draft.mount == "/tmp/flyte/draft-model"
+
+    # The draft model is passed to vLLM as the `model` key of the speculative config.
+    config = json.loads(shlex.split(" ".join(app.args))[app.args.index("--speculative-config") + 1])
+    assert config == {"method": "eagle3", "num_speculative_tokens": 3, "model": "/tmp/flyte/draft-model"}
+
+
+def test_draft_model_disables_streaming():
+    """The Flyte streaming loader is single-model, so a draft model forces download mode."""
+    app = VLLMAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+        stream_model=True,
+        draft_model_path="s3://bucket/eagle3-head",
+        speculative_config={"method": "eagle3", "num_speculative_tokens": 3},
+    )
+    assert "--load-format" not in app.args
+    assert "flyte-vllm-streaming" not in app.args
+    assert app.env_vars["FLYTE_MODEL_LOADER_STREAM_SAFETENSORS"] == "false"
+    assert app.parameters[0].download is True
+    assert app.parameters[0].mount == "/tmp/flyte/model"
+
+
+def test_draft_model_hf_path_creates_no_parameter():
+    """A Hugging Face draft model is resolved by vLLM itself, so nothing is mounted for it."""
+    app = VLLMAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+        draft_model_hf_path="Qwen/Qwen3-0.6B",
+        speculative_config={"num_speculative_tokens": 5},
+    )
+    assert [p.name for p in app.parameters] == ["model_path"]
+    config = json.loads(shlex.split(" ".join(app.args))[app.args.index("--speculative-config") + 1])
+    assert config == {"num_speculative_tokens": 5, "model": "Qwen/Qwen3-0.6B"}
+
+
+def test_speculative_config_without_draft_model():
+    """Draft-model-free methods (ngram) need no mounted weights."""
+    app = VLLMAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+        speculative_config={"method": "ngram", "num_speculative_tokens": 5, "prompt_lookup_max": 4},
+    )
+    assert len(app.parameters) == 1
+    config = json.loads(shlex.split(" ".join(app.args))[app.args.index("--speculative-config") + 1])
+    assert config == {"method": "ngram", "num_speculative_tokens": 5, "prompt_lookup_max": 4}
+    # Streaming is unaffected: there is only one set of weights.
+    assert "flyte-vllm-streaming" in app.args
+
+
+def test_draft_model_without_speculative_config_raises_error():
+    with pytest.raises(ValueError, match="speculative_config must be defined when a draft model is set"):
+        VLLMAppEnvironment(
+            name="test-app",
+            model_path="s3://bucket/model",
+            model_id="test-model",
+            draft_model_path="s3://bucket/eagle3-head",
+        )
+
+
+def test_speculative_config_model_key_raises_error():
+    with pytest.raises(ValueError, match="speculative_config cannot set 'model'"):
+        VLLMAppEnvironment(
+            name="test-app",
+            model_path="s3://bucket/model",
+            model_id="test-model",
+            draft_model_path="s3://bucket/eagle3-head",
+            speculative_config={"method": "eagle3", "model": "/somewhere/else"},
+        )
+
+
+def test_both_draft_model_path_and_hf_path_raises_error():
+    with pytest.raises(ValueError, match="draft_model_path and draft_model_hf_path cannot be set at the same time"):
+        VLLMAppEnvironment(
+            name="test-app",
+            model_path="s3://bucket/model",
+            model_id="test-model",
+            draft_model_path="s3://bucket/eagle3-head",
+            draft_model_hf_path="Qwen/Qwen3-0.6B",
+            speculative_config={"method": "eagle3"},
+        )
+
+
+# Tests for shell-safe args
+
+
+def test_speculative_config_json_is_shell_quoted():
+    """fserve joins args and runs them through a shell, so the JSON blob must be quoted."""
+    app = VLLMAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+        draft_model_path="s3://bucket/eagle3-head",
+        speculative_config={"method": "eagle3", "num_speculative_tokens": 3},
+    )
+    blob = app.args[app.args.index("--speculative-config") + 1]
+    assert blob.startswith("'") and blob.endswith("'")
+    # What the shell hands to vLLM round-trips back to the original config.
+    assert json.loads(shlex.split(blob)[0])["method"] == "eagle3"
+
+
+def test_extra_args_with_spaces_are_shell_quoted():
+    app = VLLMAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+        extra_args=["--chat-template", '{"foo": "bar"}'],
+    )
+    assert shlex.split(" ".join(app.args))[-1] == '{"foo": "bar"}'
+
+
+def test_ordinary_args_are_not_quoted():
+    """shlex.quote is the identity for ordinary tokens, so plain args stay readable."""
+    app = VLLMAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+        extra_args="--max-model-len 8192",
+    )
+    assert "--max-model-len" in app.args
+    assert "8192" in app.args
+    assert "vllm-fserve" in app.args
+
+
+def test_env_var_args_are_left_unquoted():
+    """fserve expands $VARS before joining; quoting would turn the marker into a literal."""
+    app = VLLMAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+        extra_args=["--api-key", "$VLLM_API_KEY"],
+    )
+    assert "$VLLM_API_KEY" in app.args
+
+
+# Tests for clone_with with speculative decoding
+
+
+def test_clone_with_draft_model():
+    app = VLLMAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+    )
+    cloned = app.clone_with(
+        name="spec-app",
+        draft_model_path="s3://bucket/eagle3-head",
+        speculative_config={"method": "eagle3", "num_speculative_tokens": 3},
+    )
+    assert cloned.name == "spec-app"
+    assert cloned.draft_model_path == "s3://bucket/eagle3-head"
+    assert [p.name for p in cloned.parameters] == ["model_path", "draft_model_path"]
+    # The original is untouched.
+    assert app.draft_model_path == ""
+    assert [p.name for p in app.parameters] == ["model_path"]
+
+
+def test_clone_with_drops_draft_model():
+    app = VLLMAppEnvironment(
+        name="test-app",
+        model_path="s3://bucket/model",
+        model_id="test-model",
+        draft_model_path="s3://bucket/eagle3-head",
+        speculative_config={"method": "eagle3", "num_speculative_tokens": 3},
+    )
+    baseline = app.clone_with(name="baseline-app", draft_model_path=None, speculative_config=None)
+    assert baseline.draft_model_path == ""
+    assert baseline.speculative_config is None
+    assert [p.name for p in baseline.parameters] == ["model_path"]
+    assert "--speculative-config" not in baseline.args

--- a/plugins/vllm/tests/test_prefetch_sync.py
+++ b/plugins/vllm/tests/test_prefetch_sync.py
@@ -1,0 +1,31 @@
+"""Guards the version contract between prefetch's sharder and this plugin's model loader.
+
+`flyte.prefetch.hf_model(shard_config=...)` shards a checkpoint by calling vLLM's
+`save_sharded_state`, which writes rank-partitioned tensors under names taken from *that*
+vLLM's model implementation. `FlyteModelLoader._load_sharded_model` in this plugin reads them
+back into a `state_dict` built from *its* vLLM's model implementation and raises
+`Missing keys ... in loaded state!` for anything it cannot fill.
+
+Nothing at either end declares the other's version, so the two pins can drift apart in a
+single-sided bump and the mismatch only surfaces when a real deploy loads a real sharded
+checkpoint -- after an image build, a GPU allocation, and a weight download. These tests turn
+that into a CI failure instead.
+"""
+
+from flyte.prefetch._hf_model import VLLM_SHARDING_IMAGE_PACKAGES, VLLM_SHARDING_VERSION
+
+from flyteplugins.vllm._constants import VLLM_MIN_VERSION_STR
+
+
+def test_prefetch_sharding_version_matches_plugin_pin():
+    assert VLLM_SHARDING_VERSION == VLLM_MIN_VERSION_STR, (
+        f"prefetch shards with vllm=={VLLM_SHARDING_VERSION} but this plugin serves with "
+        f"vllm=={VLLM_MIN_VERSION_STR}. Sharded state written by one is not guaranteed to "
+        f"load in the other -- bump flyte.prefetch._hf_model.VLLM_SHARDING_VERSION and "
+        f"flyteplugins.vllm._constants.VLLM_MIN_VERSION together."
+    )
+
+
+def test_prefetch_sharding_image_installs_the_plugin_pin():
+    """The constant is only worth asserting if the image actually installs it."""
+    assert f"vllm=={VLLM_MIN_VERSION_STR}" in VLLM_SHARDING_IMAGE_PACKAGES

--- a/src/flyte/prefetch/_hf_model.py
+++ b/src/flyte/prefetch/_hf_model.py
@@ -147,9 +147,30 @@ HF_DOWNLOAD_IMAGE_PACKAGES = [
     "markdown>=3.10",
 ]
 
+#: The exact vLLM used to shard prefetched checkpoints. A pin, not a floor: `_shard_model`
+#: below calls `save_sharded_state`, which writes rank-partitioned tensors that only
+#: `flyteplugins.vllm`'s model loader reads back -- and that loader rebuilds the expected
+#: `state_dict` from *its own* vLLM's model implementation, then raises on any key it cannot
+#: fill. Producer and consumer are two halves of one format, so this must equal
+#: `flyteplugins.vllm._constants.VLLM_MIN_VERSION_STR`. The vLLM plugin's test suite asserts
+#: exactly that, so a one-sided bump fails in CI rather than at model-load time on a deploy.
+#:
+#: The previous `vllm>=0.11.0` was a floor, which resolves to whatever is newest at
+#: image-build time: two prefetch runs weeks apart could shard with different vLLMs, and
+#: nothing tied either of them to the version doing the serving.
+VLLM_SHARDING_VERSION = "0.26.0"
+
+#: CUDA 13, matching the wheels VLLM_SHARDING_VERSION itself pins (0.26.0 ->
+#: nvidia-cutlass-dsl[cu13]). The toolkit is here so the kernels vLLM JIT-compiles during
+#: engine startup have an nvcc to compile with; one from a different CUDA major than the
+#: installed runtime is worse than none, since it fails deep inside a warmup compile rather
+#: than at install time.
+CUDA_VERSION = "13.0"
+CUDA_HOME = f"/usr/local/cuda-{CUDA_VERSION}"
+
 VLLM_SHARDING_IMAGE_PACKAGES = [
     *HF_DOWNLOAD_IMAGE_PACKAGES,
-    "vllm>=0.11.0",
+    f"vllm=={VLLM_SHARDING_VERSION}",
 ]
 
 #: Serving facts, as versioned JSON, under the same reserved `flyte.io/`
@@ -857,13 +878,13 @@ def hf_model(
                     "wget https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/cuda-keyring_1.1-1_all.deb",
                     "dpkg -i cuda-keyring_1.1-1_all.deb",
                     "apt-get update",
-                    "apt-get install -y cuda-toolkit-12-9",
+                    f"apt-get install -y cuda-toolkit-{CUDA_VERSION.replace('.', '-')}",
                 ]
             )
             .with_env_vars(
                 {
-                    "CUDA_HOME": "/usr/local/cuda-12.9",
-                    "LD_LIBRARY_PATH": "/usr/local/cuda-12.9/lib64/stubs",
+                    "CUDA_HOME": CUDA_HOME,
+                    "LD_LIBRARY_PATH": f"{CUDA_HOME}/lib64/stubs",
                     "VLLM_USE_V1": "1",
                 }
             )

--- a/tests/flyte/prefetch/test_hf_model.py
+++ b/tests/flyte/prefetch/test_hf_model.py
@@ -11,6 +11,7 @@ import pytest
 from flyte.prefetch._hf_model import (
     HF_DOWNLOAD_IMAGE_PACKAGES,
     VLLM_SHARDING_IMAGE_PACKAGES,
+    VLLM_SHARDING_VERSION,
     HuggingFaceModelInfo,
     ShardConfig,
     StoredModelInfo,
@@ -446,8 +447,18 @@ def test_vllm_sharding_image_packages():
     """Test vLLM sharding image packages are defined."""
     assert "huggingface-hub>=0.27.0" in VLLM_SHARDING_IMAGE_PACKAGES
     assert "hf-transfer>=0.1.8" in VLLM_SHARDING_IMAGE_PACKAGES
-    assert "vllm>=0.11.0" in VLLM_SHARDING_IMAGE_PACKAGES
+    assert f"vllm=={VLLM_SHARDING_VERSION}" in VLLM_SHARDING_IMAGE_PACKAGES
     assert "markdown>=3.10" in VLLM_SHARDING_IMAGE_PACKAGES
+
+
+def test_vllm_sharding_pin_is_exact():
+    """The sharding vLLM is pinned, not floored.
+
+    A floor lets the resolver pick whatever is newest at image-build time, which silently
+    decouples the vLLM writing the sharded state from the one reading it back at serve time.
+    """
+    vllm_specs = [pkg for pkg in VLLM_SHARDING_IMAGE_PACKAGES if pkg.startswith("vllm")]
+    assert vllm_specs == [f"vllm=={VLLM_SHARDING_VERSION}"]
 
 
 # =============================================================================


### PR DESCRIPTION
## Motivation

This PR fills in current gaps in the plugin implementation:

- A draft model is a *second* set of weights, and both environments have room for exactly one — they own a single `model_path` and raise on both `parameters` and `args`.
- vLLM's `--speculative-config` is JSON and `fserve` runs the command through a shell, so the blob has to be quoted or the shell eats its inner quotes.
- Mounts have to sit under `/tmp`, not `/root` — the released Flyte base image runs non-root.
- The pinned engines (vLLM 0.11.0, SGLang 0.5.2) predate the algorithms the recipes are about, and both engines have since moved to CUDA 13 wheels that the images' hand-pinned flashinfer layers cannot match.
- Cache-aware routing has to live inside the pod, because Flyte apps have no session affinity or per-replica address — and the plugin had no way to express it.

This PR closes those gaps so the recipes' configurations are expressible natively.

## Summary

**Speculative decoding (both plugins).** New `speculative_config`, plus optional `draft_model_path` / `draft_model_hf_path`. Draft weights are mounted as a second `Parameter` next to the target and wired into the engine — vLLM's single `--speculative-config` JSON blob, SGLang's flat `--speculative-*` flags (`{"algorithm": "EAGLE3"}` → `--speculative-algorithm EAGLE3`). Draft-model-free methods (ngram) work with no mounted weights. The Flyte streaming loader is process-wide and describes a single set of weights, so configuring a draft model falls back to downloading both models and warns rather than silently feeding the target's tensors to the drafter.

**Shell-safe args (both plugins).** `fserve` runs the app with `Popen(" ".join(args), shell=True)` (`flyte/_bin/serve.py`), so any token with spaces or quotes reached the engine mangled — `--speculative-config` being the obvious casualty. Args are now `shlex.quote`d, except `$VAR` tokens, which `fserve` expands *before* joining and which quoting would turn into literals.

**Writable mount path (both plugins).** Model mounts move from `/root/flyte` to `/tmp/flyte/...`. `_ensure_dest_writable` needs the image's user to create the parent directory, and the released base image runs non-root, so `/root` failed with `Permission denied` before the engine ever started.

**SGLang cache-aware routing.** `router=True` swaps the entrypoint to `sglang_router.launch_server`; worker count and policy stay ordinary server args (`--dp-size`, `--router-policy`). Streaming is unavailable in this mode — the router launches its workers as separate processes that never load the patched loader — so it falls back to download and warns.

**SGLang host binding.** The server now binds `0.0.0.0` unless the caller passes their own `--host`. SGLang's own default is `127.0.0.1`, which is unreachable from outside the container.

**Engine pins and images.** vLLM `0.11.0` → `0.26.0` (DFlash needs 0.20.1+) and SGLang `0.5.2` → `0.5.16` (DFLASH landed 2026-04, on the Spec V2 engine that became default in the 2026-06 line). Both now pull CUDA 13 wheels, so:

- **vLLM image**: `flashinfer-jit-cache` moves to the `cu130` index, pinned to vLLM's own flashinfer version (`0.6.14`), in a layer *after* vLLM — layers resolve independently, so an earlier unpinned layer is just overwritten by vLLM's exact pin and leaves the cache mismatched. `flashinfer-cubin` is dropped: it publishes no `0.6.14`. Without a matching jit-cache, the FlashInfer sampler JIT-compiles during warmup and dies on missing `nvcc`, long after the weights load.
- **SGLang image**: CUDA toolkit `12.8` → `13.0`; the hand-pinned flashinfer layers are dropped (SGLang pins `flashinfer_python[cu13]` itself, and a `cu128` jit-cache against a `cu13` flashinfer is actively wrong); `pre=True` added, which is required rather than cosmetic — 0.5.16 depends on the pre-release `flash-attn-4>=4.0.0b18`, and without it uv reports the package as simply unsatisfiable. Also ships `sglang-router` for `router=True`.

Version-tracking constants (`FLASHINFER_VERSION`, `FLASHINFER_JIT_CACHE_INDEX_URL`, `SGLANG_ROUTER_VERSION`, `CUDA_TOOLKIT_PACKAGE`) are pulled into `_constants.py` with notes on what has to be re-checked together on the next bump.

**Examples.** Every example using these plugins hand-rolled an image that was a near-copy of the plugin default, and each had drifted to a version *below* the new minimum (vllm 0.11.0 / 0.19.0 / 0.20.0, sglang 0.5.7) — so the shims' version check would have rejected them at container startup, and their `cu128`/`cu129` flashinfer layers could not match engines pinning CUDA 13 wheels. Rather than re-pin nine copies, they now build on `DEFAULT_VLLM_IMAGE` / `DEFAULT_SGLANG_IMAGE`: six use it as-is, three `.clone(name=...)` it and add only what they actually need (TriAttention, librosa/soundfile, a separate build cache). The engine version, its matching flashinfer build and the CUDA toolkit now live in exactly one place and cannot drift again.

One casualty: the `transformers==4.57.6` pins are gone, because vLLM 0.26 requires `transformers>=5.5.3` — no vLLM new enough for the plugin can satisfy the old pin. In `vllm_app_artifact.py` that pin carried a comment claiming newer transformers break the `fserve` tokenizer load path; there was no way to keep both, so that claim needs re-validating on a real deploy.

**Prefetch sharding pin.** `flyte.prefetch.hf_model(shard_config=...)` shards a checkpoint with vLLM's `save_sharded_state`, and this plugin's `FlyteModelLoader._load_sharded_model` is the only thing that reads those files back — rebuilding the expected `state_dict` from *its own* vLLM's model implementation and raising `Missing keys ... in loaded state!` on anything it cannot fill. The two are halves of one format, but nothing tied their versions together: `VLLM_SHARDING_IMAGE_PACKAGES` asked for `vllm>=0.11.0`, a floor rather than a pin, so it installed whatever was newest at image-build time — two prefetch runs weeks apart could shard with different vLLMs, and neither was pinned to the one doing the serving. It is now pinned to `0.26.0`, and the sharding image's CUDA toolkit moves 12.9 → 13.0 to match the wheels vLLM 0.26 pins (the toolkit is there so startup JIT compiles have an `nvcc`; one from the wrong CUDA major fails inside a warmup compile). A test in the vLLM plugin's suite asserts the two constants stay equal, so a one-sided bump fails in CI rather than at model-load time on a real deploy.

## Test Plan

- 13 new vLLM tests and 19 new SGLang tests covering: draft-model mounting, HF draft models, draft-model-free (ngram) configs, forced download when a draft model or the router is configured, the `speculative_config` validation errors, flag rendering (including `speculative_`-prefixed keys and booleans), shell quoting of JSON args, `$VAR` args left unquoted, router entrypoint selection, host defaulting, and `clone_with` round-trips that add or drop a draft model.
- 2 new tests guarding the prefetch/plugin version contract, verified to actually fail (with an actionable message) when the two constants are desynced.
- Existing suites pass unchanged apart from the two intentional mount-path assertions: **39 passed** (vLLM), **43 passed** (SGLang), **64 passed** (`tests/flyte/prefetch`).
- All nine example modules import and their app envs build with the inherited images; `make fmt`, `make mypy`, `make ty` and `make check-docstrings` clean across the repo.
- `ruff format --check` and `ruff check` clean on both plugins; `mypy` clean on the changed files (the 2 remaining errors are pre-existing, in the untouched SGLang shim).

⚠️ **Not exercised:** the container image builds themselves, which need a GPU-class builder and a registry (`maint_tools/build_plugin_image.py`). The pins are verified against PyPI and the flashinfer indexes — `flashinfer-jit-cache==0.6.14` exists on `cu130`, and the previously pinned `cu128`/`cu129` indexes top out at `0.6.9`, so they could never have matched the new engines. Worth a real build + serve before merge.

**Out of scope, adjacent:** `examples/ml/batch_inference_saturate.py` and `batch_inference_saturate_app.py` install an unpinned `vllm` alongside `flashinfer-python==0.6.4` / a `cu129` jit-cache. Unpinned resolves to 0.26.x, which pins flashinfer exactly at 0.6.14 — so those layers are both overwritten and CUDA-mismatched. Same bug class as this PR fixes, but a different subsystem: they use vLLM directly and touch neither plugin nor the sharded-state format, so they are left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

