### PR TITLE
fix: survive a broken pyOpenSSL install (FLYTE-SDK-7T)

### DIFF
--- a/src/flyte/remote/_client/auth/_session.py
+++ b/src/flyte/remote/_client/auth/_session.py
@@ -9,7 +9,6 @@ from typing import Any
 from urllib.parse import urlparse
 
 import pyqwest
-from OpenSSL import SSL, crypto
 
 from flyte._logging import logger
 from flyte._utils.org_discovery import hostname_from_url
@@ -20,6 +19,23 @@ from ._authenticators.factory import (
     create_proxy_auth_interceptors,
     get_async_proxy_authenticator,
 )
+
+# pyOpenSSL is a hard dependency but it is only *used* on the insecure_skip_verify
+# path below, and its import is unusually fragile: it binds names out of the
+# `cryptography` C bindings at class-body time, so a mismatched pyOpenSSL/cryptography
+# pair fails during import with an `AttributeError` such as
+# `module 'lib' has no attribute 'GEN_EMAIL'` rather than a clean `ImportError`.
+# Importing it unguarded meant that mismatch took down every command that builds a
+# client -- `flyte deploy` died at `_initialize_client` with a bare AttributeError
+# naming a module the user never imported (FLYTE-SDK-7T). Hold the failure instead and
+# report it from the one function that needs pyOpenSSL.
+_PYOPENSSL_IMPORT_ERROR: BaseException | None = None
+try:
+    from OpenSSL import SSL, crypto
+except (ImportError, AttributeError) as _e:  # pragma: no cover - depends on the install
+    SSL = None  # type: ignore[assignment]
+    crypto = None  # type: ignore[assignment]
+    _PYOPENSSL_IMPORT_ERROR = _e
 
 _USE_PYQWEST_DNS_RESOLVER_ENV = "_FLYTE_USE_PYQWEST_DNS_RESOLVER"
 _TRUE_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
