### PR TITLE
Use flytectl config scopes in client credentials if configured

### DIFF
--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -100,6 +100,10 @@ def _platform_to_client_kwargs(pc: "PlatformConfig") -> dict[str, typing.Any]:
         kw["client_id"] = pc.client_id
     if pc.client_credentials_secret:
         kw["client_credentials_secret"] = pc.client_credentials_secret
+    # An empty list means "not configured" and must continue to fall back to
+    # the scopes advertised by AuthMetadataService.
+    if pc.scopes:
+        kw["scopes"] = pc.scopes
     if pc.auth_mode:
         kw["auth_type"] = pc.auth_mode
     if pc.command:
@@ -132,6 +136,7 @@ async def _initialize_client(
     proxy_command: List[str] | None = None,
     client_id: str | None = None,
     client_credentials_secret: str | None = None,
+    scopes: List[str] | None = None,
     rpc_retries: int = 3,
     http_proxy_url: str | None = None,
     disable_keyring: bool = False,
@@ -155,6 +160,7 @@ async def _initialize_client(
             proxy_command=proxy_command,
             client_id=client_id,
             client_credentials_secret=client_credentials_secret,
+            scopes=scopes,
             client_config=client_config,
             rpc_retries=rpc_retries,
             http_proxy_url=http_proxy_url,
@@ -172,6 +178,7 @@ async def _initialize_client(
             proxy_command=proxy_command,
             client_id=client_id,
             client_credentials_secret=client_credentials_secret,
+            scopes=scopes,
             client_config=client_config,
             rpc_retries=rpc_retries,
             http_proxy_url=http_proxy_url,
@@ -237,6 +244,7 @@ async def init(
     local_persistence: bool = False,
     local_tracked: bool = False,
     local_tracked_strict: bool = False,
+    scopes: List[str] | None = None,
 ) -> None:
     """
     Initialize the Flyte system with the given configuration. This method should be called before any other Flyte
@@ -266,6 +274,7 @@ async def init(
         client_credentials_secret: Used for service auth, which is automatically called during pyflyte. This will
             allow the Flyte engine to read the password directly from the environment variable. Note that this is
             less secure! Please only use this if mounting the secret as a file is impossible
+        scopes: OAuth scopes to request. When omitted, scopes are discovered from the auth metadata service.
         ca_cert_file_path: [optional] str Root Cert to be loaded and used to verify admin
         http_proxy_url: [optional] HTTP Proxy to be used for OAuth requests
         rpc_retries: [optional] int Number of times to retry the platform calls
@@ -325,6 +334,7 @@ async def init(
                 proxy_command=proxy_command,
                 client_id=client_id,
                 client_credentials_secret=client_credentials_secret,
+                scopes=scopes,
                 client_config=auth_client_config,
                 rpc_retries=rpc_retries,
                 http_proxy_url=http_proxy_url,

--- a/src/flyte/_internal/controllers/remote/__init__.py
+++ b/src/flyte/_internal/controllers/remote/__init__.py
@@ -21,6 +21,7 @@ def create_remote_controller(
     proxy_command: List[str] | None = None,
     client_id: str | None = None,
     client_credentials_secret: str | None = None,
+    scopes: List[str] | None = None,
     rpc_retries: int = 3,
     http_proxy_url: str | None = None,
 ) -> RemoteController:
@@ -39,6 +40,7 @@ def create_remote_controller(
             ca_cert_file_path=ca_cert_file_path,
             client_id=client_id,
             client_credentials_secret=client_credentials_secret,
+            scopes=scopes,
             auth_type=auth_type,
         )
     elif api_key:
@@ -49,6 +51,7 @@ def create_remote_controller(
             ca_cert_file_path=ca_cert_file_path,
             client_id=client_id,
             client_credentials_secret=client_credentials_secret,
+            scopes=scopes,
             auth_type=auth_type,
         )
 

--- a/src/flyte/remote/_client/auth/_authenticators/base.py
+++ b/src/flyte/remote/_client/auth/_authenticators/base.py
@@ -35,6 +35,7 @@ class Authenticator(object):
         ca_cert_path: typing.Optional[str] = None,
         default_header_key: str = "authorization",
         disable_keyring: bool = False,
+        scopes: typing.Optional[typing.List[str]] = None,
         **kwargs,
     ):
         """
@@ -49,6 +50,8 @@ class Authenticator(object):
             http_proxy_url: Optional HTTP proxy URL
             verify: Whether to verify SSL certificates
             ca_cert_path: Optional path to CA certificate file
+            scopes: Locally configured OAuth scopes. When omitted or empty,
+                scopes are taken from the client configuration store.
             kwargs: Additional keyword arguments passed to get_async_session, which may include:
                 - auth: Authentication implementation to use
                 - params: Query parameters to include in request URLs
@@ -75,6 +78,7 @@ class Authenticator(object):
         self._verify = verify
         self._ca_cert_path = ca_cert_path
         self._client_config = client_config
+        self._scopes = scopes
         self._cfg_store = cfg_store
         # Will be populated by _ensure_remote_config
         self._resolved_config: ClientConfig | None = None
@@ -109,6 +113,11 @@ class Authenticator(object):
         self._resolved_config = (
             remote_config.with_override(self._client_config) if self._client_config else remote_config
         )
+        # Scopes explicitly supplied by local configuration take precedence.
+        # None and [] both mean "not configured", preserving discovery from
+        # AuthMetadataService as the fallback.
+        if self._scopes:
+            self._resolved_config = self._resolved_config.model_copy(update={"scopes": self._scopes})
 
         return self._resolved_config
 

--- a/tests/flyte/remote/test_auth_config_scopes.py
+++ b/tests/flyte/remote/test_auth_config_scopes.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytest
+
+from flyte.remote._client.auth._authenticators.base import Authenticator
+from flyte.remote._client.auth._client_config import ClientConfig, StaticClientConfigStore
+from flyte.remote._client.auth._keyring import Credentials
+
+
+class _TestAuthenticator(Authenticator):
+    async def _do_refresh_credentials(self) -> Credentials:
+        raise NotImplementedError
+
+
+def _remote_config() -> ClientConfig:
+    return ClientConfig(
+        token_endpoint="https://example.com/token",
+        authorization_endpoint="https://example.com/authorize",
+        redirect_uri="http://localhost:12345/callback",
+        client_id="remote-client",
+        scopes=["metadata-scope"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_configured_scopes_override_auth_metadata_scopes():
+    authenticator = _TestAuthenticator(
+        endpoint="https://example.com",
+        cfg_store=StaticClientConfigStore(_remote_config()),
+        scopes=["configured-scope-a", "configured-scope-b"],
+        disable_keyring=True,
+    )
+
+    resolved = await authenticator._resolve_config()
+
+    assert resolved.scopes == ["configured-scope-a", "configured-scope-b"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scopes", [None, []])
+async def test_missing_configured_scopes_fall_back_to_auth_metadata(scopes):
+    authenticator = _TestAuthenticator(
+        endpoint="https://example.com",
+        cfg_store=StaticClientConfigStore(_remote_config()),
+        scopes=scopes,
+        disable_keyring=True,
+    )
+
+    resolved = await authenticator._resolve_config()
+
+    assert resolved.scopes == ["metadata-scope"]

--- a/tests/user_api/test_init_in_cluster_fallback.py
+++ b/tests/user_api/test_init_in_cluster_fallback.py
@@ -31,6 +31,9 @@ def yaml_config(tmp_path: Path) -> Path:
   clientId: test-client
   clientSecretLocation: {secret}
   authType: ClientSecret
+  scopes:
+    - configured-scope-a
+    - configured-scope-b
 """
     )
     return p
@@ -65,6 +68,7 @@ class TestInitInClusterFallback:
         assert result["client_id"] == "test-client"
         assert result["client_credentials_secret"] == "test-secret-value"
         assert result["auth_type"] == "ClientSecret"
+        assert result["scopes"] == ["configured-scope-a", "configured-scope-b"]
         assert result["headless"] is True
 
     @pytest.mark.asyncio
@@ -174,6 +178,12 @@ class TestInitInClusterFallback:
         assert kw["client_id"] == cfg.platform.client_id
         assert kw["client_credentials_secret"] == cfg.platform.client_credentials_secret
         assert kw["auth_type"] == cfg.platform.auth_mode
+        assert kw["scopes"] == cfg.platform.scopes
+
+    def test_platform_kwargs_helper_omits_empty_scopes(self):
+        """No configured scopes preserves AuthMetadataService discovery."""
+        kw = _platform_to_client_kwargs(PlatformConfig(endpoint="dns:///example.com:443"))
+        assert "scopes" not in kw
 
     def test_platform_kwargs_helper_omits_disable_keyring(self):
         """disable_keyring is intentionally NOT in the helper output:


### PR DESCRIPTION
I am working to deploy Flyte 2 OSS across multiple clusters. One of the things I'm currently working through is allowing the driver pod to reach back out to actions service in order to enqueue more tasks. We have authentication enabled and we are trying to configure client credentials for our driver pods to use but the client credentials code is not picking up on the configured scopes. Instead it reaches out to the auth metadata API to get scopes that we've configured for CLI based usage by humans. So this pull request updates the client credentials logic to use scopes from the config file if they are defined and then fallback to the auth metadata API scopes.