### PR TITLE
docs: correct with_uv_project's install args and reset_root_logger, in Google style

### DIFF
--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -1357,10 +1357,12 @@ class Image:
 
         Args:
             packages: list of pip packages to install, follows pip install syntax
-            index_url: index url to use for pip install, default is None
-            extra_index_urls: extra index urls to use for pip install, default is None
+            index_url: index URL for dependency resolution, passed to `uv sync`, default is None
+            extra_index_urls: extra index URLs for dependency resolution, passed to `uv sync`,
+                default is None
             pre: whether to allow pre-release versions, default is False
-            extra_args: extra arguments to pass to pip install, default is None
+            extra_args: extra arguments passed to `uv sync`, for example `--only-group <group>` to
+                install a single dependency group, default is None
             secret_mounts: list of secret to mount for the build process.
 
         Returns:

--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -260,7 +260,12 @@ async def init(
             defaults to the editable install directory if the cwd is in a Python editable install, else just the cwd.
         log_level: Optional logging level for the logger, default is set using the default initialization policies
         log_format: Optional logging format for the logger, default is "console"
-        reset_root_logger: By default, we clear out root logger handlers and set up our own.
+        reset_root_logger: If True, replace the root logger's handlers with Flyte's own, so lines
+            from third-party libraries that propagate to the root logger are formatted the same way
+            as Flyte's (JSON when `log_format` is `json`, otherwise Rich or plain console). Defaults
+            to False, which leaves those handlers in place and instead wraps each one so its output
+            carries the run and action context. Can also be turned on with the environment variable
+            `FLYTE_RESET_ROOT_LOGGER=1`.
         api_key: Optional API key for authentication
         endpoint: Optional API endpoint URL
         headless: Optional Whether to run in headless mode

--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -1655,7 +1655,12 @@ def with_runcontext(
         log_level: Optional Log level to set for the run. If not provided, it will be set to the default log level
             set using `flyte.init()`
         log_format: Optional Log format to set for the run. If not provided, it will be set to the default log format
-        reset_root_logger: If true, the root logger will be preserved and not modified by Flyte.
+        reset_root_logger: If True, replace the root logger's handlers with Flyte's own, so lines
+            from third-party libraries that propagate to the root logger are formatted the same way
+            as Flyte's (JSON when `log_format` is `json`, otherwise Rich or plain console). Defaults
+            to False, which leaves those handlers in place and instead wraps each one so its output
+            carries the run and action context. Can also be turned on with the environment variable
+            `FLYTE_RESET_ROOT_LOGGER=1`.
         disable_run_cache: Optional If true, the run cache will be disabled. This is useful for testing purposes.
         queue: Optional The queue to use for the run. This is used to specify the cluster to use for the run.
         max_action_concurrency: Optional Maximum number of actions that can run concurrently within this run.


### PR DESCRIPTION
Replaces **#1302** and **#1316**, closed rather than rebased. Both corrections are still valid — I re-verified each against today's code before reopening them — but both were written in Sphinx `:param` style, and `main` has **none left**: `838b41f4` (#1376, "strip inert reStructuredText from docstrings") converted those files to Google style. 60–70 `:param` lines on each old branch, zero on target. That is a rewrite, not a conflict.

Two independent corrections, one commit each.

## 1. `with_uv_project` — the args feed `uv sync`, not pip

Three parameters were documented "for pip install". They never reach pip. All three uv-project templates in `docker_builder.py` run:

```
uv sync --active --inexact $PIP_INSTALL_ARGS
```

and `$PIP_INSTALL_ARGS` is `get_pip_install_args()` — where `index_url`, `extra_index_urls`, `--pre` and `extra_args` end up. That helper's name is presumably why the docstring reads as it does; it is shared with the layers that genuinely do call pip.

It matters because the accepted flags differ. `uv sync` takes `--only-group`, which pip has no equivalent for, and rejects plenty pip accepts — so a reader following this docstring reaches for the wrong flag set. The docstring now gives that example.

## 2. `reset_root_logger` — documented backwards, in both places

```
_initialize.py   "By default, we clear out root logger handlers and set up our own."
_run.py          "If true, the root logger will be preserved and not modified by Flyte."
```

They disagree with each other and both disagree with the code. The default is `False`, and `False` clears nothing; `True` is what replaces the root handlers. So the first states the wrong default, and the second **inverts the flag** — a reader wanting to keep their own root handlers would set the exact flag that destroys them.

Both now describe what `initialize_logger` does: `True` replaces the root handlers with Flyte's (JSON when `log_format` is `json`, else Rich or plain console); the default `False` leaves them and wraps each so third-party lines routed through root still carry run and action context.

Also documents `FLYTE_RESET_ROOT_LOGGER=1`, which enables it and was mentioned nowhere.

## Verification

`check-docstrings` clean · 433 tests · `make fmt` idempotent · ruff clean on all three files.

---
— docsy · automated docs agent · [DOC-1481](https://linear.app/unionai/issue/DOC-1481)