@@ -87,6 +103,19 @@ def _bootstrap_ssl_from_server(endpoint: str) -> bytes:
     This is a blocking call.  Callers should run it via asyncio.to_thread().
     """
     from flyte.errors import InitializationError
+
+    if _PYOPENSSL_IMPORT_ERROR is not None:
+        # A broken pyOpenSSL install is the user's environment, not an SDK bug, and the
+        # raw AttributeError names neither package involved.
+        raise InitializationError(
+            "PyOpenSSLUnavailable",
+            "user",
+            f"Could not import pyOpenSSL, which is needed to retrieve the server's TLS "
+            f"certificate chain when insecure_skip_verify is enabled: "
+            f"{_PYOPENSSL_IMPORT_ERROR}. This usually means the installed pyOpenSSL and "
+            f"cryptography versions are incompatible - reinstall them together with "
+            f"`pip install --upgrade pyOpenSSL cryptography`.",
+        ) from _PYOPENSSL_IMPORT_ERROR
 
     hostname = hostname_from_url(endpoint)
     parts = hostname.rsplit(":", 1)

--- a/src/flyte/remote/_client/auth/_session.py
+++ b/src/flyte/remote/_client/auth/_session.py
@@ -33,8 +33,8 @@ _PYOPENSSL_IMPORT_ERROR: BaseException | None = None
 try:
     from OpenSSL import SSL, crypto
 except (ImportError, AttributeError) as _e:  # pragma: no cover - depends on the install
-    SSL = None  # type: ignore[assignment]
-    crypto = None  # type: ignore[assignment]
+    SSL = None  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+    crypto = None  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
     _PYOPENSSL_IMPORT_ERROR = _e
 
 _USE_PYQWEST_DNS_RESOLVER_ENV = "_FLYTE_USE_PYQWEST_DNS_RESOLVER"

--- a/tests/flyte/remote/test_session.py
+++ b/tests/flyte/remote/test_session.py
@@ -409,6 +409,90 @@ class TestBootstrapSslFromServer:
         mock_sock.close.assert_called_once()
 
 
+class TestPyOpenSSLImportFailure:
+    """A pyOpenSSL/cryptography version mismatch must not take down unrelated commands.
+
+    pyOpenSSL binds names out of the cryptography C bindings at class-body time, so an
+    incompatible pair fails during import with `AttributeError: module 'lib' has no
+    attribute 'GEN_EMAIL'` (FLYTE-SDK-7T) instead of a clean ImportError.
+    """
+
+    _BOOM_MESSAGE = "module 'lib' has no attribute 'GEN_EMAIL'"
+
+    def _load_module_with_broken_pyopenssl(self):
+        """Execute the real module body with `import OpenSSL` raising.
+
+        Loaded into a fresh module object rather than reloaded in place, so the live
+        `_session` (and the classes other modules imported from it) stays untouched.
+        """
+        import builtins
+        import importlib.util
+
+        from flyte.remote._client.auth import _session
+
+        boom = AttributeError(self._BOOM_MESSAGE)
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "OpenSSL":
+                raise boom
+            return real_import(name, *args, **kwargs)
+
+        spec = importlib.util.spec_from_file_location(
+            "flyte.remote._client.auth._session_broken_pyopenssl_probe", _session.__file__
+        )
+        module = importlib.util.module_from_spec(spec)
+        with patch.object(builtins, "__import__", fake_import):
+            spec.loader.exec_module(module)
+        return module, boom
+
+    def test_module_imports_despite_broken_pyopenssl(self):
+        """Importing the session module is what `flyte deploy` does; it must survive."""
+        module, boom = self._load_module_with_broken_pyopenssl()
+
+        assert module._PYOPENSSL_IMPORT_ERROR is boom
+        assert module.SSL is None
+        assert module.crypto is None
+        # The rest of the module is intact -- only the cold path is degraded.
+        assert module.normalize_rpc_endpoint("example.com", insecure=True) == "http://example.com"
+
+    def test_bootstrap_reports_broken_pyopenssl_as_user_error(self):
+        from flyte.errors import InitializationError
+
+        module, boom = self._load_module_with_broken_pyopenssl()
+
+        with patch(f"{_SESSION_MOD}.socket") as mock_socket:
+            with pytest.raises(InitializationError) as exc_info:
+                module._bootstrap_ssl_from_server("https://example.com:443")
+
+        # Raised before any connection is attempted -- nothing to clean up.
+        mock_socket.create_connection.assert_not_called()
+
+        err = exc_info.value
+        assert err.kind == "user"
+        assert err.__cause__ is boom
+        message = str(err)
+        assert "pyOpenSSL" in message
+        assert "cryptography" in message
+        assert self._BOOM_MESSAGE in message
+
+    def test_broken_pyopenssl_error_is_not_reported_to_sentry(self):
+        """The point of the conversion: a broken install is the environment, not a bug."""
+        from unittest import mock as _mock
+
+        from flyte import _sentry
+        from flyte.errors import InitializationError
+
+        module, _ = self._load_module_with_broken_pyopenssl()
+
+        with pytest.raises(InitializationError) as exc_info:
+            module._bootstrap_ssl_from_server("https://example.com:443")
+
+        with _mock.patch.object(_sentry, "init") as init_mock:
+            _sentry.capture_exception(exc_info.value)
+        init_mock.assert_not_called()
+
+
 class TestClientSetSessionConfig:
     def test_exposes_session_config(self):
         from flyte.remote._client.controlplane import ClientSet


### PR DESCRIPTION
Sentry: [FLYTE-SDK-7T](https://unionai.sentry.io/issues/7693268977/) — `AttributeError: module 'lib' has no attribute 'GEN_EMAIL'`, 2 events, release 2.5.6.

## What happens

`flyte deploy` dies during client initialisation, before it does any work:

```
flyte/cli/_deploy.py                     invoke
flyte/cli/_common.py                     initialize_config -> init
flyte/_initialize.py                     init -> _initialize_client
flyte/remote/_client/controlplane.py     <module>
flyte/remote/_client/auth/_session.py    <module>      <- from OpenSSL import SSL, crypto
OpenSSL/SSL.py                           <module>
OpenSSL/crypto.py                        X509Extension
AttributeError: module 'lib' has no attribute 'GEN_EMAIL'
```

`_session.py` imported pyOpenSSL at module scope, and `controlplane.py` imports `_session`, so importing pyOpenSSL was on the path of **every command that builds a client**.

That import is unusually fragile. pyOpenSSL binds names out of the `cryptography` C bindings *at class-body time* — `X509Extension` reads `_lib.GEN_EMAIL` while the module is still executing — so an incompatible pyOpenSSL/cryptography pair fails during **import**, with an `AttributeError`, not the `ImportError` an optional-dependency guard would normally catch. The reporting host is an Ubuntu box running out of `/usr/local/lib/python3.10/dist-packages`, the classic shape for this: a distro-packaged pyOpenSSL sitting alongside a newer pip-installed `cryptography`.

Two things went wrong: the user's `flyte deploy` failed with a message naming a module they never imported and giving no hint what to reconcile, and the SDK reported its own crash to Sentry, where a broken third-party install in someone's environment is not an SDK bug.

## The fix

pyOpenSSL is only *used* by `_bootstrap_ssl_from_server`, i.e. only when `insecure_skip_verify` is set. Nothing else in the module touches it. So the import failure is held at module scope rather than propagated, and converted at the one call site that needs the library:

```python
_PYOPENSSL_IMPORT_ERROR: BaseException | None = None
try:
    from OpenSSL import SSL, crypto
except (ImportError, AttributeError) as _e:
    SSL = None
    crypto = None
    _PYOPENSSL_IMPORT_ERROR = _e
```

`_bootstrap_ssl_from_server` then raises an `InitializationError` naming both packages and the command that reconciles them, chained to the original `AttributeError`. `InitializationError` is already on `_is_user_error`'s allow-list, so this class of report stops reaching Sentry — same treatment `EndpointUnreachable` got a few lines below in #1387.

`AttributeError` is deliberately in the `except` tuple alongside `ImportError`; catching only `ImportError` would not have caught this crash at all.

Note the module-level `SSL` / `crypto` names are kept rather than moved into a function-local import, so the eight existing tests that `patch(f"{_SESSION_MOD}.SSL")` keep working untouched.

## Verification

The three new tests execute the real module body into a fresh module object with `import OpenSSL` raising the production `AttributeError`, so they exercise the actual module-level guard without reloading — and therefore without disturbing the live `_session` other modules imported from.

On clean `origin/main` all three fail, reproducing the Sentry signature exactly:

```
src/flyte/remote/_client/auth/_session.py:12: in <module>
    from OpenSSL import SSL, crypto
E   AttributeError: module 'lib' has no attribute 'GEN_EMAIL'
```

On this branch all three pass. They cover: the module imports despite the broken install; the cold path converts it to a user-kind `InitializationError` with the cause chained and both package names in the message, raised *before* any socket connect is attempted; and `_sentry.capture_exception` drops it.

`tests/flyte/remote` + `tests/flyte/test_sentry.py`: 657 passed. Full `tests/flyte`: 3631 passed, 21 failed — the same 21 that fail on clean `origin/main` in this environment (verified by running both and diffing; no test fails only on this branch). ruff, mypy and `check-docstrings` clean.

## Left alone deliberately

I enumerated every third-party package that importing `controlplane` pulls in, to see whether 7T had siblings. pyOpenSSL is the only one that is imported but not needed by the failing command — everything else on that list (`pyqwest`, `obstore`, `pydantic_core`, `cryptography` itself) is genuinely used, so guarding its import would only move the failure rather than remove it.

Worth flagging separately, though: that same import pulls in **pandas and pyarrow**, which `flyte deploy` has no use for. That is an import-cost issue rather than a crash, with no Sentry evidence behind it, so it is not touched here.

fixes FLYTE-SDK-7T
