### PR TITLE
fix: clear stale error.pb at the start of every clustered attempt

### DIFF
--- a/examples/clustered/ddp_train_restart.py
+++ b/examples/clustered/ddp_train_restart.py
@@ -1,18 +1,28 @@
 """
-DDP training that FAILS on attempt 0 and SUCCEEDS on the JobSet restart.
+DDP training that FAILS on the first torchrun attempt and SUCCEEDS on the in-pod restart.
 
-This is a regression test for the clustered-restart fix on this branch: when a
-JobSet restarts (``JOBSET_RESTART_ATTEMPT`` > 0), ``upload_outputs`` must first
-delete the stale ``error.pb`` written by the previous failed attempt. Otherwise
-the successful retry's outputs land alongside a leftover error file and the
-execution is still reported as FAILED.
+Regression test for the stale ``error.pb`` cleanup in the clustered runtime
+(``flyte._internal.runtime.io.clear_stale_clustered_error``): whenever a clustered rank-0
+worker starts, it removes any ``error.pb`` an earlier restart left under the attempt's output
+prefix, before the task body runs. Without that cleanup a successful restart uploads
+``outputs.pb`` next to the leftover ``error.pb`` and the executor still reports the run FAILED.
 
-Mechanics:
-    - ``ClusterFailurePolicy(max_restarts=1)`` lets the JobSet restart once.
-    - Attempt 0 (``JOBSET_RESTART_ATTEMPT`` unset / "0") raises -> writes error.pb.
-    - Attempt 1 (``JOBSET_RESTART_ATTEMPT`` == "1") runs DDP and uploads outputs.
-      With the fix, the stale error.pb is cleared and the run ends SUCCEEDED.
-      Without the fix, the run ends FAILED despite the successful retry.
+The stale file is produced here without any backend help:
+    - ``ClusterFailurePolicy(max_restarts=0)`` makes every attempt look terminal to the SDK's
+      terminal-attempt gate (``JOBSET_RESTART_ATTEMPT 0 >= JOBSET_MAX_RESTARTS 0``), so the first
+      failure writes ``error.pb`` right away and the worker exits 1.
+    - ``PET_MAX_RESTARTS=1`` lets torchrun restart the worker group once inside the same pod.
+      (``TorchRun(max_restarts=...)`` is not wired through to torchrun yet, so the env var is set
+      directly; torchrun reads ``PET_<FLAG>`` for every CLI flag.)
+    - Attempt 0 (``TORCHELASTIC_RESTART_COUNT`` == "0") raises on every rank.
+    - Attempt 1 (``TORCHELASTIC_RESTART_COUNT`` == "1") trains and uploads outputs. Rank-0 logs
+      "Removed stale ... error.pb" at startup.
+
+Expected: run phase SUCCEEDED. Without the cleanup: FAILED with the attempt-0 error.
+
+A JobSet-level restart (``ClusterFailurePolicy(max_restarts >= 1)``) goes through the same cleanup,
+but without free host-maintenance restarts the gate never writes a premature ``error.pb``, so that
+variant passes with or without the fix and is not a useful regression test.
 
 Run:
     uv run python examples/clustered/ddp_train_restart.py
@@ -33,14 +43,14 @@ image = (
 )
 
 # --- Knobs ---------------------------------------------------------------------------------------
-USE_GPU = True
-REPLICAS = 2  # pods (== nodes)
-NPROC_PER_NODE = 1  # processes (one per GPU) per pod  => world_size = REPLICAS * NPROC_PER_NODE
+USE_GPU = False
+REPLICAS = 1  # one pod: torchrun's in-pod restart then needs no cross-node re-rendezvous
+NPROC_PER_NODE = 2  # processes per pod  => world_size = REPLICAS * NPROC_PER_NODE
 
 _BACKEND = "nccl" if USE_GPU else "gloo"
 
 resources = (
-    flyte.Resources(cpu=(2, 4), memory=("4Gi", "8Gi"), gpu="L4:1")
+    flyte.Resources(cpu=(2, 4), memory=("4Gi", "8Gi"), gpu="L4:2")  # one GPU per process (NPROC_PER_NODE)
     if USE_GPU
     else flyte.Resources(cpu=(1, 2), memory=("1Gi", "2Gi"))
 )
@@ -51,21 +61,28 @@ env = ClusteredTaskEnvironment(
     resources=resources,
     replicas=REPLICAS,
     nproc_per_node=NPROC_PER_NODE,
-    runtime=TorchRun(rdzv_backend="static", max_restarts=0),
-    failure_policy=ClusterFailurePolicy(max_restarts=1),  # allow ONE JobSet restart
+    # max_restarts here is not wired through to torchrun yet; PET_MAX_RESTARTS below is what works today.
+    runtime=TorchRun(rdzv_backend="static", max_restarts=1),
+    failure_policy=ClusterFailurePolicy(max_restarts=0),  # every attempt looks terminal to the SDK gate
+    env_vars={"PET_MAX_RESTARTS": "1"},  # ONE in-pod torchrun restart (see module docstring)
 )
 
 
 @env.task
 async def train_ddp_with_restart(steps: int = 50, lr: float = 0.05) -> float:
-    """Fail on the first JobSet attempt, then train + return loss on the restart."""
-    restart_attempt = int(os.environ.get("JOBSET_RESTART_ATTEMPT", "0") or "0")
+    """Fail on the first torchrun attempt, then train + return loss on the in-pod restart."""
+    restart_attempt = int(os.environ.get("TORCHELASTIC_RESTART_COUNT", "0") or "0")
     rank = os.environ.get("RANK", "0")
-    print(f"[rank {rank}] JOBSET_RESTART_ATTEMPT={restart_attempt}", flush=True)
+    print(
+        f"[rank {rank}] TORCHELASTIC_RESTART_COUNT={restart_attempt} "
+        f"JOBSET_RESTART_ATTEMPT={flyte.ctx().restart_attempt}",
+        flush=True,
+    )
 
-    # Attempt 0 fails on every worker -> writes error.pb for the execution.
+    # Attempt 0 fails on every rank -> rank-0 writes error.pb (the SDK gate sees 0 >= 0) and every
+    # worker exits 1, so torchrun restarts the worker group in-pod.
     if restart_attempt == 0:
-        raise RuntimeError("Intentional failure on attempt 0 to force a JobSet restart")
+        raise RuntimeError("Intentional failure on torchrun attempt 0 to leave a stale error.pb behind")
 
     import torch
     import torch.distributed as dist
@@ -120,5 +137,5 @@ if __name__ == "__main__":
     run = flyte.run(train_ddp_with_restart, steps=50)
     print("Run URL:", run.url)
     run.wait()
-    # Expected WITH the fix: SUCCEEDED. Without it: FAILED (stale error.pb).
+    # Expected WITH the cleanup: SUCCEEDED. Without it: FAILED (stale error.pb from attempt 0).
     print("Final phase:", run.phase)

--- a/src/flyte/_internal/runtime/entrypoints.py
+++ b/src/flyte/_internal/runtime/entrypoints.py
@@ -269,6 +269,13 @@ async def load_and_run_task(
     """
     sw = Stopwatch("load_and_run_task_total")
     sw.start()
