### PR TITLE
docsy: harden the CLI index builder after #1463

### DIFF
--- a/src/flyte/cli/_gen.py
+++ b/src/flyte/cli/_gen.py
@@ -290,11 +290,7 @@ def _build_index_table(
                     if noun_is_plugin and include_plugins:
                         noun_display = f"{noun}⁺"
                     noun_links.append(f"[`{noun_display}`](#flyte-{key}-{noun})")
-                if len(filtered) == 0:
-                    verb_link = f"[`{key_display}`](#flyte-{key})"
-                    output.append(f"| {verb_link} | - |")
-                else:
-                    output.append(f"| `{key_display}` | {', '.join(noun_links)}  |")
+                output.append(f"| `{key_display}` | {', '.join(noun_links)}  |")
         else:
             # Noun table
             filtered = [(v, ip, pm) for v, ip, pm in entries if include_plugins or not ip]

--- a/tests/cli/test_gen_plugin_detection.py
+++ b/tests/cli/test_gen_plugin_detection.py
@@ -84,3 +84,20 @@ def test_plugin_verb_with_no_subcommands_is_still_indexed():
     rows = "\n".join(_build_index_table(groups, metadata, True, include_plugins=True))
     assert "fork⁺" in rows
     assert "#flyte-fork" in rows
+
+
+def test_plugin_verb_with_no_subcommands_stays_out_of_the_core_index():
+    """The mirror of the test above, and the property the OSS variant rests on.
+
+    A plugin verb is dropped from the core table by an early `continue`, which runs
+    before the branch that lists subcommand-less verbs. That ordering is the only
+    thing keeping `flyte fork` out of the OSS docs now that the branch is
+    unconditional -- remove the `continue` and every other test in this file still
+    passes while the leak returns.
+    """
+    from flyte.cli._gen import _build_index_table
+
+    groups = {"fork": []}
+    metadata = {"fork": (True, "flyteplugins.union.cli.fork")}
+    rows = "\n".join(_build_index_table(groups, metadata, True, include_plugins=False))
+    assert "fork" not in rows


### PR DESCRIPTION
Two follow-ups to #1463, found by reviewing it after it merged. Neither changes generated output: byte-identical across all 1517 lines.

## 1. An unreachable branch

`_build_index_table` still carried this inside the `else:` of `if not filtered:`, where `filtered` is non-empty by construction:

```python
if len(filtered) == 0:
    verb_link = f"[`{key_display}`](#flyte-{key})"
    output.append(f"| {verb_link} | - |")
else:
    output.append(...)
```

It duplicates the row the `if not filtered:` branch already emits. Pre-existing, but #1463 rewrote the lines immediately above and left a dead copy of the case it had just simplified sitting underneath.

## 2. The safety property #1463 relies on had no test

#1463 made the "verb with no subcommands" branch unconditional. That is safe, but only because of an earlier guard:

```python
if key_is_plugin and not include_plugins:
    continue
```

By the time control reaches the unconditional branch, the verb is already known to belong in the table being built. Nothing enforced that. **Delete the `continue` and all seven existing tests still pass while `flyte fork` returns to the OSS variant** — the exact leak #1463 exists to prevent.

`test_plugin_verb_with_no_subcommands_stays_out_of_the_core_index` is the negative twin of the test #1463 added, asserting the plugin verb is absent from the `include_plugins=False` table.

## Verification

- `tests/cli`: **400 passed**
- Adversarial: with the `continue` removed, the new test fails and the other seven pass
- Generator output diffed against `main` with a plugin registering a dispatch-only group: identical

---
— docsy · automated docs agent · [DOC-1478](https://linear.app/unionai/issue/DOC-1478)