### PR TITLE
fix(code-bundle): rebuild after source changes

### DIFF
--- a/examples/integration_tests.py
+++ b/examples/integration_tests.py
@@ -26,16 +26,10 @@ from datetime import datetime, timedelta
 import pytest
 
 import flyte
-from flyte._code_bundle import build_code_bundle
 
 # =============================================================================
 # FIXTURES
 # =============================================================================
-
-
-@pytest.fixture(autouse=True)
-def clear_lru_caches():
-    build_code_bundle.cache_clear()
 
 
 @pytest.fixture(scope="session")

--- a/src/flyte/_code_bundle/bundle.py
+++ b/src/flyte/_code_bundle/bundle.py
@@ -20,8 +20,6 @@ try:
 except ImportError:  # pragma: no cover - Windows local dev; task containers are POSIX
     fcntl = None  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
 
-from async_lru import alru_cache
-
 from flyte._logging import log, logger
 from flyte._status import status
 from flyte._utils import AsyncLRUCache
@@ -184,7 +182,6 @@ async def build_pkl_bundle(
             return CodeBundle(pkl=str(dest), computed_version=str_digest)
 
 
-@alru_cache
 async def build_code_bundle(
     from_dir: Path,
     *ignore: Type[Ignore],
@@ -292,7 +289,6 @@ async def build_code_bundle(
         return CodeBundle(tgz=remote_path, destination=extract_dir, computed_version=hash_digest, files=files)
 
 
-@alru_cache
 async def build_code_bundle_from_relative_paths(
     relative_paths: tuple[str, ...],
     from_dir: Path,

--- a/src/flyte/connectors/_connector.py
+++ b/src/flyte/connectors/_connector.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
 import os
+import pathlib
+import tempfile
 import typing
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
@@ -248,24 +250,12 @@ class AsyncConnectorExecutorMixin:
             if not storage.is_remote(tctx.raw_data_path.path):
                 return await TaskTemplate.execute(self, **kwargs)
             else:
-                local_code_bundle = await build_code_bundle(
-                    from_dir=cfg.root_dir,
-                    dryrun=True,
-                )
-                if local_code_bundle.tgz is None:
-                    raise RuntimeError("no tgz found in code bundle")
-                remote_code_path = await storage.put(
-                    local_code_bundle.tgz, prefix + "/code_bundle/" + os.path.basename(local_code_bundle.tgz)
-                )
+                code_bundle = await _build_and_upload_code_bundle(cfg.root_dir, prefix)
                 sc = SerializationContext(
                     project=tctx.action.project,
                     domain=tctx.action.domain,
                     org=tctx.action.org,
-                    code_bundle=CodeBundle(
-                        tgz=remote_code_path,
-                        computed_version=local_code_bundle.computed_version,
-                        destination="/opt/flyte/",
-                    ),
+                    code_bundle=code_bundle,
                     version=tctx.version,
                     image_cache=await build_images.aio(task.parent_env()) if task.parent_env else None,
                     root_dir=cfg.root_dir,
@@ -329,6 +319,25 @@ class AsyncConnectorExecutorMixin:
         if resource.outputs is None:
             return None
         return tuple(resource.outputs.values())
+
+
+async def _build_and_upload_code_bundle(from_dir: pathlib.Path, prefix: str) -> CodeBundle:
+    with tempfile.TemporaryDirectory(prefix="flyte-code-bundle-") as tmp_dir:
+        local_code_bundle = await build_code_bundle(
+            from_dir=from_dir,
+            dryrun=True,
+            copy_bundle_to=pathlib.Path(tmp_dir),
+        )
+        if local_code_bundle.tgz is None:
+            raise RuntimeError("no tgz found in code bundle")
+        remote_code_path = await storage.put(
+            local_code_bundle.tgz, prefix + "/code_bundle/" + os.path.basename(local_code_bundle.tgz)
+        )
+    return CodeBundle(
+        tgz=remote_code_path,
+        computed_version=local_code_bundle.computed_version,
+        destination="/opt/flyte/",
+    )
 
 
 async def get_resource_proto(resource: Resource) -> connector_pb2.Resource:

--- a/tests/flyte/app/test_app_code_bundling.py
+++ b/tests/flyte/app/test_app_code_bundling.py
@@ -50,7 +50,7 @@ async def test_code_bundle_consistency_with_include_files(temp_app_directory):
         from_dir=temp_app_directory,
         dryrun=True,
     )
-    build_code_bundle_from_relative_paths.cache_clear()
+
     bundle2 = await build_code_bundle_from_relative_paths(
         relative_paths=include_files,
         from_dir=temp_app_directory,
@@ -70,7 +70,7 @@ async def test_code_bundle_consistency_with_subdirectory_files(temp_app_director
         from_dir=temp_app_directory,
         dryrun=True,
     )
-    build_code_bundle_from_relative_paths.cache_clear()
+
     bundle2 = await build_code_bundle_from_relative_paths(
         relative_paths=include_files,
         from_dir=temp_app_directory,
@@ -89,7 +89,7 @@ async def test_code_bundle_different_files_produce_different_versions(temp_app_d
         from_dir=temp_app_directory,
         dryrun=True,
     )
-    build_code_bundle_from_relative_paths.cache_clear()
+
     bundle2 = await build_code_bundle_from_relative_paths(
         relative_paths=("app.py", "utils.py"),
         from_dir=temp_app_directory,
@@ -106,7 +106,7 @@ async def test_code_bundle_file_content_changes_version(temp_app_directory):
         from_dir=temp_app_directory,
         dryrun=True,
     )
-    build_code_bundle_from_relative_paths.cache_clear()
+
     (temp_app_directory / "app.py").write_text("print('Modified content!')")
     bundle2 = await build_code_bundle_from_relative_paths(
         relative_paths=("app.py",),

--- a/tests/flyte/code_bundle/test_build_code_bundle.py
+++ b/tests/flyte/code_bundle/test_build_code_bundle.py
@@ -24,10 +24,7 @@ from typing import Callable, Iterator
 
 import pytest
 
-from flyte._code_bundle.bundle import (
-    build_code_bundle,
-    build_code_bundle_from_relative_paths,
-)
+from flyte._code_bundle.bundle import build_code_bundle
 
 TESTDATA_ROOT = Path(__file__).parent / "testdata"
 
@@ -101,20 +98,6 @@ def importer() -> Iterator[Callable[[Path, str], ModuleType]]:
     for name in list(sys.modules.keys()):
         if name not in pre_existing:
             sys.modules.pop(name, None)
-
-
-@pytest.fixture(autouse=True)
-def _clear_bundle_cache() -> Iterator[None]:
-    """
-    ``build_code_bundle`` is wrapped in ``alru_cache`` at module level. Clear
-    it before and after each test so cached results from one layout never leak
-    into another — and so determinism tests can re-run the same inputs.
-    """
-    build_code_bundle.cache_clear()
-    build_code_bundle_from_relative_paths.cache_clear()
-    yield
-    build_code_bundle.cache_clear()
-    build_code_bundle_from_relative_paths.cache_clear()
 
 
 # ---------------------------------------------------------------------------
@@ -360,6 +343,40 @@ async def test_build_code_bundle_multi_file_loaded_modules_with_include(importer
 
 
 @pytest.mark.asyncio
+async def test_build_code_bundle_refreshes_after_source_file_changes():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        layout = _copy_layout("single_file", tmp_dir)
+        bundle_out = _bundle_out(tmp_dir)
+
+        bundle_before = await build_code_bundle(
+            from_dir=layout,
+            dryrun=True,
+            copy_style="all",
+            copy_bundle_to=bundle_out,
+        )
+
+        updated_source = """\
+def fn(x: int) -> int:
+    return x + 1
+"""
+        (layout / "hello.py").write_text(updated_source)
+
+        bundle_after = await build_code_bundle(
+            from_dir=layout,
+            dryrun=True,
+            copy_style="all",
+            copy_bundle_to=bundle_out,
+        )
+
+        with tarfile.open(Path(bundle_after.tgz), "r:gz") as tar:
+            bundled_file = tar.extractfile("hello.py")
+            assert bundled_file is not None
+            assert bundled_file.read().decode("utf-8") == updated_source
+        assert bundle_after.computed_version != bundle_before.computed_version
+
+
+@pytest.mark.asyncio
 async def test_build_code_bundle_digest_is_content_addressed():
     """
     Two identical layouts in different parent directories must produce the
@@ -399,8 +416,6 @@ async def test_build_code_bundle_include_changes_digest():
             copy_style="all",
             copy_bundle_to=_bundle_out(tmp_dir, "out_1"),
         )
-        # Clear so the second call doesn't return the cached result.
-        build_code_bundle.cache_clear()
 
         bundle_with_extra = await build_code_bundle(
             from_dir=layout,

--- a/tests/flyte/connector/test_connector_executor.py
+++ b/tests/flyte/connector/test_connector_executor.py
@@ -1,0 +1,78 @@
+import pathlib
+
+import pytest
+
+from flyte.connectors import _connector
+from flyte.models import CodeBundle
+
+
+@pytest.mark.asyncio
+async def test_upload_code_bundle_cleans_up_local_copy(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    bundle_dirs: list[pathlib.Path] = []
+
+    async def build_code_bundle(
+        *, from_dir: pathlib.Path, dryrun: bool, copy_bundle_to: pathlib.Path | None = None
+    ) -> CodeBundle:
+        assert from_dir == tmp_path
+        assert dryrun is True
+        assert copy_bundle_to is not None
+        bundle_dirs.append(copy_bundle_to)
+        local_bundle = copy_bundle_to / "bundle.tar.gz"
+        local_bundle.write_bytes(b"bundle")
+        return CodeBundle(tgz=str(local_bundle), computed_version="v1")
+
+    async def put(from_path: str, to_path: str) -> str:
+        local_path = pathlib.Path(from_path)
+        assert bundle_dirs
+        assert local_path.parent == bundle_dirs[0]
+        assert local_path.exists()
+        assert to_path == "s3://bucket/prefix/code_bundle/bundle.tar.gz"
+        return "s3://bucket/uploaded/bundle.tar.gz"
+
+    monkeypatch.setattr(_connector, "build_code_bundle", build_code_bundle)
+    monkeypatch.setattr(_connector.storage, "put", put)
+
+    result = await _connector._build_and_upload_code_bundle(tmp_path, "s3://bucket/prefix")
+
+    assert result == CodeBundle(
+        tgz="s3://bucket/uploaded/bundle.tar.gz",
+        computed_version="v1",
+        destination="/opt/flyte/",
+    )
+    assert len(bundle_dirs) == 1
+    assert not bundle_dirs[0].exists()
+
+
+@pytest.mark.asyncio
+async def test_upload_code_bundle_cleans_up_local_copy_when_upload_fails(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bundle_dirs: list[pathlib.Path] = []
+
+    async def build_code_bundle(
+        *, from_dir: pathlib.Path, dryrun: bool, copy_bundle_to: pathlib.Path | None = None
+    ) -> CodeBundle:
+        assert from_dir == tmp_path
+        assert dryrun is True
+        assert copy_bundle_to is not None
+        bundle_dirs.append(copy_bundle_to)
+        local_bundle = copy_bundle_to / "bundle.tar.gz"
+        local_bundle.write_bytes(b"bundle")
+        return CodeBundle(tgz=str(local_bundle), computed_version="v1")
+
+    async def put(from_path: str, to_path: str) -> str:
+        local_path = pathlib.Path(from_path)
+        assert bundle_dirs
+        assert local_path.parent == bundle_dirs[0]
+        assert local_path.exists()
+        assert to_path == "s3://bucket/prefix/code_bundle/bundle.tar.gz"
+        raise OSError("upload failed")
+
+    monkeypatch.setattr(_connector, "build_code_bundle", build_code_bundle)
+    monkeypatch.setattr(_connector.storage, "put", put)
+
+    with pytest.raises(OSError, match="upload failed"):
+        await _connector._build_and_upload_code_bundle(tmp_path, "s3://bucket/prefix")
+
+    assert len(bundle_dirs) == 1
+    assert not bundle_dirs[0].exists()


### PR DESCRIPTION
Fixes flyteorg/flyte#7923

Bug: `build_code_bundle` memoizes only its arguments → long-lived processes reuse stale source after files are edited

### Summary

`build_code_bundle` and `build_code_bundle_from_relative_paths` are wrapped in `@alru_cache`. The cache key contains function arguments such as `from_dir`, `copy_style`, and `additional_files`, **but it does not contain the selected files or their contents**.

In a long-lived process, the first `run()` builds and caches a `CodeBundle`. If source files are then edited and the task is run or forked again with the same bundling arguments, `alru_cache` returns the original bundle before the working tree is scanned again.

The later run therefore executes the pre-edit source without rebuilding the bundle or emitting a warning.

### Impact

- `run()` → edit source → `fork()` can execute the original source instead of the edited source.
- Agent debugging loops, interactive sessions, and other long-lived processes can silently retry stale code.
- The file-listing and content-digest code is never reached on an argument-cache hit, so the existing content-addressed cache cannot detect the edit.
- `skip_cache=True` does not provide a complete guarantee because repeated calls using the same `skip_cache=True` arguments can themselves be memoized.

### Root cause

`src/flyte/_code_bundle/bundle.py` memoizes the entire bundling operation:

```python
@alru_cache
async def build_code_bundle(
    from_dir: Path,
    *,
    copy_style: CopyFiles = "loaded_modules",
    skip_cache: bool = False,
    additional_files: tuple[str, ...] = (),
) -> CodeBundle:
    ...
```

The same applies to the explicit-path builder:

```python
@alru_cache
async def build_code_bundle_from_relative_paths(
    relative_paths: tuple[str, ...],
    from_dir: Path,
    *,
    skip_cache: bool = False,
) -> CodeBundle:
    ...
```

The content-sensitive portion of the operation runs inside the memoized function:

```python
files, digest = list_files_to_bundle(
    from_dir,
    True,
    *ignore,
    copy_style=copy_style,
    additional_files=additional_files or None,
)
```

On an `alru_cache` hit, execution returns before `list_files_to_bundle` or `list_relative_files_to_bundle` can recompute the digest.

The bundler already has a content-addressed persistent cache after file discovery:

```python
cached = _read_bundle_cache(digest)
if cached:
    hash_digest, remote_path = cached
    return CodeBundle(
        tgz=remote_path,
        destination=extract_dir,
        computed_version=hash_digest,
        files=files,
    )
```

This change removes the outer argument-only memoization while preserving the digest-backed persistent cache. Each invocation now scans and hashes the current source state; unchanged source still reuses the existing uploaded bundle and skips compression and upload.

Regression tests modify a source file between calls made with identical arguments and verify that:

- the new tarball contains the edited source;
- `computed_version` changes;
- both code-bundle builders detect edits without callers invoking `cache_clear()`.

## Test script result

I ran this locally on my Mac (M1 pro), and here are the logs.

cc @popojk 

```bash
[flyte] >> Building 1 image...
[flyte]   >> Building image flyte for environment bundle_cache_check
[flyte]   -- Image localhost:30000/flyte:1f0330ec1afa0fcf7873c2b864d56435 already exists, skipping build
[flyte] OK Built image for environment bundle_cache_check: localhost:30000/flyte:1f0330ec1afa0fcf7873c2b864d56435
[flyte] OK Code bundle found in cache, skipping upload
[flyte] >> Waiting for run 'rcdkbdjbd9w8cb9dkdxc'...
[flyte] -- Run 'rcdkbdjbd9w8cb9dkdxc': ActionPhase.QUEUED (0:00:00.140879 secs, attempt 1)
[flyte] -- Run 'rcdkbdjbd9w8cb9dkdxc': ActionPhase.INITIALIZING (0:00:00.726295 secs, attempt 1)
[flyte] -- Run 'rcdkbdjbd9w8cb9dkdxc': ActionPhase.RUNNING (0:00:02.116723 secs, attempt 1)
[flyte] -- Run 'rcdkbdjbd9w8cb9dkdxc': ActionPhase.SUCCEEDED (0:00:03.179049 secs, attempt 1)
[flyte] OK Run 'rcdkbdjbd9w8cb9dkdxc' completed successfully
[flyte] >> Building 1 image...
[flyte]   >> Building image flyte for environment bundle_cache_check
[flyte] OK Built image for environment bundle_cache_check: localhost:30000/flyte:1f0330ec1afa0fcf7873c2b864d56435
[flyte] OK Code bundle found in cache, skipping upload
[flyte] >> Waiting for run 'rhn7rvrxncj7vvzx2hxw'...
[flyte] -- Run 'rhn7rvrxncj7vvzx2hxw': ActionPhase.QUEUED (0:00:00.030412 secs, attempt 1)
[flyte] -- Run 'rhn7rvrxncj7vvzx2hxw': ActionPhase.INITIALIZING (0:00:01.109061 secs, attempt 1)
[flyte] -- Run 'rhn7rvrxncj7vvzx2hxw': ActionPhase.RUNNING (0:00:02.157140 secs, attempt 1)
[flyte] -- Run 'rhn7rvrxncj7vvzx2hxw': ActionPhase.SUCCEEDED (0:00:03.199646 secs, attempt 1)
[flyte] OK Run 'rhn7rvrxncj7vvzx2hxw' completed successfully
[flyte] >> Building 1 image...
[flyte]   >> Building image flyte for environment bundle_cache_check
[flyte] OK Built image for environment bundle_cache_check: localhost:30000/flyte:1f0330ec1afa0fcf7873c2b864d56435
[flyte] OK Code bundle found in cache, skipping upload
[flyte] >> Waiting for run 'r5dg2b292vczp7gzwphj'...
[flyte] -- Run 'r5dg2b292vczp7gzwphj': ActionPhase.QUEUED (0:00:00.022630 secs, attempt 1)
[flyte] -- Run 'r5dg2b292vczp7gzwphj': ActionPhase.INITIALIZING (0:00:01.118085 secs, attempt 1)
[flyte] -- Run 'r5dg2b292vczp7gzwphj': ActionPhase.RUNNING (0:00:02.430836 secs, attempt 1)
[flyte] -- Run 'r5dg2b292vczp7gzwphj': ActionPhase.SUCCEEDED (0:00:04.374561 secs, attempt 1)
[flyte] OK Run 'r5dg2b292vczp7gzwphj' completed successfully

===== run #1  initial =====
run #1  initial -> remote returned: 'ActionOutputs(o0="v1-ORIGINAL")'  (http://localhost:30080/v2/domain/development/project/flytesnacks/runs/rcdkbdjbd9w8cb9dkdxc)

>>> rewrote VALUE to v2-EDITED (same process, no restart)

===== run #2  after edit =====
run #2  after edit -> remote returned: 'ActionOutputs(o0="v2-EDITED")'  (http://localhost:30080/v2/domain/development/project/flytesnacks/runs/rhn7rvrxncj7vvzx2hxw)

===== run #3  unchanged, expect a cache hit =====
run #3  unchanged, expect a cache hit -> remote returned: 'ActionOutputs(o0="v2-EDITED")'  (http://localhost:30080/v2/domain/development/project/flytesnacks/runs/r5dg2b292vczp7gzwphj)

================ result ================
run #1 saw the original value : True
edit picked up on rerun       : True  PASS
unchanged rerun is consistent : True  PASS

(restored bundle_cache_check.py)
```