### PR TITLE
Add timeout on Logs.tail for terminal runs

### DIFF
--- a/src/flyte/remote/_action.py
+++ b/src/flyte/remote/_action.py
@@ -42,6 +42,10 @@ from flyte.remote._common import TimeFilter, ToJSONMixin, time_filtering
 from flyte.remote._logs import Logs
 from flyte.syncify import syncify
 
+# How long to keep tailing a terminal action's log stream with no new messages before
+# giving up. The log plane never closes the stream on its own once the pod has exited.
+TERMINAL_LOG_IDLE_TIMEOUT_SECONDS = 30.0
+
 WaitFor = Literal["terminal", "running", "logs-ready"]
 
 # ACTION_PHASE_RECOVERED landed in flyteidl2 2.0.28; tolerate older bindings (the wire value
@@ -502,6 +506,9 @@ class Action(ToJSONMixin):
             details = await self.details()
         if not attempt:
             attempt = details.attempts
+        # A terminal action's pod is gone, so the log stream can stay open forever without
+        # ever delivering a message. Bound the tail so following a short run still returns.
+        idle_timeout = TERMINAL_LOG_IDLE_TIMEOUT_SECONDS if details.done() else None
         return await Logs.create_viewer(
             action_id=self.action_id,
             attempt=attempt,
@@ -509,6 +516,7 @@ class Action(ToJSONMixin):
             show_ts=show_ts,
             raw=raw,
             filter_system=filter_system,
+            idle_timeout=idle_timeout,
         )
 
     @syncify

--- a/src/flyte/remote/_logs.py
+++ b/src/flyte/remote/_logs.py
@@ -156,9 +156,7 @@ class Logs:
                     except StopAsyncIteration:
                         return
                     except asyncio.TimeoutError:
-                        logger.debug(
-                            f"Log stream idle for {idle_timeout}s for action {action_id.name}; stopping tail."
-                        )
+                        logger.debug(f"Log stream idle for {idle_timeout}s for action {action_id.name}; stopping tail.")
                         return
                     if log_set.logs:
                         for log in log_set.logs:

--- a/src/flyte/remote/_logs.py
+++ b/src/flyte/remote/_logs.py
@@ -121,6 +121,7 @@ class Logs:
         action_id: identifier_pb2.ActionIdentifier,
         attempt: int = 1,
         retry: int = 5,
+        idle_timeout: float | None = None,
     ) -> AsyncGenerator[payload_pb2.LogLine, None]:
         """
         Tail the logs for a given action ID and attempt.
@@ -128,6 +129,11 @@ class Logs:
         Args:
             action_id: The action ID to tail logs for.
             attempt: The attempt number (default is 0).
+            retry: How many times to retry while the log stream is not yet available.
+            idle_timeout: Stop tailing after this many seconds without a message. The log
+                plane keeps the stream open indefinitely for an action whose pod has already
+                exited, so callers that know the action is terminal must bound the wait or
+                the tail never returns. Leave unset to follow a running action.
         """
         ensure_client()
         client = get_client()
@@ -140,12 +146,24 @@ class Logs:
                         attempt=attempt,
                     )
                 )
-                async for log_set in resp:
+                stream = resp.__aiter__()
+                while True:
+                    try:
+                        if idle_timeout is None:
+                            log_set = await stream.__anext__()
+                        else:
+                            log_set = await asyncio.wait_for(stream.__anext__(), timeout=idle_timeout)
+                    except StopAsyncIteration:
+                        return
+                    except asyncio.TimeoutError:
+                        logger.debug(
+                            f"Log stream idle for {idle_timeout}s for action {action_id.name}; stopping tail."
+                        )
+                        return
                     if log_set.logs:
                         for log in log_set.logs:
                             for line in log.lines:
                                 yield line
-                return
             except asyncio.CancelledError:
                 return
             except KeyboardInterrupt:
@@ -174,6 +192,7 @@ class Logs:
         raw: bool = False,
         filter_system: bool = False,
         panel: bool = False,
