### PR TITLE
docs(examples): SaaS integration recipes over the vendors' own SDKs

### DIFF
--- a/examples/external_saas_integrations/README.md
+++ b/examples/external_saas_integrations/README.md
@@ -1,0 +1,65 @@
+# External SaaS integrations
+
+Recipes for driving GitHub, Slack, Linear, ClickUp, and Jira from Flyte.
+
+There is deliberately **no Flyte client plugin** for these products. Each vendor
+already ships (or the community maintains) a Python client that is tested
+against the live API by people who get deprecation notices first, and a task is
+just a function — so calling `PyGithub` or `slack_sdk` from a task needs nothing
+in between. A wrapper here would only add a surface to keep in sync with someone
+else's release calendar.
+
+What *is* Flyte's job, and what these examples use from it:
+
+- **`flyte.extras.webhooks`** — ships with flyte: one app that authenticates an inbound
+  delivery with the product's own scheme, normalizes it into a single event
+  model, and launches a run once per event key with `idempotent_run`.
+- **`flyteplugins-webhooks-<product>`** — one small package per product,
+  contributing just its verification and parsing.
+- **`flyte.new_condition`** — park a run on a human decision, with a typed
+  payload coming back. `flyteplugins.github.review_pr` wraps this into a PR
+  review gate, which is the one place a plugin beats calling the vendor SDK:
+  the condition is Flyte's, not GitHub's.
+
+## The examples
+
+| File | What it shows | Client |
+| --- | --- | --- |
+| `webhook_receiver.py` | One app receiving from all five products, launching a task per event | `flyteplugins-webhooks-*` |
+| `github_pr_review_gate.py` | Human-gated merge, on `flyteplugins.github.review_pr` | plugin + `PyGithub` |
+| `github_triage_pr.py` | Label, comment, and report a check run | `PyGithub` |
+| `slack_notify.py` | Post, thread, react, answer a mention | `slack_sdk` |
+| `linear_triage_issue.py` | Query a backlog and comment, over GraphQL | `gql` |
+| `clickup_manage_ticket.py` | Open and close tickets, with a status pre-check | `httpx` |
+| `jira_manage_ticket.py` | Open, transition, and search issues | `jira` |
+
+Linear and ClickUp ship no official Python SDK. Linear's API is a single GraphQL
+endpoint, so `gql` is the maintained client; ClickUp's is a handful of REST
+calls, so `httpx` directly beats a thin third-party wrapper.
+
+## Putting it together
+
+The receiver and the tasks are separate on purpose: the app authenticates and
+dispatches, the tasks do the work and can be run, tested, and retried on their
+own.
+
+```bash
+# 1. deploy the tasks the receiver will launch
+flyte deploy examples/external_saas_integrations/github_triage_pr.py env
+flyte deploy examples/external_saas_integrations/slack_notify.py env
+
+# 2. run one directly, to confirm credentials work before any webhook is involved
+flyte run examples/external_saas_integrations/github_triage_pr.py triage_pr \
+    --repo <owner>/<repo> --number <pr>
+
+# 3. deploy the receiver and point each provider at the URL its dashboard shows
+python examples/external_saas_integrations/webhook_receiver.py
+```
+
+Task names are qualified by their environment when deployed — `triage_pr` in
+`github_triage_pr.py` becomes `github-triage.triage_pr`, which is what the
+receiver looks up. That qualifier is also what keeps the two `triage_issue`
+tasks here (Linear's and Jira's) from colliding.
+
+`plugins/webhooks/README.md` has the full end-to-end testing guide, including
+how to wire up each provider and what to check at every step.

