### PR TITLE
fix: auto-size multipart parts for File uploads (from_local_sync + hashed from_local)

### DIFF
--- a/examples/basics/file_hash_upload.py
+++ b/examples/basics/file_hash_upload.py
@@ -17,9 +17,27 @@ import tempfile
 
 import flyte
 from flyte.io import File
-from flyte.io._hashing_io import HashlibAccumulator, PrecomputedValue
 
 env = flyte.TaskEnvironment("file_hash_upload")
+
+
+class Sha256Accumulator:
+    """
+    A streaming `HashMethod`: the uploader calls `update()` with each chunk as it is sent, so the
+    hash is computed without a second pass over the file. Any object with update/result/reset works.
+    """
+
+    def __init__(self) -> None:
+        self._h = hashlib.sha256()
+
+    def update(self, data: memoryview, /) -> None:
+        self._h.update(data)
+
+    def result(self) -> str:
+        return self._h.hexdigest()
+
+    def reset(self) -> None:
+        self._h = hashlib.sha256()
 
 
 def _write_local(size_bytes: int) -> tuple[str, str]:
@@ -53,7 +71,7 @@ def upload_sync_with_hash(size_mib: int) -> tuple[File, str]:
     """Sync upload with a streaming sha256: from_local_sync -> syncify(_upload_hashed) -> put_stream(size_hint)."""
     path, expected = _write_local(size_mib << 20)
     try:
-        f = File.from_local_sync(path, hash_method=HashlibAccumulator.from_hash_name("sha256"))
+        f = File.from_local_sync(path, hash_method=Sha256Accumulator())
         print(f"[sync/hash] {path} -> {f.path}\n  streamed={f.hash}\n  expected={expected}")
         assert f.hash == expected, "streamed hash must match independently computed sha256"
         return f, expected
@@ -63,10 +81,10 @@ def upload_sync_with_hash(size_mib: int) -> tuple[File, str]:
 
 @env.task
 def upload_sync_precomputed(size_mib: int) -> File:
-    """Sync upload with a precomputed hash: skips hashing, still goes through storage.put."""
+    """Sync upload with a precomputed hash (plain str): skips hashing, still goes through storage.put."""
     path, expected = _write_local(size_mib << 20)
     try:
-        f = File.from_local_sync(path, hash_method=PrecomputedValue(expected))
+        f = File.from_local_sync(path, hash_method=expected)
         print(f"[sync/precomputed] {path} -> {f.path} (hash={f.hash})")
         assert f.hash == expected
         return f
@@ -79,7 +97,7 @@ async def upload_async_with_hash(size_mib: int) -> tuple[File, str]:
     """Async upload with a streaming sha256: from_local -> _upload_hashed -> put_stream(size_hint)."""
     path, expected = _write_local(size_mib << 20)
     try:
-        f = await File.from_local(path, hash_method=HashlibAccumulator.from_hash_name("sha256"))
+        f = await File.from_local(path, hash_method=Sha256Accumulator())
         print(f"[async/hash] {path} -> {f.path}\n  streamed={f.hash}\n  expected={expected}")
         assert f.hash == expected, "streamed hash must match independently computed sha256"
         return f, expected

