### PR TITLE
docsy: add `flyte gen docs --type json` and record plugin provenance at registration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ dev-rs-dist:
 cli-docs-gen: ## Generate CLI documentation
 	@echo "📖 Generating CLI documentation..."
 	@uv run flyte gen docs --type markdown
+	@uv run flyte gen docs --type json | uv run python maint_tools/check_cli_json.py
 
 .PHONY: check-docstrings
 check-docstrings: ## Reject reStructuredText and NumPy sections in docstrings

--- a/maint_tools/check_cli_json.py
+++ b/maint_tools/check_cli_json.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Check that `flyte gen docs --type json` describes the real command tree.
+
+Reads the JSON on stdin. Run by `make cli-docs-gen`, which is the only thing
+that exercises the doc generator against the live CLI rather than against
+commands a test constructed.
+
+That distinction is the point. The unit tests build their own click objects, so
+they cannot see the failures that only exist on the real tree: a walker that
+stopped descending because a private type it matches by class NAME was renamed,
+or a genuine command whose default does not serialise. Both produce a generator
+that exits 0 and emits a plausible, wrong document.
+
+The floor is deliberately far below the real count. It is here to catch a
+collapse, not to be updated every time a command is added.
+"""
+
+import json
+import sys
+
+MIN_COMMANDS = 20
+REQUIRED_KEYS = {"path", "name", "is_group", "distribution", "help", "arguments", "options"}
+
+
+def main() -> None:
+    try:
+        doc = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        sys.exit(f"ERROR: `flyte gen docs --type json` did not emit valid JSON: {exc}")
+
+    commands = doc.get("commands")
+    if not isinstance(commands, list):
+        sys.exit("ERROR: no `commands` list in the output.")
+
+    if len(commands) < MIN_COMMANDS:
+        sys.exit(
+            f"ERROR: only {len(commands)} command(s) described, below the floor of {MIN_COMMANDS}.\n"
+            "       The generator exited 0, so the likely cause is a tree walk that stopped\n"
+            "       descending -- check whether a private type `walk_commands` matches on by\n"
+            "       class name was renamed."
+        )
+
+    for command in commands:
+        missing = REQUIRED_KEYS - command.keys()
+        if missing:
+            sys.exit(f"ERROR: {command.get('path', '<unnamed>')} is missing {sorted(missing)}.")
+
+    if not any(c["path"] == "flyte" for c in commands):
+        sys.exit("ERROR: the root command is absent, so the walk did not start where it should.")
+
+    print(f"check-cli-json: {len(commands)} commands described, all keys present")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/flyte/cli/_gen.py
+++ b/src/flyte/cli/_gen.py
@@ -1,4 +1,5 @@
 import inspect
+import json
 import sys
 import textwrap
 from os import getcwd
@@ -6,7 +7,9 @@ from typing import Generator, Tuple
 
 import rich_click as click
 
+import flyte
 import flyte.cli._common as common
+from flyte.cli._plugins import get_command_distribution
 
 
 @click.group(name="gen")
@@ -17,7 +20,13 @@ def gen():
 
 
 @gen.command(cls=common.CommandBase)
-@click.option("--type", "doc_type", type=str, required=True, help="Type of documentation (valid: markdown)")
+@click.option(
+    "--type",
+    "doc_type",
+    type=str,
+    required=True,
+    help="Type of documentation (valid: markdown, json)",
+)
 @click.option(
     "--plugin-variants",
     "plugin_variants",
@@ -40,6 +49,8 @@ def docs(
     """
     if doc_type == "markdown":
         markdown(cfg, plugin_variants=plugin_variants)
+    elif doc_type == "json":
+        json_tree(cfg)
     else:
         raise click.ClickException("Invalid documentation type: {}".format(doc_type))
 
@@ -451,6 +462,103 @@ def markdown(cfg: common.CLIConfig, plugin_variants: str | None = None):
             print("\n".join(rendered))
 
     # Flush stdout to ensure all output is written before the process exits.
