### PR TITLE
introduce service-account on task environment

### DIFF
--- a/src/flyte/_environment.py
+++ b/src/flyte/_environment.py
@@ -49,6 +49,7 @@ class Environment:
             `Resources` object.
         env_vars: Environment variables as `dict[str, str]`.
         secrets: Secrets to inject into the environment.
+        service_account: Kubernetes service account to run task pods as.
         pod_template: Kubernetes pod template as a string reference to a
             named template or a `PodTemplate` object. To set a termination grace
             period without depending on the `kubernetes` package, use
@@ -75,6 +76,7 @@ class Environment:
     interruptible: bool = False
     image: Union[str, Image, Literal["auto"], None] = "auto"
     include: Tuple[str, ...] = field(default_factory=tuple)
+    service_account: Optional[str] = None
 
     # Absolute path of the user file where this environment was instantiated.
     # Populated in __post_init__. Used to anchor relative `include` paths.
@@ -128,6 +130,8 @@ class Environment:
             raise TypeError(f"Expected image to be of type str or Image, got {type(self.image)}")
         if self.secrets and not isinstance(self.secrets, (str, Secret, List)):
             raise TypeError(f"Expected secrets to be of type SecretRequest, got {type(self.secrets)}")
+        if self.service_account is not None and not isinstance(self.service_account, str):
+            raise TypeError(f"Expected service_account to be of type str, got {type(self.service_account)}")
         for dep in self.depends_on:
             if not isinstance(dep, Environment):
                 raise TypeError(f"Expected depends_on to be of type List[Environment], got {type(dep)}")
@@ -208,6 +212,8 @@ class Environment:
             kwargs["resources"] = self.resources
         if self.secrets is not None:
             kwargs["secrets"] = self.secrets
+        if self.service_account is not None:
+            kwargs["service_account"] = self.service_account
         if self.env_vars is not None:
             kwargs["env_vars"] = self.env_vars
         if self.pod_template is not None:

--- a/src/flyte/_internal/runtime/task_serde.py
+++ b/src/flyte/_internal/runtime/task_serde.py
@@ -96,7 +96,7 @@ def get_security_context(
                 env_var=secret.as_env_var,
             )
             for secret in secret_list
-        ]
+        ],
     )
 
 