+        idle_timeout: float | None = None,
     ):
         """
         Create a log viewer for a given action ID and attempt.
@@ -198,13 +217,13 @@ class Logs:
 
         if raw:
             console = Console()
-            async for line in cls.tail.aio(action_id=action_id, attempt=attempt):
+            async for line in cls.tail.aio(action_id=action_id, attempt=attempt, idle_timeout=idle_timeout):
                 line_text = _format_line(line, show_ts=show_ts, filter_system=filter_system)
                 if line_text:
                     console.print(line_text, end="")
             return
         viewer = AsyncLogViewer(
-            log_source=cls.tail.aio(action_id=action_id, attempt=attempt),
+            log_source=cls.tail.aio(action_id=action_id, attempt=attempt, idle_timeout=idle_timeout),
             max_lines=max_lines,
             show_ts=show_ts,
             name=f"{action_id.run.name}:{action_id.name} ({attempt})",

--- a/tests/flyte/remote/test_log_tail_idle_timeout.py
+++ b/tests/flyte/remote/test_log_tail_idle_timeout.py
@@ -1,0 +1,81 @@
+"""Tests for Logs.tail terminating when a completed action's log stream stays open."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flyteidl2.common import identifier_pb2, phase_pb2
+from flyteidl2.workflow import run_definition_pb2
+
+from flyte.remote._action import Action, ActionDetails
+from flyte.remote._logs import Logs
+
+
+def _make_action_id() -> identifier_pb2.ActionIdentifier:
+    return identifier_pb2.ActionIdentifier(run=identifier_pb2.RunIdentifier(name="run-1"), name="a0")
+
+
+class _NeverYieldingStream:
+    """A server stream that is accepted but never delivers a message or closes.
+
+    This is what the log plane does for an action whose pod has already exited: the
+    stream opens, then stays silent forever.
+    """
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        await asyncio.sleep(3600)
+        raise AssertionError("unreachable")
+
+
+def _client_returning(stream) -> MagicMock:
+    client = MagicMock()
+    client.dataproxy_service.tail_logs = MagicMock(return_value=stream)
+    return client
+
+
+class TestTailIdleTimeout:
+    @pytest.mark.asyncio
+    async def test_returns_when_stream_is_silent_and_idle_timeout_set(self):
+        with (
+            patch("flyte.remote._logs.ensure_client"),
+            patch("flyte.remote._logs.get_client", return_value=_client_returning(_NeverYieldingStream())),
+        ):
+
+            async def collect():
+                return [line async for line in Logs.tail.aio(action_id=_make_action_id(), idle_timeout=0.2)]
+
+            # Without the idle timeout this never returns and the wait_for below fires.
+            lines = await asyncio.wait_for(collect(), timeout=10)
+
+        assert lines == []
+
+    @pytest.mark.asyncio
+    async def test_show_logs_arms_idle_timeout_for_a_completed_action(self):
+        pb2 = run_definition_pb2.ActionDetails()
+        pb2.status.phase = phase_pb2.ACTION_PHASE_SUCCEEDED
+        pb2.status.attempts = 1
+        details = ActionDetails(pb2=pb2)
+
+        action = Action(pb2=run_definition_pb2.Action(id=_make_action_id()))
+
+        with (
+            patch.object(Action, "details", return_value=details) as mock_details,
+            patch("flyte.remote._action.Logs.create_viewer") as mock_viewer,
+        ):
+            mock_details.return_value = details
+
+            async def _details(self):
+                return details
+
+            with patch.object(Action, "details", _details):
+                await action.show_logs.aio()
+
+        _, kwargs = mock_viewer.call_args
+        assert kwargs.get("idle_timeout") is not None, (
+            "a completed action's log stream never closes on its own, so the tail must be bounded"
+        )


### PR DESCRIPTION
For fast runs, a task transition to terminal super quickly and the log stream can be stuck tailing an already terminated run in perpetuity.