+    sys.stdout.flush()
+
+
+def _option_default(param: click.Parameter):
+    """A JSON-safe rendering of a parameter default.
+
+    The working directory is stripped because it is a property of the machine
+    that ran the generator, not of the CLI being described.
+    """
+    default = param.default
+    if default is None or isinstance(default, (bool, int, float)):
+        return default
+    return str(default).replace(f"{getcwd()}/", "")
+
+
+def _describe(cmd_path: str, cmd: click.Command, cmd_ctx: click.Context, distribution: str | None) -> dict:
+    """One command as data.
+
+    Deliberately excludes anything about presentation. Help text is normalised
+    with `inspect.cleandoc` (undoing click's indentation, which is an artefact of
+    how the string was written) but is otherwise verbatim: no escaping, no code
+    fencing, no markup. A consumer that needs those applies its own.
+    """
+    params = cmd.get_params(cmd_ctx)
+    return {
+        "path": cmd_path,
+        "name": cmd_path.rsplit(" ", 1)[-1],
+        "is_group": isinstance(cmd, click.Group),
+        "distribution": distribution,
+        "help": inspect.cleandoc(cmd.help) if cmd.help else None,
+        "arguments": [
+            {"name": p.name, "required": p.required} for p in params if isinstance(p, click.Argument) and p.name
+        ],
+        "options": [
+            {
+                "opts": list(p.opts),
+                "secondary_opts": list(p.secondary_opts),
+                "type": p.type.name,
+                "default": _option_default(p),
+                "help": textwrap.dedent(p.help) if p.help else None,
+            }
+            for p in params
+            if isinstance(p, click.Option)
+        ],
+    }
+
+
+def _resolve_distribution(cmd_path: str, own: str | None, by_path: dict[str, str | None]) -> str | None:
+    """A command's distribution, inheriting from its nearest stamped ancestor.
+
+    Inheritance is not a nicety. Only 35 of the CLI's plugin-provided commands
+    are entry points; `flyte explore volume` and the three `flyte undelete`
+    subcommands are defined inside a plugin's own group and so carry no stamp of
+    their own. Attributing them by entry point alone would report them as core,
+    which is the exact defect this data exists to prevent -- and one the older
+    `__module__` guess happened to get right.
+    """
+    if own:
+        return own
+    parts = cmd_path.split(" ")
+    for i in range(len(parts) - 1, 0, -1):
+        inherited = by_path.get(" ".join(parts[:i]))
+        if inherited:
+            return inherited
+    return None
+
+
+def json_tree(cfg: common.CLIConfig):
+    """Print the command tree as JSON.
+
+    The machine-readable half of this generator. It reports what the CLI *is*:
+    the commands, their parameters, and which distribution provided each one.
+    It takes no view on who should see them -- audience is a decision for the
+    documentation that consumes this, not a property of the CLI.
+    """
+    ctx = cfg.ctx
+    commands = [("flyte", ctx.command, ctx), *walk_commands(ctx)]
+
+    own_by_path: dict[str, str | None] = {}
+    seen: list[click.Command] = []
+    ordered: list[tuple[str, click.Command, click.Context]] = []
+    for cmd_path, cmd, cmd_ctx in commands:
+        if cmd in seen:
+            continue
+        seen.append(cmd)
+        own_by_path[cmd_path] = get_command_distribution(cmd)
+        ordered.append((cmd_path, cmd, cmd_ctx))
+
+    out = {
+        "cli": "flyte",
+        "version": flyte.__version__,
+        "commands": [
+            _describe(p, c, cc, _resolve_distribution(p, own_by_path[p], own_by_path)) for p, c, cc in ordered
+        ],
+    }
+    json.dump(out, sys.stdout, indent=2)
+    sys.stdout.write("\n")
     sys.stdout.flush()
 
 

--- a/src/flyte/cli/_plugins.py
+++ b/src/flyte/cli/_plugins.py
@@ -87,6 +87,38 @@ def discover_and_register_plugins(root_group: click.Group):
     _load_hook_plugins(root_group)
 
 