--- a/examples/external_saas_integrations/clickup_manage_ticket.py
+++ b/examples/external_saas_integrations/clickup_manage_ticket.py
@@ -1,0 +1,90 @@
+"""Read and write ClickUp from tasks, with `httpx` against its REST v2 API.
+
+ClickUp ships no official Python SDK and the community ones are thin and
+sporadically maintained, so this calls the REST API directly with `httpx`
+rather than adding a dependency that wraps four endpoints.
+
+Requirements:
+    pip install flyte httpx
+
+Setup:
+    flyte create secret CLICKUP_TOKEN --value pk_...
+
+Usage:
+    flyte run examples/external_saas_integrations/clickup_manage_ticket.py \\
+        open_ticket --list_id <list-id> --name "From Flyte"
+"""
+
+import os
+
+import flyte
+
+image = flyte.Image.from_debian_base(python_version=(3, 12)).with_pip_packages("httpx")
+
+env = flyte.TaskEnvironment(
+    name="clickup-tickets",
+    image=image,
+    secrets=[flyte.Secret("CLICKUP_TOKEN", as_env_var="CLICKUP_TOKEN")],
+)
+
+API = "https://api.clickup.com/api/v2"
+
+
+def _client():
+    import httpx
+
+    return httpx.AsyncClient(base_url=API, headers={"Authorization": os.environ["CLICKUP_TOKEN"]}, timeout=30)
+
+
+@env.task
+async def open_ticket(list_id: str, name: str, description: str = "") -> str:
+    """Create a task and return its URL."""
+    async with _client() as client:
+        response = await client.post(f"/list/{list_id}/task", json={"name": name, "description": description})
+        response.raise_for_status()
+        return response.json()["url"]
+
+
+@env.task
+async def triage_task(task_id: str) -> str:
+    """Comment on a newly created task.
+
+    This is what `webhook_receiver.py` launches for every `taskCreated`.
+    """
+    async with _client() as client:
+        task = await client.get(f"/task/{task_id}")
+        task.raise_for_status()
+        status = (task.json().get("status") or {}).get("status")
+        posted = await client.post(
+            f"/task/{task_id}/comment", json={"comment_text": f"Flyte triaged this ticket (status: {status})."}
+        )
+        posted.raise_for_status()
+    return f"triaged {task_id}"
+
+
+@env.task
+async def close_ticket(task_id: str, done_status: str = "done") -> str:
+    """Move a ticket to a Done-like status, validating it first.
+
+    ClickUp rejects transitions to statuses the ticket's list does not define,
+    with an opaque 400 — so check the list's statuses before trying.
+    """
+    async with _client() as client:
+        task = await client.get(f"/task/{task_id}")
+        task.raise_for_status()
+        list_id = (task.json().get("list") or {}).get("id")
+
+        listing = await client.get(f"/list/{list_id}")
+        listing.raise_for_status()
+        valid = [s["status"] for s in listing.json().get("statuses", [])]
+        if done_status not in valid:
+            raise ValueError(f"status {done_status!r} is not defined on list {list_id}; valid: {valid}")
+
+        updated = await client.put(f"/task/{task_id}", json={"status": done_status})
+        updated.raise_for_status()
+    return f"{task_id} -> {done_status}"
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    print(flyte.run(open_ticket, list_id="LIST_ID", name="Flyte test ticket").url)

--- a/examples/external_saas_integrations/github_pr_review_gate.py
+++ b/examples/external_saas_integrations/github_pr_review_gate.py
@@ -1,0 +1,78 @@
+"""Human-gated PR merging: a condition carrying a JSON payload.
+
+A task collects review metadata from a pull request, embeds it as JSON in a
+markdown condition prompt, parks the run until a human answers in the Flyte UI,
+and parses the response into a typed decision. Approved PRs get merged.
+
+The gate itself is `flyteplugins.github.review_pr` — it lives in the plugin
+because `flyte.new_condition` is the part only Flyte can do. Merging is
+`PyGithub`, called directly here.
+
+Requirements:
+    pip install "flyteplugins-github[review]"
+
+Setup:
+    flyte create secret GITHUB_TOKEN --value <token-with-repo-scope>
+
+Usage:
+    flyte run examples/external_saas_integrations/github_pr_review_gate.py \\
+        gated_merge --repo octocat/hello-world --number 1
+"""
+
+import asyncio
+import os
+
+from flyteplugins.github import ReviewDecision, review_pr
+
+import flyte
+
+image = flyte.Image.from_debian_base(python_version=(3, 12)).with_pip_packages("flyteplugins-github[review]")
+
+env = flyte.TaskEnvironment(
+    name="github-review-gate",
+    image=image,
+    secrets=[flyte.Secret("GITHUB_TOKEN", as_env_var="GITHUB_TOKEN")],
+)
+
+
+def _comment(repo: str, number: int, body: str) -> None:
+    from github import Auth, Github
+
+    with Github(auth=Auth.Token(os.environ["GITHUB_TOKEN"])) as gh:
+        gh.get_repo(repo).get_issue(number).create_comment(body)
+
+
+def _merge(repo: str, number: int) -> str:
+    from github import Auth, Github
+
+    with Github(auth=Auth.Token(os.environ["GITHUB_TOKEN"])) as gh:
+        result = gh.get_repo(repo).get_pull(number).merge(merge_method="squash")
+    return f"merged {result.sha}"
+
+
+@env.task
+async def gated_merge(repo: str, number: int) -> str:
+    """Wait for a human review, then merge if approved.
+
+    The run parks at `review_pr` until someone answers the condition in the
+    Flyte UI. Pass `timeout=` to bound that wait.
+    """
+    decision: ReviewDecision = await review_pr(repo, number)
+
+    if not decision.is_approved:
+        # Post the reviewer's reasoning back to the PR before bailing out, so
+        # the decision is visible where the author is looking.
+        blockers = "\n".join(f"- `{c.path}`: {c.body}" for c in decision.blocking_comments)
+        await asyncio.to_thread(
+            _comment, repo, number, f"Review gate blocked this merge: {decision.summary}\n{blockers}"
+        )
+        return f"blocked: {decision.summary}"
+
+    # PyGithub is synchronous; keep it off the event loop.
+    return await asyncio.to_thread(_merge, repo, number)
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.with_runcontext().run(gated_merge, repo="octocat/hello-world", number=1)
+    print(run.url)

