### PR TITLE
Add task-level cache max age support

### DIFF
--- a/plugins/agento11y/uv.lock
+++ b/plugins/agento11y/uv.lock
@@ -1230,7 +1230,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -1300,7 +1300,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -1309,7 +1309,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/bigquery/uv.lock
+++ b/plugins/bigquery/uv.lock
@@ -463,7 +463,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -533,7 +533,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -542,7 +542,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/codegen/uv.lock
+++ b/plugins/codegen/uv.lock
@@ -765,7 +765,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -835,7 +835,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -844,7 +844,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/dask/uv.lock
+++ b/plugins/dask/uv.lock
@@ -619,7 +619,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -689,7 +689,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -698,7 +698,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/databricks/uv.lock
+++ b/plugins/databricks/uv.lock
@@ -648,7 +648,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -718,7 +718,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -727,7 +727,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/echo/uv.lock
+++ b/plugins/echo/uv.lock
@@ -356,7 +356,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -426,7 +426,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -435,7 +435,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/hitl/uv.lock
+++ b/plugins/hitl/uv.lock
@@ -389,7 +389,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -459,7 +459,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -468,7 +468,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/huggingface/uv.lock
+++ b/plugins/huggingface/uv.lock
@@ -712,7 +712,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -782,7 +782,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -791,7 +791,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/hydra/uv.lock
+++ b/plugins/hydra/uv.lock
@@ -485,7 +485,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -555,7 +555,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -564,7 +564,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/jsonl/uv.lock
+++ b/plugins/jsonl/uv.lock
@@ -365,7 +365,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -435,7 +435,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -444,7 +444,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/lance/uv.lock
+++ b/plugins/lance/uv.lock
@@ -394,7 +394,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -464,7 +464,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -473,7 +473,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/nsight/uv.lock
+++ b/plugins/nsight/uv.lock
@@ -666,7 +666,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -736,7 +736,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -745,7 +745,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/omegaconf/uv.lock
+++ b/plugins/omegaconf/uv.lock
@@ -371,7 +371,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -441,7 +441,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -450,7 +450,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/otel/uv.lock
+++ b/plugins/otel/uv.lock
@@ -480,7 +480,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -550,7 +550,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -559,7 +559,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/pandera/uv.lock
+++ b/plugins/pandera/uv.lock
@@ -585,7 +585,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -655,7 +655,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -664,7 +664,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/polars/uv.lock
+++ b/plugins/polars/uv.lock
@@ -366,7 +366,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -436,7 +436,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -445,7 +445,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/pytorch/uv.lock
+++ b/plugins/pytorch/uv.lock
@@ -445,7 +445,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -515,7 +515,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -524,7 +524,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/ray/uv.lock
+++ b/plugins/ray/uv.lock
@@ -536,7 +536,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -606,7 +606,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -615,7 +615,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/redis/uv.lock
+++ b/plugins/redis/uv.lock
@@ -388,7 +388,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -458,7 +458,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -467,7 +467,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/sglang/uv.lock
+++ b/plugins/sglang/uv.lock
@@ -365,7 +365,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -435,7 +435,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -444,7 +444,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/snowflake/uv.lock
+++ b/plugins/snowflake/uv.lock
@@ -509,7 +509,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -579,7 +579,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -588,7 +588,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/spark/uv.lock
+++ b/plugins/spark/uv.lock
@@ -463,7 +463,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -533,7 +533,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -542,7 +542,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/trackio/uv.lock
+++ b/plugins/trackio/uv.lock
@@ -433,7 +433,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -503,7 +503,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -512,7 +512,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/vllm/uv.lock
+++ b/plugins/vllm/uv.lock
@@ -365,7 +365,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -435,7 +435,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -444,7 +444,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/plugins/wandb/uv.lock
+++ b/plugins/wandb/uv.lock
@@ -459,7 +459,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "../../rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -529,7 +529,7 @@ dev = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -538,7 +538,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "async-lru>=2.0.5",
     "mashumaro>=3.15",
     "aiolimiter>=1.2.1",
