### PR TITLE
feat(image): add Image.from_pixi_script()

### DIFF
--- a/examples/image/pixi_image.py
+++ b/examples/image/pixi_image.py
@@ -1,0 +1,60 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#    "flyte",
+# ]
+#
+# [tool.pixi.workspace]
+# channels = ["conda-forge"]
+#
+# [tool.pixi.dependencies]
+# numpy = "*"
+# ///
+"""Build a task image from a pixi script.
+
+`Image.from_pixi_script` is the pixi counterpart to `Image.from_uv_script`: the image is
+described by the PEP 723 block at the top of this very file. What pixi adds over uv is the
+conda side of the world — `[tool.pixi.dependencies]` pulls packages from conda channels,
+which is how you get binaries (MKL builds, GDAL, CUDA toolkits) that are not on PyPI.
+
+Note that `flyte` itself has to be listed in `dependencies`: unlike `from_debian_base`, a
+script-defined image installs exactly what the script declares.
+
+`[tool.pixi.workspace]` deliberately leaves `platforms` out here, so flyte fills it in from
+the platforms the image is built for. Declare it explicitly if you want to pin the
+resolution — for instance before running `pixi lock --script` to produce a
+`pixi_image.py.pixi.lock` sidecar, which flyte then installs with `--locked`.
+
+Run it with:
+
+    python examples/image/pixi_image.py
+"""
+
+import flyte
+from flyte import Image
+
+image = Image.from_pixi_script(__file__, name="pixi-hello", registry="ghcr.io/flyteorg")
+
+env = flyte.TaskEnvironment(name="pixi_hello", image=image)
+
+
+@env.task
+async def mean(values: list[float]) -> float:
+    # numpy comes from the conda channel via [tool.pixi.dependencies].
+    import numpy as np
+
+    return float(np.mean(values))
+
+
+@env.task
+async def main(values: list[float] | None = None) -> str:
+    values = values or [1.0, 2.0, 3.0, 4.0]
+    return f"mean({values}) = {await mean(values)}"
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(main)
+    print(run.name)
+    print(run.url)
+    run.wait()

--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -352,6 +352,75 @@ class UVScript(PipOption, Layer):
 
 @rich.repr.auto
 @dataclass(frozen=True, repr=True)
+class PixiScript(Layer):
+    """
+    A standalone Python script whose dependencies are declared in a PEP 723 block with
+    pixi-specific `[tool.pixi.*]` tables.
+
+    Pixi has no `install --script`, so at build time the script's metadata is lowered into
+    an equivalent `pixi.toml` workspace manifest and installed like any other
+    [`PixiProject`][flyte.Image.with_pixi_project]. Like `PixiProject`, pixi resolves conda
+    and PyPI packages from its own manifest, so this layer does not inherit `PipOption`.
+    """
+
+    script: Path
+    script_name: str = field(init=False)
+    #: Conda subdirs the generated workspace supports, derived from the image's platforms.
+    #: A `platforms` key declared by the script itself takes precedence over these.
+    platforms: Tuple[str, ...] = ("linux-64",)
+    environment: str = "default"
+    extra_args: Optional[str] = None
+    secret_mounts: Optional[Tuple[str | Secret, ...]] = None
+
+    def __post_init__(self):
+        object.__setattr__(self, "script_name", self.script.name)
+        super().__post_init__()
+
+    @property
+    def pixi_lock(self) -> Optional[Path]:
+        """The script's sidecar lock file (`<script>.pixi.lock`), if `pixi lock --script` made one."""
+        lock = self.script.with_name(f"{self.script.name}.pixi.lock")
+        return lock if lock.exists() else None
+
+    def validate(self):
+        if not self.script.exists():
+            raise FileNotFoundError(f"Pixi script {self.script} does not exist")
+        if not self.script.is_file():
+            raise ValueError(f"Pixi script {self.script} is not a file")
+        if self.script.suffix != ".py":
+            raise ValueError(f"Pixi script {self.script} must have a .py extension")
+
+        from ._utils import check_pixi_platforms_supported, parse_pixi_script_file
+
+        check_pixi_platforms_supported(parse_pixi_script_file(self.script), self.platforms)
+        super().validate()
+
+    def render_manifest(self) -> str:
+        """The source of the `pixi.toml` this script lowers to."""
+        from ._utils import parse_pixi_script_file, render_pixi_manifest
+
+        return render_pixi_manifest(parse_pixi_script_file(self.script), self.platforms)
+
+    def update_hash(self, hasher: hashlib._Hash, ignore: Optional[Any] = None):
+        # Hash the generated manifest rather than the script body: only the PEP 723 block
+        # affects the image, so edits to the script's code reuse the built image.
+        hash_input = self.render_manifest() + self.environment
+        if self.extra_args:
+            hash_input += self.extra_args
+        if self.secret_mounts:
+            for secret_mount in self.secret_mounts:
+                hash_input += str(secret_mount)
+        hasher.update(hash_input.encode("utf-8"))
+
+        pixi_lock = self.pixi_lock
+        if pixi_lock is not None:
+            from ._utils import filehash_update
+
+            filehash_update(pixi_lock, hasher)
+
+
+@rich.repr.auto
+@dataclass(frozen=True, repr=True)
 class AptPackages(Layer):
     packages: Tuple[str, ...]
     secret_mounts: Optional[Tuple[str | Secret, ...]] = None
@@ -515,6 +584,9 @@ class Env(Layer):
 
 Architecture = Literal["linux/amd64", "linux/arm64"]
 
+# Platforms a default image is built for when the caller does not name any.
+_DEFAULT_PLATFORMS: Tuple[Architecture, ...] = ("linux/amd64", "linux/arm64")
+
 _BASE_REGISTRY = "ghcr.io/flyteorg"
 _LOCALHOST_REGISTRY = "localhost:30000"
 _DEFAULT_IMAGE_NAME = "flyte"
@@ -610,6 +682,7 @@ class Image:
     - `from_debian_base()` — Debian-based image with a specified Python version
     - `from_base()` — Any base image by name (e.g., `"python:3.12-slim"`)
     - `from_uv_script()` — Image from a `uv`-compatible script with inline dependencies
+    - `from_pixi_script()` — Image from a `pixi`-compatible script with inline dependencies
     - `from_dockerfile()` — Image from a custom Dockerfile
     - `from_ref_name()` — Reference to a pre-built image by name
 
@@ -719,7 +792,7 @@ class Image:
                     registry=_get_push_registry(),
                     name=_DEFAULT_IMAGE_NAME,
                     python_version=python_version,