--- a/examples/external_saas_integrations/github_triage_pr.py
+++ b/examples/external_saas_integrations/github_triage_pr.py
@@ -1,0 +1,71 @@
+"""Read and write GitHub from tasks, with PyGithub.
+
+The task the webhook receiver launches when a PR opens. There is no Flyte
+plugin between you and GitHub here — PyGithub is the maintained client, and a
+task is just a function that calls it.
+
+Requirements:
+    pip install flyte PyGithub
+
+Setup:
+    flyte create secret GITHUB_TOKEN --value <token-with-repo-scope>
+
+Usage:
+    flyte run examples/external_saas_integrations/github_triage_pr.py \\
+        triage_pr --repo octocat/hello-world --number 1
+"""
+
+import os
+
+import flyte
+
+image = flyte.Image.from_debian_base(python_version=(3, 12)).with_pip_packages("PyGithub")
+
+env = flyte.TaskEnvironment(
+    name="github-triage",
+    image=image,
+    secrets=[flyte.Secret("GITHUB_TOKEN", as_env_var="GITHUB_TOKEN")],
+)
+
+
+def _client():
+    from github import Auth, Github
+
+    return Github(auth=Auth.Token(os.environ["GITHUB_TOKEN"]))
+
+
+@env.task
+def summarize_pr(repo: str, number: int) -> str:
+    """Read a pull request and summarize what it changes."""
+    with _client() as gh:
+        pr = gh.get_repo(repo).get_pull(number)
+        lines = [f"- {f.filename} (+{f.additions}/-{f.deletions})" for f in pr.get_files()[:20]]
+        return f"{pr.title} ({pr.head.ref} -> {pr.base.ref})\n" + "\n".join(lines)
+
+
+@env.task
+def triage_pr(repo: str, number: int) -> str:
+    """Label a new PR, comment on it, and report a check run.
+
+    This is what `webhook_receiver.py` launches for every newly opened PR.
+    """
+    with _client() as gh:
+        repository = gh.get_repo(repo)
+        pr = repository.get_pull(number)
+        pr.add_to_labels("flyte-triage")
+        pr.create_issue_comment(
+            f"Flyte triage: this PR touches {pr.changed_files} files (+{pr.additions}/-{pr.deletions})."
+        )
+        repository.create_check_run(
+            name="flyte-triage",
+            head_sha=pr.head.sha,
+            status="completed",
+            conclusion="success",
+            output={"title": "flyte-triage", "summary": "Flyte triaged this pull request."},
+        )
+    return f"triaged {repo}#{number}"
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    print(flyte.run(triage_pr, repo="octocat/hello-world", number=1).url)

