### PR TITLE
fix: async LocalDB connection never opened after sync-only init

### DIFF
--- a/src/flyte/_persistence/_db.py
+++ b/src/flyte/_persistence/_db.py
@@ -167,10 +167,15 @@ class LocalDB:
         # aiosqlite `await` in `_initialize_async`: a second coroutine hitting a held
         # sync lock would block the loop thread, the aiosqlite worker callback could
         # never be delivered, and the first coroutine's await would never resolve.
-        if LocalDB._initialized:
+        #
+        # Gate on the async connection itself, not `_initialized`: a sync-only init
+        # (e.g. run persistence warming the DB from a plain thread before any task
+        # runs) sets the flag without opening the async connection, and skipping
+        # async init on that basis leaves `get_async()` unable to ever connect.
+        if LocalDB._conn is not None:
             return
         async with LocalDB._get_async_lock():
-            if LocalDB._initialized:
+            if LocalDB._conn is not None:
                 return
             if HAS_AIOSQLITE:
                 await LocalDB._initialize_async()
@@ -187,19 +192,21 @@ class LocalDB:
             await conn.execute(idx_stmt)
         await conn.commit()
         LocalDB._conn = conn
-        # Also open a sync connection for sync callers
-        sync_conn = sqlite3.connect(db_path, check_same_thread=False)
-        for ddl in _ALL_TABLE_DDLS:
-            sync_conn.execute(ddl)
-        _migrate_sync(sync_conn)
-        LocalDB._conn_sync = sync_conn
+        # Also open a sync connection for sync callers, unless a sync-only init
+        # already beat us to it.
+        if LocalDB._conn_sync is None:
+            sync_conn = sqlite3.connect(db_path, check_same_thread=False)
+            for ddl in _ALL_TABLE_DDLS:
+                sync_conn.execute(ddl)
+            _migrate_sync(sync_conn)
+            LocalDB._conn_sync = sync_conn
         LocalDB._initialized = True
 
     @staticmethod
     def initialize_sync():
         """Open sync connection and create all tables."""
         with LocalDB._lock:
-            if LocalDB._initialized:
+            if LocalDB._conn_sync is not None:
                 return
             LocalDB._initialize_sync_inner()
 
@@ -216,7 +223,7 @@ class LocalDB:
     @staticmethod
     def get_sync() -> sqlite3.Connection:
         """Get sync connection, auto-initializing if needed."""
-        if not LocalDB._initialized:
+        if LocalDB._conn_sync is None:
             LocalDB.initialize_sync()
         if LocalDB._conn_sync is None:
             raise RuntimeError("LocalDB not properly initialized (sync)")
@@ -225,7 +232,7 @@ class LocalDB:
     @staticmethod
     async def get_async() -> "aiosqlite.Connection":
         """Get async connection, auto-initializing if needed."""
-        if not LocalDB._initialized:
+        if LocalDB._conn is None:
             await LocalDB.initialize()
         if LocalDB._conn is None:
             raise RuntimeError("LocalDB not properly initialized (async)")

--- a/tests/persistence/test_db.py
+++ b/tests/persistence/test_db.py
@@ -107,6 +107,44 @@ async def test_close_async():
     assert LocalDB._conn is None
 
 
+@pytest.mark.asyncio
+@pytest.mark.skipif(not HAS_AIOSQLITE, reason="aiosqlite not installed")
+async def test_get_async_after_sync_init():
+    """Regression: a sync-only init (e.g. run persistence warming the DB) must
+    not leave `get_async()` unable to ever open the async connection.
+
+    This is the Google Colab failure mode: `flyte.init(local_persistence=True)`
+    sync-initializes the DB at run start, and a later cached child task's
+    `LocalTaskCache.get` raised `RuntimeError: LocalDB not properly initialized
+    (async)` because init was gated on the shared `_initialized` flag.
+    """
+    LocalDB.initialize_sync()
+    assert LocalDB._initialized is True
+    assert LocalDB._conn is None
+
+    conn = await LocalDB.get_async()
+    assert conn is not None
+    assert LocalDB._conn is conn
+    # The pre-existing sync connection is preserved, not replaced.
+    assert LocalDB._conn_sync is not None
+    # And the async connection is usable.
+    async with conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='task_cache'") as cursor:
+        assert await cursor.fetchone() is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not HAS_AIOSQLITE, reason="aiosqlite not installed")
+async def test_get_sync_after_async_init_reuses_connection():
+    """Async-first init opens both connections; later sync callers reuse them."""
+    await LocalDB.initialize()
+    sync_conn_before = LocalDB._conn_sync
+    conn = LocalDB.get_sync()
+    assert conn is sync_conn_before
+    # Re-initializing async must not replace the existing sync connection.
+    await LocalDB.initialize()
+    assert LocalDB._conn_sync is sync_conn_before
+
+
 def test_migration_adds_missing_columns(tmp_path, monkeypatch):
     """Simulate an old DB without the new columns and verify migration adds them."""
     db_path = str(tmp_path / "old.db")


### PR DESCRIPTION
## Problem

Cached local tasks fail on Google Colab with:

```
RuntimeError: LocalDB not properly initialized (async)
```

when running e.g.

```python
flyte.init(local_persistence=True)

@env.task(cache="auto")
def slow_square(x: int) -> int:
    time.sleep(2)
    return x**2

@env.task
def cached_pipeline(xs: list[int]) -> list[int]:
    return [slow_square(x) for x in xs]

run = await flyte.run.aio(cached_pipeline, xs=[1, 2, 2, 3, 3, 3])
```

## Root cause

`LocalDB` manages a sync (`sqlite3`) and an async (`aiosqlite`) connection gated by a **single shared `_initialized` flag**. Whichever init ran first won:

1. `flyte.init(local_persistence=True)` + `flyte.run.aio` → `RunRecorder.initialize_persistence()` → `LocalDB.initialize_sync()` opens only the sync connection but sets `_initialized = True` (`_conn` stays `None`).
2. A cached child task lookup → `LocalTaskCache.get()` → `LocalDB.get_async()` sees `_initialized == True`, skips async init, finds `_conn is None`, and raises.

**Why only Colab:** two conditions coincide — the Colab base image ships `aiosqlite` (an *optional* extra of flyte, so the async DB path is taken; without it the sync fallback works fine), and the quickstart pattern enables `local_persistence`, which sync-initializes the DB before any cached task runs.

## Fix

Gate connection readiness on the connections themselves instead of the shared flag:

- `get_async()`/`initialize()` check `_conn is None` so async init can still happen after a sync-only init
- `get_sync()`/`initialize_sync()` check `_conn_sync is None`
- `_initialize_async()` no longer clobbers a pre-existing sync connection

`_initialized` keeps its existing semantics (set on any init, cleared on close) for test compatibility.

## Verification

- Reproduced the exact Colab error locally (aiosqlite installed + persistence enabled), confirmed fixed: first run `3.4s` (3 unique executions), second run `0.0s` (all cache hits)
- Added regression tests in `tests/persistence/test_db.py` — `test_get_async_after_sync_init` fails with the exact reported error on the unfixed code
- `tests/persistence`, `tests/flyte/local_controller`, `tests/flyte/cache`: **145 passed**