+    if output_path:
+        # Clustered rank-0 only; a no-op for regular tasks. Must precede every upload_error site (the load
+        # failure below, taskrunner.extract_download_run_upload, runtime._run_and_stop) and the task body.
+        # rusty.run_task bypasses this function but never hosts clustered workers (clustered.py execs a0).
+        from .io import clear_stale_clustered_error
+
+        await clear_stale_clustered_error(output_path)
     try:
         task = await _download_and_load_task(code_bundle, resolver, resolver_args)
     except Exception as e:

--- a/src/flyte/_internal/runtime/io.py
+++ b/src/flyte/_internal/runtime/io.py
@@ -8,6 +8,7 @@ import os
 
 from flyteidl2.core import execution_pb2
 from flyteidl2.task import common_pb2
+from fsspec.asyn import AsyncFileSystem
 
 import flyte.storage as storage
 from flyte._logging import logger
@@ -40,6 +41,9 @@ def _is_nonzero_rank_clustered_worker() -> bool:
 
 
 def _get_clustered_restart_attempt() -> int | None:
+    """JOBSET_RESTART_ATTEMPT mirrors JobSet `Status.Restarts`, which also counts free host-maintenance
+    restarts, so it can run ahead of the charged budget (`RestartsCountTowardsMax`, never exposed to pods).
+    """
     raw_attempt = os.environ.get("JOBSET_RESTART_ATTEMPT")
     if raw_attempt is None:
         return None