+#: Attribute stamped onto a plugin-registered command naming the distribution
+#: that provided it. Absent on core commands.
+PLUGIN_DISTRIBUTION_ATTR = "_flyte_plugin_distribution"
+
+
+def get_command_distribution(command: click.Command) -> str | None:
+    """The distribution that registered this command, or None for a core command.
+
+    Recorded at registration time by `_load_command_plugins`, where the entry
+    point -- and therefore the owning distribution -- is known for certain.
+
+    This exists so that consumers do not have to infer provenance from
+    `__module__`, which is a property of where code was written rather than of
+    what shipped it. That inference published `flyte fork` to the open-source
+    CLI reference: the command is a `click.Group` with no callback, so the
+    module was never consulted at all.
+    """
+    return getattr(command, PLUGIN_DISTRIBUTION_ATTR, None)
+
+
+def _stamp_distribution(command: click.Command, ep) -> None:
+    """Record which distribution provided `command`.
+
+    Best-effort by design: a command whose entry point carries no distribution
+    metadata is left unstamped rather than mislabelled, and a command object
+    shared by two entry points keeps its first attribution rather than flapping.
+    """
+    dist = getattr(getattr(ep, "dist", None), "name", None)
+    if dist and getattr(command, PLUGIN_DISTRIBUTION_ATTR, None) is None:
+        setattr(command, PLUGIN_DISTRIBUTION_ATTR, dist)
+
+
 def _load_command_plugins(root_group: click.Group):
     """Load and register command plugins."""
     for ep in entry_points(group="flyte.plugins.cli.commands"):
@@ -95,6 +127,11 @@ def _load_command_plugins(root_group: click.Group):
             if not isinstance(command, click.Command):
                 logger.warning(f"Plugin {ep.name} did not return a click.Command, got {type(command).__name__}")
                 continue
+
+            # Stamp before dispatching, so top-level commands and dotted
+            # subcommands are attributed identically. 31 of the 35 CLI entry
+            # points flyteplugins-union declares are dotted.
+            _stamp_distribution(command, ep)
 
             # Check if this is a subcommand (contains dot notation)
             if "." in ep.name:

--- a/tests/cli/test_gen_json.py
+++ b/tests/cli/test_gen_json.py
@@ -1,0 +1,258 @@
+"""The machine-readable half of the CLI doc generator, and the provenance it reports.
+
+`--type json` exists so that whoever renders the CLI reference is given facts
+rather than inferences. The fact that matters most is which distribution
+provided each command, because the rendered page shows Union-only commands to a
+different audience than open-source ones, and getting that wrong publishes a
+command the reader cannot run (DOC-1478: `flyte fork`).
+
+Two properties are easy to lose in a refactor and are pinned here:
+
+  * Provenance is RECORDED, not derived. `_plugins.py` stamps the distribution
+    at registration, where the entry point is in hand. Nothing consults
+    `__module__`, which describes where code was written rather than what
+    shipped it -- and which said nothing at all about a `click.Group` with no
+    callback, which is how `flyte fork` reached the open-source docs.
+  * Provenance is INHERITED. Only 35 plugin commands are entry points;
+    `flyte explore volume` and the three `flyte undelete` subcommands live
+    inside a plugin's own group and carry no stamp. Attributing by entry point
+    alone reports them as core, reintroducing the defect from the other side.
+"""
+
+import os
+
+import click
+import pytest
+
+import flyte.cli._common as common
+from flyte.cli._gen import (
+    _describe,
+    _option_default,
+    _resolve_distribution,
+    walk_commands,
+)
+from flyte.cli._plugins import (
+    PLUGIN_DISTRIBUTION_ATTR,
+    _stamp_distribution,
+    get_command_distribution,
+)
+
+
+class _EP:
+    """Minimal stand-in for an entry point, which carries `.dist.name`."""
+
+    def __init__(self, dist_name):
+        self.dist = type("D", (), {"name": dist_name})() if dist_name else None
+
+
+# --- stamping ----------------------------------------------------------------
+
+
+def test_a_core_command_has_no_distribution():
+    @click.command("run")
+    def run(): ...
+
+    assert get_command_distribution(run) is None
+
+
+def test_registration_records_the_distribution():
+    @click.command("fork")
+    def fork(): ...
+
+    _stamp_distribution(fork, _EP("flyteplugins-union"))
+    assert get_command_distribution(fork) == "flyteplugins-union"
+
+
+def test_a_callbackless_group_is_stamped_like_any_other():
+    """The `flyte fork` shape. It has no callback, so `__module__` was never
+    reached and it was reported as core. Registration does not care."""
+    group = click.Group(name="fork")
+    assert group.callback is None
+    _stamp_distribution(group, _EP("flyteplugins-union"))
+    assert get_command_distribution(group) == "flyteplugins-union"
+
+
+def test_an_entry_point_without_distribution_metadata_is_left_unstamped():
+    """Unattributed beats mislabelled: a missing distribution must not become a
+    guess, or the check downstream inherits a fiction."""
+    cmd = click.Group(name="x")
+    _stamp_distribution(cmd, _EP(None))
+    assert get_command_distribution(cmd) is None
+    assert not hasattr(cmd, PLUGIN_DISTRIBUTION_ATTR)
+
+
+def test_a_second_registration_does_not_reattribute():
+    cmd = click.Group(name="x")
+    _stamp_distribution(cmd, _EP("flyteplugins-union"))
+    _stamp_distribution(cmd, _EP("flyteplugins-other"))
+    assert get_command_distribution(cmd) == "flyteplugins-union"
+
+
+# --- inheritance -------------------------------------------------------------
+
+
+def test_own_stamp_wins():
+    by_path = {"flyte fork": "flyteplugins-union"}
+    assert _resolve_distribution("flyte fork", "flyteplugins-union", by_path) == "flyteplugins-union"
+
+
+def test_a_subcommand_inherits_from_its_plugin_group():
+    """`flyte explore volume` is not an entry point. Its parent is."""
+    by_path = {"flyte explore": "flyteplugins-union", "flyte explore volume": None}
+    assert _resolve_distribution("flyte explore volume", None, by_path) == "flyteplugins-union"
+
+
+def test_inheritance_reaches_past_an_unstamped_ancestor():
+    by_path = {"flyte a": "flyteplugins-union", "flyte a b": None, "flyte a b c": None}
+    assert _resolve_distribution("flyte a b c", None, by_path) == "flyteplugins-union"
+
+
+def test_a_core_subcommand_of_a_core_group_stays_core():
+    by_path = {"flyte get": None, "flyte get run": None}
+    assert _resolve_distribution("flyte get run", None, by_path) is None
+
+
+def test_a_plugin_subcommand_of_a_core_group_keeps_its_own_stamp():
+    """The dotted form: `get.api-key` attaches to the CORE `get` group. The
+    parent must not launder it back to core."""
+    by_path = {"flyte get": None, "flyte get api-key": "flyteplugins-union"}
+    assert _resolve_distribution("flyte get api-key", "flyteplugins-union", by_path) == "flyteplugins-union"
+
+
+# --- what a command looks like as data ---------------------------------------
+
+
+def _ctx(cmd):
+    return click.Context(cmd, info_name=cmd.name)
+
+
+def test_describe_reports_options_arguments_and_provenance():
+    @click.command("api-key")
+    @click.argument("name", required=True)
+    @click.argument("note", required=False)
+    @click.option("-p", "--project", type=str, help="Project to which this applies.")
+    @click.option("--flag/--no-flag", default=False)
+    def cmd(): ...
+
+    out = _describe("flyte create api-key", cmd, _ctx(cmd), "flyteplugins-union")
+
+    assert out["path"] == "flyte create api-key"
+    assert out["name"] == "api-key"
+    assert out["is_group"] is False
+    assert out["distribution"] == "flyteplugins-union"
+    assert out["arguments"] == [
+        {"name": "name", "required": True},
+        {"name": "note", "required": False},
+    ]
+    project = next(o for o in out["options"] if "--project" in o["opts"])
+    assert project["opts"] == ["-p", "--project"]
+    assert project["type"] == "text"
+    assert project["help"] == "Project to which this applies."
+    flag = next(o for o in out["options"] if "--flag" in o["opts"])
+    assert flag["secondary_opts"] == ["--no-flag"]
+
+
+def test_a_group_is_marked_as_one():
+    grp = click.Group(name="get")
+    assert _describe("flyte get", grp, _ctx(grp), None)["is_group"] is True
+
+
+def test_help_is_normalised_but_not_marked_up():
+    """`inspect.cleandoc` undoes click's indentation, which is an artefact of how
+    the docstring was written. Everything past that -- escaping, code fencing --
+    is presentation and belongs to the consumer, not here."""
+
+    @click.command("x")
+    def cmd():
+        """First line.
+
+            indented block
+
+        Mentions {{< shortcode >}} literally.
+        """
+
+    out = _describe("flyte x", cmd, _ctx(cmd), None)
+    assert out["help"].startswith("First line.")
+    assert "    indented block" in out["help"]
+    assert "{{< shortcode >}}" in out["help"]
+    assert "```" not in out["help"]
+
+
+def test_defaults_are_json_safe_and_drop_the_build_directory():
+    @click.command("x")
+    @click.option("--n", type=int, default=3)
+    @click.option("--on", is_flag=True, default=False)
+    @click.option("--path", type=str, default=f"{os.getcwd()}/somewhere")
+    def cmd(): ...
+
+    opts = {o["opts"][0]: o["default"] for o in _describe("flyte x", cmd, _ctx(cmd), None)["options"]}
+    assert opts["--n"] == 3
+    assert opts["--on"] is False
+    assert opts["--path"] == "somewhere"
+
+
+def test_option_default_stringifies_an_arbitrary_object():
+    class Sentinel:
+        def __str__(self):
+            return "UNSET"
+
+    param = click.Option(["--x"], default=Sentinel())
+    assert _option_default(param) == "UNSET"
+
+
+# --- the walker, which stays in this repo and had no tests at all -------------
+
+
+def test_walk_yields_subcommands_of_a_plain_group():
+    grp = click.Group(name="get")
+
+    @grp.command("run")
+    def run(): ...
+
+    paths = [p for p, _, _ in walk_commands(click.Context(grp, info_name="flyte"))]
+    assert paths == ["flyte run"]
+
+
+def test_walk_does_not_descend_into_remotetaskgroup():
+    """Matched by class NAME, with no import. Enumerating it needs a live
+    backend, so descending hangs or fails at doc-generation time. A rename
+    upstream silently re-enables that, which is what this pins."""
+    RemoteTaskGroup = type("RemoteTaskGroup", (click.Group,), {})
+    inner = RemoteTaskGroup(name="task")
+
+    @inner.command("should-not-appear")
+    def hidden(): ...
+
+    outer = click.Group(name="get")
+    outer.add_command(inner, name="task")
+
+    paths = [p for p, _, _ in walk_commands(click.Context(outer, info_name="flyte"))]
+    assert "flyte task" in paths
+    assert "flyte task should-not-appear" not in paths
+
+
+def test_walk_does_not_enumerate_a_filegroups_files(tmp_path):
+    """A FileGroup builds one subcommand per .py file in the working directory.
+    Those are the user's files, not the CLI's surface, so the walk stops."""
+    (tmp_path / "user_script.py").write_text("")
+    fg = common.FileGroup(name="run", directory=tmp_path)
+    outer = click.Group(name="root")
+    outer.add_command(fg, name="run")
+
+    paths = [p for p, _, _ in walk_commands(click.Context(outer, info_name="flyte"))]
+    assert "flyte run" in paths
+    assert not any("user_script" in p for p in paths)
+
+
+@pytest.mark.parametrize("name", ["TaskFiles", "RemoteTaskGroup"])
+def test_the_private_type_names_the_walker_matches_on_still_exist(name):
+    """`walk_commands` matches these by `type(...).__name__`, so a rename breaks
+    doc generation with no import to fail first. If this test fails, the walker
+    needs updating -- that is the point of it failing here rather than silently
+    at the next regen."""
+    import flyte.cli._common as c
+    import flyte.cli._run as r
+
+    assert any(getattr(m, name, None) is not None for m in (c, r)), (
+        f"{name} was not found; walk_commands matches it by class-name string"
+    )


