### PR TITLE
fix: resume checkpoints across JobSet whole-set restarts in clustered tasks

### DIFF
--- a/src/flyte/models.py
+++ b/src/flyte/models.py
@@ -316,7 +316,15 @@ class TaskContext:
             return cached
         prev = cps.prev_checkpoint_path
         prev_n = prev.strip() if prev else None
-        cp = CheckpointCls(str(dest).strip(), prev_n or None)
+        src = prev_n or None
+        # JobSet (clustered) whole-set restarts recreate pods from the same template, so the
+        # backend-templated prev path can never point at a checkpoint saved by an earlier restart
+        # attempt — that attempt saved to THIS attempt's own checkpoint_path. Load from it instead.
+        # JOBSET_RESTART_ATTEMPT is only ever set on jobset pods; regular tasks are unaffected.
+        restart = self.restart_attempt
+        if restart is not None and restart > 0:
+            src = str(dest).strip()
+        cp = CheckpointCls(str(dest).strip(), src)
         self.data[CHECKPOINT_CACHE_KEY] = cp
         return cp
 

--- a/tests/flyte/test_checkpoint.py
+++ b/tests/flyte/test_checkpoint.py
@@ -273,3 +273,68 @@ def test_task_context_checkpoint_none_empty_dest() -> None:
         checkpoint_paths=CheckpointPaths(checkpoint_path="  ", prev_checkpoint_path=None),
     )
     assert tctx.checkpoint is None
+
+
+# --- TaskContext.checkpoint on JobSet (clustered) whole-set restarts ---
+#
+# JobSet restarts recreate pods from the same template, so the backend-templated
+# `--prev-checkpoint` can never point at a checkpoint saved by an earlier restart attempt —
+# that attempt saved to THIS attempt's own checkpoint_path. The property must load from it
+# when JOBSET_RESTART_ATTEMPT > 0 (the env var is only ever set on jobset pods).
+
+
+def _tctx_with_checkpoints(base: pathlib.Path, out: str, prev: str | None) -> TaskContext:
+    return TaskContext(
+        action=ActionID(name="a0"),
+        version="v1",
+        raw_data_path=RawDataPath(path=str(base)),
+        output_path=str(base / "outputs"),
+        run_base_dir=str(base),
+        report=Report(name="t"),
+        checkpoint_paths=CheckpointPaths(checkpoint_path=out, prev_checkpoint_path=prev),
+    )
+
+
+def test_task_context_checkpoint_jobset_restart_loads_own_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Restarted set (JOBSET_RESTART_ATTEMPT=1), prev templated as the literal '""': the load
+    source is the task's own checkpoint_path, where the previous restart attempt saved."""
+    with tempfile.TemporaryDirectory() as td:
+        base = pathlib.Path(td)
+        out_blob = base / "out_flytecheckpoints"
+        out_blob.write_bytes(b"15")  # written by the previous restart attempt
+        monkeypatch.setenv("JOBSET_RESTART_ATTEMPT", "1")
+        cp = _tctx_with_checkpoints(base, out_blob.as_uri(), '""').checkpoint
+        assert cp is not None
+        assert cp.remote_source == out_blob.as_uri()
+        payload = cp.load_sync()
+        assert payload is not None
+        assert payload.read_bytes() == b"15"
+
+
+def test_task_context_checkpoint_jobset_restart_before_first_save(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Restarted set that crashed before any save: nothing at the own path; load returns None."""
+    with tempfile.TemporaryDirectory() as td:
+        base = pathlib.Path(td)
+        monkeypatch.setenv("JOBSET_RESTART_ATTEMPT", "1")
+        cp = _tctx_with_checkpoints(base, (base / "never_saved").as_uri(), None).checkpoint
+        assert cp is not None
+        assert cp.load_sync() is None
+
+
+def test_task_context_checkpoint_no_jobset_restart_keeps_prev(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without JOBSET_RESTART_ATTEMPT (regular tasks) and on restart attempt 0, the source stays
+    the backend-templated prev path — behavior unchanged."""
+    with tempfile.TemporaryDirectory() as td:
+        base = pathlib.Path(td)
+        out = (base / "out").as_uri()
+        prev = (base / "prev").as_uri()
+
+        monkeypatch.delenv("JOBSET_RESTART_ATTEMPT", raising=False)
+        cp = _tctx_with_checkpoints(base, out, prev).checkpoint
+        assert cp is not None
+        assert cp.remote_source == prev
+
+        monkeypatch.setenv("JOBSET_RESTART_ATTEMPT", "0")
+        cp0 = _tctx_with_checkpoints(base, out, prev).checkpoint
+        assert cp0 is not None
+        assert cp0.remote_source == prev


### PR DESCRIPTION
## Problem
  
  In `ClusteredTaskEnvironment` tasks, checkpoint saving works but a JobSet whole-set restart never loads
  the checkpoint saved by the previous attempt — `ctx.checkpoint.load()` returns None and training
  silently restarts from step 0, losing all progress.

  ## Root cause
  
  The backend templates `--checkpoint-path` / `--prev-checkpoint` into the container args once, per Flyte 
  attempt (`prevCheckpointPrefix` is only populated from Flyte attempt ≥ 2, pointing at the previous
  Flyte attempt). JobSet whole-set restarts happen entirely at the K8s layer: the JobSet controller
  recreates pods from the same pod template, so the backend never gets a chance to re-template
  `--prev-checkpoint`. Every restart attempt within a Flyte attempt therefore ships with
  `--prev-checkpoint '""'` while sharing one `--checkpoint-path`
  `(.../<action>/<attempt>/_flytecheckpoints)`.

  Verified on a live reproduction `(examples/clustered/failure_cascade.py)`: the restarted pod's args
  carried the empty prev path while the checkpoint blob from the previous attempt sat at the exact
  `--checkpoint-path` URI the pod was given — the SDK just never looked there.

  This can only be fixed in the SDK: the sole signal that a pod is a restarted set is the
  `JOBSET_RESTART_ATTEMPT` env var (downward-API projection of the `jobset.sigs.k8s.io/restart-attempt` annotation), which exists only inside the pod at runtime.

  ## Fix

  In `TaskContext.checkpoint` (`src/flyte/models.py`): when `restart_attempt > 0`, use the task's own
  `checkpoint_path` as the load source — the previous restart attempt saved there. Otherwise keep the
  backend-templated prev path exactly as before.

  - Scoped strictly to jobsets: `JOBSET_RESTART_ATTEMPT` is only ever set on jobset pods, so regular
    tasks hit the identical code path as today. `flyte._checkpoint.Checkpoint` is untouched.
  - `restart == 0` keeps prev, preserving cross-Flyte-attempt resume (backend templates that correctly).
  - A set that restarts before its first save finds nothing at its own path; `Checkpoint.load()` already
    treats a missing object as "no checkpoint" and returns None gracefully.

  ## Testing
  
  - Unit (`tests/flyte/test_checkpoint.py`, +3 tests): restarted set loads from its own path (including
    the literal `'""'` prev the backend templates); restart before first save returns None; env unset / 0
    keeps prev — regular-task behavior pinned unchanged.
  - E2E before: `failure_cascade.py` on a local devbox (JobSet controller v0.8.1) — attempt 1 logged
    `restart_attempt=1`, no resume, reran all 40 steps; checkpoint blob confirmed present in the object
    store.
  - E2E after: same example on local devbox and`demo.hosted.unionai.cloud` (run `uvmmvthbbdnmh4gmklw2`, SUCCEEDED) — attempt 1 logged resumed from checkpoint at step 25 and completed only the remaining steps.