### PR TITLE
examples/apps: unpin streamlit so protobuf>=6 can resolve

### DIFF
--- a/examples/apps/basic_app.py
+++ b/examples/apps/basic_app.py
@@ -3,7 +3,9 @@
 import flyte
 import flyte.app
 
-image = flyte.Image.from_debian_base(python_version=(3, 12)).with_pip_packages("streamlit==1.41.1")
+# streamlit must allow protobuf>=6 (>=1.46 relaxed the cap to <7); older pins force
+# protobuf<6, which is incompatible with flyteidl2's gencode and crashes the app.
+image = flyte.Image.from_debian_base(python_version=(3, 12)).with_pip_packages("streamlit>=1.46")
 
 # The `App` declaration.
 # Uses the `ImageSpec` declared above.


### PR DESCRIPTION
`streamlit<1.46` pins `protobuf<6`, downgrading the app image to protobuf 5.29.6 — older than flyteidl2's compiled gencode (6.33.5). The app then crashes at startup with a protobuf Gencode/Runtime `VersionError` before Streamlit runs. streamlit 1.46 relaxed the cap to `protobuf<7`, so requiring `streamlit>=1.46` lets protobuf resolve to 6.x and the app boots.

Verified end-to-end on a self-hosted canary: the app image built from `ghcr.io/flyteorg/flyte:py3.12-v2.6.13` + `streamlit>=1.46` starts cleanly (Knative revision Ready); the old `streamlit==1.41.1` image crash-loops with the VersionError.