--- a/examples/external_saas_integrations/jira_manage_ticket.py
+++ b/examples/external_saas_integrations/jira_manage_ticket.py
@@ -1,0 +1,91 @@
+"""Read and write Jira from tasks, with the official `jira` package.
+
+Requirements:
+    pip install flyte jira
+
+Setup:
+    flyte create secret JIRA_BASE_URL  --value https://<site>.atlassian.net
+    flyte create secret JIRA_EMAIL     --value you@example.com
+    flyte create secret JIRA_API_TOKEN --value <api-token>
+
+Usage:
+    flyte run examples/external_saas_integrations/jira_manage_ticket.py \\
+        open_ticket --project_key PROJ --summary "From Flyte"
+"""
+
+import os
+
+import flyte
+
+image = flyte.Image.from_debian_base(python_version=(3, 12)).with_pip_packages("jira")
+
+env = flyte.TaskEnvironment(
+    name="jira-tickets",
+    image=image,
+    secrets=[
+        flyte.Secret("JIRA_BASE_URL", as_env_var="JIRA_BASE_URL"),
+        flyte.Secret("JIRA_EMAIL", as_env_var="JIRA_EMAIL"),
+        flyte.Secret("JIRA_API_TOKEN", as_env_var="JIRA_API_TOKEN"),
+    ],
+)
+
+
+def _client():
+    from jira import JIRA
+
+    return JIRA(
+        server=os.environ["JIRA_BASE_URL"],
+        basic_auth=(os.environ["JIRA_EMAIL"], os.environ["JIRA_API_TOKEN"]),
+    )
+
+
+@env.task
+def open_ticket(project_key: str, summary: str, description: str = "") -> str:
+    """Create an issue and return its key."""
+    issue = _client().create_issue(
+        project=project_key, summary=summary, description=description, issuetype={"name": "Task"}
+    )
+    return issue.key
+
+
+@env.task
+def triage_issue(issue_key: str) -> str:
+    """Comment on a newly created issue.
+
+    This is what `webhook_receiver.py` launches for every `jira:issue_created`.
+    """
+    jira = _client()
+    issue = jira.issue(issue_key)
+    jira.add_comment(issue, f"Flyte triaged this issue (status: {issue.fields.status.name}).")
+    return f"triaged {issue_key}"
+
+
+@env.task
+def summarize_open_bugs(project_key: str, limit: int = 20) -> str:
+    """Summarize open bugs via JQL."""
+    issues = _client().search_issues(
+        f'project = "{project_key}" AND issuetype = Bug AND statusCategory != Done', maxResults=limit
+    )
+    return "\n".join(f"- {i.key}: {i.fields.summary}" for i in issues) or "no open bugs"
+
+
+@env.task
+def start_work(issue_key: str, transition: str = "In Progress") -> str:
+    """Transition an issue by name, listing the valid ones when it does not apply.
+
+    Jira rejects transitions the issue's workflow does not offer, so resolve the
+    name against what is actually available rather than guessing an id.
+    """
+    jira = _client()
+    issue = jira.issue(issue_key)
+    available = {t["name"].lower(): t["id"] for t in jira.transitions(issue)}
+    target = available.get(transition.lower())
+    if target is None:
+        raise ValueError(f"{issue_key} cannot transition to {transition!r}; available: {sorted(available)}")
+    jira.transition_issue(issue, target)
+    return f"{issue_key} -> {transition}"
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    print(flyte.run(open_ticket, project_key="PROJ", summary="Flyte test issue").url)