-                    platform=("linux/amd64", "linux/arm64") if platform is None else platform,
+                    platform=_DEFAULT_PLATFORMS if platform is None else platform,
                     extendable=True,
                 )
         image = Image._new(
@@ -727,7 +800,7 @@ class Image:
             registry=_get_push_registry(),
             name=_DEFAULT_IMAGE_NAME,
             python_version=python_version,
-            platform=("linux/amd64", "linux/arm64") if platform is None else platform,
+            platform=_DEFAULT_PLATFORMS if platform is None else platform,
             extendable=True,
         )
         labels = _DockerLines(
@@ -925,6 +998,99 @@ class Image:
             install_flyte=False,
             name=name,
             python_version=python_version,
+            platform=platform,
+        )
+
+        return img.clone(addl_layer=ll)
+
+    @classmethod
+    def from_pixi_script(
+        cls,
+        script: Path | str,
+        *,
+        name: str,
+        registry: str | None = None,
+        registry_secret: Optional[str | Secret] = None,
+        environment: str = "default",
+        extra_args: Optional[str] = None,
+        platform: Optional[Tuple[Architecture, ...]] = None,
+        secret_mounts: Optional[SecretRequest] = None,
+    ) -> Image:
+        """
+        Create an image from a `pixi`-compatible script, using the PEP 723 block at the top of
+        the script to determine the Python version and the conda and PyPI packages to install.
+
+        A pixi script declares portable PEP 723 fields alongside pixi-specific `[tool.pixi.*]`
+        tables, which is what lets it pull conda packages that `from_uv_script` cannot:
+
+        ```python
+        #!/usr/bin/env -S pixi run --script
+        # /// script
+        # requires-python = ">=3.12"
+        # dependencies = ["flyte"]
+        #
+        # [tool.pixi.workspace]
+        # channels = ["conda-forge"]
+        #
+        # [tool.pixi.dependencies]
+        # gdal = "*"
+        # ///
+        ```
+
+        `requires-python` becomes the environment's Python (an explicit
+        `[tool.pixi.dependencies].python` wins over it), `dependencies` become PyPI packages, and
+        `[tool.pixi.dependencies]` become conda packages. Channels default to `conda-forge` and
+        the supported platforms default to those of the image, unless `[tool.pixi.workspace]`
+        declares its own. Every other `[tool.pixi.*]` table (`target`, `feature`, `activation`,
+        ...) is passed through to pixi untouched.
+
+        If a sidecar lock file created by `pixi lock --script <script>` sits next to the script
+        as `<script>.pixi.lock`, it is used and the install is run with `--locked`. Note that
+        pixi locks only the platforms the workspace declares, so to lock an image built for
+        `linux/amd64` the script should declare `platforms = ["linux-64"]` under
+        `[tool.pixi.workspace]` before locking.
+
+        Unlike `from_uv_script`, flyte is not installed for you: list `flyte` in the script's
+        `dependencies` so the task can run in the resulting environment.
+
+        For more information on the pixi script format, see the documentation:
+        [Pixi: Python scripts](https://pixi.prefix.dev/latest/python/scripts/)
+
+        Args:
+            script: path to the pixi script
+            name: name of the image
+            registry: registry to use for the image
+            registry_secret: Secret to use to pull/push the private image.
+            environment: pixi environment to install, default is "default"
+            extra_args: extra arguments to pass to `pixi install`, default is None
+            platform: architecture to use for the image, default is linux/amd64, use tuple for
+                multiple values
+            secret_mounts: Secret mounts to use for the image, default is None.
+
+        Returns:
+            Image
+        """
+        from ._utils import pixi_platforms_for
+
+        # The generated manifest must name the platforms it supports, so resolve them from the
+        # image's platforms up front and keep them on the layer: the layer has no way to reach
+        # back to the image at build time. Mirrors the multi-arch default `from_debian_base`
+        # applies when no platform is given.
+        resolved_platform = platform or _DEFAULT_PLATFORMS
+
+        ll = PixiScript(
+            script=Path(script),
+            platforms=pixi_platforms_for(resolved_platform),
+            environment=environment,
+            extra_args=extra_args,
+            secret_mounts=_ensure_tuple(secret_mounts) if secret_mounts else None,
+        )
+
+        img = cls.from_debian_base(
+            registry=registry,
+            registry_secret=registry_secret,
+            install_flyte=False,
+            name=name,
             platform=platform,
         )
 