@@ -62,13 +66,18 @@ def _get_clustered_max_restarts() -> int | None:
 
 
 def _is_terminal_clustered_attempt() -> bool:
-    """Whether a failure in this attempt should write error.pb.
+    """Best-effort guess whether a failure in this attempt should write error.pb.
 
     For a clustered/jobset task the JobSet restarts the whole pod set up to `max_restarts` times
-    within a single Flyte attempt. We only write error.pb on the terminal attempt (budget exhausted)
-    so transient restarts don't leave a stale error that a later successful restart would have to
-    delete. Returns True (write) for non-clustered tasks, and as a safe fallback whenever the budget
-    is unknown — errors must never be silently hidden.
+    within a single Flyte attempt, so error.pb is only written once the budget looks exhausted, which
+    avoids needless writes on transient restarts. The guess can be EARLY but never late:
+    JOBSET_RESTART_ATTEMPT mirrors JobSet `Status.Restarts`, which also counts free host-maintenance
+    restarts (`restart_on_host_maintenance`), while the budget is charged from
+    `RestartsCountTowardsMax`, which pods cannot see. A premature error.pb is harmless because
+    `clear_stale_clustered_error` removes it at the start of the next attempt — that cleanup, not this
+    gate, is what keeps a later successful attempt from being reported as failed. Returns True (write)
+    for non-clustered tasks, and as a safe fallback whenever the budget is unknown — errors must never
+    be silently hidden.
     """
     attempt = _get_clustered_restart_attempt()
     if attempt is None:
@@ -77,6 +86,50 @@ def _is_terminal_clustered_attempt() -> bool:
     if max_restarts is None:
         return True  # budget unknown (env not injected yet) → write, never hide errors
     return attempt >= max_restarts
+
+
+async def _delete_path(path: str) -> None:
+    """Delete one object. Raises FileNotFoundError when it is already gone (GCS/Azure/local; S3 returns OK)."""
+    fs = storage.get_underlying_filesystem(path=path)
+    if isinstance(fs, AsyncFileSystem):
+        # The sync rm_file() of an AsyncFileSystem re-enters the running loop and fails from inside a
+        # coroutine; obstore's FsspecStore (s3/gs/abfs) implements the async _rm_file directly.
+        await fs._rm_file(path)  # pylint: disable=W0212
+        return
+    fs.rm_file(path)
+
+
+async def clear_stale_clustered_error(output_path: str) -> None:
+    """Remove an error.pb left under this attempt's output prefix by an earlier restart of the pod set.
+
+    Runs at startup of every clustered rank-0 worker (JobSet whole-set restarts and in-pod torchrun
+    restarts both re-exec `a0`). Deliberately unconditional rather than keyed on a restart counter:
+    JOBSET_RESTART_ATTEMPT mirrors JobSet `Status.Restarts`, which also counts free host-maintenance
+    restarts, so `_is_terminal_clustered_attempt` can write error.pb on a non-terminal attempt and a
+    later successful attempt would then be reported as failed (the executor reads error.pb before
+    outputs.pb). Restart attempts are strictly sequential, so there is no concurrent writer, and only
+    rank-0 ever writes or deletes the file. Never raises: a failed delete just leaves today's behavior.
+    """
+    if not _is_clustered_worker() or _is_nonzero_rank_clustered_worker():
+        return
+    error_uri = error_path(output_path)
+    restart_ctx = (
+        f"JOBSET_RESTART_ATTEMPT={os.environ.get('JOBSET_RESTART_ATTEMPT')}, "
+        f"TORCHELASTIC_RESTART_COUNT={os.environ.get('TORCHELASTIC_RESTART_COUNT')}"
+    )
+    try:
+        if not await storage.exists(error_uri):
+            return
+        await _delete_path(error_uri)
+    except FileNotFoundError:
+        logger.debug(f"Stale {error_uri} disappeared before it could be deleted ({restart_ctx})")
+        return
+    except Exception as e:
+        logger.warning(f"Could not remove stale {error_uri} ({restart_ctx}): {e}")
+        return
+    # Warning, not info: the default pod log level is WARNING, and this line is the operator's evidence
+    # that the terminal-attempt gate fired early. It fires at most once per restarted attempt.
+    logger.warning(f"Removed stale {error_uri} left by an earlier restart of this task ({restart_ctx})")
 
 
 def pkl_path(base_path: str, pkl_name: str) -> str:
@@ -148,11 +201,15 @@ async def upload_error(err: execution_pb2.ExecutionError, output_prefix: str, re
     # so they don't race to clobber error.pb.
     if _is_nonzero_rank_clustered_worker():
         return error_uri
-    # For a clustered task, only write error.pb once the JobSet has exhausted its restart budget.
-    # Transient restarts recover on their own, so writing on every attempt would leave a stale
-    # error that a later successful restart would have to delete.
+    # For a clustered task, only write error.pb once the JobSet looks to have exhausted its restart
+    # budget. Transient restarts recover on their own; if this guess is early (free host-maintenance
+    # restarts inflate JOBSET_RESTART_ATTEMPT), clear_stale_clustered_error removes the file at the
+    # start of the next attempt.
     if not _is_terminal_clustered_attempt():
-        logger.info(f"Skipping error.pb on transient JobSet restart (budget remaining): {error_uri}")
+        logger.info(
+            f"Skipping error.pb on transient JobSet restart (budget remaining, "
+            f"attempt={_get_clustered_restart_attempt()} max_restarts={_get_clustered_max_restarts()}): {error_uri}"
+        )
         return error_uri
     error_document = execution_pb2.ErrorDocument(
         error=execution_pb2.ContainerError(

--- a/src/flyte/clustered/_environment.py
+++ b/src/flyte/clustered/_environment.py
@@ -36,7 +36,8 @@ class ClusterFailurePolicy:
         max_restarts: Number of times the entire JobSet may be restarted before Flyte
             surfaces a RetryableFailure.
         restart_on_host_maintenance: When True, node evictions (DisruptionTarget condition)
-            trigger a free restart that does not consume the max_restarts budget.
+            trigger a free restart that does not consume the max_restarts budget. Free restarts
+            still increment `flyte.ctx().restart_attempt`.
     """
 
     max_restarts: int = 0

