### PR TITLE
feat(rerun): support new inputs alongside --recover, in the CLI and the API

### DIFF
--- a/examples/rerun/README.md
+++ b/examples/rerun/README.md
@@ -10,14 +10,17 @@ One verb, two behaviours:
 | ---- | ------------ |
 | `flyte.rerun(run)` / `flyte rerun <run>` | A whole new run with the same inputs. Every action executes again, subject to global caching. |
 | `flyte.rerun(run, recover=True)` / `flyte rerun <run> --recover` | A whole new run with the same inputs, but actions that already succeeded are reused as-is. Only what failed or never ran executes. |
+| `flyte.rerun(run, x=2)` / `flyte rerun <run> --input x=2` | Same code, changed parameters. Every input left out keeps the prior run's value. Composes with `recover=True` / `--recover`. |
 
 Reused actions land in the `RECOVERED` phase — terminal and success-equivalent — so
 `flyte get action <run>` tells you exactly what recovery skipped.
 
-Recovery is durability against *intermittent* failures, not a way to patch a run. It replays
-the source run's code and inputs as-is; the run environment (`-e KEY=VALUE`) is the only lever
-you get. `recover=True` combined with changed inputs raises — change inputs on a plain rerun
-instead.
+Recovery is durability against *intermittent* failures. It always replays the source run's
+*code* as-is — substituting local code is `flyte fork`, reserved for `flyteplugins-union`.
+Inputs and the run environment (`-e KEY=VALUE`) are the levers you get: `recover=True` combined
+with changed inputs starts the new run from those inputs, while every recovered action keeps the
+output it produced under the *original* inputs. Force the ones that must re-execute against the
+new values with `--force-rerun-action`.
 
 `--action-name` narrows a rerun to a single action: the new run is rooted at that action's task,
 run with the exact inputs it received. Because recovery matches succeeded actions by name and a
@@ -32,7 +35,7 @@ its children, so list those too to force a whole subtree; unknown names are igno
 
 | File | What it shows |
 | ---- | ------------- |
-| `rerun_and_recover.py` | All four whole-run variants end to end — pure rerun, recover, recover with a forced action replay, and rerun with changed inputs — against a pipeline whose join step fails unless `FLAKY_OK=1` is in the run environment. |
+| `rerun_and_recover.py` | All five whole-run variants end to end — pure rerun, recover, recover with a forced action replay, rerun with changed inputs, and recover with changed inputs — against a pipeline whose join step fails unless `FLAKY_OK=1` is in the run environment. |
 | `rerun_single_action.py` | `--action-name` / `action_name=`: re-run one action out of a prior run, rooted at that action's task with the inputs it received. Finds the failed leaf by phase rather than guessing its hashed name. |
 
 Both include the equivalent `flyte` CLI command for every variant they show.

--- a/examples/rerun/README.md
+++ b/examples/rerun/README.md
@@ -10,7 +10,7 @@ One verb, two behaviours:
 | ---- | ------------ |
 | `flyte.rerun(run)` / `flyte rerun <run>` | A whole new run with the same inputs. Every action executes again, subject to global caching. |
 | `flyte.rerun(run, recover=True)` / `flyte rerun <run> --recover` | A whole new run with the same inputs, but actions that already succeeded are reused as-is. Only what failed or never ran executes. |
-| `flyte.rerun(run, x=2)` / `flyte rerun <run> --input x=2` | Same code, changed parameters. Every input left out keeps the prior run's value. Composes with `recover=True` / `--recover`. |
+| `flyte.rerun(run, x=2)` / `flyte rerun <run> --x 2` | Same code, changed parameters. Every input left out keeps the prior run's value. Composes with `recover=True` / `--recover`. |
 
 Reused actions land in the `RECOVERED` phase — terminal and success-equivalent — so
 `flyte get action <run>` tells you exactly what recovery skipped.
