### PR TITLE
Log client retries: warning on RESOURCE_EXHAUSTED, debug otherwise

### DIFF
--- a/src/flyte/remote/_client/auth/_interceptors/retry.py
+++ b/src/flyte/remote/_client/auth/_interceptors/retry.py
@@ -6,7 +6,29 @@ import random
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 
+from flyte._logging import logger
+
 RETRYABLE_CODES = frozenset({Code.UNAVAILABLE, Code.RESOURCE_EXHAUSTED, Code.INTERNAL})
+
+
+def _log_retry(ctx, e: ConnectError, delay: float, attempt: int, max_attempts: int) -> None:
+    method = getattr(getattr(ctx, "method", None), "name", "rpc")
+    if e.code == Code.RESOURCE_EXHAUSTED:
+        # The server explicitly asked us to back off (e.g. a queue at max
+        # depth); surface why the call is pausing instead of sleeping silently.
+        logger.warning(
+            "%s rejected: %s; retrying in %.1fs (attempt %d/%d)", method, e.message, delay, attempt + 1, max_attempts
+        )
+    else:
+        logger.debug(
+            "%s failed (code=%s): %s; retrying in %.1fs (attempt %d/%d)",
+            method,
+            e.code,
+            e.message,
+            delay,
+            attempt + 1,
+            max_attempts,
+        )
 
 
 class RetryUnaryInterceptor:
@@ -32,7 +54,9 @@ class RetryUnaryInterceptor:
             except ConnectError as e:
                 if e.code not in RETRYABLE_CODES or attempt == self._max_attempts - 1:
                     raise
-                await asyncio.sleep(backoff * (0.5 + random.random()))
+                delay = backoff * (0.5 + random.random())
+                _log_retry(ctx, e, delay, attempt, self._max_attempts)
+                await asyncio.sleep(delay)
                 backoff = min(backoff * self._multiplier, self._max_backoff)
 
 
@@ -61,5 +85,7 @@ class RetryServerStreamInterceptor:
             except ConnectError as e:
                 if e.code not in RETRYABLE_CODES or attempt == self._max_attempts - 1:
                     raise
-                await asyncio.sleep(backoff * (0.5 + random.random()))
+                delay = backoff * (0.5 + random.random())
+                _log_retry(ctx, e, delay, attempt, self._max_attempts)
+                await asyncio.sleep(delay)
                 backoff = min(backoff * self._multiplier, self._max_backoff)

--- a/tests/flyte/remote/test_connectrpc_interceptors.py
+++ b/tests/flyte/remote/test_connectrpc_interceptors.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import re
 from unittest.mock import AsyncMock, Mock
 from uuid import UUID
@@ -640,6 +641,47 @@ class TestRetryUnaryInterceptor:
         assert 0.5 <= sleep_durations[0] < 1.5  # base=1.0
         assert 1.0 <= sleep_durations[1] < 3.0  # base=2.0
         assert 2.0 <= sleep_durations[2] < 6.0  # base=4.0
+
+    @pytest.mark.asyncio
+    async def test_resource_exhausted_retry_logs_warning(self, caplog, monkeypatch):
+        # The "flyte" logger disables propagation; re-enable it so caplog sees records.
+        monkeypatch.setattr(logging.getLogger("flyte"), "propagate", True)
+        interceptor = RetryUnaryInterceptor(max_attempts=3, initial_backoff=0.001)
+        call_next = AsyncMock(
+            side_effect=[
+                ConnectError(Code.RESOURCE_EXHAUSTED, 'queue "q" is at max depth (5), retry later'),
+                "ok",
+            ]
+        )
+        ctx, _ = _make_ctx_mock()
+
+        with caplog.at_level("WARNING", logger="flyte"):
+            result = await interceptor.intercept_unary(call_next, "req", ctx)
+
+        assert result == "ok"
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1
+        assert 'queue "q" is at max depth (5)' in warnings[0].getMessage()
+        assert "attempt 1/3" in warnings[0].getMessage()
+
+    @pytest.mark.asyncio
+    async def test_unavailable_retry_logs_debug_only(self, caplog, monkeypatch):
+        monkeypatch.setattr(logging.getLogger("flyte"), "propagate", True)
+        interceptor = RetryUnaryInterceptor(max_attempts=3, initial_backoff=0.001)
+        call_next = AsyncMock(
+            side_effect=[
+                ConnectError(Code.UNAVAILABLE, "down"),
+                "ok",
+            ]
+        )
+        ctx, _ = _make_ctx_mock()
+
+        with caplog.at_level("DEBUG", logger="flyte"):
+            result = await interceptor.intercept_unary(call_next, "req", ctx)
+
+        assert result == "ok"
+        assert not [r for r in caplog.records if r.levelname == "WARNING"]
+        assert any("retrying in" in r.getMessage() for r in caplog.records if r.levelname == "DEBUG")
 
 
 class TestRetryServerStreamInterceptor:


### PR DESCRIPTION
The retry interceptors silently sleep through transient failures, so when the server rejects with `RESOURCE_EXHAUSTED` (e.g. a queue at max depth) the CLI just hangs through the backoff with no explanation. Each retry now logs the RPC name, server message, sleep duration, and attempt count — at warning level for `RESOURCE_EXHAUSTED` since the server explicitly asked the client to back off, and at debug for `UNAVAILABLE`/`INTERNAL`.