--- a/examples/external_saas_integrations/linear_triage_issue.py
+++ b/examples/external_saas_integrations/linear_triage_issue.py
@@ -1,0 +1,80 @@
+"""Read and write Linear from tasks, with `gql` over Linear's GraphQL API.
+
+Linear ships no official Python SDK; `gql` is the maintained GraphQL client and
+Linear's API is a single endpoint, so there is little to wrap.
+
+Requirements:
+    pip install flyte "gql[httpx]"
+
+Setup:
+    flyte create secret LINEAR_API_KEY --value lin_api_...
+
+Usage:
+    flyte run examples/external_saas_integrations/linear_triage_issue.py \\
+        summarize_backlog --team_key ENG
+"""
+
+import os
+
+import flyte
+
+image = flyte.Image.from_debian_base(python_version=(3, 12)).with_pip_packages("gql[httpx]")
+
+env = flyte.TaskEnvironment(
+    name="linear-triage",
+    image=image,
+    secrets=[flyte.Secret("LINEAR_API_KEY", as_env_var="LINEAR_API_KEY")],
+)
+
+ENDPOINT = "https://api.linear.app/graphql"
+
+
+async def _execute(query: str, variables: dict | None = None) -> dict:
+    from gql import Client, gql
+    from gql.transport.httpx import HTTPXAsyncTransport
+
+    transport = HTTPXAsyncTransport(url=ENDPOINT, headers={"Authorization": os.environ["LINEAR_API_KEY"]})
+    async with Client(transport=transport, fetch_schema_from_transport=False) as session:
+        return await session.execute(gql(query), variable_values=variables or {})
+
+
+@env.task
+async def summarize_backlog(team_key: str, limit: int = 25) -> str:
+    """List a team's open issues."""
+    data = await _execute(
+        """
+        query Backlog($teamKey: String!, $first: Int!) {
+          issues(first: $first, filter: {team: {key: {eq: $teamKey}},
+                                         completedAt: {null: true},
+                                         canceledAt: {null: true}}) {
+            nodes { identifier title state { name } }
+          }
+        }
+        """,
+        {"teamKey": team_key, "first": limit},
+    )
+    nodes = data["issues"]["nodes"]
+    return "\n".join(f"- {n['identifier']}: {n['title']} [{n['state']['name']}]" for n in nodes) or "backlog is empty"
+
+
+@env.task
+async def triage_issue(issue_id: str) -> str:
+    """Comment on an issue by its UUID.
+
+    This is what `webhook_receiver.py` launches for every `Issue.create`. Linear
+    webhooks carry the entity UUID, which is what `commentCreate` wants.
+    """
+    await _execute(
+        """
+        mutation Comment($input: CommentCreateInput!) {
+          commentCreate(input: $input) { success }
+        }
+        """,
+        {"input": {"issueId": issue_id, "body": "Flyte triaged this issue."}},
+    )
+    return f"triaged {issue_id}"
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    print(flyte.run(summarize_backlog, team_key="ENG").url)

--- a/examples/external_saas_integrations/slack_notify.py
+++ b/examples/external_saas_integrations/slack_notify.py
@@ -1,0 +1,69 @@
+"""Post to Slack from tasks, with the official `slack_sdk`.
+
+Requirements:
+    pip install flyte slack_sdk
+
+Setup:
+    flyte create secret SLACK_BOT_TOKEN --value xoxb-...
+    Invite the bot to the channel: /invite @your-app
+
+Usage:
+    flyte run examples/external_saas_integrations/slack_notify.py \\
+        notify --channel C01234567 --message "Hello from Flyte!"
+"""
+
+import os
+
+import flyte
+
+image = flyte.Image.from_debian_base(python_version=(3, 12)).with_pip_packages("slack_sdk")
+
+env = flyte.TaskEnvironment(
+    name="slack-notify",
+    image=image,
+    secrets=[flyte.Secret("SLACK_BOT_TOKEN", as_env_var="SLACK_BOT_TOKEN")],
+)
+
+
+def _client():
+    from slack_sdk.web.async_client import AsyncWebClient
+
+    return AsyncWebClient(token=os.environ["SLACK_BOT_TOKEN"])
+
+
+@env.task
+async def notify(channel: str, message: str) -> str:
+    """Post a message and return its permalink."""
+    client = _client()
+    posted = await client.chat_postMessage(channel=channel, text=message)
+    link = await client.chat_getPermalink(channel=channel, message_ts=posted["ts"])
+    return link["permalink"]
+
+
+@env.task
+async def answer_mention(channel: str, thread_ts: str, question: str) -> str:
+    """Reply in the thread that mentioned the bot.
+
+    This is what `webhook_receiver.py` launches for every mention. Swap the
+    canned reply for an agent call to make it do real work.
+    """
+    client = _client()
+    await client.chat_postMessage(channel=channel, thread_ts=thread_ts, text=f"Got it — working on: {question}")
+    return f"answered {channel}/{thread_ts}"
+
+
+@env.task
+async def progress_thread(channel: str, status: str) -> str:
+    """Start a thread, post progress in it, and react to the root."""
+    client = _client()
+    root = await client.chat_postMessage(channel=channel, text=f":rocket: {status} started")
+    await client.chat_postMessage(channel=channel, thread_ts=root["ts"], text="Working on it...")
+    await client.chat_postMessage(channel=channel, thread_ts=root["ts"], text=f":white_check_mark: {status} finished")
+    await client.reactions_add(channel=channel, timestamp=root["ts"], name="white_check_mark")
+    return str(root["ts"])
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    # Replace with a channel id your bot is a member of.
+    print(flyte.run(notify, channel="C01234567", message="Hello from Flyte!").url)

