### PR TITLE
docsy: report `declares_options` in `--type json`

### DIFF
--- a/maint_tools/check_cli_json.py
+++ b/maint_tools/check_cli_json.py
@@ -19,7 +19,16 @@ import json
 import sys
 
 MIN_COMMANDS = 20
-REQUIRED_KEYS = {"path", "name", "is_group", "distribution", "help", "arguments", "options"}
+REQUIRED_KEYS = {
+    "path",
+    "name",
+    "is_group",
+    "distribution",
+    "declares_options",
+    "help",
+    "arguments",
+    "options",
+}
 
 
 def main() -> None:

--- a/src/flyte/cli/_gen.py
+++ b/src/flyte/cli/_gen.py
@@ -480,6 +480,10 @@ def _describe(cmd_path: str, cmd: click.Command, cmd_ctx: click.Context, distrib
     with `inspect.cleandoc` (undoing click's indentation, which is an artefact of
     how the string was written) but is otherwise verbatim: no escaping, no code
     fencing, no markup. A consumer that needs those applies its own.
+
+    `options` includes the `--help` that click adds to every command, because a
+    renderer that shows an option table needs to show it. `declares_options`
+    reports separately whether the command declared any option of its own.
     """
     params = cmd.get_params(cmd_ctx)
     return {
@@ -487,6 +491,12 @@ def _describe(cmd_path: str, cmd: click.Command, cmd_ctx: click.Context, distrib
         "name": cmd_path.rsplit(" ", 1)[-1],
         "is_group": isinstance(cmd, click.Group),
         "distribution": distribution,
+        # click adds `--help` to every command, so `options` being non-empty says
+        # nothing about whether this command has any of its own. A renderer needs
+        # that to decide whether to advertise `[OPTIONS]` in the usage line and
+        # whether an option table carries information, and it cannot recover it
+        # from `options` without assuming `--help` is the only thing click adds.
+        "declares_options": any(isinstance(p, click.Option) for p in cmd.params),
         "help": inspect.cleandoc(cmd.help) if cmd.help else None,
         "arguments": [
             {"name": p.name, "required": p.required} for p in params if isinstance(p, click.Argument) and p.name

--- a/tests/cli/test_gen_json.py
+++ b/tests/cli/test_gen_json.py
@@ -152,6 +152,38 @@ def test_describe_reports_options_arguments_and_provenance():
     assert flag["secondary_opts"] == ["--no-flag"]
 
 
+def test_declares_options_separates_a_command_own_options_from_click_help():
+    """click adds `--help` everywhere, so `options` being non-empty says nothing.
+
+    A renderer needs this to decide whether to advertise `[OPTIONS]` in the usage
+    line and whether an option table carries information. Reconstructing it by
+    assuming `--help` is the only thing click ever adds is the kind of guess this
+    output exists to remove.
+    """
+
+    @click.command("bare")
+    def bare(): ...
+
+    @click.command("has-one")
+    @click.option("--x")
+    def has_one(): ...
+
+    @click.command("only-an-argument")
+    @click.argument("name")
+    def only_arg(): ...
+
+    bare_out = _describe("flyte bare", bare, _ctx(bare), None)
+    assert bare_out["declares_options"] is False
+    assert [o["opts"] for o in bare_out["options"]] == [["--help"]]
+
+    assert _describe("flyte has-one", has_one, _ctx(has_one), None)["declares_options"] is True
+
+    # Declares a parameter, but not an option: the two questions differ.
+    arg_out = _describe("flyte only-an-argument", only_arg, _ctx(only_arg), None)
+    assert arg_out["declares_options"] is False
+    assert arg_out["arguments"] == [{"name": "name", "required": True}]
+
+
 def test_a_group_is_marked_as_one():
     grp = click.Group(name="get")
     assert _describe("flyte get", grp, _ctx(grp), None)["is_group"] is True


### PR DESCRIPTION
A one-field addition to the JSON output added in #1470, found while building the renderer that consumes it.

## The gap

click adds `--help` to **every** command, so `options` being non-empty says nothing about whether a command declared any options of its own. The renderer needs exactly that, in two places:

- whether the usage line advertises `[OPTIONS]`
- whether an option table carries information, or is just the help flag alone

Today 18 of the 94 commands in the tree are in that state — `flyte abort`, `flyte create`, `flyte get config` and so on — and the JSON reports them identically to a command that genuinely has one option.

## Why not reconstruct it

It is reconstructible: treat a lone `--help` as "declared nothing". That is what the port does today, and it is a guess — it assumes `--help` is the only thing click ever adds, made in a consumer that has no way to notice when that stops being true. Removing exactly this kind of guess is why `--type json` exists.

## Note the two questions differ

A command declaring only an **argument** has no options of its own but does have a parameter. `arguments` already reports that, so `declares_options` is genuinely about options and not a stand-in for "declares anything". There is a test for it.

## Timing

**This is why it is worth landing now rather than later.** `--type json` is merged but has not shipped in a release, so nothing consumes it and the shape is still free to change. Once it is in a published version this becomes a breaking change to a contract you have just agreed to hold stable.

421 tests, `make cli-docs-gen` green (the smoke check now requires the key), ruff and format clean.

---
— docsy · automated docs agent · [DOC-1481](https://linear.app/unionai/issue/DOC-1481)