@@ -21,6 +21,11 @@ Inputs and the run environment (`-e KEY=VALUE`) are the levers you get: `recover
 with changed inputs starts the new run from those inputs, while every recovered action keeps the
 output it produced under the *original* inputs. Force the ones that must re-execute against the
 new values with `--force-rerun-action`.
+
+On the CLI the task's inputs are options, built from the source run's interface exactly as
+`flyte run` builds them from local code — `flyte rerun <run> --help` lists them. Unlike `flyte
+run`, none of them is required and none carries the task's default: an input you leave out keeps
+the prior run's value.
 
 `--action-name` narrows a rerun to a single action: the new run is rooted at that action's task,
 run with the exact inputs it received. Because recovery matches succeeded actions by name and a

--- a/examples/rerun/rerun_and_recover.py
+++ b/examples/rerun/rerun_and_recover.py
@@ -12,9 +12,10 @@ behaviours live behind one verb:
   Recovered actions land in the `RECOVERED` phase, which is terminal and success-equivalent.
 
 Recovery is durability against *intermittent* failures — a flaky dependency, a node going away,
-a credential that had expired. It is deliberately NOT a way to patch a run: it replays the source
-run's code and inputs as-is, so `recover=True` combined with changed inputs raises (demonstrated
-in `main()` below). The run environment (`-e KEY=VALUE`) is the one lever you get.
+a credential that had expired. It never substitutes local *code* (that is `flyte fork`), but it
+does compose with changed inputs: `recover=True` plus new inputs starts the new run from those
+inputs while still reusing the succeeded actions, which keep the outputs they produced under the
+original inputs unless `force_rerun_actions` names them (demonstrated in `main()` below).
 
 The pipeline here fans out four `prep` tasks and joins them in `flaky_join`, which fails unless
 `FLAKY_OK=1` is present in the run's environment. That gives a run with four succeeded actions
@@ -29,8 +30,7 @@ Run the whole tour (remote only — rerun and recover are not supported locally)
 Equivalent `flyte` CLI commands
 --------------------------------------------------------------------------------------------
 The script prints the seed run's name; substitute it for <RUN> below. `flyte rerun` covers the
-same ground as `flyte.rerun`, except for changing inputs (no CLI flag for that yet — use the
-Python API).
+same ground as `flyte.rerun`.
 
     # Seed run: launches local code, fails at flaky_join.
     flyte run examples/rerun/rerun_and_recover.py pipeline --n 4
@@ -48,6 +48,15 @@ Python API).
 
     # Repeatable — a listed parent re-enqueues its children, so list those too to force a subtree:
     flyte rerun <RUN> --recover -e FLAKY_OK=1 --force-rerun-action <A1> --force-rerun-action <A2>
+
+    # 4. Change inputs instead of reusing the prior run's. Repeatable; every input left out
+    #    keeps the prior run's value, and values are parsed against the source task's interface.
+    flyte rerun <RUN> --input n=6
+
+    # 5. Recover AND change inputs. Recovered actions keep the outputs they produced under the
+    #    original inputs, so force the ones that must re-execute against the new value.
+    flyte rerun <RUN> --recover -e FLAKY_OK=1 --input n=6
+    flyte rerun <RUN> --recover -e FLAKY_OK=1 --input n=6 --force-rerun-action <ACTION>
 
     # Useful extras on any of the above: name the new run, stream its logs, retarget it.
     flyte rerun <RUN> --recover -e FLAKY_OK=1 --name recovered-1 --follow
@@ -150,17 +159,24 @@ def main() -> None:
         summarize(forced.name)
 
     # --- 4. Rerun with different inputs: same code, new parameters. ---------------------------
-    #     Keyword arguments are converted against the interface fetched from the platform.
-    #     No CLI equivalent yet — this one is Python-only.
+    #     Keyword arguments (or inputs={...}) are converted against the interface fetched from
+    #     the platform; every input left out keeps the source run's value.
+    #     CLI: flyte rerun <RUN> --input n=6
     changed = flyte.with_runcontext(env_vars={FLAKY_OK: "1"}).rerun(seed.name, n=6)
     print(f"\n4. rerun(n=6) -> {changed.name}\n  {changed.url}")
 
-    # --- The boundary: recovery never changes what it replays. --------------------------------
-    #     Changing inputs is fine on a plain rerun (4 above), but not while recovering.
-    try:
-        flyte.rerun(seed.name, recover=True, n=6)
-    except ValueError as e:
-        print(f"\n5. recover + changed inputs is rejected, as designed:\n   {e}")
+    # --- 5. Recover AND change inputs: the two compose. ---------------------------------------
+    #     The new run starts from the changed inputs, but each action recovered from the seed run
+    #     keeps the output it produced under the ORIGINAL inputs — name the ones that must re-run
+    #     against the new value in force_rerun_actions.
+    #     CLI: flyte rerun <RUN> --recover -e FLAKY_OK=1 --input n=6
+    patched = flyte.with_runcontext(env_vars={FLAKY_OK: "1"}).rerun(
+        seed.name,
+        recover=True,
+        inputs={"n": 6},
+        force_rerun_actions=[a_prep] if a_prep else None,
+    )
+    print(f"\n5. rerun(recover=True, inputs={{'n': 6}}) -> {patched.name}\n  {patched.url}")
 
 
 if __name__ == "__main__":

--- a/examples/rerun/rerun_and_recover.py
+++ b/examples/rerun/rerun_and_recover.py
@@ -49,14 +49,16 @@ same ground as `flyte.rerun`.
     # Repeatable — a listed parent re-enqueues its children, so list those too to force a subtree:
     flyte rerun <RUN> --recover -e FLAKY_OK=1 --force-rerun-action <A1> --force-rerun-action <A2>
 
-    # 4. Change inputs instead of reusing the prior run's. Repeatable; every input left out
-    #    keeps the prior run's value, and values are parsed against the source task's interface.
-    flyte rerun <RUN> --input n=6
+    # 4. Change inputs instead of reusing the prior run's. The task's inputs are options here,
+    #    built from the source run's interface — list them with --help. Every input left out
+    #    keeps the prior run's value.
+    flyte rerun <RUN> --help
+    flyte rerun <RUN> --n 6
 
     # 5. Recover AND change inputs. Recovered actions keep the outputs they produced under the
     #    original inputs, so force the ones that must re-execute against the new value.
-    flyte rerun <RUN> --recover -e FLAKY_OK=1 --input n=6
-    flyte rerun <RUN> --recover -e FLAKY_OK=1 --input n=6 --force-rerun-action <ACTION>
+    flyte rerun <RUN> --recover -e FLAKY_OK=1 --n 6
+    flyte rerun <RUN> --recover -e FLAKY_OK=1 --n 6 --force-rerun-action <ACTION>
 
     # Useful extras on any of the above: name the new run, stream its logs, retarget it.
     flyte rerun <RUN> --recover -e FLAKY_OK=1 --name recovered-1 --follow
@@ -159,9 +161,9 @@ def main() -> None:
         summarize(forced.name)
 
     # --- 4. Rerun with different inputs: same code, new parameters. ---------------------------
-    #     Keyword arguments (or inputs={...}) are converted against the interface fetched from
-    #     the platform; every input left out keeps the source run's value.
-    #     CLI: flyte rerun <RUN> --input n=6
+    #     Keyword arguments are converted against the interface fetched from the platform;
+    #     every input left out keeps the source run's value.
+    #     CLI: flyte rerun <RUN> --n 6
     changed = flyte.with_runcontext(env_vars={FLAKY_OK: "1"}).rerun(seed.name, n=6)
     print(f"\n4. rerun(n=6) -> {changed.name}\n  {changed.url}")
 
@@ -169,14 +171,14 @@ def main() -> None:
     #     The new run starts from the changed inputs, but each action recovered from the seed run
     #     keeps the output it produced under the ORIGINAL inputs — name the ones that must re-run
     #     against the new value in force_rerun_actions.
-    #     CLI: flyte rerun <RUN> --recover -e FLAKY_OK=1 --input n=6
+    #     CLI: flyte rerun <RUN> --recover -e FLAKY_OK=1 --n 6
     patched = flyte.with_runcontext(env_vars={FLAKY_OK: "1"}).rerun(
         seed.name,
         recover=True,
-        inputs={"n": 6},
+        n=6,
         force_rerun_actions=[a_prep] if a_prep else None,
     )
-    print(f"\n5. rerun(recover=True, inputs={{'n': 6}}) -> {patched.name}\n  {patched.url}")
+    print(f"\n5. rerun(recover=True, n=6) -> {patched.name}\n  {patched.url}")
 
 
 if __name__ == "__main__":

--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -1313,8 +1313,7 @@ class _Runner:
         recover: bool = False,
         force_rerun_actions: Sequence[str] | None = None,
         allow_missing_source_outputs: bool = False,
-        inputs: Dict[str, Any] | None = None,
-        **kwargs: Any,
+        **inputs: Any,
     ) -> Run:
         """Re-run a prior run, returning a new `Run`.
 
@@ -1323,14 +1322,14 @@ class _Runner:
           global caching.
         - `rerun("r1", recover=True)` creates a whole new run with the same inputs, but reuses the
           prior run's succeeded actions and re-executes only what failed or never ran.
-        - `rerun("r1", x=2)` or `rerun("r1", inputs={"x": 2})` changes input parameters (converted
-          against the fetched task interface); every input left out keeps the source run's value.
-          Task inputs share the keyword namespace with the arguments above, so a task input named
-          `run_name`, `action_name`, `recover`, `force_rerun_actions`,
-          `allow_missing_source_outputs` or `inputs` is only reachable through the `inputs` dict.
-        - `rerun("r1", recover=True, inputs={"x": 2})` combines the two: the new run starts from
-          the changed inputs while still reusing the source run's succeeded actions. Recovered
-          actions keep the outputs they produced under the *original* inputs — name them in
+        - `rerun("r1", x=2)` changes input parameters (converted against the fetched task
+          interface); every input left out keeps the source run's value. Task inputs share the
+          keyword namespace with the arguments above, so a task input named `run_name`,
+          `action_name`, `recover`, `force_rerun_actions` or `allow_missing_source_outputs` is not
+          reachable this way.
+        - `rerun("r1", recover=True, x=2)` combines the two: the new run starts from the changed
+          inputs while still reusing the source run's succeeded actions. Recovered actions keep
+          the outputs they produced under the *original* inputs — name them in
           `force_rerun_actions` to re-execute them against the new inputs.
 
         The prior run's code is always replayed as-is: this never substitutes local code. Replaying
@@ -1360,13 +1359,9 @@ class _Runner:
                 still exist — if they were deleted too, the new run fails at runtime. Irrelevant
                 when the new inputs cover every input of the task, since the source inputs are
                 then not read at all.
-            inputs: Optional native inputs to change parameters, as a dict. Equivalent to passing
-                them as keyword arguments, and the only way to reach a task input whose name
-                collides with one of the arguments above. Merged with `**kwargs`; passing the same
-                input both ways is an error.
-            kwargs: Optional native keyword inputs to change parameters. Any input not passed
-                (here or in `inputs`) keeps the source run's value, so omitting both reuses the
-                source run's inputs wholesale.
+            inputs: Optional native keyword inputs to change parameters. Any input not passed
+                keeps the source run's value, so passing none reuses the source run's inputs
+                wholesale.
 
         Returns:
             the new Run.
@@ -1375,15 +1370,6 @@ class _Runner:
             raise NotImplementedError(f"rerun is only supported in remote mode, got mode={self._mode!r}")
         if force_rerun_actions and not recover:
             raise ValueError("force_rerun_actions requires recover=True")
-        # Inputs may arrive as a dict, as **kwargs, or both; a name given twice is ambiguous.
-        new_inputs: Dict[str, Any] = dict(inputs or {})
-        duplicated = sorted(set(new_inputs) & set(kwargs))
-        if duplicated:
-            raise ValueError(
-                f"Input(s) {duplicated} passed both in inputs={{...}} and as keyword arguments; "
-                f"pass each input exactly once."
-            )
-        new_inputs.update(kwargs)
         # Recovery still replays the source run's code as-is: substituting code is `flyte fork`,
         # reserved for flyteplugins-union.
         # Recovery matches succeeded actions from the source run by deterministic name; a run
@@ -1395,12 +1381,12 @@ class _Runner:
                 f"single action has a different action tree. Re-run the action on its own "
                 f"(recover=False), or recover the whole run."
             )
-        if recover and new_inputs:
+        if recover and inputs:
             # Recovery reuses succeeded actions by name, and those actions ran under the source
             # run's inputs. Changing the root inputs is allowed, but the reused outputs are stale
             # with respect to them unless the actions are forced to re-execute.
             logger.warning(
-                f"Recovering {run_name} with changed inputs {sorted(new_inputs)}: the new run "
+                f"Recovering {run_name} with changed inputs {sorted(inputs)}: the new run "
                 f"starts from the changed inputs, but every action recovered from {run_name} "
                 f"keeps the output it produced under the original inputs. Pass "
                 f"force_rerun_actions=[...] for the actions that must re-execute against the "
@@ -1436,19 +1422,19 @@ class _Runner:
         proto_inputs = None
         offloaded_input_data = None
         reduced_iface = None
-        if new_inputs:
+        if inputs:
             from flyte.models import NativeInterface
             from flyte.types._interface import guess_interface
 
             iface = guess_interface(task_spec.task_template.interface)
-            unknown = sorted(set(new_inputs) - set(iface.inputs))
+            unknown = sorted(set(inputs) - set(iface.inputs))
             if unknown:
                 known = ", ".join(iface.inputs) or "<none>"
                 raise ValueError(f"Unknown input(s) {unknown} for {run_name}/{action_name}. Known inputs: {known}.")
             # Only the changed inputs are converted; the rest keep the source run's literals. Built
             # in interface order so the resulting Inputs keep the task's declared ordering.
             reduced_iface = NativeInterface(
-                inputs={k: v for k, v in iface.inputs.items() if k in new_inputs},
+                inputs={k: v for k, v in iface.inputs.items() if k in inputs},
                 outputs={},
                 _remote_defaults=iface._remote_defaults,
             )
@@ -1523,7 +1509,7 @@ class _Runner:
             from flyteidl2.task import common_pb2 as task_common_pb2
 
             converted = await convert_from_native_to_inputs(
-                reduced_iface, custom_context=self._custom_context, **new_inputs
+                reduced_iface, custom_context=self._custom_context, **inputs
             )
             if changes_every_input:
                 proto_inputs = converted.proto_inputs
@@ -1535,7 +1521,7 @@ class _Runner:
                 raise flyte.errors.RuntimeUserError(
                     "SourceRunInputsUnavailableError",
                     f"Source run {run_name}'s inputs could not be read, so the changed inputs "
-                    f"{sorted(new_inputs)} cannot be merged with the ones being kept. Pass every "
+                    f"{sorted(inputs)} cannot be merged with the ones being kept. Pass every "
                     f"input of {run_name}/{action_name} explicitly instead.",
                 )
             else:
@@ -1780,20 +1766,18 @@ async def rerun(
     recover: bool = False,
     force_rerun_actions: Sequence[str] | None = None,
     allow_missing_source_outputs: bool = False,
-    inputs: Dict[str, Any] | None = None,
-    **kwargs: Any,
+    **inputs: Any,
 ) -> Run:
     """Re-run a prior run, returning a new `Run`.
 
     `rerun("r1")` creates a whole new run with the prior run's exact inputs (fetching its code from
     the platform); `rerun("r1", recover=True)` does the same but reuses the prior run's succeeded
-    actions, re-executing only what failed or never ran. Pass new inputs to change parameters,
-    either as keywords (`rerun("r1", x=2)`) or as a dict (`rerun("r1", inputs={"x": 2})`); inputs
-    left out keep the prior run's values. New inputs combine with recovery
-    (`rerun("r1", recover=True, inputs={"x": 2})`), in which case recovered actions keep the
-    outputs they produced under the original inputs unless listed in `force_rerun_actions`. Use
-    `with_runcontext(...).rerun(...)` to apply run-context overrides (env_vars, labels, …). The
-    prior run's code is always replayed as-is.
+    actions, re-executing only what failed or never ran. Pass keyword inputs to change
+    parameters (`rerun("r1", x=2)`); inputs left out keep the prior run's values. New inputs
+    combine with recovery (`rerun("r1", recover=True, x=2)`), in which case recovered actions keep
+    the outputs they produced under the original inputs unless listed in `force_rerun_actions`.
+    Use `with_runcontext(...).rerun(...)` to apply run-context overrides (env_vars, labels, …).
+    The prior run's code is always replayed as-is.
 
     Args:
         run_name: Name of the prior run to re-run.
@@ -1812,13 +1796,8 @@ async def rerun(
             exist — if they were deleted too, the new run fails at runtime. Irrelevant when the
             new inputs cover every input of the task, since the source inputs are then not read
             at all.
-        inputs: Optional native inputs to change parameters, as a dict. Equivalent to passing them
-            as keyword arguments, and the only way to reach a task input whose name collides with
-            one of the arguments above. Merged with `**kwargs`; passing the same input both ways
-            is an error.
-        kwargs: Optional native keyword inputs to change parameters. Any input not passed (here or
-            in `inputs`) keeps the source run's value, so omitting both reuses the source run's
-            inputs wholesale.
+        inputs: Optional native keyword inputs to change parameters. Any input not passed keeps
+            the source run's value, so passing none reuses the source run's inputs wholesale.
 
     Returns:
         the new Run.
@@ -1829,6 +1808,5 @@ async def rerun(
         recover=recover,
         force_rerun_actions=force_rerun_actions,
         allow_missing_source_outputs=allow_missing_source_outputs,
-        inputs=inputs,
-        **kwargs,
+        **inputs,
     )

--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -1313,7 +1313,8 @@ class _Runner:
         recover: bool = False,
         force_rerun_actions: Sequence[str] | None = None,
         allow_missing_source_outputs: bool = False,
-        **inputs: Any,
+        inputs: Dict[str, Any] | None = None,
+        **kwargs: Any,
     ) -> Run:
         """Re-run a prior run, returning a new `Run`.
 
@@ -1322,10 +1323,15 @@ class _Runner:
           global caching.
         - `rerun("r1", recover=True)` creates a whole new run with the same inputs, but reuses the
           prior run's succeeded actions and re-executes only what failed or never ran.
-        - `rerun("r1", x=2)` changes input parameters (converted against the fetched task
-          interface). Task inputs share the keyword namespace with the arguments above, so a task
-          input named `run_name`, `action_name`, `recover` or `force_rerun_actions` is not
-          reachable this way.
+        - `rerun("r1", x=2)` or `rerun("r1", inputs={"x": 2})` changes input parameters (converted
+          against the fetched task interface); every input left out keeps the source run's value.
+          Task inputs share the keyword namespace with the arguments above, so a task input named
+          `run_name`, `action_name`, `recover`, `force_rerun_actions`,
+          `allow_missing_source_outputs` or `inputs` is only reachable through the `inputs` dict.
+        - `rerun("r1", recover=True, inputs={"x": 2})` combines the two: the new run starts from
+          the changed inputs while still reusing the source run's succeeded actions. Recovered
+          actions keep the outputs they produced under the *original* inputs — name them in
+          `force_rerun_actions` to re-execute them against the new inputs.
 
         The prior run's code is always replayed as-is: this never substitutes local code. Replaying
         a run with new code is fork, reserved for flyteplugins-union.
@@ -1351,8 +1357,16 @@ class _Runner:
                 for a new signal. Unknown names are ignored.
             allow_missing_source_outputs: Proceed when the source run's outputs were cleaned up
                 from storage, using its inputs URI directly. The client cannot verify the inputs
-                still exist — if they were deleted too, the new run fails at runtime.
-            inputs: Optional native keyword inputs to change parameters; omit to reuse prior inputs.
+                still exist — if they were deleted too, the new run fails at runtime. Irrelevant
+                when the new inputs cover every input of the task, since the source inputs are
+                then not read at all.
+            inputs: Optional native inputs to change parameters, as a dict. Equivalent to passing
+                them as keyword arguments, and the only way to reach a task input whose name
+                collides with one of the arguments above. Merged with `**kwargs`; passing the same
+                input both ways is an error.
+            kwargs: Optional native keyword inputs to change parameters. Any input not passed
+                (here or in `inputs`) keeps the source run's value, so omitting both reuses the
+                source run's inputs wholesale.
 
         Returns:
             the new Run.
@@ -1361,9 +1375,17 @@ class _Runner:
             raise NotImplementedError(f"rerun is only supported in remote mode, got mode={self._mode!r}")
         if force_rerun_actions and not recover:
             raise ValueError("force_rerun_actions requires recover=True")
-        # Recovery reuses the source run's code and inputs as-is: it is durability against
-        # infrastructure failures, not a way to patch a run. Recovering *with* code or input
-        # changes is `flyte fork`, reserved for flyteplugins-union.
+        # Inputs may arrive as a dict, as **kwargs, or both; a name given twice is ambiguous.
+        new_inputs: Dict[str, Any] = dict(inputs or {})
+        duplicated = sorted(set(new_inputs) & set(kwargs))
+        if duplicated:
+            raise ValueError(
+                f"Input(s) {duplicated} passed both in inputs={{...}} and as keyword arguments; "
+                f"pass each input exactly once."
+            )
+        new_inputs.update(kwargs)
+        # Recovery still replays the source run's code as-is: substituting code is `flyte fork`,
+        # reserved for flyteplugins-union.
         # Recovery matches succeeded actions from the source run by deterministic name; a run
         # rooted at a sub-action has a different action tree, so the reuse set would not line up.
         if recover and action_name != "a0":
@@ -1373,11 +1395,16 @@ class _Runner:
                 f"single action has a different action tree. Re-run the action on its own "
                 f"(recover=False), or recover the whole run."
             )
-        if recover and inputs:
-            raise ValueError(
-                "recover=True cannot be combined with changed inputs: recovery replays the "
-                "source run's code and inputs as-is. To replay a run with new code or inputs, "
-                "use fork (`pip install flyteplugins-union`)."
+        if recover and new_inputs:
+            # Recovery reuses succeeded actions by name, and those actions ran under the source
+            # run's inputs. Changing the root inputs is allowed, but the reused outputs are stale
+            # with respect to them unless the actions are forced to re-execute.
+            logger.warning(
+                f"Recovering {run_name} with changed inputs {sorted(new_inputs)}: the new run "
+                f"starts from the changed inputs, but every action recovered from {run_name} "
+                f"keeps the output it produced under the original inputs. Pass "
+                f"force_rerun_actions=[...] for the actions that must re-execute against the "
+                f"new inputs."
             )
 
         from flyteidl2.dataproxy import dataproxy_service_pb2
@@ -1403,16 +1430,33 @@ class _Runner:
             raise ValueError(f"Action {run_name}/{action_name} has no task spec to rerun.")
         task_spec = action_details.pb2.task
 
-        # Inputs: reuse the prior raw proto inputs, or convert new native kwargs against the interface.
+        # Inputs: reuse the prior run's raw proto inputs, with any new native inputs overlaid on
+        # top of them. New inputs that cover the whole interface stand on their own, so the source
+        # inputs are not fetched at all (the escape hatch when they are gone from storage).
         proto_inputs = None
         offloaded_input_data = None
-        if inputs:
+        reduced_iface = None
+        if new_inputs:
+            from flyte.models import NativeInterface
             from flyte.types._interface import guess_interface
 
             iface = guess_interface(task_spec.task_template.interface)
-            converted = await convert_from_native_to_inputs(iface, custom_context=self._custom_context, **inputs)
-            proto_inputs = converted.proto_inputs
+            unknown = sorted(set(new_inputs) - set(iface.inputs))
+            if unknown:
+                known = ", ".join(iface.inputs) or "<none>"
+                raise ValueError(f"Unknown input(s) {unknown} for {run_name}/{action_name}. Known inputs: {known}.")
+            # Only the changed inputs are converted; the rest keep the source run's literals. Built
+            # in interface order so the resulting Inputs keep the task's declared ordering.
+            reduced_iface = NativeInterface(
+                inputs={k: v for k, v in iface.inputs.items() if k in new_inputs},
+                outputs={},
+                _remote_defaults=iface._remote_defaults,
+            )
+            changes_every_input = len(reduced_iface.inputs) == len(iface.inputs)
         else:
+            changes_every_input = False
+
+        if not changes_every_input:
             # Rerun/recover only need the source run's INPUTS. GetActionData resolves inputs AND
             # outputs server-side concurrently and 404s wholesale when either blob has been
             # cleaned up (retention) — and which half the error names is a race. The client has
@@ -1441,7 +1485,7 @@ class _Runner:
                         "SourceRunInputsUnavailableError",
                         f"Source run {run_name}'s inputs are no longer in storage (deleted by "
                         f"retention/cleanup), so it cannot be rerun or recovered with its "
-                        f"original inputs. Pass new inputs explicitly instead: "
+                        f"original inputs. Pass every input explicitly instead: "
                         f"flyte.with_runcontext(...).rerun('{run_name}', x=..., y=...), or "
                         f"launch fresh local code with `flyte run ...` "
                         f"(inputs come from the CLI parameters).",
@@ -1454,7 +1498,7 @@ class _Runner:
                         f"from the client. If you know the inputs are intact, retry with "
                         f"--allow-missing-outputs "
                         f"(rerun(..., allow_missing_source_outputs=True)); if they were "
-                        f"deleted too, the new run would fail at runtime — pass new inputs "
+                        f"deleted too, the new run would fail at runtime — pass every input "
                         f"explicitly instead (rerun('{run_name}', x=..., y=...) or "
                         f"`flyte run ...`).",
                     ) from e
@@ -1473,6 +1517,38 @@ class _Runner:
                 offloaded_input_data = common_run_pb2.OffloadedInputData(
                     uri=uris.inputs_uri,
                     inputs_hash=_uri_inputs_hash(uris.inputs_uri),
+                )
+
+        if reduced_iface is not None:
+            from flyteidl2.task import common_pb2 as task_common_pb2
+
+            converted = await convert_from_native_to_inputs(
+                reduced_iface, custom_context=self._custom_context, **new_inputs
+            )
+            if changes_every_input:
+                proto_inputs = converted.proto_inputs
+            elif proto_inputs is None:
+                # Only the source inputs' URI is in hand (--allow-missing-outputs), so the
+                # unchanged inputs cannot be read to merge the changed ones into.
+                import flyte.errors
+
+                raise flyte.errors.RuntimeUserError(
+                    "SourceRunInputsUnavailableError",
+                    f"Source run {run_name}'s inputs could not be read, so the changed inputs "
+                    f"{sorted(new_inputs)} cannot be merged with the ones being kept. Pass every "
+                    f"input of {run_name}/{action_name} explicitly instead.",
+                )
+            else:
+                overrides = {lit.name: lit.value for lit in converted.proto_inputs.literals}
+                merged = [
+                    task_common_pb2.NamedLiteral(name=lit.name, value=overrides.pop(lit.name, lit.value))
+                    for lit in proto_inputs.literals
+                ]
+                # An input the source run never carried (e.g. added since) still has to land.
+                merged += [task_common_pb2.NamedLiteral(name=name, value=v) for name, v in overrides.items()]
+                proto_inputs = task_common_pb2.Inputs(
+                    literals=merged,
+                    context=converted.proto_inputs.context or proto_inputs.context,
                 )
 
         run_id, project_id = self._resolve_run_target(project, domain, cfg.org)
@@ -1704,15 +1780,20 @@ async def rerun(
     recover: bool = False,
     force_rerun_actions: Sequence[str] | None = None,
     allow_missing_source_outputs: bool = False,
-    **inputs: Any,
+    inputs: Dict[str, Any] | None = None,
+    **kwargs: Any,
 ) -> Run:
     """Re-run a prior run, returning a new `Run`.
 
     `rerun("r1")` creates a whole new run with the prior run's exact inputs (fetching its code from
     the platform); `rerun("r1", recover=True)` does the same but reuses the prior run's succeeded
-    actions, re-executing only what failed or never ran. Pass keyword inputs to change parameters
-    (`rerun("r1", x=2)`). Use `with_runcontext(...).rerun(...)` to apply run-context overrides
-    (env_vars, labels, …). The prior run's code is always replayed as-is.
+    actions, re-executing only what failed or never ran. Pass new inputs to change parameters,
+    either as keywords (`rerun("r1", x=2)`) or as a dict (`rerun("r1", inputs={"x": 2})`); inputs
+    left out keep the prior run's values. New inputs combine with recovery
+    (`rerun("r1", recover=True, inputs={"x": 2})`), in which case recovered actions keep the
+    outputs they produced under the original inputs unless listed in `force_rerun_actions`. Use
+    `with_runcontext(...).rerun(...)` to apply run-context overrides (env_vars, labels, …). The
+    prior run's code is always replayed as-is.
 
     Args:
         run_name: Name of the prior run to re-run.
@@ -1728,8 +1809,16 @@ async def rerun(
             children — list them too to force the whole subtree. Unknown names are ignored.
         allow_missing_source_outputs: Proceed when the source run's outputs were cleaned up from
             storage, using its inputs URI directly. The client cannot verify the inputs still
-            exist — if they were deleted too, the new run fails at runtime.
-        inputs: Optional native keyword inputs to change parameters; omit to reuse prior inputs.
+            exist — if they were deleted too, the new run fails at runtime. Irrelevant when the
+            new inputs cover every input of the task, since the source inputs are then not read
+            at all.
+        inputs: Optional native inputs to change parameters, as a dict. Equivalent to passing them
+            as keyword arguments, and the only way to reach a task input whose name collides with
+            one of the arguments above. Merged with `**kwargs`; passing the same input both ways
+            is an error.
+        kwargs: Optional native keyword inputs to change parameters. Any input not passed (here or
+            in `inputs`) keeps the source run's value, so omitting both reuses the source run's
+            inputs wholesale.
 
     Returns:
         the new Run.
@@ -1740,5 +1829,6 @@ async def rerun(
         recover=recover,
         force_rerun_actions=force_rerun_actions,
         allow_missing_source_outputs=allow_missing_source_outputs,
-        **inputs,
+        inputs=inputs,
+        **kwargs,
     )

--- a/src/flyte/cli/_params.py
+++ b/src/flyte/cli/_params.py
@@ -782,11 +782,10 @@ class FlyteLiteralConverter(object):
         return isinstance(self.click_type, UnionParamType) and self.click_type.optional
 
     def convert(
-        self, ctx: typing.Optional[click.Context], param: typing.Optional[click.Parameter], value: typing.Any
+        self, ctx: click.Context, param: typing.Optional[click.Parameter], value: typing.Any
     ) -> typing.Union[Literal, typing.Any]:
         """
-        Convert the value to a python native type. This is used by click to convert the input, and
-        directly (with no click context) wherever a value has to be parsed outside option parsing.
+        Convert the value to a python native type. This is used by click to convert the input.
         """
         try:
             # If the expected Python type is datetime.date, adjust the value to date

--- a/src/flyte/cli/_params.py
+++ b/src/flyte/cli/_params.py
@@ -782,10 +782,11 @@ class FlyteLiteralConverter(object):
         return isinstance(self.click_type, UnionParamType) and self.click_type.optional
 
     def convert(
-        self, ctx: click.Context, param: typing.Optional[click.Parameter], value: typing.Any
+        self, ctx: typing.Optional[click.Context], param: typing.Optional[click.Parameter], value: typing.Any
     ) -> typing.Union[Literal, typing.Any]:
         """
-        Convert the value to a python native type. This is used by click to convert the input.
+        Convert the value to a python native type. This is used by click to convert the input, and
+        directly (with no click context) wherever a value has to be parsed outside option parsing.
         """
         try:
             # If the expected Python type is datetime.date, adjust the value to date

--- a/src/flyte/cli/_rerun.py
+++ b/src/flyte/cli/_rerun.py
@@ -10,9 +10,10 @@ fetching its task + inputs from the platform, so no local code is needed.
 * `flyte rerun <run> --action-name <action>` re-runs just that one action from the run: the new
   run is rooted at that action's task, executed with the exact inputs it received. Mutually
   exclusive with `--recover`.
-* `flyte rerun <run> --input x=2` replaces individual inputs; every input left out keeps the
-  prior run's value. Values are converted against the source task's interface, which is fetched
-  from the platform. This composes with `--recover`.
+* `flyte rerun <run> --x 2` changes input parameters. The task's inputs become options on this
+  command exactly as they do for `flyte run` — same literal-type-to-click-type conversion — except
+  that the interface is read off the source run instead of local code, and every option is
+  optional: an input left out keeps the prior run's value. This composes with `--recover`.
 
 Rerun always replays the source run's *code* as-is — substituting local code is `flyte fork`,
 reserved for flyteplugins-union.
@@ -21,11 +22,18 @@ reserved for flyteplugins-union.
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import rich_click as click
+from click.core import ParameterSource
 
 from . import _common as common
+
+# Keyword arguments of `rerun()` itself. A task input by one of these names cannot be forwarded as
+# a keyword, so it never becomes an option here; it stays reachable from the Python API only via a
+# run whose interface does not collide. rerun's own option names are excluded separately, straight
+# off the declared parameters, so the two lists cannot drift apart.
+_RESERVED_INPUT_NAMES = frozenset({"run_name", "action_name", "recover", "force_rerun_actions"})
 
 
 def _parse_kv(items: Tuple[str, ...], flag: str) -> Optional[Dict[str, str]]:
@@ -43,7 +51,143 @@ def _parse_kv(items: Tuple[str, ...], flag: str) -> Optional[Dict[str, str]]:
     return parsed
 
 
-@click.command("rerun", cls=click.RichCommand)
+async def _fetch_source_interface(run_name: str, action_name: str):
+    """The typed interface of the action that supplies the task, or None if it carries no task.
+
+    Rerun never uses local code, so the interface the input options are built from lives on the
+    platform: it is read off the same action `rerun()` sources the task spec from.
+    """
+    from flyte.remote._action import ActionDetails
+    from flyte.remote._run import RunDetails
+
+    if action_name == "a0":
+        action_details = (await RunDetails.get.aio(name=run_name)).action_details
+    else:
+        action_details = await ActionDetails.get.aio(run_name=run_name, name=action_name)
+    if not action_details.pb2.HasField("task"):
+        return None
+    return action_details.pb2.task.task_template.interface
+
+
+def _to_optional_option(name: str, var, python_type) -> click.Option:
+    """`flyte run`'s option for this input, made optional.
+
+    `flyte run` marks an input required when the task declares no default, and shows that default
+    in `--help`. Neither fits rerun: the fallback for an input the user leaves out is the source
+    run's value, not the task's default and not an error.
+    """
+    from ._params import FlyteLiteralConverter, to_click_option
+
+    if FlyteLiteralConverter(literal_type=var.type, python_type=python_type).is_bool():
+        # to_click_option only offers `--x/--no-x` when the task's default is True. Here either
+        # value has to be expressible, because "not passed" already means "keep the prior value".
+        return click.Option(
+            param_decls=[f"--{name}/--no-{name}"],
+            default=None,
+            required=False,
+            help=var.description,
+        )
+    option = to_click_option(name, var, python_type, None)
+    option.required = False
+    option.default = None
+    option.show_default = False
+    return option
+
+
+def _input_options(interface, taken_names: set[str], taken_opts: set[str]) -> List[click.Parameter]:
+    """One option per input of the source task, skipping the ones a CLI cannot express."""
+    from flyte.types._interface import guess_interface
+
+    native_inputs = guess_interface(interface).inputs
+    options: List[click.Parameter] = []
+    for entry in interface.inputs.variables:
+        name, var = entry.key, entry.value
+        # An input that collides with one of rerun's own options (or with a keyword `rerun()`
+        # already takes) cannot be an option here without shadowing it. Everything else about the
+        # rerun still works; only that one input keeps the prior run's value.
+        if name in taken_names or name in _RESERVED_INPUT_NAMES or f"--{name}" in taken_opts:
+            continue
+        if name not in native_inputs:
+            continue
+        python_type, _ = native_inputs[name]
+        try:
+            options.append(_to_optional_option(name, var, python_type))
+        except Exception:
+            # e.g. an uppercase input name, which click cannot express as an option, or a type
+            # with no click equivalent. Same outcome: that input keeps the prior run's value.
+            continue
+    return options
+
+
+def _peek_declared_args(args: Sequence[str], declared_params: List[click.Parameter]):
+    """Read rerun's own arguments out of `args`, tolerating input options not yet built.
+
+    Returns the parsed values plus whatever was left over. Nothing left over means no input was
+    passed, which is what makes the extra round trip to the platform skippable.
+    """
+    shadow = click.Command(
+        "rerun",
+        params=list(declared_params),
+        add_help_option=False,
+        context_settings={"ignore_unknown_options": True, "allow_extra_args": True},
+    )
+    try:
+        ctx = shadow.make_context("rerun", list(args), resilient_parsing=True)
+    except Exception:
+        return {}, []
+    return ctx.params, list(ctx.args)
+
+
+class RerunCommand(click.RichCommand):
+    """`flyte rerun`, with an option per input of the source run's task.
+
+    Those inputs come from the platform rather than from local code, so they can only be
+    discovered once RUN_NAME has been read off the command line — hence the two-pass parse:
+    rerun's own options first, then the interface, then the real parse with both sets of options.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._declared_params: List[click.Parameter] = list(self.params)
+        self._input_params: List[click.Parameter] = []
+
+    def get_params(self, ctx: click.Context) -> List[click.Parameter]:
+        # Note this may be called several times by click (parsing, help, completion).
+        self.params = [*self._declared_params, *self._input_params]
+        return super().get_params(ctx)
+
+    def parse_args(self, ctx: click.Context, args: List[str]) -> List[str]:
+        self._input_params = self._build_input_params(ctx, args)
+        return super().parse_args(ctx, args)
+
+    def _build_input_params(self, ctx: click.Context, args: List[str]) -> List[click.Parameter]:
+        declared, leftover = _peek_declared_args(args, self._declared_params)
+        run_name = declared.get("run_name")
+        # No leftover means every token was consumed by rerun's own options, so no input was
+        # passed and there is nothing for the interface to interpret (`--help` counts as leftover,
+        # so `flyte rerun <run> --help` does list the run's inputs).
+        if not run_name or not leftover:
+            return []
+        try:
+            common.initialize_config(ctx, project=declared.get("project"), domain=declared.get("domain"))
+            interface = asyncio.run(_fetch_source_interface(run_name, declared.get("action_name") or "a0"))
+        except Exception as e:
+            # `--help` has to render even with no config or no connectivity; it just cannot list
+            # the run's inputs in that case.
+            if "--help" in args:
+                return []
+            raise click.UsageError(
+                f"Could not read the inputs of {run_name} from the platform, so "
+                f"{' '.join(leftover)} cannot be interpreted: {e}"
+            ) from e
+        if interface is None:
+            return []
+        taken_names = {p.name for p in self._declared_params if p.name}
+        taken_opts = {o for p in self._declared_params for o in [*p.opts, *p.secondary_opts]}
+        return _input_options(interface, taken_names, taken_opts)
+
+
+@click.command("rerun", cls=RerunCommand)
 @click.argument("run_name", required=True)
 @click.option("-p", "--project", default=None, help="Project for the new run (defaults to config).")
 @click.option("-d", "--domain", default=None, help="Domain for the new run (defaults to config).")
@@ -74,14 +218,6 @@ def _parse_kv(items: Tuple[str, ...], flag: str) -> Optional[Dict[str, str]]:
     "force the whole subtree); unknown names are ignored.",
 )
 @click.option(
-    "--input",
-    "inputs",
-    multiple=True,
-    help="Input KEY=VALUE for the new run, replacing the prior run's value for KEY. Repeatable. "
-    "VALUE is parsed against the source task's interface (JSON for structured types). Any input "
-    "not given here keeps the prior run's value. Composes with --recover.",
-)
-@click.option(
     "--allow-missing-outputs",
     "allow_missing_outputs",
     is_flag=True,
@@ -103,8 +239,8 @@ def rerun(
     recover: bool,
     action_name: Optional[str],
     force_rerun_action: Tuple[str, ...],
-    inputs: Tuple[str, ...],
     allow_missing_outputs: bool,
+    **task_inputs: Any,
 ) -> None:
     """Re-run an existing run RUN_NAME with its original code and inputs.
 
@@ -117,10 +253,11 @@ def rerun(
     action's task, run with the exact inputs it received inside RUN_NAME. That is always a plain
     re-execution, so it cannot be combined with `--recover`.
 
-    `--input KEY=VALUE` replaces individual inputs; the rest are inherited from RUN_NAME. With
-    `--recover`, the new run starts from the changed inputs but still reuses RUN_NAME's succeeded
-    actions, which keep the outputs they produced under the *original* inputs — force the ones
-    that must re-execute with `--force-rerun-action`.
+    The task's own inputs are options too, built from RUN_NAME's interface just as `flyte run`
+    builds them from local code — run `flyte rerun RUN_NAME --help` to list them. Every input left
+    out keeps RUN_NAME's value. With `--recover`, the new run starts from the changed inputs but
+    still reuses RUN_NAME's succeeded actions, which keep the outputs they produced under the
+    *original* inputs — force the ones that must re-execute with `--force-rerun-action`.
 
     Examples:
 
@@ -129,8 +266,9 @@ def rerun(
         $ flyte rerun rxyz --recover
         $ flyte rerun rxyz --recover --force-rerun-action a3 --force-rerun-action a7
         $ flyte rerun rxyz --action-name a3
-        $ flyte rerun rxyz --input n=10 --input cfg='{"lr": 0.1}'
-        $ flyte rerun rxyz --recover --input n=10 --force-rerun-action a3
+        $ flyte rerun rxyz --help
+        $ flyte rerun rxyz --n 10 --cfg '{"lr": 0.1}'
+        $ flyte rerun rxyz --recover --n 10 --force-rerun-action a3
     """
     if force_rerun_action and not recover:
         raise click.UsageError("--force-rerun-action requires --recover")
@@ -140,6 +278,11 @@ def rerun(
             "from the source run by name, and a run rooted at a single action has a different "
             "action tree. Re-run the action on its own, or recover the whole run."
         )
+    # Only inputs actually typed on the command line are changes; the rest are absent on purpose,
+    # so that they keep the source run's value rather than the task's default.
+    new_inputs = {
+        key: value for key, value in task_inputs.items() if ctx.get_parameter_source(key) is ParameterSource.COMMANDLINE
+    }
     config = common.initialize_config(ctx, project=project, domain=domain)
     asyncio.run(
         _execute(
@@ -151,49 +294,11 @@ def rerun(
             recover,
             action_name,
             force_rerun_action,
-            inputs,
+            new_inputs,
             allow_missing_outputs,
             config,
         )
     )
-
-
-async def _resolve_inputs(run_name: str, action_name: str, raw: Dict[str, str]) -> Dict[str, Any]:
-    """Convert `--input KEY=VALUE` strings into native values for `rerun()`.
-
-    Rerun never uses local code, so the interface to convert against lives on the platform: it is
-    read off the same action that supplies the task spec (the root action, or `--action-name`).
-    """
-    from flyte.remote._action import ActionDetails
-    from flyte.remote._run import RunDetails
-    from flyte.types._interface import guess_interface
-
-    from ._params import FlyteLiteralConverter
-
-    if action_name == "a0":
-        action_details = (await RunDetails.get.aio(name=run_name)).action_details
-    else:
-        action_details = await ActionDetails.get.aio(run_name=run_name, name=action_name)
-    if not action_details.pb2.HasField("task"):
-        raise click.UsageError(f"Action {run_name}/{action_name} has no task spec to rerun.")
-
-    interface = action_details.pb2.task.task_template.interface
-    variables = {entry.key: entry.value for entry in interface.inputs.variables}
-    native_inputs = guess_interface(interface).inputs
-
-    converted: Dict[str, Any] = {}
-    for key, value in raw.items():
-        if key not in variables or key not in native_inputs:
-            known = ", ".join(sorted(variables)) or "<none>"
-            raise click.BadParameter(
-                f"Unknown input {key!r} for {run_name}/{action_name}. Known inputs: {known}.", param_hint="--input"
-            )
-        python_type, _ = native_inputs[key]
-        converter = FlyteLiteralConverter(literal_type=variables[key].type, python_type=python_type)
-        # Two steps, mirroring what click does for `flyte run`: the param type parses the string,
-        # then the converter's callback applies the python-type fixups (e.g. datetime -> date).
-        converted[key] = converter.convert(None, None, converter.click_type.convert(value, None, None))
-    return converted
 
 
 async def _execute(
@@ -205,7 +310,7 @@ async def _execute(
     recover: bool,
     action_name: Optional[str],
     force_rerun_action: Tuple[str, ...],
-    inputs: Tuple[str, ...],
+    new_inputs: Dict[str, Any],
     allow_missing_outputs: bool,
     config: common.CLIConfig,
 ) -> None:
@@ -213,16 +318,6 @@ async def _execute(
     from flyte._status import status
 
     console = common.get_console()
-    raw_inputs = _parse_kv(inputs, "--input")
-    try:
-        # Resolving inputs reads the source task's interface, so it can fail the same way the
-        # launch below can; a bad --input value is a usage error and keeps click's rendering.
-        new_inputs = await _resolve_inputs(run_name, action_name or "a0", raw_inputs) if raw_inputs else None
-    except click.ClickException:
-        raise
-    except Exception as e:
-        console.print(f"[red]\u2715 {'Recovery' if recover else 'Re-run'} failed:[/red] {e}")
-        return
     try:
         target = f"{run_name}/{action_name}" if action_name else run_name
         status.step(f"{'Recovering' if recover else 'Re-running'} {target}...")
@@ -238,7 +333,7 @@ async def _execute(
             recover=recover,
             force_rerun_actions=force_rerun_action or None,
             allow_missing_source_outputs=allow_missing_outputs,
-            inputs=new_inputs,
+            **new_inputs,
         )
     except Exception as e:
         console.print(f"[red]✕ {'Recovery' if recover else 'Re-run'} failed:[/red] {e}")

--- a/src/flyte/cli/_rerun.py
+++ b/src/flyte/cli/_rerun.py
@@ -10,15 +10,18 @@ fetching its task + inputs from the platform, so no local code is needed.
 * `flyte rerun <run> --action-name <action>` re-runs just that one action from the run: the new
   run is rooted at that action's task, executed with the exact inputs it received. Mutually
   exclusive with `--recover`.
+* `flyte rerun <run> --input x=2` replaces individual inputs; every input left out keeps the
+  prior run's value. Values are converted against the source task's interface, which is fetched
+  from the platform. This composes with `--recover`.
 
-Recovery deliberately reuses the source run's code and inputs as-is — it provides durability
-against intermittent system- or network-level failures, not a way to patch a run.
+Rerun always replays the source run's *code* as-is — substituting local code is `flyte fork`,
+reserved for flyteplugins-union.
 """
 
 from __future__ import annotations
 
 import asyncio
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import rich_click as click
 
@@ -71,6 +74,14 @@ def _parse_kv(items: Tuple[str, ...], flag: str) -> Optional[Dict[str, str]]:
     "force the whole subtree); unknown names are ignored.",
 )
 @click.option(
+    "--input",
+    "inputs",
+    multiple=True,
+    help="Input KEY=VALUE for the new run, replacing the prior run's value for KEY. Repeatable. "
+    "VALUE is parsed against the source task's interface (JSON for structured types). Any input "
+    "not given here keeps the prior run's value. Composes with --recover.",
+)
+@click.option(
     "--allow-missing-outputs",
     "allow_missing_outputs",
     is_flag=True,
@@ -92,6 +103,7 @@ def rerun(
     recover: bool,
     action_name: Optional[str],
     force_rerun_action: Tuple[str, ...],
+    inputs: Tuple[str, ...],
     allow_missing_outputs: bool,
 ) -> None:
     """Re-run an existing run RUN_NAME with its original code and inputs.
@@ -105,6 +117,11 @@ def rerun(
     action's task, run with the exact inputs it received inside RUN_NAME. That is always a plain
     re-execution, so it cannot be combined with `--recover`.
 
+    `--input KEY=VALUE` replaces individual inputs; the rest are inherited from RUN_NAME. With
+    `--recover`, the new run starts from the changed inputs but still reuses RUN_NAME's succeeded
+    actions, which keep the outputs they produced under the *original* inputs — force the ones
+    that must re-execute with `--force-rerun-action`.
+
     Examples:
 
         $ flyte rerun rxyz
@@ -112,6 +129,8 @@ def rerun(
         $ flyte rerun rxyz --recover
         $ flyte rerun rxyz --recover --force-rerun-action a3 --force-rerun-action a7
         $ flyte rerun rxyz --action-name a3
+        $ flyte rerun rxyz --input n=10 --input cfg='{"lr": 0.1}'
+        $ flyte rerun rxyz --recover --input n=10 --force-rerun-action a3
     """
     if force_rerun_action and not recover:
         raise click.UsageError("--force-rerun-action requires --recover")
@@ -124,9 +143,57 @@ def rerun(
     config = common.initialize_config(ctx, project=project, domain=domain)
     asyncio.run(
         _execute(
-            run_name, name, env, label, follow, recover, action_name, force_rerun_action, allow_missing_outputs, config
+            run_name,
+            name,
+            env,
+            label,
+            follow,
+            recover,
+            action_name,
+            force_rerun_action,
+            inputs,
+            allow_missing_outputs,
+            config,
         )
     )
+
+
+async def _resolve_inputs(run_name: str, action_name: str, raw: Dict[str, str]) -> Dict[str, Any]:
+    """Convert `--input KEY=VALUE` strings into native values for `rerun()`.
+
+    Rerun never uses local code, so the interface to convert against lives on the platform: it is
+    read off the same action that supplies the task spec (the root action, or `--action-name`).
+    """
+    from flyte.remote._action import ActionDetails
+    from flyte.remote._run import RunDetails
+    from flyte.types._interface import guess_interface
+
+    from ._params import FlyteLiteralConverter
+
+    if action_name == "a0":
+        action_details = (await RunDetails.get.aio(name=run_name)).action_details
+    else:
+        action_details = await ActionDetails.get.aio(run_name=run_name, name=action_name)
+    if not action_details.pb2.HasField("task"):
+        raise click.UsageError(f"Action {run_name}/{action_name} has no task spec to rerun.")
+
+    interface = action_details.pb2.task.task_template.interface
+    variables = {entry.key: entry.value for entry in interface.inputs.variables}
+    native_inputs = guess_interface(interface).inputs
+
+    converted: Dict[str, Any] = {}
+    for key, value in raw.items():
+        if key not in variables or key not in native_inputs:
+            known = ", ".join(sorted(variables)) or "<none>"
+            raise click.BadParameter(
+                f"Unknown input {key!r} for {run_name}/{action_name}. Known inputs: {known}.", param_hint="--input"
+            )
+        python_type, _ = native_inputs[key]
+        converter = FlyteLiteralConverter(literal_type=variables[key].type, python_type=python_type)
+        # Two steps, mirroring what click does for `flyte run`: the param type parses the string,
+        # then the converter's callback applies the python-type fixups (e.g. datetime -> date).
+        converted[key] = converter.convert(None, None, converter.click_type.convert(value, None, None))
+    return converted
 
 
 async def _execute(
@@ -138,6 +205,7 @@ async def _execute(
     recover: bool,
     action_name: Optional[str],
     force_rerun_action: Tuple[str, ...],
+    inputs: Tuple[str, ...],
     allow_missing_outputs: bool,
     config: common.CLIConfig,
 ) -> None:
@@ -145,6 +213,16 @@ async def _execute(
     from flyte._status import status
 
     console = common.get_console()
+    raw_inputs = _parse_kv(inputs, "--input")
+    try:
+        # Resolving inputs reads the source task's interface, so it can fail the same way the
+        # launch below can; a bad --input value is a usage error and keeps click's rendering.
+        new_inputs = await _resolve_inputs(run_name, action_name or "a0", raw_inputs) if raw_inputs else None
+    except click.ClickException:
+        raise
+    except Exception as e:
+        console.print(f"[red]\u2715 {'Recovery' if recover else 'Re-run'} failed:[/red] {e}")
+        return
     try:
         target = f"{run_name}/{action_name}" if action_name else run_name
         status.step(f"{'Recovering' if recover else 'Re-running'} {target}...")
@@ -160,6 +238,7 @@ async def _execute(
             recover=recover,
             force_rerun_actions=force_rerun_action or None,
             allow_missing_source_outputs=allow_missing_outputs,
+            inputs=new_inputs,
         )
     except Exception as e:
         console.print(f"[red]✕ {'Recovery' if recover else 'Re-run'} failed:[/red] {e}")

--- a/tests/cli/test_rerun.py
+++ b/tests/cli/test_rerun.py
@@ -3,6 +3,8 @@
 import re
 from unittest import mock
 
+import pytest
+import rich_click as click
 from click.testing import CliRunner
 from mock.mock import AsyncMock
 
@@ -24,6 +26,7 @@ def test_rerun_options():
     assert "--recover" in opts
     assert "--force-rerun-action" in opts
     assert "--allow-missing-outputs" in opts
+    assert "--input" in opts
     # Takes the run name as a positional argument.
     assert any(p.name == "run_name" for p in rerun.params)
 
@@ -64,6 +67,7 @@ def test_rerun_delegates_to_runner_rerun():
         recover=False,
         force_rerun_actions=None,
         allow_missing_source_outputs=False,
+        inputs=None,
     )
 
 
@@ -123,6 +127,108 @@ def test_rerun_allow_missing_outputs_goes_to_rerun_not_run_context():
     assert wrc.call_args.kwargs["labels"] == {"team": "ml"}
     assert "allow_missing_source_outputs" not in wrc.call_args.kwargs
     assert runner_obj.rerun.aio.call_args.kwargs["allow_missing_source_outputs"] is True
+
+
+def test_rerun_input_is_converted_and_passed_through():
+    """`--input k=v` values are converted against the source task's interface, not sent raw."""
+    runner_obj = _mock_runner()
+
+    with (
+        mock.patch("flyte.cli._common.initialize_config") as init_cfg,
+        mock.patch("flyte.with_runcontext", return_value=runner_obj),
+        mock.patch("flyte.cli._rerun._resolve_inputs", AsyncMock(return_value={"n": 10})) as resolve,
+    ):
+        init_cfg.return_value = mock.MagicMock(output_format="table")
+        result = CliRunner().invoke(rerun, ["my-run", "--input", "n=10"])
+
+    assert result.exit_code == 0, result.output
+    resolve.assert_awaited_once_with("my-run", "a0", {"n": "10"})
+    assert runner_obj.rerun.aio.call_args.kwargs["inputs"] == {"n": 10}
+
+
+def test_rerun_input_composes_with_recover():
+    """--recover and new inputs are supported together."""
+    runner_obj = _mock_runner()
+
+    with (
+        mock.patch("flyte.cli._common.initialize_config") as init_cfg,
+        mock.patch("flyte.with_runcontext", return_value=runner_obj),
+        mock.patch("flyte.cli._rerun._resolve_inputs", AsyncMock(return_value={"n": 10})),
+    ):
+        init_cfg.return_value = mock.MagicMock(output_format="table")
+        result = CliRunner().invoke(rerun, ["my-run", "--recover", "--input", "n=10", "--force-rerun-action", "a3"])
+
+    assert result.exit_code == 0, result.output
+    kwargs = runner_obj.rerun.aio.call_args.kwargs
+    assert kwargs["recover"] is True
+    assert kwargs["inputs"] == {"n": 10}
+    assert kwargs["force_rerun_actions"] == ("a3",)
+
+
+def test_rerun_input_reads_interface_of_the_selected_action():
+    """With --action-name, inputs are converted against that action's interface."""
+    runner_obj = _mock_runner()
+
+    with (
+        mock.patch("flyte.cli._common.initialize_config") as init_cfg,
+        mock.patch("flyte.with_runcontext", return_value=runner_obj),
+        mock.patch("flyte.cli._rerun._resolve_inputs", AsyncMock(return_value={"n": 10})) as resolve,
+    ):
+        init_cfg.return_value = mock.MagicMock(output_format="table")
+        result = CliRunner().invoke(rerun, ["my-run", "--action-name", "a3", "--input", "n=10"])
+
+    assert result.exit_code == 0, result.output
+    resolve.assert_awaited_once_with("my-run", "a3", {"n": "10"})
+
+
+def test_rerun_input_requires_key_value():
+    with mock.patch("flyte.cli._common.initialize_config"):
+        result = CliRunner().invoke(rerun, ["my-run", "--input", "justakey"])
+    assert result.exit_code != 0
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    assert "expected KEY=VALUE" in plain
+
+
+@pytest.mark.asyncio
+async def test_resolve_inputs_converts_against_the_remote_interface():
+    """Values arrive as strings from the shell and are parsed with the source task's types."""
+    from flyteidl2.core import identifier_pb2, interface_pb2, tasks_pb2, types_pb2
+    from flyteidl2.task import task_definition_pb2
+    from flyteidl2.workflow import run_definition_pb2
+
+    from flyte.cli._rerun import _resolve_inputs
+
+    iface = interface_pb2.TypedInterface(
+        inputs=interface_pb2.VariableMap(
+            variables=[
+                interface_pb2.VariableEntry(
+                    key="n",
+                    value=interface_pb2.Variable(type=types_pb2.LiteralType(simple=types_pb2.SimpleType.INTEGER)),
+                ),
+                interface_pb2.VariableEntry(
+                    key="s",
+                    value=interface_pb2.Variable(type=types_pb2.LiteralType(simple=types_pb2.SimpleType.STRING)),
+                ),
+            ]
+        )
+    )
+    action = mock.MagicMock()
+    action.pb2 = run_definition_pb2.ActionDetails(
+        task=task_definition_pb2.TaskSpec(
+            task_template=tasks_pb2.TaskTemplate(
+                id=identifier_pb2.Identifier(name="test.task1", version="v1"), interface=iface
+            )
+        )
+    )
+    run_details = mock.MagicMock(action_details=action)
+
+    with mock.patch("flyte.remote._run.RunDetails") as RD:
+        RD.get.aio = AsyncMock(return_value=run_details)
+        converted = await _resolve_inputs("my-run", "a0", {"n": "10", "s": "hello"})
+        assert converted == {"n": 10, "s": "hello"}
+
+        with pytest.raises(click.BadParameter, match="Unknown input 'nope'"):
+            await _resolve_inputs("my-run", "a0", {"nope": "1"})
 
 
 def test_rerun_has_action_name_option():

--- a/tests/cli/test_rerun.py
+++ b/tests/cli/test_rerun.py
@@ -3,8 +3,6 @@
 import re
 from unittest import mock
 
-import pytest
-import rich_click as click
 from click.testing import CliRunner
 from mock.mock import AsyncMock
 
@@ -26,7 +24,6 @@ def test_rerun_options():
     assert "--recover" in opts
     assert "--force-rerun-action" in opts
     assert "--allow-missing-outputs" in opts
-    assert "--input" in opts
     # Takes the run name as a positional argument.
     assert any(p.name == "run_name" for p in rerun.params)
 
@@ -67,7 +64,6 @@ def test_rerun_delegates_to_runner_rerun():
         recover=False,
         force_rerun_actions=None,
         allow_missing_source_outputs=False,
-        inputs=None,
     )
 
 
@@ -129,106 +125,150 @@ def test_rerun_allow_missing_outputs_goes_to_rerun_not_run_context():
     assert runner_obj.rerun.aio.call_args.kwargs["allow_missing_source_outputs"] is True
 
 
-def test_rerun_input_is_converted_and_passed_through():
-    """`--input k=v` values are converted against the source task's interface, not sent raw."""
-    runner_obj = _mock_runner()
+def _interface(**types):
+    """A TypedInterface with one input per keyword, e.g. _interface(n="INTEGER", s="STRING")."""
+    from flyteidl2.core import interface_pb2, types_pb2
 
+    return interface_pb2.TypedInterface(
+        inputs=interface_pb2.VariableMap(
+            variables=[
+                interface_pb2.VariableEntry(
+                    key=name,
+                    value=interface_pb2.Variable(type=types_pb2.LiteralType(simple=getattr(types_pb2.SimpleType, t))),
+                )
+                for name, t in types.items()
+            ]
+        )
+    )
+
+
+def _invoke_with_interface(args, interface, runner_obj=None):
+    """Invoke `flyte rerun` with the source task's interface stubbed out."""
+    runner_obj = runner_obj or _mock_runner()
     with (
         mock.patch("flyte.cli._common.initialize_config") as init_cfg,
         mock.patch("flyte.with_runcontext", return_value=runner_obj),
-        mock.patch("flyte.cli._rerun._resolve_inputs", AsyncMock(return_value={"n": 10})) as resolve,
+        mock.patch("flyte.cli._rerun._fetch_source_interface", AsyncMock(return_value=interface)) as fetch,
     ):
         init_cfg.return_value = mock.MagicMock(output_format="table")
-        result = CliRunner().invoke(rerun, ["my-run", "--input", "n=10"])
+        result = CliRunner().invoke(rerun, args)
+    return result, runner_obj, fetch
+
+
+def test_rerun_builds_an_option_per_input_of_the_source_task():
+    """Inputs become options the way `flyte run` builds them, typed by the source interface."""
+    result, runner_obj, fetch = _invoke_with_interface(
+        ["my-run", "--n", "10", "--s", "hello"], _interface(n="INTEGER", s="STRING")
+    )
 
     assert result.exit_code == 0, result.output
-    resolve.assert_awaited_once_with("my-run", "a0", {"n": "10"})
-    assert runner_obj.rerun.aio.call_args.kwargs["inputs"] == {"n": 10}
+    fetch.assert_awaited_once_with("my-run", "a0")
+    kwargs = runner_obj.rerun.aio.call_args.kwargs
+    # Converted to native types by click, not forwarded as strings.
+    assert kwargs["n"] == 10
+    assert kwargs["s"] == "hello"
 
 
-def test_rerun_input_composes_with_recover():
+def test_rerun_omitted_inputs_are_not_sent_at_all():
+    """An input left out keeps the source run's value, so it must not be sent as a default."""
+    result, runner_obj, _ = _invoke_with_interface(["my-run", "--n", "10"], _interface(n="INTEGER", s="STRING"))
+
+    assert result.exit_code == 0, result.output
+    kwargs = runner_obj.rerun.aio.call_args.kwargs
+    assert kwargs["n"] == 10
+    assert "s" not in kwargs
+
+
+def test_rerun_bool_input_can_be_set_to_either_value():
+    """`--flag/--no-flag`: on rerun "not passed" means "keep the prior value", so False has to be
+    expressible on its own."""
+    result, runner_obj, _ = _invoke_with_interface(["my-run", "--flag"], _interface(flag="BOOLEAN"))
+    assert result.exit_code == 0, result.output
+    assert runner_obj.rerun.aio.call_args.kwargs["flag"] is True
+
+    result, runner_obj, _ = _invoke_with_interface(["my-run", "--no-flag"], _interface(flag="BOOLEAN"))
+    assert result.exit_code == 0, result.output
+    assert runner_obj.rerun.aio.call_args.kwargs["flag"] is False
+
+    result, runner_obj, _ = _invoke_with_interface(["my-run"], _interface(flag="BOOLEAN"))
+    assert result.exit_code == 0, result.output
+    assert "flag" not in runner_obj.rerun.aio.call_args.kwargs
+
+
+def test_rerun_inputs_compose_with_recover():
     """--recover and new inputs are supported together."""
-    runner_obj = _mock_runner()
-
-    with (
-        mock.patch("flyte.cli._common.initialize_config") as init_cfg,
-        mock.patch("flyte.with_runcontext", return_value=runner_obj),
-        mock.patch("flyte.cli._rerun._resolve_inputs", AsyncMock(return_value={"n": 10})),
-    ):
-        init_cfg.return_value = mock.MagicMock(output_format="table")
-        result = CliRunner().invoke(rerun, ["my-run", "--recover", "--input", "n=10", "--force-rerun-action", "a3"])
+    result, runner_obj, _ = _invoke_with_interface(
+        ["my-run", "--recover", "--n", "10", "--force-rerun-action", "a3"], _interface(n="INTEGER")
+    )
 
     assert result.exit_code == 0, result.output
     kwargs = runner_obj.rerun.aio.call_args.kwargs
     assert kwargs["recover"] is True
-    assert kwargs["inputs"] == {"n": 10}
+    assert kwargs["n"] == 10
     assert kwargs["force_rerun_actions"] == ("a3",)
 
 
-def test_rerun_input_reads_interface_of_the_selected_action():
-    """With --action-name, inputs are converted against that action's interface."""
-    runner_obj = _mock_runner()
-
-    with (
-        mock.patch("flyte.cli._common.initialize_config") as init_cfg,
-        mock.patch("flyte.with_runcontext", return_value=runner_obj),
-        mock.patch("flyte.cli._rerun._resolve_inputs", AsyncMock(return_value={"n": 10})) as resolve,
-    ):
-        init_cfg.return_value = mock.MagicMock(output_format="table")
-        result = CliRunner().invoke(rerun, ["my-run", "--action-name", "a3", "--input", "n=10"])
+def test_rerun_without_inputs_skips_the_interface_fetch():
+    """Nothing left over on the command line means no input was passed, so no extra round trip."""
+    result, runner_obj, fetch = _invoke_with_interface(["my-run", "--name", "n"], _interface(n="INTEGER"))
 
     assert result.exit_code == 0, result.output
-    resolve.assert_awaited_once_with("my-run", "a3", {"n": "10"})
+    fetch.assert_not_awaited()
+    runner_obj.rerun.aio.assert_awaited_once_with(
+        "my-run",
+        action_name="a0",
+        recover=False,
+        force_rerun_actions=None,
+        allow_missing_source_outputs=False,
+    )
 
 
-def test_rerun_input_requires_key_value():
-    with mock.patch("flyte.cli._common.initialize_config"):
-        result = CliRunner().invoke(rerun, ["my-run", "--input", "justakey"])
+def test_rerun_inputs_are_read_off_the_selected_action():
+    """With --action-name, the options come from that action's interface."""
+    result, runner_obj, fetch = _invoke_with_interface(
+        ["my-run", "--action-name", "a3", "--n", "10"], _interface(n="INTEGER")
+    )
+
+    assert result.exit_code == 0, result.output
+    fetch.assert_awaited_once_with("my-run", "a3")
+    assert runner_obj.rerun.aio.call_args.kwargs["n"] == 10
+
+
+def test_rerun_own_options_are_not_shadowed_by_task_inputs():
+    """A task input named like one of rerun's own options stays rerun's: `--name` names the new
+    run. That input simply keeps the prior run's value."""
+    result, runner_obj, _ = _invoke_with_interface(
+        ["my-run", "--name", "retry-1", "--n", "10"], _interface(name="STRING", n="INTEGER")
+    )
+
+    assert result.exit_code == 0, result.output
+    kwargs = runner_obj.rerun.aio.call_args.kwargs
+    assert kwargs["n"] == 10
+    assert "name" not in kwargs
+
+
+def test_rerun_rejects_an_input_the_source_task_does_not_have():
+    result, _runner_obj, _ = _invoke_with_interface(["my-run", "--nope", "1"], _interface(n="INTEGER"))
+
     assert result.exit_code != 0
     plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
-    assert "expected KEY=VALUE" in plain
+    assert "No such option" in plain
 
 
-@pytest.mark.asyncio
-async def test_resolve_inputs_converts_against_the_remote_interface():
-    """Values arrive as strings from the shell and are parsed with the source task's types."""
-    from flyteidl2.core import identifier_pb2, interface_pb2, tasks_pb2, types_pb2
-    from flyteidl2.task import task_definition_pb2
-    from flyteidl2.workflow import run_definition_pb2
+def test_rerun_help_for_a_run_lists_its_inputs():
+    """`flyte rerun <run> --help` is how the available inputs are discovered."""
+    result, _runner_obj, _ = _invoke_with_interface(["my-run", "--help"], _interface(n="INTEGER"))
 
-    from flyte.cli._rerun import _resolve_inputs
+    assert result.exit_code == 0, result.output
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    assert "--n" in plain
 
-    iface = interface_pb2.TypedInterface(
-        inputs=interface_pb2.VariableMap(
-            variables=[
-                interface_pb2.VariableEntry(
-                    key="n",
-                    value=interface_pb2.Variable(type=types_pb2.LiteralType(simple=types_pb2.SimpleType.INTEGER)),
-                ),
-                interface_pb2.VariableEntry(
-                    key="s",
-                    value=interface_pb2.Variable(type=types_pb2.LiteralType(simple=types_pb2.SimpleType.STRING)),
-                ),
-            ]
-        )
-    )
-    action = mock.MagicMock()
-    action.pb2 = run_definition_pb2.ActionDetails(
-        task=task_definition_pb2.TaskSpec(
-            task_template=tasks_pb2.TaskTemplate(
-                id=identifier_pb2.Identifier(name="test.task1", version="v1"), interface=iface
-            )
-        )
-    )
-    run_details = mock.MagicMock(action_details=action)
 
-    with mock.patch("flyte.remote._run.RunDetails") as RD:
-        RD.get.aio = AsyncMock(return_value=run_details)
-        converted = await _resolve_inputs("my-run", "a0", {"n": "10", "s": "hello"})
-        assert converted == {"n": 10, "s": "hello"}
-
-        with pytest.raises(click.BadParameter, match="Unknown input 'nope'"):
-            await _resolve_inputs("my-run", "a0", {"nope": "1"})
+def test_rerun_help_without_a_run_needs_no_platform_call():
+    with mock.patch("flyte.cli._rerun._fetch_source_interface", AsyncMock()) as fetch:
+        result = CliRunner().invoke(rerun, ["--help"])
+    assert result.exit_code == 0, result.output
+    fetch.assert_not_awaited()
 
 
 def test_rerun_has_action_name_option():

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -158,19 +158,6 @@ def test_run_hello_world(runner):
             raise ve
 
 
-def test_run_command_has_no_rerun_from_option():
-    """--rerun-from re-ran a prior run with THIS local code; substituting code is now fork,
-    reserved for flyteplugins-union (SDK-16)."""
-    opt_names = {decl for p in run.params for decl in p.opts}
-    assert "--rerun-from" not in opt_names
-
-    from dataclasses import fields
-
-    from flyte.cli._run import RunArguments
-
-    assert "rerun_from" not in {f.name for f in fields(RunArguments)}
-
-
 def test_run_remote_from_home_directory_warns(runner, monkeypatch, tmp_path):
     """`flyte run` should warn (not fail) when the root directory is $HOME, per the caveat
     documented in the quickstart guide: running from $HOME risks bundling the entire home folder.
@@ -1729,19 +1716,6 @@ def test_run_command_has_tracked_option():
     """--tracked is a visible option on `flyte run` (tracked run reported to the control plane)."""
     opt_names = {decl for p in run.params for decl in p.opts}
     assert "--tracked" in opt_names
-
-
-def test_run_tracked_rejects_rerun_from(runner):
-    """--tracked implies --local, so it cannot be combined with --rerun-from (remote-only)."""
-    cmd = ["--tracked", "--rerun-from", "someprevrun", str(HELLO_WORLD_PY), "say_hello"]
-    try:
-        result = runner.invoke(run, cmd)
-    except ValueError as ve:
-        if "I/O operation on closed file" in str(ve):
-            return
-        raise
-    assert result.exit_code != 0
-    assert "--rerun-from" in result.output
 
 
 def test_run_command_has_tracked_strict_option():

--- a/tests/flyte/test_rerun.py
+++ b/tests/flyte/test_rerun.py
@@ -163,51 +163,6 @@ async def test_rerun_changed_inputs_converts_against_fetched_interface():
 
 
 @pytest.mark.asyncio
-async def test_rerun_inputs_dict_is_equivalent_to_keyword_inputs():
-    """`inputs={...}` is the dict form of the keyword inputs — and the only way to reach a task
-    input whose name collides with a rerun argument."""
-    mock_client, _mock_run_service, mock_dataproxy, _ = _mock_client_with_run()
-    await _init_for_testing(client=mock_client, project="test", domain="test")
-
-    with mock.patch("flyte.remote._run.RunDetails") as RD:
-        RD.get.aio = AsyncMock(return_value=_fake_prior_run())
-        run = await flyte.with_runcontext(mode="remote").rerun.aio("r1", inputs={"v": "changed"})
-
-    assert run
-    mock_dataproxy.get_action_data.assert_not_called()
-    upload_req = mock_dataproxy.upload_inputs.call_args[0][0]
-    assert upload_req.inputs.literals[0].name == "v"
-    assert upload_req.inputs.literals[0].value.scalar.primitive.string_value == "changed"
-
-
-@pytest.mark.asyncio
-async def test_rerun_merges_inputs_dict_with_keyword_inputs():
-    mock_client, _mock_run_service, mock_dataproxy, _ = _mock_client_with_run()
-    await _init_for_testing(client=mock_client, project="test", domain="test")
-
-    # A second input so the two forms can be combined on one call.
-    prior = _fake_prior_run()
-    _add_string_input(prior.action_details.pb2.task.task_template.interface, "w")
-
-    with mock.patch("flyte.remote._run.RunDetails") as RD:
-        RD.get.aio = AsyncMock(return_value=prior)
-        await flyte.with_runcontext(mode="remote").rerun.aio("r1", inputs={"v": "from-dict"}, w="from-kwarg")
-
-    upload_req = mock_dataproxy.upload_inputs.call_args[0][0]
-    literals = {lit.name: lit.value.scalar.primitive.string_value for lit in upload_req.inputs.literals}
-    assert literals == {"v": "from-dict", "w": "from-kwarg"}
-
-
-@pytest.mark.asyncio
-async def test_rerun_rejects_input_passed_both_ways():
-    mock_client, _mock_run_service, _mock_dataproxy, _ = _mock_client_with_run()
-    await _init_for_testing(client=mock_client, project="test", domain="test")
-
-    with pytest.raises(ValueError, match=r"\['v'\] passed both in inputs"):
-        await flyte.with_runcontext(mode="remote").rerun.aio("r1", inputs={"v": "a"}, v="b")
-
-
-@pytest.mark.asyncio
 async def test_rerun_partial_inputs_merge_with_the_source_run_inputs():
     """Changing one input keeps the source run's value for every input left out."""
     mock_client, _mock_run_service, mock_dataproxy, _ = _mock_client_with_run()
@@ -241,7 +196,7 @@ async def test_rerun_full_input_set_skips_the_source_input_fetch():
 
     with mock.patch("flyte.remote._run.RunDetails") as RD:
         RD.get.aio = AsyncMock(return_value=prior)
-        await flyte.with_runcontext(mode="remote").rerun.aio("r1", inputs={"v": "a", "w": "b"})
+        await flyte.with_runcontext(mode="remote").rerun.aio("r1", v="a", w="b")
 
     mock_dataproxy.get_action_data.assert_not_called()
     upload_req = mock_dataproxy.upload_inputs.call_args[0][0]
@@ -285,9 +240,7 @@ async def test_partial_inputs_need_readable_source_inputs():
     with mock.patch("flyte.remote._run.RunDetails") as RD:
         RD.get.aio = AsyncMock(return_value=prior)
         with pytest.raises(flyte.errors.RuntimeUserError, match="cannot be merged"):
-            await flyte.with_runcontext(mode="remote").rerun.aio(
-                "r1", allow_missing_source_outputs=True, inputs={"w": "changed"}
-            )
+            await flyte.with_runcontext(mode="remote").rerun.aio("r1", allow_missing_source_outputs=True, w="changed")
 
 
 @needs_relation
@@ -304,7 +257,7 @@ async def test_recover_with_partial_inputs_merges_and_still_recovers():
 
     with mock.patch("flyte.remote._run.RunDetails") as RD:
         RD.get.aio = AsyncMock(return_value=prior)
-        await flyte.with_runcontext(mode="remote").rerun.aio("r1", recover=True, inputs={"w": "changed"})
+        await flyte.with_runcontext(mode="remote").rerun.aio("r1", recover=True, w="changed")
 
     upload_req = mock_dataproxy.upload_inputs.call_args[0][0]
     literals = {lit.name: lit.value.scalar.primitive.string_value for lit in upload_req.inputs.literals}
@@ -323,7 +276,7 @@ async def test_recover_with_changed_inputs_uses_new_inputs_and_recover_relation(
 
     with mock.patch("flyte.remote._run.RunDetails") as RD:
         RD.get.aio = AsyncMock(return_value=_fake_prior_run())
-        run = await flyte.with_runcontext(mode="remote").rerun.aio("r1", recover=True, inputs={"v": "changed"})
+        run = await flyte.with_runcontext(mode="remote").rerun.aio("r1", recover=True, v="changed")
 
     assert run
     mock_dataproxy.get_action_data.assert_not_called()
@@ -345,7 +298,7 @@ async def test_recover_with_changed_inputs_keeps_force_rerun_actions():
     with mock.patch("flyte.remote._run.RunDetails") as RD:
         RD.get.aio = AsyncMock(return_value=_fake_prior_run())
         await flyte.with_runcontext(mode="remote").rerun.aio(
-            "r1", recover=True, force_rerun_actions=["a3"], inputs={"v": "changed"}
+            "r1", recover=True, force_rerun_actions=["a3"], v="changed"
         )
 
     req: run_service_pb2.CreateRunRequest = mock_run_service.create_run.call_args[0][0]

--- a/tests/flyte/test_rerun.py
+++ b/tests/flyte/test_rerun.py
@@ -94,6 +94,33 @@ def _task_spec_with_string_input():
     return task_definition_pb2.TaskSpec(task_template=tmpl)
 
 
+def _string_inputs(**values) -> task_common_pb2.Inputs:
+    """A prior-run Inputs proto with one string literal per keyword."""
+    return task_common_pb2.Inputs(
+        literals=[
+            task_common_pb2.NamedLiteral(
+                name=name,
+                value=literals_pb2.Literal(
+                    scalar=literals_pb2.Scalar(primitive=literals_pb2.Primitive(string_value=value))
+                ),
+            )
+            for name, value in values.items()
+        ]
+    )
+
+
+def _add_string_input(iface, name: str):
+    """Append another string input to a TypedInterface built by _task_spec_with_string_input."""
+    from flyteidl2.core import interface_pb2, types_pb2
+
+    iface.inputs.variables.append(
+        interface_pb2.VariableEntry(
+            key=name,
+            value=interface_pb2.Variable(type=types_pb2.LiteralType(simple=types_pb2.SimpleType.STRING)),
+        )
+    )
+
+
 @pytest.mark.asyncio
 async def test_rerun_same_inputs_inherits_runspec_and_reuses_prior_inputs():
     mock_client, mock_run_service, mock_dataproxy, prior_inputs = _mock_client_with_run()
@@ -133,6 +160,213 @@ async def test_rerun_changed_inputs_converts_against_fetched_interface():
     upload_req = mock_dataproxy.upload_inputs.call_args[0][0]
     assert upload_req.inputs.literals[0].name == "v"
     assert upload_req.inputs.literals[0].value.scalar.primitive.string_value == "changed"
+
+
+@pytest.mark.asyncio
+async def test_rerun_inputs_dict_is_equivalent_to_keyword_inputs():
+    """`inputs={...}` is the dict form of the keyword inputs — and the only way to reach a task
+    input whose name collides with a rerun argument."""
+    mock_client, _mock_run_service, mock_dataproxy, _ = _mock_client_with_run()
+    await _init_for_testing(client=mock_client, project="test", domain="test")
+
+    with mock.patch("flyte.remote._run.RunDetails") as RD:
+        RD.get.aio = AsyncMock(return_value=_fake_prior_run())
+        run = await flyte.with_runcontext(mode="remote").rerun.aio("r1", inputs={"v": "changed"})
+
+    assert run
+    mock_dataproxy.get_action_data.assert_not_called()
+    upload_req = mock_dataproxy.upload_inputs.call_args[0][0]
+    assert upload_req.inputs.literals[0].name == "v"
+    assert upload_req.inputs.literals[0].value.scalar.primitive.string_value == "changed"
+
+
+@pytest.mark.asyncio
+async def test_rerun_merges_inputs_dict_with_keyword_inputs():
+    mock_client, _mock_run_service, mock_dataproxy, _ = _mock_client_with_run()
+    await _init_for_testing(client=mock_client, project="test", domain="test")
+
+    # A second input so the two forms can be combined on one call.
+    prior = _fake_prior_run()
+    _add_string_input(prior.action_details.pb2.task.task_template.interface, "w")
+
+    with mock.patch("flyte.remote._run.RunDetails") as RD:
+        RD.get.aio = AsyncMock(return_value=prior)
+        await flyte.with_runcontext(mode="remote").rerun.aio("r1", inputs={"v": "from-dict"}, w="from-kwarg")
+
+    upload_req = mock_dataproxy.upload_inputs.call_args[0][0]
+    literals = {lit.name: lit.value.scalar.primitive.string_value for lit in upload_req.inputs.literals}
+    assert literals == {"v": "from-dict", "w": "from-kwarg"}
+
+
+@pytest.mark.asyncio
+async def test_rerun_rejects_input_passed_both_ways():
+    mock_client, _mock_run_service, _mock_dataproxy, _ = _mock_client_with_run()
+    await _init_for_testing(client=mock_client, project="test", domain="test")
+
+    with pytest.raises(ValueError, match=r"\['v'\] passed both in inputs"):
+        await flyte.with_runcontext(mode="remote").rerun.aio("r1", inputs={"v": "a"}, v="b")
+
+
+@pytest.mark.asyncio
+async def test_rerun_partial_inputs_merge_with_the_source_run_inputs():
+    """Changing one input keeps the source run's value for every input left out."""
+    mock_client, _mock_run_service, mock_dataproxy, _ = _mock_client_with_run()
+    await _init_for_testing(client=mock_client, project="test", domain="test")
+
+    prior = _fake_prior_run()
+    _add_string_input(prior.action_details.pb2.task.task_template.interface, "w")
+    mock_dataproxy.get_action_data.return_value = dataproxy_service_pb2.GetActionDataResponse(
+        inputs=_string_inputs(v="prior-v", w="prior-w")
+    )
+
+    with mock.patch("flyte.remote._run.RunDetails") as RD:
+        RD.get.aio = AsyncMock(return_value=prior)
+        await flyte.with_runcontext(mode="remote").rerun.aio("r1", w="changed")
+
+    # The unchanged input can only come from the source run, so it is fetched.
+    mock_dataproxy.get_action_data.assert_called_once()
+    upload_req = mock_dataproxy.upload_inputs.call_args[0][0]
+    literals = {lit.name: lit.value.scalar.primitive.string_value for lit in upload_req.inputs.literals}
+    assert literals == {"v": "prior-v", "w": "changed"}
+
+
+@pytest.mark.asyncio
+async def test_rerun_full_input_set_skips_the_source_input_fetch():
+    """Covering every input is the escape hatch when the source inputs are gone."""
+    mock_client, _mock_run_service, mock_dataproxy, _ = _mock_client_with_run()
+    await _init_for_testing(client=mock_client, project="test", domain="test")
+
+    prior = _fake_prior_run()
+    _add_string_input(prior.action_details.pb2.task.task_template.interface, "w")
+
+    with mock.patch("flyte.remote._run.RunDetails") as RD:
+        RD.get.aio = AsyncMock(return_value=prior)
+        await flyte.with_runcontext(mode="remote").rerun.aio("r1", inputs={"v": "a", "w": "b"})
+
+    mock_dataproxy.get_action_data.assert_not_called()
+    upload_req = mock_dataproxy.upload_inputs.call_args[0][0]
+    literals = {lit.name: lit.value.scalar.primitive.string_value for lit in upload_req.inputs.literals}
+    assert literals == {"v": "a", "w": "b"}
+
+
+@pytest.mark.asyncio
+async def test_rerun_rejects_unknown_input_names():
+    """A typo would otherwise be silently dropped from the merged inputs."""
+    mock_client, _mock_run_service, _mock_dataproxy, _ = _mock_client_with_run()
+    await _init_for_testing(client=mock_client, project="test", domain="test")
+
+    with mock.patch("flyte.remote._run.RunDetails") as RD:
+        RD.get.aio = AsyncMock(return_value=_fake_prior_run())
+        with pytest.raises(ValueError, match=r"Unknown input\(s\) \['nope'\].*Known inputs: v"):
+            await flyte.with_runcontext(mode="remote").rerun.aio("r1", nope="x")
+
+
+@pytest.mark.asyncio
+async def test_partial_inputs_need_readable_source_inputs():
+    """With only the source inputs' URI in hand there is nothing to merge into, so the partial
+    change fails loudly instead of dropping the inputs that were meant to be kept."""
+    from connectrpc.code import Code
+    from connectrpc.errors import ConnectError
+
+    import flyte.errors
+
+    mock_client, mock_run_service, mock_dataproxy, _ = _mock_client_with_run()
+    mock_dataproxy.get_action_data.side_effect = ConnectError(
+        Code.NOT_FOUND, "object 's3://b/metadata/v2/p/d/r1/a0/1/outputs.pb' not found"
+    )
+    mock_run_service.get_action_data_u_r_is.return_value = run_service_pb2.GetActionDataURIsResponse(
+        inputs_uri="s3://b/metadata/v2/p/d/r1/a0/inputs.pb", outputs_uri=""
+    )
+    await _init_for_testing(client=mock_client, project="test", domain="test")
+
+    prior = _fake_prior_run()
+    _add_string_input(prior.action_details.pb2.task.task_template.interface, "w")
+
+    with mock.patch("flyte.remote._run.RunDetails") as RD:
+        RD.get.aio = AsyncMock(return_value=prior)
+        with pytest.raises(flyte.errors.RuntimeUserError, match="cannot be merged"):
+            await flyte.with_runcontext(mode="remote").rerun.aio(
+                "r1", allow_missing_source_outputs=True, inputs={"w": "changed"}
+            )
+
+
+@needs_relation
+@pytest.mark.asyncio
+async def test_recover_with_partial_inputs_merges_and_still_recovers():
+    mock_client, mock_run_service, mock_dataproxy, _ = _mock_client_with_run()
+    await _init_for_testing(client=mock_client, project="test", domain="test")
+
+    prior = _fake_prior_run()
+    _add_string_input(prior.action_details.pb2.task.task_template.interface, "w")
+    mock_dataproxy.get_action_data.return_value = dataproxy_service_pb2.GetActionDataResponse(
+        inputs=_string_inputs(v="prior-v", w="prior-w")
+    )
+
+    with mock.patch("flyte.remote._run.RunDetails") as RD:
+        RD.get.aio = AsyncMock(return_value=prior)
+        await flyte.with_runcontext(mode="remote").rerun.aio("r1", recover=True, inputs={"w": "changed"})
+
+    upload_req = mock_dataproxy.upload_inputs.call_args[0][0]
+    literals = {lit.name: lit.value.scalar.primitive.string_value for lit in upload_req.inputs.literals}
+    assert literals == {"v": "prior-v", "w": "changed"}
+    req: run_service_pb2.CreateRunRequest = mock_run_service.create_run.call_args[0][0]
+    assert req.run_spec.relation.relation_type == common_run_pb2.RELATION_TYPE_RECOVER
+
+
+@needs_relation
+@pytest.mark.asyncio
+async def test_recover_with_changed_inputs_uses_new_inputs_and_recover_relation():
+    """`--recover` + new inputs: the new run starts from the changed inputs (no prior-input
+    fetch) and still carries RECOVER provenance so succeeded actions are reused."""
+    mock_client, mock_run_service, mock_dataproxy, _ = _mock_client_with_run()
+    await _init_for_testing(client=mock_client, project="test", domain="test")
+
+    with mock.patch("flyte.remote._run.RunDetails") as RD:
+        RD.get.aio = AsyncMock(return_value=_fake_prior_run())
+        run = await flyte.with_runcontext(mode="remote").rerun.aio("r1", recover=True, inputs={"v": "changed"})
+
+    assert run
+    mock_dataproxy.get_action_data.assert_not_called()
+    upload_req = mock_dataproxy.upload_inputs.call_args[0][0]
+    assert upload_req.inputs.literals[0].value.scalar.primitive.string_value == "changed"
+
+    req: run_service_pb2.CreateRunRequest = mock_run_service.create_run.call_args[0][0]
+    assert req.run_spec.relation.relation_type == common_run_pb2.RELATION_TYPE_RECOVER
+    assert req.run_spec.relation.related_to.name == "r1"
+
+
+@needs_relation
+@pytest.mark.asyncio
+async def test_recover_with_changed_inputs_keeps_force_rerun_actions():
+    """Forcing actions is how a recovery is made to re-execute against the changed inputs."""
+    mock_client, mock_run_service, _mock_dataproxy, _ = _mock_client_with_run()
+    await _init_for_testing(client=mock_client, project="test", domain="test")
+
+    with mock.patch("flyte.remote._run.RunDetails") as RD:
+        RD.get.aio = AsyncMock(return_value=_fake_prior_run())
+        await flyte.with_runcontext(mode="remote").rerun.aio(
+            "r1", recover=True, force_rerun_actions=["a3"], inputs={"v": "changed"}
+        )
+
+    req: run_service_pb2.CreateRunRequest = mock_run_service.create_run.call_args[0][0]
+    assert list(req.run_spec.recover.force_rerun_actions) == ["a3"]
+
+
+@needs_relation
+@pytest.mark.asyncio
+async def test_recover_with_changed_inputs_warns_about_reused_outputs():
+    """Recovered actions keep the outputs they produced under the *original* inputs, so the
+    combination is warned about rather than silently accepted."""
+    mock_client, _mock_run_service, _mock_dataproxy, _ = _mock_client_with_run()
+    await _init_for_testing(client=mock_client, project="test", domain="test")
+
+    with mock.patch("flyte.remote._run.RunDetails") as RD, mock.patch("flyte._run.logger") as log:
+        RD.get.aio = AsyncMock(return_value=_fake_prior_run())
+        await flyte.with_runcontext(mode="remote").rerun.aio("r1", recover=True, v="changed")
+
+    warned = " ".join(str(c.args[0]) for c in log.warning.call_args_list)
+    assert "keeps the output it produced under the original inputs" in warned
+    assert "force_rerun_actions" in warned
 
 
 @needs_relation

--- a/tests/flyte/test_run_runspec_chars.py
+++ b/tests/flyte/test_run_runspec_chars.py
@@ -519,14 +519,6 @@ async def test_force_rerun_actions_requires_recover():
         await flyte.with_runcontext(mode="remote").rerun.aio("r1", force_rerun_actions=["a1"])
 
 
-@pytest.mark.asyncio
-async def test_rerun_rejects_input_passed_twice():
-    """An input given both in the `inputs` dict and as a keyword is ambiguous, not a merge."""
-    await flyte.init.aio()
-    with pytest.raises(ValueError, match=r"\['x'\] passed both in inputs"):
-        await flyte.with_runcontext(mode="remote").rerun.aio("r1", inputs={"x": 1}, x=2)
-
-
 # Recovering *with* changed inputs is supported (it is code substitution that stays fork's job);
 # the end-to-end behaviour lives in tests/flyte/test_rerun.py::test_recover_with_changed_inputs*.
 
@@ -574,8 +566,6 @@ def test_rerun_signatures_match_between_surfaces():
 
     fn_params, method_params = params(flyte.rerun), params(_Runner.rerun)
     assert fn_params == method_params, f"{fn_params} != {method_params}"
-    # New inputs arrive as an explicit `inputs` dict plus **kwargs on both surfaces, and the
-    # private recover hook is gone.
-    assert fn_params[-1] == ("kwargs", inspect.Parameter.VAR_KEYWORD)
-    assert fn_params[-2] == ("inputs", inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    # Inputs arrive as **kwargs on both, and the private recover hook is gone.
+    assert fn_params[-1] == ("inputs", inspect.Parameter.VAR_KEYWORD)
     assert "_allow_recover_overrides" not in dict(method_params)

--- a/tests/flyte/test_run_runspec_chars.py
+++ b/tests/flyte/test_run_runspec_chars.py
@@ -520,11 +520,15 @@ async def test_force_rerun_actions_requires_recover():
 
 
 @pytest.mark.asyncio
-async def test_recover_rejects_input_changes():
-    """Recovering *with* changed inputs is fork — reserved for flyteplugins-union."""
+async def test_rerun_rejects_input_passed_twice():
+    """An input given both in the `inputs` dict and as a keyword is ambiguous, not a merge."""
     await flyte.init.aio()
-    with pytest.raises(ValueError, match="recover=True cannot be combined with changed inputs"):
-        await flyte.with_runcontext(mode="remote").rerun.aio("r1", recover=True, x=1)
+    with pytest.raises(ValueError, match=r"\['x'\] passed both in inputs"):
+        await flyte.with_runcontext(mode="remote").rerun.aio("r1", inputs={"x": 1}, x=2)
+
+
+# Recovering *with* changed inputs is supported (it is code substitution that stays fork's job);
+# the end-to-end behaviour lives in tests/flyte/test_rerun.py::test_recover_with_changed_inputs*.
 
 
 def test_rerun_cannot_substitute_code():
@@ -570,6 +574,8 @@ def test_rerun_signatures_match_between_surfaces():
 
     fn_params, method_params = params(flyte.rerun), params(_Runner.rerun)
     assert fn_params == method_params, f"{fn_params} != {method_params}"
-    # Inputs arrive as **kwargs on both, and the private recover hook is gone.
-    assert fn_params[-1] == ("inputs", inspect.Parameter.VAR_KEYWORD)
+    # New inputs arrive as an explicit `inputs` dict plus **kwargs on both surfaces, and the
+    # private recover hook is gone.
+    assert fn_params[-1] == ("kwargs", inspect.Parameter.VAR_KEYWORD)
+    assert fn_params[-2] == ("inputs", inspect.Parameter.POSITIONAL_OR_KEYWORD)
     assert "_allow_recover_overrides" not in dict(method_params)


### PR DESCRIPTION
## What

`flyte rerun` had no way to change inputs at all, and `rerun(..., recover=True)` rejected changed inputs outright (pointing at fork). Both now work, and they compose.

- **Inputs are options on `flyte rerun`**, built from the source run's interface with the same literal-type-to-click-type conversion `flyte run` uses — `flyte rerun rxyz --n 10` reads like `flyte run ... --n 10`. `flyte rerun rxyz --help` lists them.
- **`flyte.rerun(..., x=2)`** keeps its existing `**inputs` varkwargs; nothing changed about how the Python API takes inputs.
- **`recover` + changed inputs is allowed.** The new run starts from the changed inputs while still reusing the source run's succeeded actions. A warning points out that recovered actions keep the outputs they produced under the *original* inputs, and that `force_rerun_actions` / `--force-rerun-action` is how to re-execute them.
- **Partial input changes merge** onto the source run's inputs instead of failing with "missing required inputs": only the changed inputs are converted and overlaid on the prior literals. A full set of new inputs still skips the source-input fetch entirely, which keeps that path working as the escape hatch when the source inputs are gone from storage. Unknown input names are rejected up front rather than silently dropped.

Partial merging wasn't strictly required by the ask, but without it `flyte rerun r1 --recover --n 10` would fail on any task with more than one required input, so the flag would have been a footgun.

Code substitution stays fork's job — only inputs moved.

## How the CLI options get built

The source task's interface is only discoverable once RUN_NAME has been read off the command line, so `RerunCommand` parses in two passes: rerun's own options first (a resilient parse that tolerates the not-yet-built input options), then the interface fetch, then the real parse with both sets. Nothing left over from the first pass means no input was passed, so a plain `flyte rerun r1` costs no extra round trip.

Two deliberate differences from `flyte run`, both following from "an input left out keeps the source run's value":

- No input option is required and none carries the task's default. Only what the user actually typed is forwarded, determined from click's parameter source.
- Booleans get `--x/--no-x`, since "not passed" already means "keep the prior value" and False has to stay expressible.

An input whose name would shadow one of rerun's own options (e.g. a task input called `name`) is skipped rather than silently taking it over; it keeps the prior run's value.

## Test plan

- `tests/cli` + `tests/flyte/test_rerun.py` + `tests/flyte/test_run_runspec_chars.py` — 439 passed
- `tests/flyte` top-level files — 498 passed (3 failures in `test_deploy_image_cache.py` / `test_int_image_builder.py` reproduce identically on the base commit: no local container registry)
- `tests/flyte/{remote,ai,internal,cli}` + `tests/internal/controllers` — 1516 passed
- `ruff check` / `ruff format`, `mypy`, `ty` all clean (repo pre-commit hooks passed)

New coverage: an option per input with click-native conversion, omitted inputs not being sent, `--x/--no-x` both ways, inputs composing with `--recover`, the no-input path skipping the interface fetch, `--action-name` sourcing the right interface, rerun's own options not being shadowed, unknown options rejected, `--help` with and without a run name; plus partial-input merge (plain and with recover), full-input-set skipping the fetch, the unmergeable `--allow-missing-outputs` case, unknown-input rejection, and the recover-with-inputs warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)