--- a/src/flyte/_internal/runtime/task_serde.py
+++ b/src/flyte/_internal/runtime/task_serde.py
@@ -69,6 +69,7 @@ def translate_task_to_wire(
 
 def get_security_context(
     secrets: Optional[SecretRequest],
+    service_account: Optional[str] = None,
 ) -> Optional[security_pb2.SecurityContext]:
     """
     Get the security context from a list of secrets. This is a placeholder function.
@@ -79,11 +80,12 @@ def get_security_context(
     Returns:
         The security context.
     """
-    if secrets is None:
+    if secrets is None and not service_account:
         return None
 
-    secret_list = secrets_from_request(secrets)
+    secret_list = secrets_from_request(secrets) if secrets is not None else []
     return security_pb2.SecurityContext(
+        run_as=security_pb2.Identity(k8s_service_account=service_account) if service_account else None,
         secrets=[
             security_pb2.Secret(
                 group=secret.group,
@@ -279,7 +281,7 @@ def get_proto_task(
         custom=custom if len(custom) > 0 else None,
         container=container,
         task_type_version=task.task_type_version,
-        security_context=get_security_context(task.secrets),
+        security_context=get_security_context(task.secrets, task.service_account),
         config=extra_config,
         k8s_pod=pod,
         sql=cast(Optional[tasks_pb2.Sql], sql),

--- a/src/flyte/_task.py
+++ b/src/flyte/_task.py
@@ -119,6 +119,7 @@ class TaskTemplate(Generic[P, R, F]):
         docs: Optional The documentation for the task, if not provided the function docstring will be used.
         env_vars: Optional The environment variables to set for the task.
         secrets: Optional The secrets that will be injected into the task at runtime.
+        service_account: Optional Kubernetes service account to run task pods as.
         timeout: Optional The timeout for the task.
         max_inline_io_bytes: Maximum allowed size (in bytes) for all inputs and outputs passed directly to the task
             (e.g., primitives, strings, dicts). Does not apply to files, directories, or dataframes.
@@ -142,6 +143,7 @@ class TaskTemplate(Generic[P, R, F]):
     docs: Optional[Documentation] = None
     env_vars: Optional[Dict[str, str]] = None
     secrets: Optional[SecretRequest] = None
+    service_account: Optional[str] = None
     timeout: Optional[TimeoutType] = None
     pod_template: Optional[Union[str, PodTemplate]] = None
     report: bool = False
@@ -184,6 +186,8 @@ class TaskTemplate(Generic[P, R, F]):
         if self.short_name == "":
             # If short_name is not set, use the name of the task
             self.short_name = self.name
+        if self.service_account is not None and not isinstance(self.service_account, str):
+            raise TypeError(f"Expected service_account to be of type str, got {type(self.service_account)}")
 
     def __getstate__(self):
         """
@@ -420,6 +424,7 @@ class TaskTemplate(Generic[P, R, F]):
         reusable: Union[ReusePolicy, Literal["off"], None] = None,
         env_vars: Optional[Dict[str, str]] = None,
         secrets: Optional[SecretRequest] = None,
+        service_account: Optional[str] = None,
         max_inline_io_bytes: int | None = None,
         pod_template: Optional[Union[str, PodTemplate]] = None,
         queue: Optional[str] = None,
@@ -443,6 +448,7 @@ class TaskTemplate(Generic[P, R, F]):
             reusable: Optional override for the reusability policy for the task.
             env_vars: Optional override for the environment variables to set for the task.
             secrets: Optional override for the secrets that will be injected into the task at runtime.
+            service_account: Optional override for the Kubernetes service account to run task pods as.
             max_inline_io_bytes: Optional override for the maximum allowed size (in bytes) for all inputs and outputs
                 passed directly to the task.
             pod_template: Optional override for the pod template to use for the task.
@@ -487,10 +493,17 @@ class TaskTemplate(Generic[P, R, F]):
                     " Reusable tasks will use the parent env's secrets. You can disable reusability and "
                     "override secrets if needed. (set reusable='off')"
                 )
+            if service_account is not None:
+                raise ValueError(
+                    "Cannot override service_account when reusable is set."
+                    " Reusable tasks will use the parent env's service_account. You can disable reusability and "
+                    "override service_account if needed. (set reusable='off')"
+                )
 
         resources = resources or self.resources
         env_vars = env_vars or self.env_vars
         secrets = secrets or self.secrets
+        service_account = service_account or self.service_account
 
         interruptible = interruptible if interruptible is not None else self.interruptible
         entrypoint = entrypoint if entrypoint is not None else self.entrypoint
@@ -528,6 +541,7 @@ class TaskTemplate(Generic[P, R, F]):
             reusable=cast(Optional[ReusePolicy], reusable),
             env_vars=env_vars,
             secrets=secrets,
+            service_account=service_account,
             max_inline_io_bytes=max_inline_io_bytes,
             pod_template=pod_template or self.pod_template,
             interruptible=interruptible,

--- a/src/flyte/_task_environment.py
+++ b/src/flyte/_task_environment.py
@@ -169,11 +169,11 @@ class TaskEnvironment(Environment):
         resources: Optional[Resources] = None,
         env_vars: Optional[Dict[str, str]] = None,
         secrets: Optional[SecretRequest] = None,
-        service_account: Optional[str] = None,
         depends_on: Optional[List[Environment]] = None,
         description: Optional[str] = None,
         interruptible: Optional[bool] = None,
         include: Optional[Tuple[str, ...]] = None,
+        service_account: Optional[str] = None,
         **kwargs: Any,
     ) -> TaskEnvironment:
         """

--- a/src/flyte/_task_environment.py
+++ b/src/flyte/_task_environment.py
@@ -82,6 +82,7 @@ class TaskEnvironment(Environment):
     | `resources` | Yes | — | Yes* |
     | `env_vars` | Yes | — | Yes* |
     | `secrets` | Yes | — | Yes* |
+    | `service_account` | Yes | Yes | Yes* |
     | `cache` | Yes | Yes | Yes |
     | `pod_template` | Yes | Yes | Yes |
     | `reusable` | Yes | — | Yes |
@@ -120,6 +121,9 @@ class TaskEnvironment(Environment):
             `task.override(env_vars=...)` when not using reusable containers.
         secrets: Secrets to inject. Overridable via `task.override(secrets=...)`
             when not using reusable containers.
+        service_account: Kubernetes service account to run task pods as.
+            Overridable via `@env.task(service_account=...)` or
+            `task.override(service_account=...)` when not using reusable containers.
         cache: Cache policy — `"auto"`, `"override"`, `"disable"`, or a `Cache` object.
             Also settable in `@env.task(cache=...)` and `task.override(cache=...)`.
         reusable: `ReusePolicy` for container reuse. Also overridable via
@@ -165,6 +169,7 @@ class TaskEnvironment(Environment):
         resources: Optional[Resources] = None,
         env_vars: Optional[Dict[str, str]] = None,
         secrets: Optional[SecretRequest] = None,
+        service_account: Optional[str] = None,
         depends_on: Optional[List[Environment]] = None,
         description: Optional[str] = None,
         interruptible: Optional[bool] = None,
@@ -199,6 +204,7 @@ class TaskEnvironment(Environment):
             resources: Override compute resources.
             env_vars: Override environment variables.
             secrets: Override secrets.
+            service_account: Override the Kubernetes service account.
             depends_on: Override deployment dependencies.
             description: Override the description.
             interruptible: Override the interruptible setting.
@@ -230,6 +236,8 @@ class TaskEnvironment(Environment):
             kwargs["reusable"] = reusable
         if secrets is not None:
             kwargs["secrets"] = secrets
+        if service_account is not None:
+            kwargs["service_account"] = service_account
         if depends_on is not None:
             kwargs["depends_on"] = depends_on
         if description is not None:
@@ -254,6 +262,7 @@ class TaskEnvironment(Environment):
         interruptible: bool | None = None,
         max_inline_io_bytes: int = MAX_INLINE_IO_BYTES,
         queue: Optional[str] = None,
+        service_account: Optional[str] = None,
         triggers: Tuple[Trigger, ...] | Trigger = (),
         links: Tuple[Link, ...] | Link = (),
         task_resolver: Any | None = None,
@@ -282,6 +291,7 @@ class TaskEnvironment(Environment):
         interruptible: bool | None = None,
         max_inline_io_bytes: int = MAX_INLINE_IO_BYTES,
         queue: Optional[str] = None,
+        service_account: Optional[str] = None,
         triggers: Tuple[Trigger, ...] | Trigger = (),
         links: Tuple[Link, ...] | Link = (),
         task_resolver: Any | None = None,
@@ -336,6 +346,8 @@ class TaskEnvironment(Environment):
         if self.reusable is not None:
             if pod_template is not None:
                 raise ValueError("Cannot set pod_template when environment is reusable.")
+            if service_account is not None and service_account != self.service_account:
+                raise ValueError("Cannot override service_account when environment is reusable.")
 
         def decorator(func: F) -> AsyncFunctionTaskTemplate[P, R, F]:
             func_name = cast("FunctionType", func).__name__
@@ -376,6 +388,7 @@ class TaskEnvironment(Environment):
                 docs=docs,
                 env_vars=self.env_vars,
                 secrets=self.secrets,
+                service_account=service_account or self.service_account,
                 pod_template=pod_template or self.pod_template,
                 parent_env=weakref.ref(self),
                 parent_env_name=self.name,

--- a/src/flyte/app/_app_environment.py
+++ b/src/flyte/app/_app_environment.py
@@ -376,6 +376,7 @@ class AppEnvironment(Environment):
         depends_on: Optional[List[Environment]] = None,
         description: Optional[str] = None,
         interruptible: Optional[bool] = None,
+        service_account: Optional[str] = None,
         **kwargs: Any,
     ) -> AppEnvironment:
         # validate unknown kwargs if needed
@@ -409,6 +410,8 @@ class AppEnvironment(Environment):
             kwargs["env_vars"] = env_vars
         if secrets is not None:
             kwargs["secrets"] = secrets
+        if service_account is not None:
+            kwargs["service_account"] = service_account
         if depends_on is not None:
             kwargs["depends_on"] = depends_on
         if description is not None:

--- a/src/flyte/app/_runtime/app_serde.py
+++ b/src/flyte/app/_runtime/app_serde.py
@@ -353,7 +353,7 @@ async def translate_app_env_to_idl(
         AppIDL protobuf message
     """
     # Build security context
-    task_sec_ctx = get_security_context(app_env.secrets)
+    task_sec_ctx = get_security_context(app_env.secrets, app_env.service_account)
     allow_anonymous = False
     if not app_env.requires_auth:
         allow_anonymous = True

--- a/src/flyte/remote/_task.py
+++ b/src/flyte/remote/_task.py
@@ -394,6 +394,7 @@ class TaskDetails(ToJSONMixin):
         timeout: Optional[flyte.TimeoutType] = None,
         env_vars: Optional[Dict[str, str]] = None,
         secrets: Optional[flyte.SecretRequest] = None,
+        service_account: Optional[str] = None,
         max_inline_io_bytes: Optional[int] = None,
         cache: Optional[flyte.Cache] = None,
         queue: Optional[str] = None,
@@ -409,6 +410,7 @@ class TaskDetails(ToJSONMixin):
             timeout: Execution timeout.
             env_vars: Environment variables to set.
             secrets: Secret requests for the task.
+            service_account: Kubernetes service account to run task pods as.
             max_inline_io_bytes: Maximum inline I/O size in bytes.
             cache: Cache configuration.
             queue: Queue name for task execution.
@@ -429,7 +431,16 @@ class TaskDetails(ToJSONMixin):
 
         template = pb2.spec.task_template
         if secrets:
-            template.security_context.CopyFrom(get_security_context(secrets))
+            existing_service_account = (
+                template.security_context.run_as.k8s_service_account
+                if template.HasField("security_context") and template.security_context.HasField("run_as")
+                else None
+            )
+            template.security_context.CopyFrom(
+                get_security_context(secrets, service_account or existing_service_account)
+            )
+        elif service_account:
+            template.security_context.run_as.k8s_service_account = service_account
 
         if template.HasField("container"):
             if env_vars:

--- a/tests/flyte/app/runtime/test_app_serde.py
+++ b/tests/flyte/app/runtime/test_app_serde.py
@@ -881,6 +881,53 @@ def test_app_with_secrets():
     assert app_idl.spec.security_context.secrets[0].key == "my-secret"
 
 
+def test_app_with_service_account():
+    """
+    GOAL: Verify the inherited Environment service_account is included in AppIDL.
+    """
+    app_env = AppEnvironment(
+        name="test-app",
+        image=Image.from_base("python:3.11"),
+        service_account="app-sa",
+    )
+
+    ctx = SerializationContext(
+        org="test-org",
+        project="test-project",
+        domain="test-domain",
+        version="v1",
+        root_dir=pathlib.Path.cwd(),
+    )
+
+    app_idl = translate_app_env_to_idl(app_env, ctx)
+    assert app_idl.spec.security_context.run_as.k8s_service_account == "app-sa"
+
+
+def test_app_with_secrets_and_service_account():
+    """
+    GOAL: Verify app security context preserves both secrets and service account.
+    """
+    app_env = AppEnvironment(
+        name="test-app",
+        image=Image.from_base("python:3.11"),
+        secrets="my-secret",
+        service_account="app-sa",
+    )
+
+    ctx = SerializationContext(
+        org="test-org",
+        project="test-project",
+        domain="test-domain",
+        version="v1",
+        root_dir=pathlib.Path.cwd(),
+    )
+
+    app_idl = translate_app_env_to_idl(app_env, ctx)
+    assert app_idl.spec.security_context.run_as.k8s_service_account == "app-sa"
+    assert len(app_idl.spec.security_context.secrets) == 1
+    assert app_idl.spec.security_context.secrets[0].key == "my-secret"
+
+
 def test_get_proto_container_with_image_cache():
     """
     GOAL: Verify image cache is used to resolve image URIs.

--- a/tests/flyte/app/test_app_environment.py
+++ b/tests/flyte/app/test_app_environment.py
@@ -1290,3 +1290,20 @@ def test_app_environment_clone_with_timeouts():
     # Clone clearing timeouts back to the default (no timeout)
     cloned_cleared = original.clone_with(name="cloned-cleared", timeouts=Timeouts())
     assert cloned_cleared.timeouts.request is None
+
+
+def test_app_environment_clone_with_service_account():
+    """
+    GOAL: Validate that clone_with can override the inherited Environment service_account.
+    """
+    original = AppEnvironment(
+        name="original-app",
+        image="python:3.11",
+        service_account="original-sa",
+    )
+
+    cloned = original.clone_with(name="cloned-app")
+    assert cloned.service_account == "original-sa"
+
+    cloned_override = original.clone_with(name="cloned-override", service_account="override-sa")
+    assert cloned_override.service_account == "override-sa"

--- a/tests/flyte/internal/runtime/test_task_serde.py
+++ b/tests/flyte/internal/runtime/test_task_serde.py
@@ -83,6 +83,23 @@ def test_get_security_context():
         get_security_context(["invalid_secret", 1])
 
 
+def test_get_security_context_with_service_account():
+    security_context = get_security_context(None, service_account="ml-sa")
+    assert isinstance(security_context, SecurityContext)
+    assert security_context.run_as.k8s_service_account == "ml-sa"
+    assert len(security_context.secrets) == 0
+
+
+def test_get_security_context_with_secrets_and_service_account():
+    secrets = Secret(group="group1", key="key1", as_env_var="ENV_VAR1")
+    security_context = get_security_context(secrets, service_account="ml-sa")
+
+    assert security_context.run_as.k8s_service_account == "ml-sa"
+    assert len(security_context.secrets) == 1
+    assert security_context.secrets[0].group == "group1"
+    assert security_context.secrets[0].key == "key1"
+
+
 def test_get_proto_container_task():
     # Create a real task environment
     env = flyte.TaskEnvironment(
@@ -423,6 +440,46 @@ def test_translate_task_to_wire_with_default_inputs(env_task_ctx):
     proto_task = translate_task_to_wire(task_template, context, default_inputs=default_inputs)
 
     assert proto_task.default_inputs == default_inputs
+
+
+def test_translate_task_to_wire_with_env_service_account():
+    env = flyte.TaskEnvironment(name="test_env", image="python:3.10", service_account="env-sa")
+
+    @env.task
+    async def t1() -> None:
+        return None
+
+    context = SerializationContext(
+        project="test-project",
+        domain="test-domain",
+        version="test-version",
+        org="test-org",
+        root_dir=pathlib.Path.cwd(),
+    )
+
+    proto_task = translate_task_to_wire(t1, context)
+
+    assert proto_task.task_template.security_context.run_as.k8s_service_account == "env-sa"
+
+
+def test_translate_task_to_wire_with_task_service_account_override():
+    env = flyte.TaskEnvironment(name="test_env", image="python:3.10", service_account="env-sa")
+
+    @env.task(service_account="task-sa")
+    async def t1() -> None:
+        return None
+
+    context = SerializationContext(
+        project="test-project",
+        domain="test-domain",
+        version="test-version",
+        org="test-org",
+        root_dir=pathlib.Path.cwd(),
+    )
+
+    proto_task = translate_task_to_wire(t1, context)
+
+    assert proto_task.task_template.security_context.run_as.k8s_service_account == "task-sa"
 
 
 def test_lookup_image_in_cache_with_cache():

--- a/tests/flyte/remote/test_task.py
+++ b/tests/flyte/remote/test_task.py
@@ -359,3 +359,33 @@ class TestTaskDetailsOverrideResources:
         assert "gpu" not in primary["resources"]["requests"]
         env = {e["name"]: e.get("value") for e in primary.get("env", [])}
         assert env == {"BASE": "from-pod-template"}
+
+
+class TestTaskDetailsOverrideSecurityContext:
+    def _task_details(self) -> TaskDetails:
+        from flyteidl2.task import task_definition_pb2
+
+        pb2 = task_definition_pb2.TaskDetails()
+        return TaskDetails(pb2)
+
+    def test_service_account_override_preserves_existing_secrets(self):
+        td = self._task_details()
+        td.pb2.spec.task_template.security_context.secrets.add(group="group1", key="key1")
+
+        out = td.override(service_account="ml-sa")
+
+        sc = out.pb2.spec.task_template.security_context
+        assert sc.run_as.k8s_service_account == "ml-sa"
+        assert len(sc.secrets) == 1
+        assert sc.secrets[0].key == "key1"
+
+    def test_secrets_override_preserves_existing_service_account(self):
+        td = self._task_details()
+        td.pb2.spec.task_template.security_context.run_as.k8s_service_account = "ml-sa"
+
+        out = td.override(secrets=flyte.Secret(group="group2", key="key2"))
+
+        sc = out.pb2.spec.task_template.security_context
+        assert sc.run_as.k8s_service_account == "ml-sa"
+        assert len(sc.secrets) == 1
+        assert sc.secrets[0].key == "key2"


### PR DESCRIPTION
## Summary

- Add `service_account` as a task-environment/task-level setting for deployed tasks.
- Serialize the configured service account into `TaskTemplate.security_context.run_as.k8s_service_account` alongside existing secret handling.
- Preserve service-account and secret fields when overriding remote task security context.

## Why

`flyte.run(..., service_account=...)` already supports setting the Kubernetes service account for an individual run, but deployed tasks did not have an equivalent default. This is needed for `flyte deploy` so tasks can be registered with the intended pod identity.

This matters especially for trigger-invoked runs: those runs are launched by the platform from the deployed task definition, so there is no caller-provided `flyte.run(..., service_account=...)` at invocation time. Storing the service account on the deployed task template gives trigger-created executions the correct Kubernetes identity.



## Validation
- I tested this internally on demo
``` python
# hello.py
import flyte

env = flyte.TaskEnvironment(
    name="my_map_workflow",
    service_account="default",
    image=flyte.Image.from_debian_base(install_flyte=False)
    .with_apt_packages("git")
    .with_commands(
        "pip install git+https://github.com/flyteorg/flyte-sdk.git@91d1133de945fbdef91039641110585420358e34"
    ),
)

every_minute = flyte.Trigger(name="service-account-test", automation=flyte.FixedRate(1))


# use TaskEnvironments to define tasks, which are regular Python functions.
@env.task
def fn(x: int) -> int:  # type annotations are recommended.
    slope, intercept = 2, 5
    print(slope * x + intercept)
    return slope * x + intercept


# tasks can also call other tasks, which will be manifested in different containers.
@env.task(triggers=every_minute)
def main(x_list: list[int] = list(range(10))) -> float:
    x_len = len(x_list)
    if x_len < 10:
        raise ValueError(f"x_list doesn't have a larger enough sample size, found: {x_len}")

    y_list = list(flyte.map(fn, x_list))  # flyte.map is like Python map, but runs in parallel.
    y_mean = sum(y_list) / len(y_list)
    return y_mean


if __name__ == "__main__":
    flyte.init_from_config("config.yaml")
    deployed_env = flyte.deploy(env)

```
- `ruff format --check src/flyte/_internal/runtime/task_serde.py`
- `ruff check src/flyte/_environment.py src/flyte/_task_environment.py src/flyte/_internal/runtime/task_serde.py`
- `mypy --config-file pyproject.toml src/flyte/_environment.py src/flyte/_task_environment.py`
- `ty check src/flyte/_environment.py src/flyte/_task_environment.py`