--- a/src/flyte/models.py
+++ b/src/flyte/models.py
@@ -384,6 +384,10 @@ class TaskContext:
 
     @property
     def restart_attempt(self) -> Optional[int]:
+        """How many times the JobSet has restarted the whole pod set within this Flyte attempt; None
+        outside clustered tasks. Free host-maintenance restarts count too, so treat this as a
+        "has the set restarted" counter, not as a position within `ClusterFailurePolicy.max_restarts`.
+        """
         v = os.environ.get("JOBSET_RESTART_ATTEMPT")
         return int(v) if v is not None else None
 

--- a/tests/flyte/clustered/test_runtime_io_cleanup.py
+++ b/tests/flyte/clustered/test_runtime_io_cleanup.py
@@ -1,0 +1,203 @@
+"""Unit tests for the stale error.pb cleanup that runs at the start of every clustered rank-0 worker."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from fsspec.asyn import AsyncFileSystem
+
+from flyte._internal.runtime import io
+
+OUTPUT_PATH = "s3://bucket/outputs"
+ERROR_URI = io.error_path(OUTPUT_PATH)
+
+
+def _isolate_clustered_env(monkeypatch):
+    for var in (
+        "JOBSET_RESTART_ATTEMPT",
+        "JOBSET_MAX_RESTARTS",
+        "TORCHELASTIC_RUN_ID",
+        "TORCHELASTIC_RESTART_COUNT",
+        "RANK",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _as_rank0_clustered(monkeypatch, restart_attempt: str | None = "1"):
+    _isolate_clustered_env(monkeypatch)
+    monkeypatch.setenv("TORCHELASTIC_RUN_ID", "run-123")
+    monkeypatch.setenv("RANK", "0")
+    if restart_attempt is not None:
+        monkeypatch.setenv("JOBSET_RESTART_ATTEMPT", restart_attempt)
+
+
+def _fail(*_args, **_kwargs):
+    raise AssertionError("storage must not be touched")
+
+
+async def _exists_only_error(path: str, **_kwargs) -> bool:
+    return path == ERROR_URI
+
+
+async def _exists_false(_path: str, **_kwargs) -> bool:
+    return False
+
+
+@pytest.fixture
+def warnings(monkeypatch) -> list[str]:
+    captured: list[str] = []
+    monkeypatch.setattr(io.logger, "warning", captured.append)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_clear_stale_error_deletes_via_async_rm_file(monkeypatch, warnings):
+    """Remote stores (obstore FsspecStore) are AsyncFileSystems: the async _rm_file must be awaited."""
+    _as_rank0_clustered(monkeypatch, "1")
+    monkeypatch.setenv("TORCHELASTIC_RESTART_COUNT", "0")
+    fs = mock.MagicMock(spec=AsyncFileSystem)
+    monkeypatch.setattr(io.storage, "exists", _exists_only_error)
+    monkeypatch.setattr(io.storage, "get_underlying_filesystem", lambda **_kwargs: fs)
+
+    await io.clear_stale_clustered_error(OUTPUT_PATH)
+
+    fs._rm_file.assert_awaited_once_with(ERROR_URI)
+    fs.rm_file.assert_not_called()
+    assert len(warnings) == 1
+    assert "Removed stale" in warnings[0]
+    assert ERROR_URI in warnings[0]
+    assert "JOBSET_RESTART_ATTEMPT=1" in warnings[0]
+    assert "TORCHELASTIC_RESTART_COUNT=0" in warnings[0]
+
+
+@pytest.mark.asyncio
+async def test_clear_stale_error_deletes_via_sync_rm_file_on_local_fs(monkeypatch, tmp_path, warnings):
+    """Real local filesystem end to end: storage.exists + LocalFileSystem.rm_file (the sync branch)."""
+    _as_rank0_clustered(monkeypatch, "2")
+    stale = tmp_path / io._ERROR_FILE_NAME
+    stale.write_bytes(b"stale")
+
+    await io.clear_stale_clustered_error(str(tmp_path))
+
+    assert not stale.exists()
+    assert len(warnings) == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_path_uses_sync_rm_file_for_sync_filesystems(monkeypatch):
+    class SyncFS:
+        def __init__(self) -> None:
+            self.deleted: list[str] = []
+
+        def rm_file(self, path: str) -> None:
+            self.deleted.append(path)
+
+    fs = SyncFS()
+    monkeypatch.setattr(io.storage, "get_underlying_filesystem", lambda **_kwargs: fs)
+
+    await io._delete_path(ERROR_URI)
+
+    assert fs.deleted == [ERROR_URI]
+
+
+@pytest.mark.asyncio
+async def test_clear_stale_error_absent_file_is_noop(monkeypatch, warnings):
+    _as_rank0_clustered(monkeypatch, "1")
+    monkeypatch.setattr(io.storage, "exists", _exists_false)
+    monkeypatch.setattr(io.storage, "get_underlying_filesystem", _fail)
+
+    await io.clear_stale_clustered_error(OUTPUT_PATH)
+
+    assert warnings == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("restart_attempt", ["0", None])
+async def test_clear_stale_error_runs_on_first_start_too(monkeypatch, restart_attempt):
+    """The cleanup is deliberately not keyed on JOBSET_RESTART_ATTEMPT: that counter is exactly what
+    over-counts under free restarts, and a first start is a cheap no-op after one existence check."""
+    _as_rank0_clustered(monkeypatch, restart_attempt)
+    seen: list[str] = []
+
+    async def exists_spy(path: str, **_kwargs) -> bool:
+        seen.append(path)
+        return False
+
+    monkeypatch.setattr(io.storage, "exists", exists_spy)
+    monkeypatch.setattr(io.storage, "get_underlying_filesystem", _fail)
+
+    await io.clear_stale_clustered_error(OUTPUT_PATH)
+
+    assert seen == [ERROR_URI]
+
+
+@pytest.mark.asyncio
+async def test_clear_stale_error_skips_nonzero_rank(monkeypatch):
+    """Only rank-0 owns error.pb; a late-starting rank must never delete what rank-0 just wrote."""
+    _as_rank0_clustered(monkeypatch, "2")
+    monkeypatch.setenv("RANK", "1")
+    monkeypatch.setattr(io.storage, "exists", _fail)
+    monkeypatch.setattr(io.storage, "get_underlying_filesystem", _fail)
+
+    await io.clear_stale_clustered_error(OUTPUT_PATH)
+
+
+@pytest.mark.asyncio
+async def test_clear_stale_error_skips_non_clustered_task(monkeypatch):
+    """RANK / JOBSET_RESTART_ATTEMPT without the torchrun marker is not a clustered worker."""
+    _isolate_clustered_env(monkeypatch)
+    monkeypatch.setenv("JOBSET_RESTART_ATTEMPT", "2")
+    monkeypatch.setenv("RANK", "0")
+    monkeypatch.setattr(io.storage, "exists", _fail)
+    monkeypatch.setattr(io.storage, "get_underlying_filesystem", _fail)
+
+    await io.clear_stale_clustered_error(OUTPUT_PATH)
+
+
+@pytest.mark.asyncio
+async def test_clear_stale_error_delete_failure_is_soft(monkeypatch, warnings):
+    _as_rank0_clustered(monkeypatch, "1")
+    fs = mock.MagicMock(spec=AsyncFileSystem)
+    fs._rm_file.side_effect = RuntimeError("delete failed")
+    monkeypatch.setattr(io.storage, "exists", _exists_only_error)
+    monkeypatch.setattr(io.storage, "get_underlying_filesystem", lambda **_kwargs: fs)
+
+    await io.clear_stale_clustered_error(OUTPUT_PATH)  # must not raise
+
+    assert len(warnings) == 1
+    assert "Could not remove" in warnings[0]
+    assert "delete failed" in warnings[0]
+
+
+@pytest.mark.asyncio
+async def test_clear_stale_error_vanished_before_delete_is_debug(monkeypatch, warnings):
+    _as_rank0_clustered(monkeypatch, "1")
+    debugs: list[str] = []
+    monkeypatch.setattr(io.logger, "debug", debugs.append)
+    fs = mock.MagicMock(spec=AsyncFileSystem)
+    fs._rm_file.side_effect = FileNotFoundError(ERROR_URI)
+    monkeypatch.setattr(io.storage, "exists", _exists_only_error)
+    monkeypatch.setattr(io.storage, "get_underlying_filesystem", lambda **_kwargs: fs)
+
+    await io.clear_stale_clustered_error(OUTPUT_PATH)
+
+    assert warnings == []
+    assert len(debugs) == 1
+    assert ERROR_URI in debugs[0]
+
+
+@pytest.mark.asyncio
+async def test_clear_stale_error_exists_failure_is_soft(monkeypatch, warnings):
+    _as_rank0_clustered(monkeypatch, "1")
+
+    async def exists_boom(_path: str, **_kwargs) -> bool:
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(io.storage, "exists", exists_boom)
+    monkeypatch.setattr(io.storage, "get_underlying_filesystem", _fail)
+
+    await io.clear_stale_clustered_error(OUTPUT_PATH)  # must not raise
+
+    assert len(warnings) == 1
+    assert "denied" in warnings[0]

--- a/tests/flyte/internal/runtime/test_entrypoints.py
+++ b/tests/flyte/internal/runtime/test_entrypoints.py
@@ -241,6 +241,10 @@ async def test_load_failure_without_output_path_still_raises():
             "flyte._internal.runtime.io.upload_error",
             new_callable=mock.AsyncMock,
         ) as mock_upload_error,
+        mock.patch(
+            "flyte._internal.runtime.io.clear_stale_clustered_error",
+            new_callable=mock.AsyncMock,
+        ) as mock_cleanup,
     ):
         with pytest.raises(ModuleNotFoundError):
             await load_and_run_task(
@@ -255,3 +259,68 @@ async def test_load_failure_without_output_path_still_raises():
             )
 
     mock_upload_error.assert_not_awaited()
+    mock_cleanup.assert_not_awaited()
+
+
+def _run_kwargs(output_path: str = "s3://bucket/outputs") -> dict:
+    return {
+        "action": ActionID(name="a0", run_name="r0"),
+        "raw_data_path": RawDataPath(path="/tmp/raw"),
+        "output_path": output_path,
+        "run_base_dir": "s3://bucket/run",
+        "version": "v1",
+        "controller": None,
+        "resolver": "some.resolver",
+        "resolver_args": ["mod", "task"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_clustered_cleanup_runs_before_task_load_and_error_upload():
+    """The stale-error.pb cleanup for clustered rank-0 workers must run before the task is loaded, so it
+    also precedes the error.pb written for a load failure (a restarted attempt must never delete the
+    fresh error it is about to write). See io.clear_stale_clustered_error.
+    """
+    calls: list[tuple] = []
+
+    async def fake_cleanup(output_path: str) -> None:
+        calls.append(("cleanup", output_path))
+
+    async def fake_load(*_args, **_kwargs):
+        calls.append(("load",))
+        raise ModuleNotFoundError("No module named 'emoji'")
+
+    async def fake_upload_error(*_args, **_kwargs) -> str:
+        calls.append(("upload_error",))
+        return "s3://bucket/outputs/error.pb"
+
+    with (
+        mock.patch("flyte._internal.runtime.io.clear_stale_clustered_error", side_effect=fake_cleanup),
+        mock.patch("flyte._internal.runtime.entrypoints._download_and_load_task", side_effect=fake_load),
+        mock.patch("flyte._internal.runtime.io.upload_error", side_effect=fake_upload_error),
+    ):
+        with pytest.raises(ModuleNotFoundError):
+            await load_and_run_task(**_run_kwargs())
+
+    assert calls == [("cleanup", "s3://bucket/outputs"), ("load",), ("upload_error",)]
+
+
+@pytest.mark.asyncio
+async def test_clustered_cleanup_runs_before_task_execution():
+    """On the happy path the cleanup precedes the task body (contextual_run)."""
+    calls: list[str] = []
+
+    async def fake_cleanup(_output_path: str) -> None:
+        calls.append("cleanup")
+
+    async def fake_run(*_args, **_kwargs) -> None:
+        calls.append("run")
+
+    with (
+        mock.patch("flyte._internal.runtime.io.clear_stale_clustered_error", side_effect=fake_cleanup),
+        mock.patch("flyte._internal.runtime.entrypoints._download_and_load_task", return_value=object()),
+        mock.patch("flyte._internal.runtime.entrypoints.contextual_run", side_effect=fake_run),
+    ):
+        await load_and_run_task(**_run_kwargs())
+
+    assert calls == ["cleanup", "run"]


### PR DESCRIPTION
  ## Motivation

  For clustered (JobSet) tasks the SDK writes `error.pb` only on what it believes is the terminal
  restart attempt, using `JOBSET_RESTART_ATTEMPT >= JOBSET_MAX_RESTARTS`. That guess mirrors the
  JobSet's `Status.Restarts`, which also counts free host-maintenance restarts
  (`RestartJobSetAndIgnoreMaxRestarts`, flyteorg/flyte#7947), while the budget is charged from
  `RestartsCountTowardsMax`, which pods never see. So after a free restart the guess fires early, a
  genuine failure writes `error.pb` on a non-terminal attempt, and because the executor reads
  `error.pb` before `outputs.pb`, a later successful attempt is still reported as a failure.

  ## Summary

  - Add `io.clear_stale_clustered_error()`, which removes a leftover `error.pb` from the attempt's
    output prefix. It runs on every clustered rank-0 start, not just restarted ones, since the
    restart counter is exactly what proved untrustworthy. Only rank-0 deletes, restart attempts are
    strictly sequential, and a failed delete only restores today's behavior.
  - Await it at the top of `load_and_run_task`, ahead of the code-bundle download and of all three
    `upload_error` call sites.
  - Keep the terminal-attempt gate as an optimization that avoids needless writes, and rewrite its
    docstring: the guess can be early but never late, and the cleanup is what guarantees correctness.
  - Rewrite `examples/clustered/ddp_train_restart.py` into a regression test that reproduces the
    stale file with no backend dependency, using `max_restarts=0` plus one in-pod torchrun restart.

  ## Test Plan

  - `uv run pytest tests/flyte/clustered tests/flyte/internal/runtime tests/flyte/internal/bin -q`
    covers the async and sync delete branches, absent-file and non-rank-0 and non-clustered no-ops,
    soft failure on both the existence check and the delete, and that the cleanup is awaited before
    the task load, the load-failure error upload, and the task body. 364 passed.
  - `make lint` and `make mypy` are clean.
  - End to end on dogfood: `make dist && uv run python examples/clustered/ddp_train_restart.py`.
    Expect SUCCEEDED. `flyte get logs <run>` should show attempt 0 uploading `.../a0/0/error.pb`,
    then the restarted rank-0 logging `Removed stale ... error.pb (JOBSET_RESTART_ATTEMPT=0,
    TORCHELASTIC_RESTART_COUNT=1)`, then training. Verified as run `udvvrchxvfqpnwjvbfwp`.
    Reverting the `entrypoints.py` hook makes the same run end FAILED with the attempt-0 error.