-    "flyteidl2==2.0.44",
+    "flyteidl2==2.0.45",
     "packaging",
     "sentry-sdk>=2.0",
     "pyOpenSSL>=24.0.0",

--- a/rs_controller/Cargo.lock
+++ b/rs_controller/Cargo.lock
@@ -269,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c63e5a04d5ad0c824cadf3bbb2ee352f0569abe4c58a4a3149e9013abc9e661"
+checksum = "044577c0d8cb24e93212f5cad44025d0c2529b4c10186eb6bb93e6ad37760e3d"
 dependencies = [
  "async-trait",
  "futures",

--- a/rs_controller/Cargo.toml
+++ b/rs_controller/Cargo.toml
@@ -56,7 +56,7 @@ async-trait = "0.1"
 thiserror = "1.0"
 # Uncomment this if you need to use local flyteidl2
 #flyteidl2 = { path = "/Users/ytong/go/src/github.com/flyteorg/flyte/gen/rust" }
-flyteidl2 = "=2.0.44"
+flyteidl2 = "=2.0.45"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/rs_controller/pyproject.toml
+++ b/rs_controller/pyproject.toml
@@ -9,7 +9,7 @@ description = "Rust controller for Union"
 requires-python = ">=3.10"
 classifiers = ["Programming Language :: Python", "Programming Language :: Rust"]
 dependencies = [
-    "flyteidl2==2.0.44",
+    "flyteidl2==2.0.45",
 ]
 [tool.maturin]
 module-name = "flyte_controller_base"

--- a/src/flyte/_cache/cache.py
+++ b/src/flyte/_cache/cache.py
@@ -1,5 +1,6 @@
 import hashlib
 from dataclasses import dataclass, field
+from datetime import timedelta
 from typing import (
     Callable,
     Generic,
@@ -112,6 +113,10 @@ class Cache:
         policies: Cache policies for version generation. Defaults to
             `[FunctionBodyPolicy()]` when `behavior="auto"`. Provide a custom
             `CachePolicy` implementation for alternative versioning strategies.
+        max_age: Maximum age of a cached result this task will reuse, as a
+            `timedelta` or an integer number of seconds. `None` uses the platform
+            default, zero disables age-based expiration, and negative values are
+            invalid.
     """
 
     behavior: CacheBehavior
@@ -120,8 +125,18 @@ class Cache:
     ignored_inputs: Union[Tuple[str, ...], str] = field(default_factory=tuple)
     salt: str = ""
     policies: Optional[Union[List[CachePolicy], CachePolicy]] = None
+    max_age: timedelta | int | None = None
 
     def __post_init__(self):
+        if isinstance(self.max_age, bool) or (
+            self.max_age is not None and not isinstance(self.max_age, (int, timedelta))
+        ):
+            raise TypeError("max_age must be an int (seconds), timedelta, or None")
+        if isinstance(self.max_age, int):
+            self.max_age = timedelta(seconds=self.max_age)
+        if self.max_age is not None and self.max_age < timedelta(0):
+            raise ValueError("max_age must be nonnegative")
+
         valid = get_args(CacheBehavior)
         if isinstance(self.behavior, str) and self.behavior not in valid:
             aliased = _CACHE_BEHAVIOR_ALIASES.get(self.behavior.lower())

--- a/src/flyte/_internal/runtime/task_serde.py
+++ b/src/flyte/_internal/runtime/task_serde.py
@@ -259,6 +259,7 @@ def get_proto_task(
             discovery_version=cache_version,
             cache_serializable=task_cache.serialize,
             cache_ignore_input_vars=(task_cache.get_ignored_inputs() if cache_enabled else None),
+            cache_max_age=_to_duration(task_cache.max_age),
             runtime=tasks_pb2.RuntimeMetadata(
                 version=flyte.version(),
                 type=tasks_pb2.RuntimeMetadata.RuntimeType.FLYTE_SDK,

--- a/src/flyte/remote/_task.py
+++ b/src/flyte/remote/_task.py
@@ -20,6 +20,7 @@ from flyte._initialize import ensure_client, get_client, get_init_config
 from flyte._internal.runtime.resources_serde import get_proto_extended_resources, get_proto_resources
 from flyte._internal.runtime.task_serde import (
     _sanitize_resource_name,
+    _to_duration,
     get_proto_max_runtime,
     get_proto_retry_strategy,
     get_proto_timeout_strategy,
@@ -326,6 +327,7 @@ class TaskDetails(ToJSONMixin):
             version_override=metadata.discovery_version or None,
             serialize=metadata.cache_serializable,
             ignored_inputs=tuple(metadata.cache_ignore_input_vars),
+            max_age=metadata.cache_max_age.ToTimedelta() if metadata.HasField("cache_max_age") else None,
         )
 
     @property
@@ -503,6 +505,10 @@ class TaskDetails(ToJSONMixin):
                 raise ValueError(f"Invalid cache behavior: {cache.behavior}.")
             md.cache_serializable = cache.serialize
             md.cache_ignore_input_vars[:] = list(cache.ignored_inputs or ())
+            if cache.max_age is None:
+                md.ClearField("cache_max_age")
+            else:
+                md.cache_max_age.CopyFrom(_to_duration(cache.max_age))
 
         return TaskDetails(
             pb2,

--- a/tests/flyte/internal/runtime/test_task_serde.py
+++ b/tests/flyte/internal/runtime/test_task_serde.py
@@ -156,6 +156,7 @@ def test_get_proto_container_task():
 
     # Check metadata
     assert proto_task.metadata.discoverable is True  # Cache is enabled
+    assert not proto_task.metadata.HasField("cache_max_age")
     assert proto_task.metadata.retries.retries == 3
     assert proto_task.metadata.timeout.seconds == 60
 
@@ -177,6 +178,38 @@ def test_get_proto_container_task():
     assert env_vars["ENV1"] == "val1"
     assert "ENV2" in env_vars
     assert env_vars["ENV2"] == "val2"
+
+
+@pytest.mark.parametrize(
+    "max_age,seconds,nanos",
+    [
+        (0, 0, 0),
+        (timedelta(days=2, microseconds=500_000), 172800, 500_000_000),
+    ],
+)
+def test_get_proto_task_cache_max_age(max_age, seconds, nanos):
+    env = flyte.TaskEnvironment(name="cache_max_age", image="python:3.10")
+
+    @env.task(cache=flyte.Cache(behavior="auto", max_age=max_age))
+    async def cached_task(value: int) -> int:
+        return value
+
+    context = SerializationContext(
+        project="test-project",
+        domain="test-domain",
+        version="test-version",
+        org="test-org",
+        input_path="/tmp/inputs",
+        output_path="/tmp/outputs",
+        image_cache=None,
+        code_bundle=None,
+        root_dir=pathlib.Path.cwd(),
+    )
+
+    metadata = get_proto_task(cached_task, context).metadata
+    assert metadata.HasField("cache_max_age")
+    assert metadata.cache_max_age.seconds == seconds
+    assert metadata.cache_max_age.nanos == nanos
 
 
 def test_get_proto_task_ignored_cache_inputs():

--- a/tests/flyte/remote/test_task.py
+++ b/tests/flyte/remote/test_task.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import timedelta
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -6,6 +7,39 @@ import pytest
 import flyte
 import flyte.errors
 from flyte.remote._task import LazyEntity, TaskDetails
+
+
+class TestTaskDetailsCacheMaxAge:
+    @staticmethod
+    def _task_details(max_age: timedelta | None, *, present: bool = True) -> TaskDetails:
+        from flyteidl2.task import task_definition_pb2
+
+        pb2 = task_definition_pb2.TaskDetails()
+        metadata = pb2.spec.task_template.metadata
+        metadata.discoverable = True
+        metadata.discovery_version = "v1"
+        if present:
+            metadata.cache_max_age.FromTimedelta(max_age or timedelta(0))
+        return TaskDetails(pb2)
+
+    def test_cache_reads_positive_max_age(self):
+        details = self._task_details(timedelta(hours=3))
+        assert details.cache.max_age == timedelta(hours=3)
+
+    def test_cache_distinguishes_unset_from_explicit_zero(self):
+        assert self._task_details(None, present=False).cache.max_age is None
+        assert self._task_details(timedelta(0)).cache.max_age == timedelta(0)
+
+    def test_cache_override_sets_and_clears_max_age(self):
+        details = self._task_details(timedelta(days=1))
+
+        zero = details.override(cache=flyte.Cache("override", version_override="v2", max_age=0))
+        zero_metadata = zero.pb2.spec.task_template.metadata
+        assert zero_metadata.HasField("cache_max_age")
+        assert zero_metadata.cache_max_age.ToTimedelta() == timedelta(0)
+
+        unset = zero.override(cache=flyte.Cache("override", version_override="v3"))
+        assert not unset.pb2.spec.task_template.metadata.HasField("cache_max_age")
 
 
 class TestLazyEntity:

--- a/tests/user_api/test_cache.py
+++ b/tests/user_api/test_cache.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 import pytest
 
 from flyte._cache import Cache
@@ -64,6 +66,31 @@ def test_cache_disabled_returns_empty_version():
 def test_cache_serialize_flag():
     cache = Cache(behavior="auto", serialize=True)
     assert cache.serialize is True
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (60, timedelta(seconds=60)),
+        (timedelta(days=2), timedelta(days=2)),
+        (0, timedelta(0)),
+    ],
+)
+def test_cache_max_age(value, expected):
+    cache = Cache(behavior="auto", max_age=value)
+    assert cache.max_age == expected
+
+
+@pytest.mark.parametrize("value", [-1, timedelta(microseconds=-1)])
+def test_cache_max_age_rejects_negative_values(value):
+    with pytest.raises(ValueError, match="max_age must be nonnegative"):
+        Cache(behavior="auto", max_age=value)
+
+
+@pytest.mark.parametrize("value", [True, 1.5, "1h"])
+def test_cache_max_age_rejects_invalid_types(value):
+    with pytest.raises(TypeError, match="max_age must be an int"):
+        Cache(behavior="auto", max_age=value)
 
 
 def test_cache_ignored_inputs_string():

--- a/uv.lock
+++ b/uv.lock
@@ -21,14 +21,14 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-21T22:05:41.580314Z"
+exclude-newer = "2026-08-27T19:25:10.869637Z"
 exclude-newer-span = "P5D"
 
 [options.exclude-newer-package]
-flyteidl2 = { timestamp = "2026-08-26T22:05:41.580374Z", span = "PT0S" }
-flyte-controller-base = { timestamp = "2026-08-26T22:05:41.580627Z", span = "PT0S" }
-ty = { timestamp = "2026-08-26T22:05:41.580628Z", span = "PT0S" }
-flyteplugins-union = { timestamp = "2026-08-26T22:05:41.580628Z", span = "PT0S" }
+flyteidl2 = { timestamp = "2026-09-01T19:25:10.869702Z", span = "PT0S" }
+flyte-controller-base = { timestamp = "2026-09-01T19:25:10.869735Z", span = "PT0S" }
+ty = { timestamp = "2026-09-01T19:25:10.869737Z", span = "PT0S" }
+flyteplugins-union = { timestamp = "2026-09-01T19:25:10.869736Z", span = "PT0S" }
 
 [[package]]
 name = "aiofiles"
@@ -1222,7 +1222,7 @@ requires-dist = [
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "fastapi", marker = "extra == 'examples-test'" },
     { name = "flyte-controller-base", marker = "extra == 'rust-controller'", directory = "rs_controller" },
-    { name = "flyteidl2", specifier = "==2.0.44" },
+    { name = "flyteidl2", specifier = "==2.0.45" },
     { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "grpcio", marker = "extra == 'connector'", specifier = ">=1.71.0" },
     { name = "grpcio-health-checking", marker = "extra == 'connector'" },
@@ -1299,11 +1299,11 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "flyteidl2", specifier = "==2.0.44" }]
+requires-dist = [{ name = "flyteidl2", specifier = "==2.0.45" }]
 
 [[package]]
 name = "flyteidl2"
-version = "2.0.44"
+version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -1312,7 +1312,7 @@ dependencies = [
     { name = "protovalidate" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/18/2b33255e806172fd20120014293dff15cd486c2e40a7f59318172a3caa4d/flyteidl2-2.0.44-py3-none-any.whl", hash = "sha256:68a28e768e603e309702b6392bed1111cc7c72719163743c65203da4c6170853", size = 377856, upload-time = "2026-08-26T21:54:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2c/c9255865f121d485988167002ebe9b5c2d22440abee02db620d369bf636f/flyteidl2-2.0.45-py3-none-any.whl", hash = "sha256:6d30c90926aa7d9a50a9dbb16fc639185c1df95fa56865e7d955b4cb4b91adec", size = 378430, upload-time = "2026-09-01T04:28:48.287Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add `Cache.max_age` as a task-level cache policy, accepting a nonnegative `timedelta` or integer number of seconds
- serialize the setting to `TaskMetadata.cache_max_age`, preserving the distinction between unset and explicit zero
- round-trip and override the setting through remote task details
- validate positive, zero, unset, negative, and invalid-type behavior

`None` uses the platform default, zero disables age-based expiration, and a positive value limits the age of cached results that the task will reuse.

## IDL dependency

This depends on `TaskMetadata.cache_max_age` from flyteorg/flyte#7938 ([commit](https://github.com/flyteorg/flyte/commit/6390805ff6495b87b2d172c35ccd5e6fab5567a5)). The dependency pin is intentionally not changed in this PR, so CI is expected to fail against `flyteidl2==2.0.44` until a new IDL version is published and the SDK pin is bumped.

## Testing

Using a locally built `flyteidl2==2.0.45.dev0` wheel:

- `pytest -q tests/user_api/test_cache.py tests/flyte/internal/runtime/test_task_serde.py tests/flyte/remote/test_task.py tests/flyte/test_image.py` — 177 passed
- Ruff passed for all changed source and test files
- `git diff --check` passed

### Dogfood validation

Validated against `dogfood/flytesnacks/development` and the leaseworker implementation in unionai/cloud#18043. The expiring task template contained `cacheMaxAge: 60s`; the normal-cache task omitted the field.

| Scenario | Run | Cache status | Execution marker |
|---|---|---|---|
| Initial 60s cache | [expiring-3](https://dogfood.cloud-staging.union.ai/v2/domain/development/project/flytesnacks/runs/pvditt-cache-age-expiring-3) | `CACHE_MISS` | `04:46:48.396163Z` |
| Immediate repeat | [expiring-4](https://dogfood.cloud-staging.union.ai/v2/domain/development/project/flytesnacks/runs/pvditt-cache-age-expiring-4) | `CACHE_HIT` | Same marker |
| Repeat after 163s | [expiring-5](https://dogfood.cloud-staging.union.ai/v2/domain/development/project/flytesnacks/runs/pvditt-cache-age-expiring-5) | `CACHE_MISS` | `04:49:31.529448Z` |
| Immediate repeat of refreshed result | [expiring-6](https://dogfood.cloud-staging.union.ai/v2/domain/development/project/flytesnacks/runs/pvditt-cache-age-expiring-6) | `CACHE_HIT` | Same refreshed marker |
| Normal cache initial | [normal-1](https://dogfood.cloud-staging.union.ai/v2/domain/development/project/flytesnacks/runs/pvditt-cache-age-normal-1) | `CACHE_MISS` | `04:47:39.246597Z` |
| Normal cache immediate repeat | [normal-2](https://dogfood.cloud-staging.union.ai/v2/domain/development/project/flytesnacks/runs/pvditt-cache-age-normal-2) | `CACHE_HIT` | Same marker |
| Normal cache after the wait | [normal-3](https://dogfood.cloud-staging.union.ai/v2/domain/development/project/flytesnacks/runs/pvditt-cache-age-normal-3) | `CACHE_HIT` | Still the original marker |

Dogfood workers were still using an older SDK without the task-side constructor argument, so the probe used this SDK build for registration and an import-time compatibility guard for the older task runtime. Cache lookup and expiration occur in leaseworker before task execution.
