### PR TITLE
Add parent filter for remote Action listall

### DIFF
--- a/src/flyte/remote/_action.py
+++ b/src/flyte/remote/_action.py
@@ -251,6 +251,7 @@ class Action(ToJSONMixin):
         cls,
         for_run_name: str,
         in_phase: Tuple[ActionPhase | str, ...] | None = None,
+        parent_name: str | None = None,
         sort_by: Tuple[str, Literal["asc", "desc"]] | None = None,
         created_at: TimeFilter | None = None,
         updated_at: TimeFilter | None = None,
@@ -261,8 +262,8 @@ class Action(ToJSONMixin):
         Args:
             for_run_name: The name of the run.
             in_phase: Filter actions by one or more phases.
-            filters: The filters to apply to the project list.
-            sort_by: The sorting criteria for the project list, in the format (field, order).
+            parent_name: Only return direct children of this action (e.g. "a0" for the root's children).
+            sort_by: The sorting criteria for the action list, in the format (field, order).
             created_at: Filter actions by creation time range.
             updated_at: Filter actions by last-update time range.
 
@@ -307,6 +308,15 @@ class Action(ToJSONMixin):
                         values=phases[0],
                     ),
                 )
+
+        if parent_name:
+            filter_list.append(
+                list_pb2.Filter(
+                    function=list_pb2.Filter.Function.EQUAL,
+                    field="parent_name",
+                    values=[parent_name],
+                ),
+            )
 
         if created_at:
             filter_list.extend(time_filtering("created_at", created_at))
@@ -416,6 +426,13 @@ class Action(ToJSONMixin):
         if self.pb2.metadata.HasField("task") and self.pb2.metadata.task.HasField("id"):
             return self.pb2.metadata.task.id.name
         return None
+
+    @property
+    def parent_name(self) -> str | None:
+        """
+        Name of the action this one is nested under, or None for the root action.
+        """
+        return self.pb2.metadata.parent or None
 
     @property
     def relation(self):
@@ -939,6 +956,13 @@ class ActionDetails(ToJSONMixin):
         if self.pb2.metadata.HasField("task") and self.pb2.metadata.task.HasField("id"):
             return self.pb2.metadata.task.id.name
         return None
+
+    @property
+    def parent_name(self) -> str | None:
+        """
+        Name of the action this one is nested under, or None for the root action.
+        """
+        return self.pb2.metadata.parent or None
 
     @property
     def action_id(self) -> identifier_pb2.ActionIdentifier:

--- a/src/flyte/remote/_condition.py
+++ b/src/flyte/remote/_condition.py
@@ -116,12 +116,22 @@ class Condition(ToJSONMixin):
             domain=cfg.domain,
             name=run_name,
         )
-        # Filter to condition actions on the backend rather than client-side.
-        condition_filter = list_pb2.Filter(
-            function=list_pb2.Filter.Function.EQUAL,
-            field="action_type",
-            values=[str(int(run_definition_pb2.ACTION_TYPE_CONDITION))],
-        )
+        # Filter to condition actions (and optionally to one parent) on the backend rather than client-side.
+        filters = [
+            list_pb2.Filter(
+                function=list_pb2.Filter.Function.EQUAL,
+                field="action_type",
+                values=[str(int(run_definition_pb2.ACTION_TYPE_CONDITION))],
+            )
+        ]
+        if action_name is not None:
+            filters.append(
+                list_pb2.Filter(
+                    function=list_pb2.Filter.Function.EQUAL,
+                    field="parent_name",
+                    values=[action_name],
+                )
+            )
 
         token = None
         while True:
@@ -131,13 +141,11 @@ class Condition(ToJSONMixin):
                     request=list_pb2.ListRequest(
                         limit=limit,
                         token=token,
-                        filters=[condition_filter],
+                        filters=filters,
                     ),
                 )
             )
             for action in resp.actions:
-                if action_name is not None and action.metadata.parent != action_name:
-                    continue
                 yield cls(pb2=action)
             if not resp.token:
                 break

--- a/tests/flyte/remote/test_listall_filters.py
+++ b/tests/flyte/remote/test_listall_filters.py
@@ -312,6 +312,42 @@ class TestActionListallFilters:
             assert "created_at" not in fields
             assert "updated_at" not in fields
 
+    def test_parent_name_filter_is_sent(self, mock_client_action, mock_init_config):
+        call_args = self._call_listall(mock_client_action, mock_init_config, parent_name="a0")
+        filters = list(call_args[0][0].request.filters)
+        parent = next(f for f in filters if f.field == "parent_name")
+        assert parent.function == list_pb2.Filter.Function.EQUAL
+        assert list(parent.values) == ["a0"]
+
+    def test_no_parent_name_sends_no_parent_filter(self, mock_client_action, mock_init_config):
+        call_args = self._call_listall(mock_client_action, mock_init_config)
+        raw_filters = call_args[0][0].request.filters
+        assert "parent_name" not in [f.field for f in (raw_filters or [])]
+
+
+# ---------------------------------------------------------------------------
+# Action.parent_name property
+# ---------------------------------------------------------------------------
+
+
+class TestActionParentName:
+    def test_child_reports_parent(self):
+        from flyteidl2.workflow import run_definition_pb2
+
+        from flyte.remote._action import Action, ActionDetails
+
+        pb = run_definition_pb2.Action()
+        pb.metadata.parent = "a0"
+        assert Action(pb2=pb).parent_name == "a0"
+        assert ActionDetails(pb2=run_definition_pb2.ActionDetails(metadata=pb.metadata)).parent_name == "a0"
+
+    def test_root_reports_none(self):
+        from flyteidl2.workflow import run_definition_pb2
+
+        from flyte.remote._action import Action
+
+        assert Action(pb2=run_definition_pb2.Action()).parent_name is None
+
 
 # ---------------------------------------------------------------------------
 # Export check

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -438,10 +438,9 @@ class TestRemoteConditionGet:
 
 class TestRemoteConditionListall:
     @pytest.mark.asyncio
-    async def test_listall_filters_by_parent_action(self):
+    async def test_listall_filters_by_parent_action_server_side(self):
         match = _mock_condition_action("c1", parent="act1")
-        other = _mock_condition_action("c2", parent="act2")
-        mock_client = _mock_list_actions_client([match, other])
+        mock_client = _mock_list_actions_client([match])
 
         with (
             patch("flyte.remote._condition.ensure_client"),
@@ -451,6 +450,10 @@ class TestRemoteConditionListall:
             conditions = [c async for c in Condition.listall.aio(run_name="run1", action_name="act1")]
 
         assert [c.pb2 for c in conditions] == [match]
+        # The parent restriction is pushed to the backend as a parent_name == act1 filter.
+        req = mock_client.run_service.list_actions.await_args.args[0]
+        fields = {f.field: list(f.values) for f in req.request.filters}
+        assert fields == {"action_type": ["3"], "parent_name": ["act1"]}
 
     @pytest.mark.asyncio
     async def test_listall_filters_condition_actions_server_side(self):


### PR DESCRIPTION
## Why
Add a parent_name filter when listing remote Actions. The backend already accepts a `parent_name` filter on `ListActions` (it's a column in the actions table and in the allowed filter set), so this just exposes it.

## What
- `Action.listall(..., parent_name="a0")` pushes a `parent_name == a0` filter to the server.
- New `parent_name` property on `Action` and `ActionDetails` (`None` for the root action).
- `Condition.listall(action_name=...)` now uses the same server-side filter instead of filtering client-side after fetching every condition.
- Fixed the copy-pasted `sort_by`/`filters` docstring on `Action.listall`.

## Verification
Unit tests for the new filter and property; existing condition test updated to assert the filter is on the request. Checked against a live run that the server-side result matches the client-side filter over all actions.