--- a/examples/basics/file_hash_upload.py
+++ b/examples/basics/file_hash_upload.py
@@ -1,0 +1,132 @@
+"""
+Upload files with a content hash computed while streaming, from both sync and async tasks.
+
+Covers the `File.from_local_sync` / `File.from_local` upload paths that route through the
+obstore-aware storage layer (auto-sized multipart parts), with and without a `HashMethod`.
+
+Run with:
+
+```
+flyte run examples/basics/file_hash_upload.py main
+```
+"""
+
+import hashlib
+import os
+import tempfile
+
+import flyte
+from flyte.io import File
+from flyte.io._hashing_io import HashlibAccumulator, PrecomputedValue
+
+env = flyte.TaskEnvironment("file_hash_upload")
+
+
+def _write_local(size_bytes: int) -> tuple[str, str]:
+    """Write `size_bytes` of pseudo-random data to a temp file; return (path, sha256)."""
+    h = hashlib.sha256()
+    with tempfile.NamedTemporaryFile(mode="wb", delete=False, suffix=".bin") as tmp:
+        remaining = size_bytes
+        while remaining > 0:
+            chunk = os.urandom(min(1 << 20, remaining))
+            tmp.write(chunk)
+            h.update(chunk)
+            remaining -= len(chunk)
+        return tmp.name, h.hexdigest()
+
+
+@env.task
+def upload_sync_no_hash(size_mib: int) -> File:
+    """Sync upload, no hash: from_local_sync -> syncify(storage.put)."""
+    path, _ = _write_local(size_mib << 20)
+    try:
+        f = File.from_local_sync(path)
+        print(f"[sync/no-hash] {path} -> {f.path} (hash={f.hash})")
+        assert f.hash is None
+        return f
+    finally:
+        os.unlink(path)
+
+
+@env.task
+def upload_sync_with_hash(size_mib: int) -> tuple[File, str]:
+    """Sync upload with a streaming sha256: from_local_sync -> syncify(_upload_hashed) -> put_stream(size_hint)."""
+    path, expected = _write_local(size_mib << 20)
+    try:
+        f = File.from_local_sync(path, hash_method=HashlibAccumulator.from_hash_name("sha256"))
+        print(f"[sync/hash] {path} -> {f.path}\n  streamed={f.hash}\n  expected={expected}")
+        assert f.hash == expected, "streamed hash must match independently computed sha256"
+        return f, expected
+    finally:
+        os.unlink(path)
+
+
+@env.task
+def upload_sync_precomputed(size_mib: int) -> File:
+    """Sync upload with a precomputed hash: skips hashing, still goes through storage.put."""
+    path, expected = _write_local(size_mib << 20)
+    try:
+        f = File.from_local_sync(path, hash_method=PrecomputedValue(expected))
+        print(f"[sync/precomputed] {path} -> {f.path} (hash={f.hash})")
+        assert f.hash == expected
+        return f
+    finally:
+        os.unlink(path)
+
+
+@env.task
+async def upload_async_with_hash(size_mib: int) -> tuple[File, str]:
+    """Async upload with a streaming sha256: from_local -> _upload_hashed -> put_stream(size_hint)."""
+    path, expected = _write_local(size_mib << 20)
+    try:
+        f = await File.from_local(path, hash_method=HashlibAccumulator.from_hash_name("sha256"))
+        print(f"[async/hash] {path} -> {f.path}\n  streamed={f.hash}\n  expected={expected}")
+        assert f.hash == expected, "streamed hash must match independently computed sha256"
+        return f, expected
+    finally:
+        os.unlink(path)
+
+
+@env.task
+def verify_remote(f: File, expected_sha256: str, expected_size: int) -> bool:
+    """Download the uploaded object (download_sync) and confirm size + sha256 survived the round trip."""
+    local = f.download_sync()
+    h = hashlib.sha256()
+    size = 0
+    with open(local, "rb") as fh:
+        while chunk := fh.read(1 << 20):
+            h.update(chunk)
+            size += len(chunk)
+    ok = h.hexdigest() == expected_sha256 and size == expected_size
+    print(f"[verify] {f.path}: size={size} sha256={h.hexdigest()} ok={ok}")
+    assert ok, f"round-trip mismatch for {f.path}"
+    return ok
+
+
+@env.task
+async def main(size_mib: int = 64) -> list[bool]:
+    """Exercise every File upload path and verify each object end to end."""
+    expected_size = size_mib << 20
+
+    # Sync tasks called from an async task must go through `.aio` (see #1472).
+    f1 = await upload_sync_no_hash.aio(size_mib)
+    f2, h2 = await upload_sync_with_hash.aio(size_mib)
+    f3 = await upload_sync_precomputed.aio(size_mib)
+    f4, h4 = await upload_async_with_hash(size_mib)
+
+    results = [
+        await verify_remote.aio(f2, h2, expected_size),
+        await verify_remote.aio(f3, f3.hash or "", expected_size),
+        await verify_remote.aio(f4, h4, expected_size),
+    ]
+    # f1 has no hash; just confirm it exists remotely with the right size.
+    local = await f1.download()
+    results.append(os.path.getsize(local) == expected_size)
+    print(f"all ok: {all(results)}")
+    return results
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    r = flyte.run(main)
+    print(r.url)

