### PR TITLE
Accept raw InlineRuleList proto in notification settings

### DIFF
--- a/src/flyte/_internal/runtime/notifications_serde.py
+++ b/src/flyte/_internal/runtime/notifications_serde.py
@@ -35,14 +35,20 @@ _ACTION_PHASE_MAP: dict[ActionPhase, phase_pb2.ActionPhase.ValueType] = {
 
 
 def resolve_notification_settings(
-    notifications: NamedRule | Notification | Tuple[Notification, ...],
+    notifications: NamedRule | Notification | Tuple[Notification, ...] | run_pb2.InlineRuleList,
 ) -> tuple[str | None, run_pb2.InlineRuleList | None]:
     """Resolve user-facing notification specs into proto fields for RunSpec.
+
+    A raw `run_pb2.InlineRuleList` passes through untouched, so notification rules
+    read off an existing spec (e.g. a trigger's `spec.run_spec.notification_rules`)
+    can be attached to a new run without reconstructing notify objects.
 
     Returns (notification_rule_name, notification_rules) — exactly one will be set.
     """
     if isinstance(notifications, NamedRule):
         return notifications.name, None
+    if isinstance(notifications, run_pb2.InlineRuleList):
+        return None, notifications
     return None, _to_inline_rule_list(notifications)
 
 

--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -39,6 +39,7 @@ from ._sentry import track_operation
 
 if TYPE_CHECKING:
     from flyteidl2.core import artifact_id_pb2
+    from flyteidl2.task import run_pb2
 
     from flyte.notify import NamedRule, Notification
     from flyte.remote import Run
@@ -257,7 +258,7 @@ class _Runner:
         queue: Optional[str] = None,
         max_action_concurrency: int | None = None,
         custom_context: Dict[str, str] | None = None,
-        notifications: NamedRule | Notification | Tuple[Notification, ...] | None = None,
+        notifications: NamedRule | Notification | Tuple[Notification, ...] | run_pb2.InlineRuleList | None = None,
         cache_lookup_scope: CacheLookupScope = "global",
         preserve_original_types: bool | None = None,
         debug: bool = False,
@@ -1009,6 +1010,8 @@ class _Runner:
         error: str = "",
     ) -> None:
         """Send notifications locally. Never raises — failures are logged."""
+        from flyteidl2.task import run_pb2
+
         from flyte.notify._notifiers import NamedRule as _NamedRule
         from flyte.notify._notifiers import Notification as _Notification
         from flyte.notify._sender import send_notifications
@@ -1016,6 +1019,9 @@ class _Runner:
         notifications = self._notifications
         if isinstance(notifications, _NamedRule):
             logger.info("Skipping named rule %r in local mode", notifications.name)
