### PR TITLE
fix: don't report a 405 from a non-Connect endpoint as an SDK crash (FLYTE-SDK-81)

### DIFF
--- a/src/flyte/_sentry.py
+++ b/src/flyte/_sentry.py
@@ -158,6 +158,16 @@ _NON_OK_SUCCESS_HTTP_PHRASES: frozenset[str] = frozenset(
 )
 
 
+# 405 Method Not Allowed. Every Connect RPC the SDK issues is a POST: connectrpc
+# sends GET only when the caller passes `use_get=True` to `execute_unary`, and the
+# SDK never does (there is no `use_get` anywhere in this repo); client/server/bidi
+# streams are hardcoded to POST. A Connect handler, meanwhile, always accepts POST
+# on its own procedure path. So a 405 cannot be the backend rejecting the SDK's
+# choice of method -- it proves the POST was answered by something that does not
+# route Connect procedures at all, exactly like the 2xx case above.
+_NOT_A_CONNECT_ROUTE_HTTP_PHRASES: frozenset[str] = frozenset({HTTPStatus.METHOD_NOT_ALLOWED.phrase})
+
+
 # connectrpc rejects a response whose content-type it cannot decode with
 # `ConnectError(Code.UNKNOWN, f"invalid content-type: '{received}'; expecting '{wanted}'")`
 # (connectrpc/_protocol_connect.py). A `text/*` body — an HTML error page, a login
@@ -184,6 +194,12 @@ def _is_non_connect_endpoint_response(exc: BaseException) -> bool:
        exact signature as a misconfigured endpoint (#1235) when it comes back from
        the auth metadata fetch; these are the same thing arriving on a data-plane
        call instead.
+    3. A 405 Method Not Allowed. FLYTE-SDK-81: `flyte run` against an endpoint whose
+       POST was refused, surfaced as `RuntimeSystemError: Upload failed for ...:
+       Method Not Allowed`. The SDK only ever POSTs (see
+       `_NOT_A_CONNECT_ROUTE_HTTP_PHRASES`), and a Connect handler always accepts
+       POST on its procedure path, so a 405 means the request was routed somewhere
+       that serves no Connect procedures.
 
     Either way it is endpoint/network configuration, never a Python-SDK logic bug,
     and the SDK cannot recover from it.
@@ -212,7 +228,7 @@ def _is_non_connect_endpoint_response(exc: BaseException) -> bool:
     if getattr(exc, "details", ()):
         return False
     message = (getattr(exc, "message", "") or "").strip()
-    if message in _NON_OK_SUCCESS_HTTP_PHRASES:
+    if message in _NON_OK_SUCCESS_HTTP_PHRASES or message in _NOT_A_CONNECT_ROUTE_HTTP_PHRASES:
         return True
     content_type = _INVALID_CONTENT_TYPE_RE.match(message)
     return bool(content_type and content_type.group("received").strip().lower().startswith("text/"))

--- a/tests/flyte/test_sentry.py
+++ b/tests/flyte/test_sentry.py
@@ -781,3 +781,76 @@ def test_non_connect_endpoint_response_ignores_message_merely_mentioning_html():
         "Body: <html>\r\n<head><title>502 Bad Gateway</title></head>\r\n",
     )
     assert not _sentry._is_non_connect_endpoint_response(err)