--- a/src/flyte/io/_file.py
+++ b/src/flyte/io/_file.py
@@ -36,6 +36,7 @@ from flyte._context import internal_ctx
 from flyte._initialize import requires_initialization
 from flyte._logging import logger
 from flyte.io._hashing_io import AsyncHashingReader, HashingWriter, HashMethod, PrecomputedValue
+from flyte.syncify import syncify
 from flyte.types import TypeEngine, TypeTransformer, TypeTransformerFailedError
 
 if typing.TYPE_CHECKING:
@@ -45,6 +46,21 @@ if typing.TYPE_CHECKING:
     from obstore import AsyncReadableFile, AsyncWritableFile
 
 _COPY_BUFSIZE = 8 * 1024 * 1024  # 8 MiB chunks for large-file transfers
+
+
+async def _upload_hashed(local_path: Union[str, Path], remote_path: str, hash_method: HashMethod) -> tuple[str, str]:
+    """
+    Stream a local file to remote storage, feeding every chunk through `hash_method` on the way out.
+
+    Shared by `File.from_local` and `File.from_local_sync` (via syncify) so both take the obstore-aware
+    `storage.put_stream` path. The file size is passed as `size_hint` so multipart parts are auto-sized
+    for very large files instead of being pinned to the writer's fixed buffer.
+    """
+    async with aiofiles.open(local_path, "rb") as src:
+        src_wrapper = AsyncHashingReader(src, accumulator=hash_method)
+        path = await storage.put_stream(src_wrapper, to_path=remote_path, size_hint=os.path.getsize(local_path))
+        return path, src_wrapper.result()
+
 
 # Type variable for the file format. Defaults to Any (PEP 696) so that calls that
 # cannot bind the format — e.g. `File(path=...)` or `File.new_remote()` — type-check
@@ -883,21 +899,17 @@ class File(BaseModel, Generic[T], SerializableType):
                     shutil.copy2(local_path, remote_path)
                 path = str(Path(remote_path).absolute())
         else:
-            fs = storage.get_underlying_filesystem(path=remote_path)
-
+            # Route through the obstore-aware storage layer (via syncify) rather than raw fs.open(..., "wb").
+            # fsspec's obstore writer uploads fixed 10 MiB multipart parts, which caps a single file at
+            # ~97.6 GiB (10,000-part S3 limit). storage.put / put_stream(size_hint=...) auto-size the part
+            # to the file, so any size uploads correctly. Mirrors the async from_local() below and
+            # Dir.from_local_sync().
             if hash_method_obj and not isinstance(hash_method_obj, PrecomputedValue):
-                with open(local_path, "rb") as src:
-                    with fs.open(remote_path, "wb") as dst:
-                        dst_wrapper = HashingWriter(dst, accumulator=hash_method_obj)
-                        shutil.copyfileobj(src, dst_wrapper, length=_COPY_BUFSIZE)
-                        hash_value = dst_wrapper.result()
+                path, hash_value = syncify(_upload_hashed)(local_path, remote_path, hash_method_obj)
             else:
-                with open(local_path, "rb") as src:
-                    with fs.open(remote_path, "wb") as dst:
-                        shutil.copyfileobj(src, dst, length=_COPY_BUFSIZE)
+                path = syncify(storage.put)(str(local_path), remote_path)
                 if hash_method_obj:
                     hash_value = hash_method_obj.result()
-            path = remote_path
 
         f = cls(path=path, name=filename, hash_method=hash_method_obj, hash=hash_value)
         return f
@@ -996,18 +1008,13 @@ class File(BaseModel, Generic[T], SerializableType):
                 path = str(Path(remote_path).absolute())
         else:
             # Otherwise upload to remote using async storage layer