--- a/examples/external_saas_integrations/webhook_receiver.py
+++ b/examples/external_saas_integrations/webhook_receiver.py
@@ -1,0 +1,136 @@
+"""One app receiving webhooks from every provider, launching tasks per event.
+
+This is the whole point of `flyteplugins-webhooks`: authenticate an inbound
+delivery, normalize it, and turn it into a run. The tasks it launches live in
+the sibling examples here and talk to each product through that product's own
+maintained SDK — no Flyte plugin sits between them and the API.
+
+Requirements:
+    pip install "flyteplugins-github[app]" flyteplugins-slack  # ...and any others
+
+Setup:
+    Store the secret for each provider you enable:
+        flyte create secret GITHUB_WEBHOOK_SECRET --value <random-string>
+        flyte create secret SLACK_SIGNING_SECRET  --value <from Slack app>
+        flyte create secret LINEAR_WEBHOOK_SECRET --value <from Linear webhook>
+        flyte create secret CLICKUP_WEBHOOK_SECRET --value <from ClickUp webhook>
+        flyte create secret JIRA_WEBHOOK_TOKEN    --value <random-string>
+
+    Deploy the tasks first — the handlers look them up by name:
+        flyte deploy examples/external_saas_integrations/github_triage_pr.py env
+        flyte deploy examples/external_saas_integrations/slack_notify.py env
+
+Usage:
+    python examples/external_saas_integrations/webhook_receiver.py
+
+    Then point each provider at the URL the dashboard shows for it.
+"""
+
+from flyteplugins.clickup import ClickUpProvider
+from flyteplugins.clickup import events as clickup_events
+from flyteplugins.github import GitHubProvider
+from flyteplugins.github import events as github_events
+from flyteplugins.jira import JiraProvider
+from flyteplugins.jira import events as jira_events
+from flyteplugins.linear import LinearProvider
+from flyteplugins.linear import events as linear_events
+from flyteplugins.slack import SlackProvider
+from flyteplugins.slack import events as slack_events
+
+import flyte
+from flyte.extras.webhooks import DuplicateRun, WebhookAppEnvironment, idempotent_run
+
+image = flyte.Image.from_debian_base(python_version=(3, 12)).with_pip_packages(
+    # Each product is its own package; the receiver itself ships with flyte.
+    "flyteplugins-github[app]",
+    "flyteplugins-slack",
+    "flyteplugins-linear",
+    "flyteplugins-clickup",
+    "flyteplugins-jira",
+)
+
+app_env = WebhookAppEnvironment(
+    name="saas-webhooks",
+    # Each provider is its own package; install and list only the ones you
+    # wire up. Anything not listed 404s.
+    providers=[GitHubProvider(), SlackProvider(), LinearProvider(), ClickUpProvider(), JiraProvider()],
+    image=image,
+    secrets=[
+        flyte.Secret("GITHUB_WEBHOOK_SECRET", as_env_var="GITHUB_WEBHOOK_SECRET"),
+        flyte.Secret("SLACK_SIGNING_SECRET", as_env_var="SLACK_SIGNING_SECRET"),
+        flyte.Secret("LINEAR_WEBHOOK_SECRET", as_env_var="LINEAR_WEBHOOK_SECRET"),
+        flyte.Secret("CLICKUP_WEBHOOK_SECRET", as_env_var="CLICKUP_WEBHOOK_SECRET"),
+        flyte.Secret("JIRA_WEBHOOK_TOKEN", as_env_var="JIRA_WEBHOOK_TOKEN"),
+    ],
+    # Only react to events from these repos / channels / teams / lists /
+    # projects. Empty means all; an allowlist also drops events it cannot
+    # attribute to a scope.
+    scopes=[],
+)
+
+
+async def _launch(task_name: str, event, **inputs):
+    """Look up a deployed task and launch it once for this event.
+
+    `task_name` is the deployed name, which Flyte qualifies with the task
+    environment: `<env-name>.<task_name>`. A bare function name never resolves,
+    and two examples here both define `triage_issue` — the qualifier keeps them
+    apart.
+
+    Always `await idempotent_run.aio(...)`. The blocking form stalls the app's
+    event loop, and webhook senders time deliveries out in seconds.
+    """
+    import flyte.remote as remote
+
+    task = remote.Task.get(name=task_name, auto_version="latest")
+    try:
+        run = await idempotent_run.aio(task, key=event.dedupe_key(), **inputs)
+    except DuplicateRun as exc:
+        return {"skipped": str(exc)}
+    return {"run": run.name}
+
+
+@app_env.on_event(github_events.PullRequest.OPENED)
+async def triage_new_pr(event):
+    """Triage every newly opened pull request."""
+    repo, _, number = (event.resource_id or "").partition("#")
+    return await _launch("github-triage.triage_pr", event, repo=repo, number=int(number))
+
+
+@app_env.on_event(slack_events.AppMention.ANY)
+async def answer_mention(event):
+    """Answer every mention of the bot.
+
+    The default key is per message, so each mention gets its own run. For one
+    run per *thread* instead, pass your own key built from `thread_ts`.
+    """
+    slack_event = event.payload.get("event", {})
+    return await _launch(
+        "slack-notify.answer_mention",
+        event,
+        channel=event.scope,
+        thread_ts=slack_event.get("thread_ts") or slack_event.get("ts"),
+        question=slack_event.get("text", ""),
+    )
+
+
+@app_env.on_event(linear_events.Issue.CREATE)
+async def triage_new_linear_issue(event):
+    return await _launch("linear-triage.triage_issue", event, issue_id=event.resource_id)
+
+
+@app_env.on_event(clickup_events.Task.CREATED)
+async def triage_new_clickup_task(event):
+    return await _launch("clickup-tickets.triage_task", event, task_id=event.resource_id)
+
+
+@app_env.on_event(jira_events.Issue.CREATED)
+async def triage_new_jira_issue(event):
+    return await _launch("jira-tickets.triage_issue", event, issue_key=event.resource_id)
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    handle = flyte.serve(app_env)
+    handle.activate(wait=True)
+    print(f"Dashboard ready at {handle.endpoint}")