+            return
+        if isinstance(notifications, run_pb2.InlineRuleList):
+            logger.info("Skipping raw notification_rules proto in local mode")
             return
 
         await send_notifications(
@@ -1608,7 +1614,7 @@ def with_runcontext(
     disable_run_cache: bool = False,
     queue: Optional[str] = None,
     max_action_concurrency: int | None = None,
-    notifications: Notification | Tuple[Notification, ...] | None = None,
+    notifications: NamedRule | Notification | Tuple[Notification, ...] | run_pb2.InlineRuleList | None = None,
     custom_context: Dict[str, str] | None = None,
     cache_lookup_scope: CacheLookupScope = "global",
     preserve_original_types: bool = False,
@@ -1690,7 +1696,10 @@ def with_runcontext(
             action holds a concurrency slot while waiting for its child actions.
         notifications: Optional Notification(s) to send when the run reaches specific execution phases.
             Accepts a single notification or a tuple of notifications. Supports Email, Slack, Teams, and Webhook types.
-            See `flyte.notify` for available notification types and template variables.
+            See `flyte.notify` for available notification types and template variables. Also accepts a
+            `flyte.notify.NamedRule` referencing a pre-defined rule, or a raw
+            `flyteidl2.task.run_pb2.InlineRuleList` proto — e.g. the `notification_rules` read off a
+            trigger's or another run's spec — which is attached to the run verbatim (remote runs only).
         custom_context: Optional global input context to pass to the task. This will be available via
             get_custom_context() within the task and will automatically propagate to sub-tasks.
             Acts as base/default values that can be overridden by context managers in the code.

--- a/src/flyte/_trigger.py
+++ b/src/flyte/_trigger.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Any, Dict, Literal, Mapping, Tuple, Union
 import rich.repr
 
 if TYPE_CHECKING:
+    from flyteidl2.task import run_pb2
+
     from flyte.notify import NamedRule, Notification
 
 Timezone = Literal[
@@ -818,7 +820,7 @@ class Trigger:
     max_action_concurrency: int | None = None
     labels: Mapping[str, str] | None = None
     annotations: Mapping[str, str] | None = None
-    notifications: NamedRule | Notification | Tuple[Notification, ...] | None = None
+    notifications: NamedRule | Notification | Tuple[Notification, ...] | run_pb2.InlineRuleList | None = None
     custom_context: Mapping[str, str] | None = None
 
     def __post_init__(self):

--- a/tests/internal/runtime/test_notifications_serde.py
+++ b/tests/internal/runtime/test_notifications_serde.py
@@ -43,6 +43,27 @@ class TestResolveNotificationSettings:
         assert name is None
         assert len(rules.rules) == 2
 
+    def test_inline_rule_list_proto_passes_through(self):
+        # Rules read off an existing spec (e.g. a trigger's run_spec.notification_rules)
+        # attach to a new run verbatim, with no notify-object reconstruction.
+        _, rules = resolve_notification_settings(
+            (
+                Email(on_phase=(ActionPhase.SUCCEEDED, ActionPhase.FAILED), recipients=("a@b.com",)),
+                Webhook(on_phase=ActionPhase.ABORTED, url="https://hook"),
+            )
+        )
+        name, passed = resolve_notification_settings(rules)
+        assert name is None
+        assert passed is rules
+
+    def test_empty_inline_rule_list_proto_passes_through(self):
+        from flyteidl2.task import run_pb2
+
+        name, passed = resolve_notification_settings(run_pb2.InlineRuleList())
+        assert name is None
+        assert passed is not None
+        assert len(passed.rules) == 0
+
 
 class TestToInlineRuleList:
     def test_single_notification_wrapped(self):


### PR DESCRIPTION
## Summary

Lets a launcher attach notification rules read directly off an existing `RunSpec` — e.g. a trigger's `spec.run_spec.notification_rules` — to a new run, without reconstructing `flyte.notify` objects.

Motivating case: a service kicks off runs but has no knowledge of how the target trigger/task defined its notifications. It should be able to read the trigger's notification spec and pass it straight through:

```python
trigger = await remote.Trigger.get.aio(name=..., task_name=...)
flyte.with_runcontext(
    notifications=trigger.pb2.spec.run_spec.notification_rules
).run(task, ...)
```

Before this change that raises `TypeError: 'InlineRuleList' object is not iterable`, and the only workaround is to deserialize the proto back into `notify.Email`/`Webhook`/… objects by hand.

## Changes

- `resolve_notification_settings` passes a raw `run_pb2.InlineRuleList` through untouched (returns it as `notification_rules`, no `notification_rule_name`).
- Widened the `notifications` parameter to accept `run_pb2.InlineRuleList` on `with_runcontext`, `_Runner.__init__`, and `flyte.Trigger` (the trigger path shares the same resolver via `trigger_serde`).
- Local mode skips a raw proto the same way it already skips a `NamedRule`, since a raw rule-list template can't be rendered for local delivery.
- Added unit tests for passthrough of a populated and an empty `InlineRuleList`.

## Testing

`tests/internal/runtime/test_notifications_serde.py`, `tests/flyte/internal/runtime/test_trigger_serde.py`, `tests/flyte/test_trigger.py`, and `tests/user_api/test_triggers.py` all pass (122 tests), including the 2 new cases. Also verified end-to-end against a live cluster: a run launched with a trigger's `notification_rules` proto carries the identical rules and fires the notification on completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)