+
+
+# --- FLYTE-SDK-81: a 405 on a POST the SDK always sends as a POST ---
+
+
+def test_capture_exception_skips_method_not_allowed():
+    """405 means the POST was routed somewhere that serves no Connect procedures."""
+    err = _wire_error_for_status(405)
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()
+
+
+def test_capture_exception_skips_method_not_allowed_wrapped_in_runtime_system_error():
+    """The real FLYTE-SDK-81 shape: the 405 arrives as the __cause__ of an upload failure."""
+    from flyte.errors import RuntimeSystemError
+
+    try:
+        raise _wire_error_for_status(405)
+    except Exception as inner:
+        err = RuntimeSystemError(
+            "UploadError",
+            "Upload failed for /var/folders/j8/T/tmpzar713fu/fastc34306b3.tar.gz "
+            "(org='flyte', project='flytesnacks', domain='development'): Method Not Allowed",
+        )
+        err.__cause__ = inner
+
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()
+
+
+@pytest.mark.parametrize("status", [400, 406, 409, 410, 500, 501])
+def test_non_connect_endpoint_response_ignores_other_4xx_and_5xx(status):
+    """Only 405 is added to the filter; every other unmapped status stays real signal.
+
+    400 is FLYTE-SDK-7C and 500 is FLYTE-SDK-64 -- both produce the identical
+    UNKNOWN/bare-phrase shape and both must keep reaching Sentry.
+    """
+    assert not _sentry._is_non_connect_endpoint_response(_wire_error_for_status(status))
+
+
+def test_method_not_allowed_carrying_details_still_reports():
+    """A real Connect JSON error body yields details; from_http_status never does."""
+    from connectrpc.code import Code
+    from connectrpc.errors import ConnectError
+    from flyteidl2.common import identity_pb2
+
+    err = ConnectError(Code.UNKNOWN, "Method Not Allowed", details=[identity_pb2.Identity()])
+    assert not _sentry._is_non_connect_endpoint_response(err)
+
+
+def test_sdk_never_sends_a_connect_get():
+    """Pins the premise of the 405 filter: no `use_get=True` call site exists in the SDK.
+
+    connectrpc's `execute_unary` sends GET only when the caller opts in with
+    `use_get=True`. If that ever changes, a 405 could become the backend legitimately
+    rejecting our method, and this filter would start hiding a real SDK bug.
+    """
+    import ast
+    import pathlib
+
+    src = pathlib.Path(_sentry.__file__).parent
+    offenders = []
+    for path in sorted(src.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover - vendored/generated sources
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and any(kw.arg == "use_get" for kw in node.keywords):
+                offenders.append(f"{path.relative_to(src)}:{node.lineno}")
+    assert offenders == [], f"SDK now issues Connect GETs at {offenders}; revisit the 405 filter"


### PR DESCRIPTION
## Problem

[FLYTE-SDK-81](https://unionai.sentry.io/issues/7707816886/) — 4 events, all from one host in a ~17 minute window on 2026-09-02, release 2.6.10:

```
RuntimeSystemError: Upload failed for /var/folders/.../fastc34306b3….tar.gz
  (org='flyte', project='flytesnacks', domain='development'): Method Not Allowed
  └── ConnectError: Method Not Allowed
```

The endpoint answered a Connect RPC with **HTTP 405**. connectrpc maps only a handful of statuses (401/403/404/429/502/503/504) onto Connect codes; everything else falls through to `ConnectWireError.from_http_status`, which yields `Code.UNKNOWN` with the bare stdlib reason phrase as the whole message — the same shape `_is_non_connect_endpoint_response` already recognises for the 2xx class.

The event pins the raise to `_protocol_connect.py:246`, the branch below `if response_content_type == CONNECT_UNARY_CONTENT_TYPE_JSON: return` — so the 405 response was not even in Connect's own JSON error format.

## Why a 405 is unambiguously not an SDK bug

**Every Connect RPC the SDK issues is a POST.** connectrpc's `execute_unary` sends GET only when the caller opts in with `use_get=True`; `execute_client_stream` / `execute_server_stream` / `execute_bidi_stream` hardcode `http_method="POST"`. There is no `use_get` anywhere in this repo.

A Connect handler always accepts POST on its own procedure path. So a 405 cannot be the backend rejecting *our* choice of method — it proves the POST was answered by something that routes no Connect procedures at all: a proxy, an ingress, a static-file host, a load balancer default backend, or simply a misconfigured endpoint. That is endpoint configuration the SDK cannot recover from, exactly like the 2xx case (FLYTE-SDK-77/78) and the `text/*` case (FLYTE-SDK-7A/6P).

Because the whole filter rests on that premise, `test_sdk_never_sends_a_connect_get` pins it: it walks the AST of every module under `src/flyte/` and fails if any call site ever passes `use_get`. If that changes, a 405 could become a legitimate backend rejection and this filter would start hiding a real bug — the test says so in its docstring.

## Fix

Add the 405 phrase to `_is_non_connect_endpoint_response`, beside the existing 2xx and `text/*` discriminators.

**Deliberately only 405.** I ran the discriminator across the whole unresolved corpus (75 non-Go issues) before writing it. Four issues carry the bare-HTTP-phrase shape:

| Issue | Events | Status | Verdict |
|---|---|---|---|
| FLYTE-SDK-81 | 4 | 405 Method Not Allowed | filtered by this PR |
| FLYTE-SDK-7C | 2 | 400 Bad Request | **untouched** — a 400 could be a genuinely malformed request from us |
| FLYTE-SDK-64 | 276 | 500 Internal Server Error | **untouched** — real backend signal |
| FLYTE-SDK-6S | 1 | 500 Internal Server Error | **untouched** |

Filtering the status *class* rather than the individual status would have silenced FLYTE-SDK-64, the largest genuine backend signal in the project. 405 is the only status in the corpus that is provably a routing answer.

## Tests

5 new tests in `tests/flyte/test_sentry.py`, using the existing `_wire_error_for_status` helper so they exercise the real `ConnectWireError.from_http_status` path rather than a hand-built error:

- a bare 405 is not reported
- the real FLYTE-SDK-81 shape — the 405 as the `__cause__` of a `RuntimeSystemError: Upload failed for …` — is not reported
- 400 / 406 / 409 / 410 / 500 / 501 all still report (parametrized; covers 7C and 64)
- a `Method Not Allowed` carrying `details` still reports, since a real Connect JSON error body always yields details and `from_http_status` never does
- the `use_get` AST guard described above

The two behavioural tests were verified failing on clean `main` with the exact production signature (`Expected 'init' to not have been called. Called 1 times.`); the three guards pass on both sides by design. Full file: 79 passed. `ruff format` / `ruff check` / `mypy` / `ty` / `check-docstrings` all clean.

fixes FLYTE-SDK-81
