### PR TITLE
fix(debug): ssh sessions exit 1 on images with a /bin/false passwd shell (Spark)

### DIFF
--- a/examples/plugins/spark_ssh_debug.py
+++ b/examples/plugins/spark_ssh_debug.py
@@ -1,0 +1,65 @@
+"""Reproduce: SSH-into-task debug against a Spark task (Slack thread, ticket #6694).
+
+Mirrors the customer's script: a Spark task launched via ``with_debugcontext`` then
+``SSHDebug.connect`` to render the ssh config. Run with::
+
+    python examples/plugins/spark_ssh_debug.py
+"""
+
+from flyteplugins.spark.task import Spark
+from flyteplugins.union import with_debugcontext
+from flyteplugins.union.remote import SSHDebug
+
+import flyte
+import flyte.remote
+
+image = (
+    flyte.Image.from_base("apache/spark-py:v3.4.0")
+    .clone(
+        name="spark-ssh-debug",
+        python_version=(3, 10),
+        registry="ghcr.io/flyteorg",
+        extendable=True,
+        platform=("linux/amd64",),
+    )
+    .with_apt_packages("curl")
+    .with_pip_packages("flyteplugins-spark>=2.6.9")
+)
+
+spark_conf = Spark(
+    spark_conf={
+        "spark.driver.cores": "1",
+        "spark.driver.memory": "2000M",
+        "spark.executor.cores": "1",
+        "spark.executor.memory": "1000M",
+        "spark.executor.instances": "1",
+        "spark.kubernetes.file.upload.path": "/opt/spark/work-dir",
+        "spark.eventLog.enabled": "false",
+    },
+)
+
+spark_env = flyte.TaskEnvironment(
+    name="spark_ssh_debug",
+    resources=flyte.Resources(cpu=(1, 2), memory=("2000Mi", "3000Mi")),
+    plugin_config=spark_conf,
+    image=image,
+    env_vars={"HOME": "/opt/spark/work-dir"},
+)
+
+
+@spark_env.task
+async def spark_hello() -> int:
+    spark = flyte.ctx().data["spark_session"]
+    return spark.sparkContext.parallelize(range(1, 11), 2).sum()
+
+
+if __name__ == "__main__":
+    import sys
+
+    flyte.init_from_config(sys.argv[1] if len(sys.argv) > 1 else None)
+    run = with_debugcontext().run(spark_hello)
+    print("run name:", run.name)
+    print("run url:", run.url)
+    info = SSHDebug.connect(run.name)
+    print("wss url:", info.wss_url)
+    print(info.ssh_config)

--- a/src/flyte/_debug/ssh.py
+++ b/src/flyte/_debug/ssh.py
@@ -88,6 +88,17 @@ def _get_ssh_user() -> str:
         return DEFAULT_SSH_USER
 
 
+def _is_login_shell(shell: str) -> bool:
+    """Whether *shell* can actually host a session.
+
+    Images that run as a non-root uid without a passwd entry often synthesize one at
+    container start with a no-login shell — e.g. Apache Spark's `entrypoint.sh` appends
+    `<uid>:x:<uid>:0:anonymous uid:/opt/spark:/bin/false`. Seeding `SHELL` from that
+    would exec `/bin/false -c <cmd>` for every session: exit 1, no output.
+    """
+    return os.path.basename(shell) not in ("false", "nologin", "true") and os.access(shell, os.X_OK)
+
+
 def _build_forwarding_server():
     """An `SSHServer` subclass that permits client-initiated TCP forwarding.
 
@@ -202,9 +213,12 @@ class SshServer:
                 if pw.pw_dir:
                     env["HOME"] = pw.pw_dir
                 env["USER"] = env["LOGNAME"] = pw.pw_name
-                if pw.pw_shell:
+                if pw.pw_shell and _is_login_shell(pw.pw_shell):
                     env.setdefault("SHELL", pw.pw_shell)
-            shell = env.get("SHELL") or shutil.which("bash") or "/bin/bash"
+            shell = env.get("SHELL")
+            if not shell or not _is_login_shell(shell):
+                shell = shutil.which("bash") or shutil.which("sh") or "/bin/sh"
+                env["SHELL"] = shell
             argv = [shell, "-c", command] if command else [shell, "-l"]
             if term:
                 env["TERM"] = term

--- a/tests/flyte/test_ssh_debug.py
+++ b/tests/flyte/test_ssh_debug.py
@@ -209,3 +209,15 @@ async def test_wsbridge_start_stop_idempotent():
     writer.close()
     await bridge.stop()
     await bridge.stop()  # second stop is a no-op, must not raise
+
+
+def test_is_login_shell_rejects_nologin_shells(tmp_path):
+    # Spark's entrypoint.sh synthesizes `<uid>:x:...:/bin/false` for anonymous uids; seeding
+    # SHELL from it makes every session exit 1 with no output.
+    assert not ssh._is_login_shell("/bin/false")
+    assert not ssh._is_login_shell("/usr/sbin/nologin")
+    assert not ssh._is_login_shell(str(tmp_path / "does-not-exist"))
+    real = tmp_path / "bash"
+    real.write_text("#!/bin/sh\n")
+    real.chmod(0o755)
+    assert ssh._is_login_shell(str(real))


### PR DESCRIPTION
## Problem

SSH-into-task against a Spark task connects and authenticates, but every session exits 1 with no output — even `ssh flyte-debug true` — and PTY logins close immediately.

`apache/spark-py`'s `entrypoint.sh` synthesizes a passwd entry for the anonymous uid with a no-login shell:

```
185:x:185:0:anonymous uid:/opt/spark:/bin/false
```

`SshServer._handle_session` seeds `SHELL` from `pwd.getpwuid(...)`, so every session exec'd `/bin/false -c <cmd>`.

## Fix

`_is_login_shell()` rejects `false` / `nologin` / `true` (and non-executable paths); the passwd shell is only used when it passes, otherwise fall back to `bash`, then `sh`.

## Verification

- Reproduced on dogfood-1 (real Spark driver pod `<run>-a0-0-driver`): before the fix `ssh flyte-debug 'echo CONNECTED; id'` → exit 1, nothing printed. With the fixed wheel baked into the image: prints `CONNECTED`, `uid=185(185)`, `SHELL=/usr/bin/bash`, lands in the code dir; `ssh -tt` PTY session works.
- Unit test for `_is_login_shell` in `tests/flyte/test_ssh_debug.py`; file passes, ruff clean.
- `examples/plugins/spark_ssh_debug.py` is the repro used (takes an optional config path).

Context: Slack ticket #6694 — the customer's reported `kex_exchange_identification: banner line contains invalid characters` did not reproduce on our side (dogfood + demo, runtime 2.5.18 and 2.6.x); this is the next failure they would have hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)