-            if hash_method:
-                # We can skip the wrapper if the hash method is just a precomputed value
-                if not isinstance(hash_method, PrecomputedValue):
-                    async with aiofiles.open(local_path, "rb") as src:
-                        src_wrapper = AsyncHashingReader(src, accumulator=hash_method)
-                        path = await storage.put_stream(src_wrapper, to_path=remote_path)
-                        hash_value = src_wrapper.result()
-                else:
-                    path = await storage.put(str(local_path), remote_path)
-                    hash_value = hash_method.result()
+            if hash_method and not isinstance(hash_method, PrecomputedValue):
+                path, hash_value = await _upload_hashed(local_path, remote_path, hash_method)
             else:
+                # We can skip the hashing wrapper if the hash method is just a precomputed value
                 path = await storage.put(str(local_path), remote_path)
+                if hash_method:
+                    hash_value = hash_method.result()
 
         f = cls(path=path, name=filename, hash_method=hash_method, hash=hash_value)
         return f

--- a/src/flyte/storage/_storage.py
+++ b/src/flyte/storage/_storage.py
@@ -39,6 +39,7 @@ BATCH_SIZE = int(os.getenv("FLYTE_IO_BATCH_SIZE", str(32)))
 _UPLOAD_CHUNK_FLOOR = 5 * 2**20  # 5 MiB -- obstore's own default; floor for small/multipart files
 _UPLOAD_MAX_CONCURRENCY = 12  # obstore's own default
 _MAX_SAFE_PARTS = 9000  # margin below the cloud 10,000-part hard limit
+_STREAM_WRITE_BUFFER_SIZE = 10 * 2**20  # obstore open_writer default; each multipart part is this size
 
 
 def _compute_upload_chunk_size(file_size: int | None) -> int:
@@ -397,7 +398,7 @@ async def _open_obstore_bypass(path: str, mode: str = "rb", **kwargs) -> AsyncRe
 
     if "w" in mode:
         attributes = kwargs.pop("attributes", {})
-        buffer_size = 10 * 2**20
+        buffer_size = _STREAM_WRITE_BUFFER_SIZE
         if "buffer_size" in kwargs:
             buffer_size = kwargs.pop("buffer_size")
         if "chunk_size" in kwargs:
@@ -432,7 +433,12 @@ async def open(path: str, mode: str = "rb", **kwargs) -> AsyncReadableFile | Asy
 
 
 async def put_stream(
-    data_iterable: typing.AsyncIterable[bytes] | bytes, *, name: str | None = None, to_path: str | None = None, **kwargs
+    data_iterable: typing.AsyncIterable[bytes] | bytes,
+    *,
+    name: str | None = None,
+    to_path: str | None = None,
+    size_hint: int | None = None,
+    **kwargs,
 ) -> str:
     """
     Put a stream of data to a remote location. This is useful for streaming data to a remote location.
@@ -448,6 +454,10 @@ async def put_stream(
         data_iterable: Iterable of bytes to be streamed.
         name: Name of the file to be created. If not provided, a random name will be generated.
         to_path: Path to the remote location where the data will be stored.
+        size_hint: Total number of bytes the stream is expected to yield, if known. On obstore-backed
+            filesystems the writer uploads one multipart part per buffer, so a fixed buffer caps a single
+            object at ~97.6 GiB (10,000 x 10 MiB). When the hint says the stream is larger than that, the
+            part size is scaled up to stay under the limit; smaller streams are unaffected.
         kwargs: Additional arguments to be passed to the underlying filesystem.
 
     Returns:
@@ -462,7 +472,12 @@ async def put_stream(
     # Check if we should use obstore bypass
     fs = get_underlying_filesystem(path=to_path)
     try:
-        file_handle = typing.cast("AsyncWritableFile", await open(to_path, "wb", **kwargs))
+        open_kwargs = dict(kwargs)
+        if size_hint and "chunk_size" not in open_kwargs and "buffer_size" not in open_kwargs:
+            chunk_size = _compute_upload_chunk_size(size_hint)
+            if chunk_size > _STREAM_WRITE_BUFFER_SIZE:
+                open_kwargs["chunk_size"] = chunk_size
+        file_handle = typing.cast("AsyncWritableFile", await open(to_path, "wb", **open_kwargs))
         if isinstance(data_iterable, bytes):
             await file_handle.write(data_iterable)
         else:

--- a/tests/flyte/io_types/test_files.py
+++ b/tests/flyte/io_types/test_files.py
@@ -4,7 +4,7 @@ import filecmp
 import os
 import tempfile
 from typing import Optional
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -654,79 +654,87 @@ def test_from_local_sync_with_hash_local_files():
 
 
 def test_from_local_sync_remote_no_hash(tmp_path):
-    """from_local_sync should use chunked copyfileobj when uploading to remote without hash."""
+    """from_local_sync should upload through the obstore-aware storage.put (auto-sized multipart parts)."""
     flyte.init()
 
     local_file = tmp_path / "source.bin"
     local_file.write_bytes(b"test data")
 
-    written_data = bytearray()
-    mock_dst = MagicMock()
-    mock_dst.write.side_effect = written_data.extend
-
-    mock_fs = MagicMock()
-    mock_fs.protocol = ("s3",)
-    mock_fs.open.return_value.__enter__ = MagicMock(return_value=mock_dst)
-    mock_fs.open.return_value.__exit__ = MagicMock(return_value=False)
-
-    with patch("flyte.storage.get_underlying_filesystem", return_value=mock_fs):
-        with patch("fsspec.utils.get_protocol", return_value="s3"):
-            result = File.from_local_sync(str(local_file), "s3://bucket/dest.bin")
+    mock_put = AsyncMock(return_value="s3://bucket/dest.bin")
+    with patch("flyte.storage.put", mock_put):
+        result = File.from_local_sync(str(local_file), "s3://bucket/dest.bin")
 
     assert result.path == "s3://bucket/dest.bin"
     assert result.hash is None
-    assert bytes(written_data) == b"test data"
+    mock_put.assert_awaited_once_with(str(local_file), "s3://bucket/dest.bin")
+
+
+def _capturing_put_stream(written: bytearray, captured: dict):
+    """Fake storage.put_stream that drains the async iterable (so hashing runs) and records kwargs."""
+
+    async def _put_stream(data_iterable, *, to_path, **kwargs):
+        async for chunk in data_iterable:
+            written.extend(chunk)
+        captured.update(kwargs)
+        return to_path
+
+    return _put_stream
 
 
 def test_from_local_sync_remote_with_hash(tmp_path):
-    """from_local_sync should compute hash via chunked HashingWriter when uploading to remote."""
+    """from_local_sync should stream through storage.put_stream with a size_hint while hashing."""
     flyte.init()
 
     local_file = tmp_path / "source.txt"
     local_file.write_text(TEST_CONTENT)
 
     written_data = bytearray()
-    mock_dst = MagicMock()
-    mock_dst.write.side_effect = written_data.extend
-
-    mock_fs = MagicMock()
-    mock_fs.protocol = ("s3",)
-    mock_fs.open.return_value.__enter__ = MagicMock(return_value=mock_dst)
-    mock_fs.open.return_value.__exit__ = MagicMock(return_value=False)
-
+    captured: dict = {}
     acc = HashlibAccumulator.from_hash_name("sha256")
 
-    with patch("flyte.storage.get_underlying_filesystem", return_value=mock_fs):
-        with patch("fsspec.utils.get_protocol", return_value="s3"):
-            result = File.from_local_sync(str(local_file), "s3://bucket/dest.txt", hash_method=acc)
+    with patch("flyte.storage.put_stream", _capturing_put_stream(written_data, captured)):
+        result = File.from_local_sync(str(local_file), "s3://bucket/dest.txt", hash_method=acc)
 
     assert result.path == "s3://bucket/dest.txt"
     assert result.hash == TEST_SHA256
     assert bytes(written_data).decode("utf-8") == TEST_CONTENT
+    assert captured["size_hint"] == local_file.stat().st_size
 
 
 def test_from_local_sync_remote_with_precomputed_hash(tmp_path):
-    """from_local_sync with PrecomputedValue should skip hash computation and use the given value."""
+    """from_local_sync with PrecomputedValue should skip hash computation and use storage.put."""
     flyte.init()
 
     local_file = tmp_path / "source.bin"
     local_file.write_bytes(b"some data")
 
-    written_data = bytearray()
-    mock_dst = MagicMock()
-    mock_dst.write.side_effect = written_data.extend
-
-    mock_fs = MagicMock()
-    mock_fs.protocol = ("s3",)
-    mock_fs.open.return_value.__enter__ = MagicMock(return_value=mock_dst)
-    mock_fs.open.return_value.__exit__ = MagicMock(return_value=False)
-
     precomputed = PrecomputedValue("my-precomputed-hash")
 
-    with patch("flyte.storage.get_underlying_filesystem", return_value=mock_fs):
-        with patch("fsspec.utils.get_protocol", return_value="s3"):
-            result = File.from_local_sync(str(local_file), "s3://bucket/dest.bin", hash_method=precomputed)
+    mock_put = AsyncMock(return_value="s3://bucket/dest.bin")
+    with patch("flyte.storage.put", mock_put):
+        result = File.from_local_sync(str(local_file), "s3://bucket/dest.bin", hash_method=precomputed)
 
     assert result.path == "s3://bucket/dest.bin"
     assert result.hash == "my-precomputed-hash"
-    assert bytes(written_data) == b"some data"
+    mock_put.assert_awaited_once_with(str(local_file), "s3://bucket/dest.bin")
+
+
+@pytest.mark.asyncio
+async def test_from_local_remote_with_hash_passes_size_hint(tmp_path):
+    """Async from_local with a HashMethod should stream via put_stream with the file size as size_hint."""
+    flyte.init()
+
+    local_file = tmp_path / "source.txt"
+    local_file.write_text(TEST_CONTENT)
+
+    written_data = bytearray()
+    captured: dict = {}
+    acc = HashlibAccumulator.from_hash_name("sha256")
+
+    with patch("flyte.storage.put_stream", _capturing_put_stream(written_data, captured)):
+        result = await File.from_local(str(local_file), "s3://bucket/dest.txt", hash_method=acc)
+
+    assert result.path == "s3://bucket/dest.txt"
+    assert result.hash == TEST_SHA256
+    assert bytes(written_data).decode("utf-8") == TEST_CONTENT
+    assert captured["size_hint"] == local_file.stat().st_size

--- a/tests/internal/storage/test_storage.py
+++ b/tests/internal/storage/test_storage.py
@@ -10,6 +10,7 @@ import flyte
 import flyte.storage as storage
 from flyte.storage._storage import (
     _MAX_SAFE_PARTS,
+    _STREAM_WRITE_BUFFER_SIZE,
     _UPLOAD_CHUNK_FLOOR,
     _UPLOAD_MAX_CONCURRENCY,
     _compute_upload_chunk_size,
@@ -250,6 +251,51 @@ async def test_put_routes_through_obstore_bypass(monkeypatch):
     assert captured[0]["remote_key"] == "path/to/obj"
     assert captured[0]["chunk_size"] == _UPLOAD_CHUNK_FLOOR
     assert captured[0]["max_concurrency"] == _UPLOAD_MAX_CONCURRENCY
+
+
+class _FakeWritableFile:
+    def __init__(self, sink):
+        self._sink = sink
+
+    async def write(self, data):
+        self._sink.extend(data)
+
+    async def close(self):
+        pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "size_hint,expect_chunk_size",
+    [
+        (None, False),  # unknown size: leave the writer's default buffer alone
+        (50 * 2**20, False),  # small stream: computed part <= default buffer, no override
+        (200 * 2**30, True),  # 200 GiB: 10 MiB parts would exceed the 10,000-part limit
+    ],
+)
+async def test_put_stream_size_hint_scales_chunk_size(monkeypatch, size_hint, expect_chunk_size):
+    from flyte.storage import _storage
+
+    sink = bytearray()
+    captured = {}
+
+    async def fake_open(path, mode="rb", **kwargs):
+        captured.update(kwargs)
+        return _FakeWritableFile(sink)
+
+    monkeypatch.setattr(_storage, "get_underlying_filesystem", lambda path: object())
+    monkeypatch.setattr(_storage, "open", fake_open)
+
+    result = await storage.put_stream(b"hello", to_path="gs://bucket/obj", size_hint=size_hint)
+
+    assert result == "gs://bucket/obj"
+    assert bytes(sink) == b"hello"
+    if expect_chunk_size:
+        cs = captured["chunk_size"]
+        assert cs > _STREAM_WRITE_BUFFER_SIZE
+        assert math.ceil(size_hint / cs) <= _MAX_SAFE_PARTS
+    else:
+        assert "chunk_size" not in captured
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up to #1462, which fixed `Dir.from_local_sync`. `File` had the same class of bug in two places.

### Summary
On obstore-backed filesystems (s3/gs/abfs), fsspec's `BufferedFile("wb")` and our `_open_obstore_bypass` both write with a fixed 10 MiB buffer, and obstore uploads one multipart part per buffer. That caps a single object at ~97.6 GiB (10,000 parts × 10 MiB) — 2× the `Dir` threshold from #1462, but the same failure (`InvalidRange` / part-limit rejection at `CompleteMultipartUpload`). The 160 GiB file in #1462 would also fail through `File.from_local_sync`.

Two paths were affected:
1. **`File.from_local_sync`** (non-hash and precomputed-hash branches) uploaded via raw `fs.open(remote_path, "wb")` + `shutil.copyfileobj` — never touched the obstore-aware `storage.put` that auto-sizes parts.
2. **`File.from_local` / `from_local_sync` with a `HashMethod`** streamed through `storage.put_stream`, which had no way to know the total size and so kept the fixed 10 MiB part. This one affected the **async** path too.

### Changes
- `File.from_local_sync`: route through `syncify(storage.put)`, mirroring `Dir.from_local_sync` (#1462) and `Dir.download_sync`.
- `storage.put_stream(..., size_hint=)`: new optional kwarg. If the hinted size would blow past `_MAX_SAFE_PARTS` at the default buffer, `chunk_size` is scaled up via the existing `_compute_upload_chunk_size`. Streams below ~88 GiB are byte-for-byte unchanged (no override is passed). Explicit `chunk_size=`/`buffer_size=` kwargs still win.
- New module-level `_upload_hashed()` helper in `_file.py`, shared by `from_local` and `from_local_sync` (via `syncify`), passing `os.path.getsize(local_path)` as `size_hint`. This also collapses the two duplicated hashed-upload implementations into one.
- Factored the `10 * 2**20` literal into `_STREAM_WRITE_BUFFER_SIZE`.

### Not changed (on purpose)
- **`DataFrame`**: encoders write via `df.to_parquet(storage_options=…)` / `pq.write_table(filesystem=…)`, i.e. pandas/pyarrow drive an fsspec file-like with no size known up front, so there's no clean place to plumb a hint. A single >97 GiB parquet file written from one in-memory frame isn't a realistic path today, so leaving it.
- **`File.download_sync`**: still raw `fs.get`. Not a correctness issue (downloads have no part cap); it just skips the parallel reader. Can follow up separately if wanted.
- `File.open_sync("wb")`: stream API with no size knowledge; callers can pass `buffer_size=`.

### Tests
- Rewrote the three `from_local_sync` remote tests (they mocked `fs.open`) to assert `storage.put` / `storage.put_stream(size_hint=…)` are used and the hash is still computed from the streamed bytes.
- Added an async `from_local` hashed test asserting `size_hint` is passed.
- Added a parametrized `put_stream` test: no hint / small hint → no `chunk_size` override; 200 GiB hint → `chunk_size` > default and `ceil(size / chunk_size) <= _MAX_SAFE_PARTS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)