--- a/src/flyte/_internal/imagebuild/docker_builder.py
+++ b/src/flyte/_internal/imagebuild/docker_builder.py
@@ -27,6 +27,7 @@ from flyte._image import (
     PipOption,
     PipPackages,
     PixiProject,
+    PixiScript,
     PoetryProject,
     PythonWheels,
     Requirements,
@@ -50,6 +51,7 @@ from flyte._internal.imagebuild.utils import (
     copy_files_to_context,
     get_and_list_dockerignore,
     get_uv_editable_install_mounts,
+    pixi_script_to_project,
 )
 from flyte._logging import logger
 from flyte._utils.asyncify import run_sync_with_loop
@@ -553,7 +555,7 @@ def _get_secret_commands(layers: typing.Tuple[Layer, ...]) -> typing.List[str]:
         return ["--secret", f"id={secret_id},src={secret_file_path}"]
 
     for layer in layers:
-        if isinstance(layer, (PipOption, AptPackages, Commands, PixiProject)):
+        if isinstance(layer, (PipOption, AptPackages, Commands, PixiProject, PixiScript)):
             if layer.secret_mounts:
                 for secret_mount in layer.secret_mounts:
                     secret = Secret(key=secret_mount) if isinstance(secret_mount, str) else secret_mount
@@ -650,6 +652,12 @@ async def _process_layer(
         case PixiProject():
             # Handle pixi project
             dockerfile = await PixiProjectHandler.handle(layer, context_path, dockerfile, docker_ignore_patterns)
+
+        case PixiScript():
+            # A pixi script installs as the pixi project its PEP 723 metadata describes.
+            dockerfile = await PixiProjectHandler.handle(
+                pixi_script_to_project(layer), context_path, dockerfile, docker_ignore_patterns
+            )
 
         case CopyConfig():
             # Handle local files and folders

--- a/src/flyte/_internal/imagebuild/remote_builder.py
+++ b/src/flyte/_internal/imagebuild/remote_builder.py
@@ -29,6 +29,7 @@ from flyte._image import (
     PipOption,
     PipPackages,
     PixiProject,
+    PixiScript,
     PoetryProject,
     PythonWheels,
     Requirements,
@@ -42,6 +43,7 @@ from flyte._internal.imagebuild.utils import (
     get_and_list_dockerignore,
     get_uv_project_editable_dependencies,
     pixi_project_to_primitive_layers,
+    pixi_script_to_project,
 )
 from flyte._internal.runtime.task_serde import get_security_context
 from flyte._logging import logger
@@ -235,7 +237,9 @@ def _get_layers_proto(image: Image, context_path: Path) -> "image_definition_pb2
     # layers (apt / copy / commands / env) that the remote builder understands.
     expanded_layers: typing.List[typing.Any] = []
     for layer in image._layers:
-        if isinstance(layer, PixiProject):
+        if isinstance(layer, PixiScript):
+            expanded_layers.extend(pixi_project_to_primitive_layers(pixi_script_to_project(layer)))
+        elif isinstance(layer, PixiProject):
             expanded_layers.extend(pixi_project_to_primitive_layers(layer))
         else:
             expanded_layers.append(layer)
@@ -470,7 +474,10 @@ def _get_build_secrets_from_image(image: Image) -> Optional[typing.List[Secret]]
     seen_secrets: typing.Set[typing.Tuple[typing.Optional[str], str]] = set()
     DEFAULT_SECRET_DIR = Path("/etc/flyte/secrets")
     for layer in image._layers:
-        if isinstance(layer, (PipOption, Commands, AptPackages, PixiProject)) and layer.secret_mounts is not None:
+        if (
+            isinstance(layer, (PipOption, Commands, AptPackages, PixiProject, PixiScript))
+            and layer.secret_mounts is not None
+        ):
             for secret_mount in layer.secret_mounts:
                 # Mount all the image secrets to a default directory that will be passed to the BuildKit server.
                 if isinstance(secret_mount, Secret):

--- a/src/flyte/_internal/imagebuild/utils.py
+++ b/src/flyte/_internal/imagebuild/utils.py
@@ -1,7 +1,9 @@
+import hashlib
 import os
 import re
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path, PurePath
 from typing import List, Optional
 
@@ -15,6 +17,7 @@ from flyte._image import (
     Image,
     Layer,
     PixiProject,
+    PixiScript,
 )
 from flyte._logging import logger
 from flyte.errors import ImageBuildError
@@ -33,6 +36,44 @@ PIXI_INSTALL_DIR = "/opt/pixi"
 # Kept stable across pixi layers so a later superset manifest incrementally updates the
 # same environment instead of resolving from scratch.
 PIXI_PROJECT_DIR = "/opt/pixi-project"
+
+
+def pixi_script_to_project(layer: PixiScript) -> PixiProject:
+    """Lower a PixiScript layer into the equivalent PixiProject layer.
+
+    Pixi cannot install a script's environment without running the script, and puts it in a
+    rattler cache directory rather than one that survives into the image. So the script's
+    PEP 723 metadata is rendered as a `pixi.toml` workspace manifest, written next to a copy
+    of the script's sidecar lock file (if it has one), and installed by the ordinary pixi
+    project path.
+
+    The generated manifest is written to a temp directory keyed by its own content, so
+    repeated calls for the same script reuse it and concurrent builds cannot collide.
+    """
+    manifest_source = layer.render_manifest()
+    pixi_lock = layer.pixi_lock
+
+    digest = hashlib.sha256(manifest_source.encode("utf-8"))
+    if pixi_lock is not None:
+        digest.update(pixi_lock.read_bytes())
+
+    project_dir = Path(tempfile.gettempdir()) / f"flyte-pixi-script-{digest.hexdigest()[:16]}"
+    project_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest = project_dir / "pixi.toml"
+    manifest.write_text(manifest_source, encoding="utf-8")
+    if pixi_lock is not None:
+        shutil.copy(pixi_lock, project_dir / "pixi.lock")
+    logger.debug(f"Lowered pixi script {layer.script} to generated manifest {manifest}")
+
+    return PixiProject(
+        manifest=manifest,
+        pixi_lock=(project_dir / "pixi.lock") if pixi_lock is not None else None,
+        environment=layer.environment,
+        extra_args=layer.extra_args,
+        project_install_mode="dependencies_only",
+        secret_mounts=layer.secret_mounts,
+    )
 
 
 def pixi_project_to_primitive_layers(layer: PixiProject) -> List[Layer]:

--- a/src/flyte/_utils/__init__.py
+++ b/src/flyte/_utils/__init__.py
@@ -11,11 +11,15 @@ from .helpers import original_std_streams, str2bool
 from .lazy_module import lazy_module
 from .module_loader import adjust_sys_path, load_python_modules
 from .org_discovery import hostname_from_url, org_from_endpoint, sanitize_endpoint
+from .pixi_script_parser import check_platforms_supported as check_pixi_platforms_supported
+from .pixi_script_parser import parse_pixi_script_file, render_pixi_manifest
+from .pixi_script_parser import platforms_for as pixi_platforms_for
 from .uv_script_parser import parse_uv_script_file
 
 __all__ = [
     "AsyncLRUCache",
     "adjust_sys_path",
+    "check_pixi_platforms_supported",
     "description_parser",
     "filehash_update",
     "hostname_from_url",
@@ -23,7 +27,10 @@ __all__ = [
     "load_python_modules",
     "org_from_endpoint",
     "original_std_streams",
+    "parse_pixi_script_file",
     "parse_uv_script_file",
+    "pixi_platforms_for",
+    "render_pixi_manifest",
     "run_coros",
     "sanitize_endpoint",
     "str2bool",

--- a/src/flyte/_utils/pixi_script_parser.py
+++ b/src/flyte/_utils/pixi_script_parser.py
@@ -1,0 +1,230 @@
+"""Parse PEP 723 inline metadata out of pixi scripts and render it as a pixi manifest.
+
+Pixi runs standalone Python scripts whose dependencies are declared in a PEP 723 block,
+with pixi-specific settings under `[tool.pixi.*]`:
+
+    # /// script
+    # requires-python = ">=3.11"
+    # dependencies = ["httpx"]
+    #
+    # [tool.pixi.workspace]
+    # channels = ["conda-forge"]
+    #
+    # [tool.pixi.dependencies]
+    # gdal = "*"
+    # ///
+
+See https://pixi.prefix.dev/latest/python/scripts/.
+
+There is no `pixi install --script`: the only commands that materialize a script's
+environment are `pixi run --script` (which runs the script) and they place it in a
+content-addressed rattler cache directory. Neither is usable at image build time, so a
+pixi script is lowered into an equivalent `pixi.toml` workspace manifest and installed
+with the ordinary `pixi install --manifest-path` path instead.
+"""
+
+import pathlib
+import re
+from dataclasses import dataclass, field
+from functools import lru_cache
+from typing import Any, Dict, List, Optional, Tuple
+
+import toml
+
+# PEP 723 block: `# /// script` ... `# ///`, where every line in between is either `#`
+# alone or starts with `# `.
+_PEP723_BLOCK = re.compile(
+    r"(?m)^# /// script\s*$\s(?P<content>(?:^#(?: .*)?$\s)*?)^# ///\s*$",
+)
+
+# Conda subdir for each container architecture flyte can build for.
+_PLATFORM_TO_SUBDIR = {
+    "linux/amd64": "linux-64",
+    "linux/arm64": "linux-aarch64",
+}
+
+DEFAULT_CHANNELS: Tuple[str, ...] = ("conda-forge",)
+
+
+@dataclass(frozen=True)
+class PixiScriptMetadata:
+    """The parsed PEP 723 block of a pixi script."""
+
+    #: `requires-python`, the PEP 723 python constraint (e.g. ">=3.11").
+    requires_python: Optional[str] = None
+    #: `dependencies`, the PEP 723 PyPI requirements, as PEP 508 strings.
+    dependencies: List[str] = field(default_factory=list)
+    #: The whole `[tool.pixi]` table, verbatim (workspace, dependencies, pypi-dependencies,
+    #: target, feature, activation, ...). Passed through to the generated manifest so that
+    #: pixi settings flyte does not model still reach pixi.
+    pixi: Dict[str, Any] = field(default_factory=dict)
+
+
+def _extract_pep723_block(text: str) -> Optional[str]:
+    """Return the TOML source of the script's PEP 723 block, or None if there isn't one."""
+    match = _PEP723_BLOCK.search(text)
+    if not match:
+        return None
+    lines = []
+    for line in match.group("content").splitlines():
+        # Each line is `#` alone or `# <content>`; strip exactly that prefix so that TOML
+        # indentation inside the block is preserved.
+        lines.append(line[2:] if line.startswith("# ") else line[1:])
+    return "\n".join(lines)
+
+
+def parse_pixi_script_file(path: pathlib.Path) -> PixiScriptMetadata:
+    """Parse the PEP 723 block of the pixi script at `path`."""
+    if not path.exists() or not path.is_file():
+        raise FileNotFoundError(f"File not found: {path}")
+
+    # Parsing is cached because the image hash re-reads the script repeatedly, but the
+    # cache is keyed on the file's mtime and size as well as its path: an edited script
+    # must produce new metadata, or a dependency change would not rebuild the image.
+    stat = path.stat()
+    return _parse_pixi_script_file(path, stat.st_mtime_ns, stat.st_size)
+
+
+@lru_cache
+def _parse_pixi_script_file(path: pathlib.Path, mtime_ns: int, size: int) -> PixiScriptMetadata:
+    raw_header = _extract_pep723_block(path.read_text(encoding="utf-8"))
+    if raw_header is None:
+        raise ValueError(
+            f"No PEP 723 script metadata block found in {path}. A pixi script must declare its "
+            "dependencies in a `# /// script` ... `# ///` block. "
+            "See https://pixi.prefix.dev/latest/python/scripts/"
+        )
+
+    try:
+        data = toml.loads(raw_header)
+    except toml.TomlDecodeError as e:
+        raise ValueError(f"Invalid TOML in the script metadata block of {path}: {e}")
+
+    return PixiScriptMetadata(
+        requires_python=data.get("requires-python"),
+        dependencies=list(data.get("dependencies", [])),
+        pixi=dict(data.get("tool", {}).get("pixi", {})),
+    )
+
+
+def platforms_for(platform: Tuple[str, ...]) -> Tuple[str, ...]:
+    """Map container platforms (`linux/amd64`) onto conda subdirs (`linux-64`)."""
+    try:
+        return tuple(_PLATFORM_TO_SUBDIR[p] for p in platform)
+    except KeyError as e:
+        raise ValueError(
+            f"Cannot build a pixi environment for platform {e.args[0]!r}: "
+            f"supported platforms are {sorted(_PLATFORM_TO_SUBDIR)}."
+        )
+
+
+def _pypi_requirement_to_pixi(requirement: str) -> Tuple[str, Any]:
+    """Convert one PEP 508 requirement string into a pixi `[pypi-dependencies]` entry."""
+    from packaging.requirements import InvalidRequirement, Requirement
+
+    try:
+        req = Requirement(requirement)
+    except InvalidRequirement as e:
+        raise ValueError(f"Invalid PEP 508 requirement {requirement!r} in script dependencies: {e}")
+
+    if req.marker is not None:
+        # pixi expresses conditional dependencies with `[tool.pixi.target.<platform>]`
+        # tables rather than with environment markers, so there is nothing faithful to
+        # translate a marker into.
+        raise ValueError(
+            f"Environment markers are not supported in pixi script dependencies: {requirement!r}. "
+            "Express platform-conditional dependencies with a "
+            "`[tool.pixi.target.<platform>.pypi-dependencies]` table instead."
+        )
+
+    spec: Dict[str, Any] = {}
+    if req.url:
+        if req.url.startswith("git+"):
+            url, _, rev = req.url[len("git+") :].partition("@")
+            spec["git"] = url
+            if rev:
+                spec["rev"] = rev
+        else:
+            spec["url"] = req.url
+    else:
+        spec["version"] = str(req.specifier) if req.specifier else "*"
+
+    if req.extras:
+        spec["extras"] = sorted(req.extras)
+
+    # Collapse the common `{version = "..."}` case to pixi's shorthand.
+    if set(spec) == {"version"}:
+        return req.name, spec["version"]
+    return req.name, spec
+
+
+def effective_platforms(metadata: PixiScriptMetadata, platforms: Tuple[str, ...]) -> Tuple[str, ...]:
+    """The conda subdirs the generated workspace will support.
+
+    A `platforms` key declared by the script under `[tool.pixi.workspace]` wins, since the
+    script author stated it explicitly (and any lock file was resolved against it);
+    otherwise the image's own platforms are used.
+    """
+    declared = metadata.pixi.get("workspace", {}).get("platforms")
+    return tuple(declared) if declared else platforms
+
+
+def check_platforms_supported(metadata: PixiScriptMetadata, platforms: Tuple[str, ...]) -> None:
+    """Raise if the script's declared platforms do not cover every platform of the image.
+
+    pixi refuses to install a workspace on a platform it does not list, so a script that
+    declares fewer platforms than the image is built for fails partway through the build.
+    Catching it here turns that into an actionable message.
+    """
+    declared = metadata.pixi.get("workspace", {}).get("platforms")
+    if not declared:
+        return
+    missing = [p for p in platforms if p not in declared]
+    if missing:
+        raise ValueError(
+            f"The pixi script declares platforms {list(declared)} under `[tool.pixi.workspace]`, "
+            f"which do not cover {missing}, needed to build this image. Either add {missing} to the "
+            f"script's `platforms`, or restrict the image with "
+            f"`from_pixi_script(..., platform=(...,))`."
+        )
+
+
+def render_pixi_manifest(metadata: PixiScriptMetadata, platforms: Tuple[str, ...]) -> str:
+    """Render `metadata` as the source of an equivalent `pixi.toml` workspace manifest.
+
+    `platforms` are the conda subdirs the workspace should support, unless the script
+    declares its own under `[tool.pixi.workspace]`.
+    """
+    workspace: Dict[str, Any] = dict(metadata.pixi.get("workspace", {}))
+    # A workspace manifest, unlike a script, must state its channels and platforms: pixi
+    # infers neither from the machine it is installing on.
+    workspace.setdefault("channels", list(DEFAULT_CHANNELS))
+    workspace["platforms"] = list(effective_platforms(metadata, platforms))
+
+    dependencies: Dict[str, Any] = dict(metadata.pixi.get("dependencies", {}))
+    if metadata.requires_python and "python" not in dependencies:
+        # An explicit `[tool.pixi.dependencies].python` wins over `requires-python`.
+        dependencies["python"] = metadata.requires_python
+
+    pypi_dependencies: Dict[str, Any] = dict(metadata.pixi.get("pypi-dependencies", {}))
+    for requirement in metadata.dependencies:
+        name, spec = _pypi_requirement_to_pixi(requirement)
+        # `[tool.pixi.pypi-dependencies]` is the more specific declaration, so it wins.
+        pypi_dependencies.setdefault(name, spec)
+
+    manifest: Dict[str, Any] = {"workspace": workspace}
+    if dependencies:
+        manifest["dependencies"] = dependencies
+    if pypi_dependencies:
+        manifest["pypi-dependencies"] = pypi_dependencies
+    # Everything else pixi understands (target, feature, environments, activation, ...)
+    # is passed through untouched.
+    for key, value in metadata.pixi.items():
+        if key not in ("workspace", "dependencies", "pypi-dependencies"):
+            manifest[key] = value
+
+    header = (
+        "# Generated by flyte from the PEP 723 metadata of a pixi script.\n"
+        "# Edit the script's `# /// script` block rather than this file.\n"
+    )
+    return header + toml.dumps(manifest)

--- a/tests/flyte/imagebuild/test_pixi_script_builder.py
+++ b/tests/flyte/imagebuild/test_pixi_script_builder.py
@@ -1,0 +1,184 @@
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import toml
+
+from flyte import Secret
+from flyte._image import PixiScript
+from flyte._internal.imagebuild.docker_builder import (
+    PIXI_VERSION,
+    PixiProjectHandler,
+    _get_secret_commands,
+    _process_layer,
+)
+from flyte._internal.imagebuild.utils import pixi_project_to_primitive_layers, pixi_script_to_project
+
+PIXI_SCRIPT = """\
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["flyte"]
+#
+# [tool.pixi.workspace]
+# channels = ["conda-forge"]
+#
+# [tool.pixi.dependencies]
+# numpy = "*"
+# ///
+import flyte
+"""
+
+
+def write_script(directory: str, content: str = PIXI_SCRIPT, name: str = "script.py") -> Path:
+    script = Path(directory) / name
+    script.write_text(content)
+    return script.absolute()
+
+
+@pytest.mark.asyncio
+async def test_pixi_script_lowers_to_a_pixi_project():
+    """A pixi script installs through the same dockerfile lines as a pixi project."""
+    with tempfile.TemporaryDirectory() as tmp_context, tempfile.TemporaryDirectory() as tmp_user:
+        script = write_script(tmp_user)
+        project = pixi_script_to_project(PixiScript(script=script, platforms=("linux-64",)))
+
+        # The generated manifest carries the script's metadata over faithfully.
+        manifest = toml.loads(project.manifest.read_text())
+        assert manifest["workspace"] == {"channels": ["conda-forge"], "platforms": ["linux-64"]}
+        assert manifest["dependencies"] == {"numpy": "*", "python": ">=3.12"}
+        assert manifest["pypi-dependencies"] == {"flyte": "*"}
+
+        result = await PixiProjectHandler.handle(
+            layer=project,
+            context_path=Path(tmp_context),
+            dockerfile="FROM python:3.12\n",
+            docker_ignore_patterns=[],
+        )
+
+        assert f"COPY --from=ghcr.io/prefix-dev/pixi:{PIXI_VERSION} /usr/local/bin/pixi /usr/local/bin/pixi" in result
+        assert " /opt/pixi-project/pixi.toml" in result
+        assert "pixi install --manifest-path /opt/pixi-project/pixi.toml" in result
+        # No sidecar lock next to the script, so the environment is resolved at build time.
+        assert "--locked" not in result
+        # The pixi environment becomes the image's runtime environment.
+        assert "VIRTUAL_ENV=/opt/pixi-project/.pixi/envs/default" in result
+
+
+@pytest.mark.asyncio
+async def test_pixi_script_with_sidecar_lock():
+    """`pixi lock --script` writes <script>.pixi.lock, which makes the install reproducible."""
+    with tempfile.TemporaryDirectory() as tmp_context, tempfile.TemporaryDirectory() as tmp_user:
+        script = write_script(tmp_user)
+        (Path(tmp_user) / "script.py.pixi.lock").write_text("version: 7")
+
+        project = pixi_script_to_project(PixiScript(script=script, platforms=("linux-64",)))
+        assert project.pixi_lock is not None
+        assert project.pixi_lock.read_text() == "version: 7"
+
+        result = await PixiProjectHandler.handle(
+            layer=project,
+            context_path=Path(tmp_context),
+            dockerfile="FROM python:3.12\n",
+            docker_ignore_patterns=[],
+        )
+        assert " /opt/pixi-project/pixi.lock" in result
+        assert "--environment default --locked" in result
+
+
+@pytest.mark.asyncio
+async def test_pixi_script_processed_as_a_layer():
+    """_process_layer dispatches PixiScript without the caller lowering it first."""
+    with tempfile.TemporaryDirectory() as tmp_context, tempfile.TemporaryDirectory() as tmp_user:
+        result = await _process_layer(
+            PixiScript(script=write_script(tmp_user), platforms=("linux-64",)),
+            Path(tmp_context),
+            "FROM python:3.12\n",
+        )
+        assert "pixi install --manifest-path /opt/pixi-project/pixi.toml" in result
+
+
+@pytest.mark.asyncio
+async def test_pixi_script_environment_and_extra_args():
+    """A non-default pixi environment and extra install args reach the pixi command."""
+    with tempfile.TemporaryDirectory() as tmp_context, tempfile.TemporaryDirectory() as tmp_user:
+        script = write_script(
+            tmp_user,
+            content=(
+                "# /// script\n"
+                '# dependencies = ["flyte"]\n'
+                "#\n"
+                "# [tool.pixi.environments]\n"
+                '# gpu = ["cuda"]\n'
+                "#\n"
+                "# [tool.pixi.feature.cuda.dependencies]\n"
+                '# cuda-version = "12.*"\n'
+                "# ///\n"
+            ),
+        )
+        layer = PixiScript(
+            script=script,
+            platforms=("linux-64",),
+            environment="gpu",
+            extra_args="--no-progress",
+        )
+        # Tables flyte does not model still reach pixi.
+        manifest = toml.loads(pixi_script_to_project(layer).manifest.read_text())
+        assert manifest["environments"] == {"gpu": ["cuda"]}
+        assert manifest["feature"] == {"cuda": {"dependencies": {"cuda-version": "12.*"}}}
+
+        result = await _process_layer(layer, Path(tmp_context), "FROM python:3.12\n")
+        assert "--environment gpu --no-progress" in result
+        assert "VIRTUAL_ENV=/opt/pixi-project/.pixi/envs/gpu" in result
+
+
+def test_pixi_script_build_secrets():
+    """Secrets on a pixi script layer reach `docker buildx build --secret`."""
+    with tempfile.TemporaryDirectory() as tmp_user:
+        layer = PixiScript(
+            script=write_script(tmp_user),
+            platforms=("linux-64",),
+            secret_mounts=(Secret(key="pixi_token"),),
+        )
+        with patch.dict("os.environ", {"PIXI_TOKEN": "shhh"}):
+            commands = _get_secret_commands([layer])
+        assert commands[0] == "--secret"
+        assert "env=PIXI_TOKEN" in commands[1]
+
+
+def test_pixi_script_remote_builder_lowering():
+    """The remote builder IDL has no pixi layer, so a script becomes primitive layers."""
+    with tempfile.TemporaryDirectory() as tmp_user:
+        layers = pixi_project_to_primitive_layers(
+            pixi_script_to_project(PixiScript(script=write_script(tmp_user), platforms=("linux-64",)))
+        )
+        assert [type(layer).__name__ for layer in layers] == [
+            "AptPackages",
+            "Commands",
+            "CopyConfig",
+            "Commands",
+            "Env",
+        ]
+        # The generated manifest is what gets copied in and installed.
+        assert layers[2].dst == "/opt/pixi-project/pixi.toml"
+        assert "pixi install --manifest-path /opt/pixi-project/pixi.toml" in layers[3].commands[0]
+
+
+def test_pixi_script_hash_tracks_metadata_not_code():
+    """Editing the script's code reuses the image; editing its dependencies rebuilds it."""
+    import hashlib
+
+    def digest(script: Path) -> str:
+        hasher = hashlib.md5()
+        PixiScript(script=script, platforms=("linux-64",)).update_hash(hasher)
+        return hasher.hexdigest()
+
+    with tempfile.TemporaryDirectory() as tmp_user:
+        script = write_script(tmp_user)
+        original = digest(script)
+
+        script.write_text(PIXI_SCRIPT + "\nprint('a new line of code')\n")
+        assert digest(script) == original
+
+        script.write_text(PIXI_SCRIPT.replace('numpy = "*"', 'numpy = "<2"'))
+        assert digest(script) != original

--- a/tests/utils/test_pixi_script_parser.py
+++ b/tests/utils/test_pixi_script_parser.py
@@ -1,0 +1,221 @@
+import pathlib
+
+import pytest
+import toml
+
+from flyte._image import Image, PixiScript
+from flyte._utils.pixi_script_parser import (
+    check_platforms_supported,
+    parse_pixi_script_file,
+    platforms_for,
+    render_pixi_manifest,
+)
+
+FULL_SCRIPT = """\
+#!/usr/bin/env -S pixi run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["httpx", "flyte"]
+#
+# [tool.pixi.workspace]
+# channels = ["conda-forge", "bioconda"]
+#
+# [tool.pixi.dependencies]
+# gdal = "*"
+#
+# [tool.pixi.target.linux-64.dependencies]
+# libblas = "*"
+# ///
+import httpx
+"""
+
+
+def write(tmp_path: pathlib.Path, content: str, name: str = "script.py") -> pathlib.Path:
+    path = tmp_path / name
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_parse_pixi_script(tmp_path: pathlib.Path):
+    metadata = parse_pixi_script_file(write(tmp_path, FULL_SCRIPT))
+
+    assert metadata.requires_python == ">=3.12"
+    assert metadata.dependencies == ["httpx", "flyte"]
+    # The whole [tool.pixi] table is kept verbatim.
+    assert metadata.pixi["workspace"] == {"channels": ["conda-forge", "bioconda"]}
+    assert metadata.pixi["dependencies"] == {"gdal": "*"}
+    assert metadata.pixi["target"] == {"linux-64": {"dependencies": {"libblas": "*"}}}
+
+
+def test_parse_pixi_script_without_metadata_block(tmp_path: pathlib.Path):
+    with pytest.raises(ValueError, match="No PEP 723 script metadata block found"):
+        parse_pixi_script_file(write(tmp_path, "import flyte\n", name="no_block.py"))
+
+
+def test_parse_pixi_script_with_invalid_toml(tmp_path: pathlib.Path):
+    script = "# /// script\n# dependencies = [oops\n# ///\n"
+    with pytest.raises(ValueError, match="Invalid TOML"):
+        parse_pixi_script_file(write(tmp_path, script, name="bad_toml.py"))
+
+
+def test_parse_pixi_script_missing_file(tmp_path: pathlib.Path):
+    with pytest.raises(FileNotFoundError):
+        parse_pixi_script_file(tmp_path / "nope.py")
+
+
+def test_render_manifest(tmp_path: pathlib.Path):
+    metadata = parse_pixi_script_file(write(tmp_path, FULL_SCRIPT))
+    manifest = toml.loads(render_pixi_manifest(metadata, ("linux-64",)))
+
+    # Channels come from the script; platforms are filled in from the image.
+    assert manifest["workspace"] == {"channels": ["conda-forge", "bioconda"], "platforms": ["linux-64"]}
+    # requires-python becomes the environment's python, alongside the conda dependencies.
+    assert manifest["dependencies"] == {"gdal": "*", "python": ">=3.12"}
+    # PEP 723 dependencies are PyPI packages.
+    assert manifest["pypi-dependencies"] == {"httpx": "*", "flyte": "*"}
+    # Tables flyte does not model are passed through untouched.
+    assert manifest["target"] == {"linux-64": {"dependencies": {"libblas": "*"}}}
+
+
+def test_render_manifest_defaults(tmp_path: pathlib.Path):
+    """A script with no [tool.pixi] table at all still produces an installable manifest."""
+    script = '# /// script\n# dependencies = ["cowsay"]\n# ///\nprint(1)\n'
+    metadata = parse_pixi_script_file(write(tmp_path, script, name="bare.py"))
+    manifest = toml.loads(render_pixi_manifest(metadata, ("linux-64", "linux-aarch64")))
+
+    # pixi defaults a script to conda-forge; a workspace manifest must say so explicitly.
+    assert manifest["workspace"] == {"channels": ["conda-forge"], "platforms": ["linux-64", "linux-aarch64"]}
+    assert manifest["pypi-dependencies"] == {"cowsay": "*"}
+    assert "dependencies" not in manifest
+
+
+def test_render_manifest_script_platforms_win(tmp_path: pathlib.Path):
+    script = (
+        '# /// script\n# dependencies = ["cowsay"]\n#\n# [tool.pixi.workspace]\n# platforms = ["linux-64"]\n# ///\n'
+    )
+    metadata = parse_pixi_script_file(write(tmp_path, script, name="pinned.py"))
+    manifest = toml.loads(render_pixi_manifest(metadata, ("linux-64",)))
+    assert manifest["workspace"]["platforms"] == ["linux-64"]
+
+
+def test_render_manifest_explicit_python_wins(tmp_path: pathlib.Path):
+    """pixi documents [tool.pixi.dependencies].python as taking precedence over requires-python."""
+    script = '# /// script\n# requires-python = ">=3.10"\n#\n# [tool.pixi.dependencies]\n# python = "3.12.*"\n# ///\n'
+    metadata = parse_pixi_script_file(write(tmp_path, script, name="py.py"))
+    manifest = toml.loads(render_pixi_manifest(metadata, ("linux-64",)))
+    assert manifest["dependencies"]["python"] == "3.12.*"
+
+
+def test_render_manifest_pypi_requirement_forms(tmp_path: pathlib.Path):
+    script = (
+        "# /// script\n"
+        "# dependencies = [\n"
+        '#   "httpx>=0.28,<1",\n'
+        '#   "pandas[performance]",\n'
+        '#   "mypkg @ https://example.com/mypkg-1.0-py3-none-any.whl",\n'
+        '#   "othpkg @ git+https://github.com/org/othpkg@v1.2.3",\n'
+        "# ]\n"
+        "# ///\n"
+    )
+    metadata = parse_pixi_script_file(write(tmp_path, script, name="forms.py"))
+    manifest = toml.loads(render_pixi_manifest(metadata, ("linux-64",)))
+
+    pypi = manifest["pypi-dependencies"]
+    # `packaging` normalizes specifier ordering, which keeps the rendered manifest stable.
+    assert pypi["httpx"] == "<1,>=0.28"
+    assert pypi["pandas"] == {"version": "*", "extras": ["performance"]}
+    assert pypi["mypkg"] == {"url": "https://example.com/mypkg-1.0-py3-none-any.whl"}
+    assert pypi["othpkg"] == {"git": "https://github.com/org/othpkg", "rev": "v1.2.3"}
+
+
+def test_render_manifest_pypi_dependencies_table_wins(tmp_path: pathlib.Path):
+    """[tool.pixi.pypi-dependencies] is the more specific declaration, so it is not overwritten."""
+    script = (
+        "# /// script\n"
+        '# dependencies = ["httpx"]\n'
+        "#\n"
+        "# [tool.pixi.pypi-dependencies]\n"
+        '# httpx = { version = ">=0.28", extras = ["socks"] }\n'
+        "# ///\n"
+    )
+    metadata = parse_pixi_script_file(write(tmp_path, script, name="dup.py"))
+    manifest = toml.loads(render_pixi_manifest(metadata, ("linux-64",)))
+    assert manifest["pypi-dependencies"]["httpx"] == {"version": ">=0.28", "extras": ["socks"]}
+
+
+def test_render_manifest_rejects_environment_markers(tmp_path: pathlib.Path):
+    script = "# /// script\n# dependencies = [\"httpx; python_version < '3.11'\"]\n# ///\n"
+    metadata = parse_pixi_script_file(write(tmp_path, script, name="marker.py"))
+    with pytest.raises(ValueError, match="Environment markers are not supported"):
+        render_pixi_manifest(metadata, ("linux-64",))
+
+
+def test_render_manifest_rejects_invalid_requirement(tmp_path: pathlib.Path):
+    script = '# /// script\n# dependencies = ["not a requirement!!"]\n# ///\n'
+    metadata = parse_pixi_script_file(write(tmp_path, script, name="invalid.py"))
+    with pytest.raises(ValueError, match="Invalid PEP 508 requirement"):
+        render_pixi_manifest(metadata, ("linux-64",))
+
+
+def test_platforms_for():
+    assert platforms_for(("linux/amd64",)) == ("linux-64",)
+    assert platforms_for(("linux/amd64", "linux/arm64")) == ("linux-64", "linux-aarch64")
+    with pytest.raises(ValueError, match="Cannot build a pixi environment for platform 'windows/amd64'"):
+        platforms_for(("windows/amd64",))
+
+
+def test_check_platforms_supported(tmp_path: pathlib.Path):
+    declared = (
+        '# /// script\n# dependencies = ["cowsay"]\n#\n# [tool.pixi.workspace]\n# platforms = ["linux-64"]\n# ///\n'
+    )
+    metadata = parse_pixi_script_file(write(tmp_path, declared, name="declared.py"))
+
+    # Covered: no complaint.
+    check_platforms_supported(metadata, ("linux-64",))
+
+    # Not covered: pixi would fail partway through the build, so say so up front.
+    with pytest.raises(ValueError, match=r"do not cover \['linux-aarch64'\]"):
+        check_platforms_supported(metadata, ("linux-64", "linux-aarch64"))
+
+    # A script that declares nothing accepts whatever the image is built for.
+    bare = parse_pixi_script_file(write(tmp_path, "# /// script\n# ///\n", name="silent.py"))
+    check_platforms_supported(bare, ("linux-64", "linux-aarch64"))
+
+
+def test_pixi_script_layer_validate_platforms(tmp_path: pathlib.Path):
+    """A platform mismatch is caught by Image.validate(), before any build starts."""
+    script = write(
+        tmp_path,
+        '# /// script\n# [tool.pixi.workspace]\n# platforms = ["linux-64"]\n# ///\n',
+        name="mismatch.py",
+    )
+    img = Image.from_pixi_script(script, name="mismatch", registry="localhost")
+    assert img._layers[-1].platforms == ("linux-64", "linux-aarch64")
+    with pytest.raises(ValueError, match=r"do not cover \['linux-aarch64'\]"):
+        img.validate()
+
+    # Restricting the image to the declared platform resolves it.
+    Image.from_pixi_script(script, name="mismatch", registry="localhost", platform=("linux/amd64",)).validate()
+
+
+def test_pixi_script_layer_validate_script(tmp_path: pathlib.Path):
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        PixiScript(script=tmp_path / "missing.py").validate()
+
+    with pytest.raises(ValueError, match="is not a file"):
+        PixiScript(script=tmp_path).validate()
+
+    not_python = write(tmp_path, "# /// script\n# ///\n", name="script.txt")
+    with pytest.raises(ValueError, match=r"must have a \.py extension"):
+        PixiScript(script=not_python).validate()
+
+
+def test_pixi_script_lock_discovery(tmp_path: pathlib.Path):
+    """`pixi lock --script foo.py` writes foo.py.pixi.lock next to the script."""
+    script = write(tmp_path, FULL_SCRIPT, name="locked.py")
+    layer = PixiScript(script=script)
+    assert layer.pixi_lock is None
+
+    lock = tmp_path / "locked.py.pixi.lock"
+    lock.write_text("version: 7")
+    assert PixiScript(script=script).pixi_lock == lock


### PR DESCRIPTION
## What

`Image.from_pixi_script()` — the pixi counterpart to `from_uv_script()`. Describe an image with the PEP 723 block at the top of a script, but resolve it with [pixi](https://pixi.prefix.dev/latest/python/scripts/) so the environment can pull **conda** packages alongside PyPI ones:

```python
# /// script
# requires-python = ">=3.12"
# dependencies = ["flyte"]
#
# [tool.pixi.workspace]
# channels = ["conda-forge"]
#
# [tool.pixi.dependencies]
# numpy = "*"
# ///

image = flyte.Image.from_pixi_script(__file__, name="pixi-hello", registry="ghcr.io/flyteorg")
```

That conda side is the reason to reach for this over `from_uv_script`: binaries that aren't on PyPI (GDAL, MKL builds, CUDA toolkits) become available to a single-file task.

## How

Pixi has no `install --script`. The only commands that materialize a script's environment are `pixi run --script` (which *runs* the script), and they place the environment in a content-addressed rattler cache directory — which the build's `--mount=type=cache` for `/root/.cache/rattler` then discards. So neither is usable at image build time.

Instead a new `PixiScript` layer is lowered into the equivalent `pixi.toml` workspace manifest and installed through the existing, tested `PixiProject` path. This is the same shape as `UVScript` lowering to `PipPackages`/`UVProject`, and it means both the local docker builder and the remote builder pick the feature up with a couple of lines each.

Translation details:

- The whole `[tool.pixi]` table is passed through verbatim, so tables flyte doesn't model (`target`, `feature`, `environments`, `activation`) still reach pixi.
- `requires-python` becomes the environment's python, unless `[tool.pixi.dependencies].python` states one (pixi documents that as taking precedence).
- PEP 723 `dependencies` become `[pypi-dependencies]`, covering version specifiers, extras, direct URLs and `git+` refs. Environment markers are rejected with a message pointing at `[tool.pixi.target.<platform>]`, since pixi has no faithful equivalent.
- A workspace manifest, unlike a script, *must* state its channels and platforms — pixi infers neither. Channels default to `conda-forge` (what pixi assumes for a script) and platforms come from the image's own platforms, so a script that declares neither builds correctly for whatever it's built for.

Two rough edges worth calling out, both handled:

- **Platform coverage.** A script that declares fewer platforms than the image is built for used to fail partway through `pixi install` with `The workspace does not support 'linux-aarch64'`. `validate()` now catches it up front and says how to fix it (add the platform, or restrict the image with `platform=(...)`).
- **Caching.** The layer hashes the *generated manifest*, not the script body, so editing a script's code reuses the built image while editing its dependencies rebuilds it. Getting this right required keying the parser's `lru_cache` on mtime/size — a test caught that a plain path-keyed cache returns stale metadata after an edit, which would have silently skipped rebuilds.

A sidecar lock from `pixi lock --script` (`<script>.pixi.lock`) validates against the generated manifest, so when present it's installed with `--locked`.

## Verification

Beyond the 24 new unit tests:

- **Local docker build, multi-arch.** The pixi environment is the active runtime — Python 3.14.7, numpy 2.5.2 from conda-forge, flyte from PyPI, and `a0` resolving from the pixi env on both `linux/amd64` and `linux/arm64`.
- **Lock file.** Generated a real `pixi lock --script` sidecar with pixi 0.77, built with it, and confirmed `pixi install ... --locked` validates against the synthesized manifest.
- **Remote builder, live cluster.** Built via the remote builder and ran the example to completion: `mean([1.0, 2.0, 3.0, 4.0]) = 2.5`.

`PIXI_VERSION` is deliberately left at 0.72.2: the image only runs `pixi install --manifest-path`, so no bump is needed. Only a user generating a lock file needs pixi ≥ 0.76, which is where `--script` landed.

## Notes

The 4 failures in `tests/flyte/test_image.py` / `tests/flyte/imagebuild/` are pre-existing on `main` — verified by stashing this branch and re-running them.

`examples/image/pixi_image.py` can't run against a released `flyte` until this ships, since the example re-imports itself at task runtime and calls `Image.from_pixi_script`. The cluster verification above pinned `flyte` to this branch to work around that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