--- a/plugins/README-saas-integrations.md
+++ b/plugins/README-saas-integrations.md
@@ -1,0 +1,100 @@
+# SaaS integration plugins
+
+Receive SaaS webhooks in Flyte and launch runs from them.
+
+The receiver lives in `flyte.extras.webhooks`; each product is its own package
+contributing one `Provider`:
+
+| Package | Product | Verification |
+| --- | --- | --- |
+| [`flyteplugins-github`](../github) | GitHub | HMAC-SHA256 (`X-Hub-Signature-256`) |
+| [`flyteplugins-slack`](../slack) | Slack Events API | HMAC-SHA256 with a replay window (`X-Slack-Signature`) |
+| [`flyteplugins-linear`](../linear) | Linear | HMAC-SHA256 (`X-Linear-Signature`) |
+| [`flyteplugins-clickup`](../clickup) | ClickUp | HMAC-SHA256 (`X-Clickup-Signature`) |
+| [`flyteplugins-jira`](../jira) | Jira Cloud | none — Jira does not sign; a shared token stands in |
+
+Install core plus the packages for the products you wire up — each row above is
+a distribution name:
+
+```bash
+pip install "flyteplugins-github[app]"
+```
+
+## Try one without an account
+
+Every plugin ships an example that replays a real sample delivery through the
+app in-process — verification, normalization, and dispatch, with nothing to
+configure:
+
+```bash
+python plugins/webhooks/github/examples/github_webhooks.py --local
+```
+
+## The division of labor
+
+**`flyte.extras.webhooks` owns** the app, the dashboard, dispatch, the scope
+allowlist, idempotent launching, the normalized event, and the verification
+primitives — the parts that are easy to get subtly wrong and expensive to get
+wrong once per product. It ships with flyte, and adds no runtime dependency:
+serving the app needs `fastapi`, which stays an optional extra.
+
+**A provider plugin owns** only what is specific to its product: which
+environment variable holds the secret, how to verify a delivery, how to parse
+one into a `WebhookEvent`, and the typed constants for its events. That is
+usually under 150 lines.
+
+**Calling the product's API** is where these packages have room to grow. Today
+they own webhooks only, and the recipes in `examples/external_saas_integrations`
+call `PyGithub`, `slack_sdk`, and the rest directly. A plugin earns a client
+method when it does something the vendor SDK cannot — return a `flyte.io.File`
+instead of an inline megabyte diff, render into the task report, or participate
+in caching and fan-out. Forwarding arguments and reshaping JSON does not.
+
+## One app, many products
+
+```python
+import flyte
+from flyte.extras.webhooks import WebhookAppEnvironment
+from flyteplugins.github import GitHubProvider
+from flyteplugins.github import events as github_events
+from flyteplugins.slack import SlackProvider
+
+app_env = WebhookAppEnvironment(name="saas-webhooks", providers=[GitHubProvider(), SlackProvider()])
+
+
+@app_env.on_event(github_events.PullRequest.OPENED)
+async def triage(event): ...
+```
+
+Each provider gets a route at `/webhook/<name>`; anything not configured 404s.
+The dashboard at `/` shows one row per provider with its payload URL, whether
+its secret is mounted, and how it is verified.
+
+## Conformance
+
+Every provider plugin ships the same one-line test:
+
+```python
+from flyte.extras.webhooks.testing import assert_provider_conforms
+import flyteplugins.github as plugin
+
+
+def test_conformance():
+    assert_provider_conforms(plugin)
+```
+
+CI fails if a plugin drifts. The harness checks the things that actually go
+wrong: a verifier that raises instead of returning False on a hostile header,
+event constants that render as `Class.MEMBER` rather than their wire value, a
+dedupe key that is unstable, a sample delivery that no constant spells.
+
+It leans on `SAMPLE_DELIVERY`, a real payload each plugin ships. Without one
+there is no way to assert that `verify` and `parse` agree with the product
+rather than merely with each other.
+
+## Adding a product
+
+Copy the smallest existing plugin, implement `verify` and `parse`, export a
+`Provider` subclass with its defaults pre-wired, `events`, and
+`SAMPLE_DELIVERY`, and add the conformance test. `examples/apps/webhook_custom_provider.py`
+is a complete worked version you can run.