### PR DESCRIPTION
Adds a machine-readable output mode to the CLI doc generator, and stops the generator guessing which plugin provided a command. **The markdown path is untouched** — generated output is byte-identical apart from the line documenting the new option.

This is the flyte-sdk half of moving the Hugo-specific rendering of the CLI reference into the docs repo, where that knowledge belongs. **It is also a question**, see the end.

## The guess that needs to stop

`get_plugin_info` decides provenance from a command's `__module__`:

```python
if not cmd or not cmd.callback:
    return False, None
module = cmd.callback.__module__
```

A `click.Group` that only dispatches to subcommands has no callback, so the module is never consulted. `flyte fork` is exactly that shape, and it shipped into the **open-source** CLI reference — a command requiring a plugin install and a Union backend, documented for readers who have neither (#1463 fixed the symptom).

`__module__` describes where code was *written*. The question is what *shipped* it, and the answer is already in hand at registration time:

```python
for ep in entry_points(group="flyte.plugins.cli.commands"):
    command = ep.load()
    _stamp_distribution(command, ep)   # ep.dist.name
```

So `_plugins.py` records it and `get_command_distribution()` reports it. No inference anywhere.

## Inheritance is not optional

Only **35** plugin commands are entry points. Four more are defined *inside* a plugin's own group and carry no stamp:

```
flyte explore volume · flyte undelete cluster · flyte undelete cluster-pool · flyte undelete queue
```

Attributing by entry point alone reports those as core — the same defect from the other side, and one the `__module__` guess happened to get right. So provenance inherits from the nearest stamped ancestor. A plugin subcommand attached to a *core* group (`flyte get api-key`) keeps its own stamp and is not laundered back to core by its parent.

**Verified against `flyteplugins-union` 0.8.1:** the 39 commands the JSON reports as plugin-provided are exactly the 39 the renderer gates to the union variant. No difference in either direction.

## What the JSON says, and what it deliberately does not

```json
{ "path": "flyte create api-key", "name": "api-key", "is_group": false,
  "distribution": "flyteplugins-union",
  "help": "...", "arguments": [{"name": "name", "required": true}],
  "options": [{"opts": ["-p","--project"], "secondary_opts": [], "type": "text",
               "default": null, "help": "Project to which this applies."}] }
```

It reports what the CLI **is**. It takes no view on who should see what — audience is a decision for the documentation that consumes this, not a property of the CLI. So there is no grouping by variant, only a per-command label; and help text is normalised with `inspect.cleandoc` (undoing click's indentation, an artefact of how the string was written) but otherwise verbatim: no escaping, no code fencing, no markup.

## Tests

`_gen.py`'s walker has never had a test. That is tolerable while it lives here — a rename breaks it in the same PR, in front of the person making the change — and stops being tolerable once anything outside depends on its output. **Both private types it matches by class-name string** (`TaskFiles`, `RemoteTaskGroup`) are now pinned, with a failure message explaining why the walker cares.

20 tests: stamping including the callback-less group that started this; inheritance in both directions; the emitted shape; help left unmarked-up; JSON-safe defaults with the build directory stripped; and the walker declining to descend into `RemoteTaskGroup` or to enumerate a `FileGroup`'s files.

`tests/cli`: **419 passed**. `ruff check`/`format` clean. `check-docstrings`: 492 files clean.

## What we would like to know

This is docs-pipeline plumbing, so it is ours to maintain — but the JSON is a contract between your repo and ours, and that is a request, not a fait accompli:

1. **Are you willing to treat `--type json` as stable-ish?** Not frozen, but not reshaped without a heads-up. If not, we should know before building on it.
2. **Does anything outside our pipeline consume `flyte gen docs --type markdown`?** We found only `Makefile:115`. If it is genuinely internal, a later PR would narrow that mode to plain Markdown and move the Hugo shortcodes out of this repo entirely.
3. **Anything you would rather see in the payload** while it costs nothing to change?

Happy to adjust the shape to whatever is easiest for you to live with.

---
— docsy · automated docs agent · [DOC-1481](https://linear.app/unionai/issue/DOC-1481)