### PR DESCRIPTION
Last of the webhook plugin stack (#1512–#1517), based on #1517 so every import resolves.

Worked recipes for driving GitHub, Slack, Linear, ClickUp, and Jira from Flyte, plus one app receiving webhooks from all five.

## The argument these examples make

There is deliberately **no Flyte client plugin** for these products. Each vendor already ships (or the community maintains) a Python client tested against the live API by people who get deprecation notices first, and a task is just a function — so calling `PyGithub` or `slack_sdk` from a task needs nothing in between. A wrapper would only add a surface to keep in sync with someone else's release calendar.

What Flyte contributes, and what these use:

- `flyteplugins-webhooks-*` — authenticate an inbound delivery and normalize it
- `idempotent_run` — launch a run once per event key
- `flyte.new_condition` — park a run on a human decision with a typed payload back

| File | Shows | Client |
| --- | --- | --- |
| `webhook_receiver.py` | One app receiving from all five products | `flyteplugins-webhooks-*` |
| `github_pr_review_gate.py` | Human-gated merge: a condition carrying JSON, parsed into a typed decision | `PyGithub` |
| `github_triage_pr.py` | Label, comment, report a check run | `PyGithub` |
| `slack_notify.py` | Post, thread, react, answer a mention | `slack_sdk` |
| `linear_triage_issue.py` | Query a backlog and comment, over GraphQL | `gql` |
| `clickup_manage_ticket.py` | Open and close tickets, with a status pre-check | `httpx` |
| `jira_manage_ticket.py` | Open, transition, and search issues | `jira` |

Linear and ClickUp ship no official Python SDK — Linear's API is a single GraphQL endpoint so `gql` is the maintained client, and ClickUp's is a handful of REST calls where `httpx` directly beats a thin third-party wrapper.

The review gate is here rather than in a plugin because `flyte.new_condition` is the only part of it that needed inventing; the rest is PyGithub calls.

## One thing I fixed while writing them

Task names are **environment-qualified** — `triage_pr` in `github_triage_pr.py` deploys as `github-triage.triage_pr`, which is what the receiver looks up. Bare names never resolve, and both the Linear and Jira recipes define a `triage_issue`, so the qualifier is also what keeps them apart. There is a check that every name the receiver launches is actually defined; the original per-product examples this replaces had bare names throughout and would have failed at the first real event.

## Verification

Verified mechanically rather than by eye: every referenced example path resolves, every `flyte create secret` name matches the actual provider `secret_env`, every `flyte deploy <file> <env>` names a real `TaskEnvironment`, every `flyte run` task is defined, and every example file executes (the receiver registers all five handlers).

`make fmt`, `make mypy`, `make ty`, ruff, and codespell pass.
