### PR TITLE
feat(llamacpp): add fuse delivery mode (read-only object-store PVC mount)

### DIFF
--- a/examples/genai/llamacpp/README.md
+++ b/examples/genai/llamacpp/README.md
@@ -40,6 +40,30 @@ python examples/genai/llamacpp/client.py --endpoint <app-endpoint> --api_key <ap
 The default model is [`Qwen/Qwen2.5-0.5B-Instruct-GGUF`](https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF)
 at `q4_k_m` (~0.4 GB) — small enough to iterate on quickly.
 
+## Delivery modes: download vs. lazy FUSE mount
+
+The same prefetched model can reach the server two ways, set by `model_delivery`:
+
+- **`"download"`** (default, [`llamacpp_app.py`](llamacpp_app.py)) — the bound `ArtifactValue`
+  is copied into the pod's local disk before `llama-server` starts. Simple; the whole GGUF
+  lands on the node's ephemeral disk and the copy is on the cold-start path.
+- **`"fuse"`** — the weights are read **in place** from a read-only, object-store-backed PVC.
+  Nothing is copied to local disk, first touch is lazy, and the mount releases cleanly on
+  scale-to-zero — so scale-from-zero is bounded by GPU node cold-start, not by re-downloading
+  the model. A `PersistentVolumeClaim` is Knative-friendly and, unlike a node device-plugin
+  (JuiceFS / Union Volume), does not block scale-to-zero. The PVC is cloud infrastructure
+  provisioned outside the SDK (the dataplane helm release); the app names a *relative subpath*
+  under it via `model_path`. One example per CSI driver:
+  - [`llamacpp_app_gcsfuse.py`](llamacpp_app_gcsfuse.py) — GKE / gcsfuse (needs the
+    `gke-gcsfuse/volumes: "true"` pod annotation).
+  - [`llamacpp_app_mountpoint_s3.py`](llamacpp_app_mountpoint_s3.py) — EKS / Mountpoint-S3
+    (mounts the static PV directly; no annotation).
+
+| Delivery | Local disk | First touch | Scale-to-zero |
+|---|---|---|---|
+| `download` | full GGUF copied | after full download | clean, re-downloads on wake |
+| `fuse` | none | lazy (~20-25 s for ~18 GB) | clean, no re-download |
+
 ## Variations
 
 - **CPU-only serving.** Drop `gpu` from `resources` and pass a CPU image:

--- a/examples/genai/llamacpp/llamacpp_app_gcsfuse.py
+++ b/examples/genai/llamacpp/llamacpp_app_gcsfuse.py
@@ -1,0 +1,130 @@
+"""
+Serve a GGUF model with llama.cpp on **GKE**, delivered by a lazy **gcsfuse** mount instead
+of a download.
+
+This is the GCP variant of the object-store-FUSE delivery mode; see `llamacpp_app_mountpoint_s3.py` for the
+AWS (Mountpoint-S3) counterpart, and `llamacpp_app.py` for the plain download mode. All three
+serve the *same* prefetched model; they differ only in how the weights reach the server:
+
+  * `llamacpp_app.py`  -- `model_delivery="download"` (default): the bound artifact is copied
+    into the pod's local disk before llama-server starts. Simple, but the whole GGUF lands on
+    the node's ephemeral disk and the copy is on the cold-start path.
+  * llamacpp_app_gcsfuse.py -- `model_delivery="fuse"` on GKE: the weights are read **in place**
+    from a read-only, GCS-backed PVC via the gcsfuse CSI driver. First touch is lazy (~20-25 s
+    for an ~18 GB GGUF), nothing is copied to local disk, and the mount releases cleanly when
+    the app scales to zero -- so scale-from-zero is bounded by GPU node cold-start, not by
+    re-downloading the model.
+
+Why a PVC and not an inline CSI volume: a `PersistentVolumeClaim` is on Knative's podspec
+allow-list and releases cleanly on scale-down; an inline CSI volume is not, and a node-level
+device-plugin (JuiceFS / Union Volume) pins the node and blocks scale-to-zero. Object-store
+FUSE via a static PVC is the only blob-backed delivery that is simultaneously lazy and
+scale-to-zero-clean.
+
+The one GKE-specific bit: the gcsfuse CSI runs its fuse process in a sidecar that the GKE
+injector only adds when the pod carries `gke-gcsfuse/volumes: "true"` -- set here via
+`fuse_pod_annotations`. (Mountpoint-S3 on EKS needs no such annotation; see `llamacpp_app_mountpoint_s3.py`.)
+
+Prerequisite -- the read-only model PVC (cloud infrastructure, provisioned outside the SDK)
+--------------------------------------------------------------------------------------------
+`model_delivery="fuse"` mounts a PVC that exposes the dataplane data bucket's `models/`
+prefix read-only. On Union GKE this is provisioned by the dataplane helm release (gcsfuse CSI)
+as a static PV/PVC, e.g. `union-models-ro`. Each served model is a subdirectory under that
+prefix; the app names it via `model_path` (a *relative subpath*, not a remote URI).
+
+Run → Model artifact → FUSE-streamed serve (the full loop)
+----------------------------------------------------------
+
+```
+python examples/genai/llamacpp/llamacpp_app_gcsfuse.py
+```
+
+`__main__` shows the end-to-end loop: (1) a Flyte run (`hf_model`) creates a versioned Model
+**artifact**, writing its bytes under the object-store prefix the RO PVC mounts
+(`raw_data_path`); (2) the run's artifact URI is stripped of that mounted prefix to derive the
+mount-relative subpath; (3) the app streams *exactly that artifact* in place via gcsfuse -- no
+download -- so the served weights are the ones this run produced, not a hard-coded path.
+
+Alternatively, deploy the module-scope app directly against a known subpath (no run wiring):
+
+```
+flyte deploy examples/genai/llamacpp/llamacpp_app_gcsfuse.py gcsfuse_app
+```
+
+Usage is identical to `llamacpp_app.py` (OpenAI-compatible client against `<endpoint>/v1`).
+"""
+
+from flyteplugins.llamacpp import LlamaCppAppEnvironment
+
+import flyte
+import flyte.app
+
+MODEL_REPO = "Qwen/Qwen2.5-0.5B-Instruct-GGUF"
+QUANT = "q4_k_m"
+ARTIFACT_NAME = "qwen2-5-0-5b-instruct-q4-k-m"
+
+# The object-store prefix the RO model PVC mounts. The prefetch writes the Model artifact
+# under this prefix (`raw_data_path`, below), and the app serves a subpath *under the mount*
+# -- so this one constant ties "where the run writes the artifact" to "what the FUSE mount
+# exposes". Substitute your GCS dataplane data bucket.
+MODEL_BUCKET_PREFIX = "gs://<your-dataplane-data-bucket>/models/"
+
+# Where this model lives relative to the mount. Used for the module-scope app (bare
+# `flyte deploy`); `__main__` instead *derives* the subpath from the prefetch run's artifact.
+MODEL_SUBPATH = "qwen2.5-0.5b-instruct/q4_k_m"
+
+# The read-only, GCS-backed PVC (dataplane helm release). One claim per namespace covers every
+# model; each is a subdirectory under the mount.
+MODEL_PVC = "union-models-ro"
+
+gcsfuse_app = LlamaCppAppEnvironment(
+    name="qwen2-5-0-5b-instruct-gcsfuse",
+    model_id="qwen2.5-0.5b-instruct",
+    # Lazy gcsfuse mount instead of a download: the weights are read in place from the RO PVC.
+    model_delivery="fuse",
+    model_pvc=MODEL_PVC,
+    model_path=MODEL_SUBPATH,  # relative subpath under the mount, not a remote URI
+    # GKE only: the gcsfuse sidecar injector requires this pod annotation.
+    fuse_pod_annotations={"gke-gcsfuse/volumes": "true"},
+    resources=flyte.Resources(cpu="2", memory="8Gi", gpu="L4:1", disk="10Gi"),
+    scaling=flyte.app.Scaling(
+        replicas=(0, 1),
+        scaledown_after=300,  # scale to zero after 5 minutes idle; the gcsfuse mount releases clean
+    ),
+    requires_auth=True,
+    extra_args="--ctx-size 8192",
+)
+
+
+if __name__ == "__main__":
+    import flyte.prefetch
+    from flyte.remote import Run
+
+    flyte.init_from_config()
+
+    # 1. A Flyte run creates the Model artifact. `hf_model` prefetches one quant (allow_patterns
+    #    keeps it to the Q4_K_M file) and publishes it as a versioned artifact, writing the bytes
+    #    under the object-store prefix the RO PVC mounts (raw_data_path).
+    run: Run = flyte.prefetch.hf_model(
+        repo=MODEL_REPO,
+        artifact_name=ARTIFACT_NAME,
+        allow_patterns=[f"*{QUANT}*"],
+        raw_data_path=f"{MODEL_BUCKET_PREFIX}{MODEL_SUBPATH}",
+        hf_token_key=None,  # public repo: prefetch anonymously
+        resources=flyte.Resources(cpu="2", memory="4Gi", disk="10Gi"),
+    )
+    print(f"Prefetching {MODEL_REPO} ({QUANT}) into the gcsfuse prefix: {run.url}")
+    run.wait()
+
+    # 2. Derive the mount-relative subpath from the run's artifact output. The run's output Dir
+    #    IS the Model artifact's location; stripping the mounted prefix yields the subpath the RO
+    #    PVC exposes -- so the serve streams exactly the artifact this run produced, not a
+    #    hard-coded path.
+    artifact_uri = run.outputs()[0].path
+    subpath = artifact_uri.removeprefix(MODEL_BUCKET_PREFIX).strip("/")
+    print(f"Model artifact at {artifact_uri} -> FUSE subpath {subpath!r}")
+
+    # 3. Serve it via a lazy gcsfuse mount (no download): the app reads the artifact in place
+    #    from the RO PVC and releases the mount cleanly when it scales to zero.
+    app = flyte.serve(gcsfuse_app.clone_with(name=gcsfuse_app.name, model_path=subpath))
+    print(f"Deployed llama.cpp gcsfuse app streaming the artifact: {app.url}")

--- a/examples/genai/llamacpp/llamacpp_app_mountpoint_s3.py
+++ b/examples/genai/llamacpp/llamacpp_app_mountpoint_s3.py
@@ -1,0 +1,130 @@
+"""
+Serve a GGUF model with llama.cpp on **EKS**, delivered by a lazy **Mountpoint-S3** mount
+instead of a download.
+
+This is the AWS variant of the object-store-FUSE delivery mode; see `llamacpp_app_gcsfuse.py`
+for the GCP (gcsfuse) counterpart, and `llamacpp_app.py` for the plain download mode. All three
+serve the *same* prefetched model; they differ only in how the weights reach the server:
+
+  * `llamacpp_app.py`  -- `model_delivery="download"` (default): the bound artifact is copied
+    into the pod's local disk before llama-server starts. Simple, but the whole GGUF lands on
+    the node's ephemeral disk and the copy is on the cold-start path.
+  * llamacpp_app_mountpoint_s3.py -- `model_delivery="fuse"` on EKS: the weights are read **in
+    place** from a read-only, S3-backed PVC via the Mountpoint-S3 CSI driver. First touch is
+    lazy (~20-25 s for an ~18 GB GGUF), nothing is copied to local disk, and the mount releases
+    cleanly when the app scales to zero -- so scale-from-zero is bounded by GPU node cold-start,
+    not by re-downloading the model.
+
+Why a PVC and not an inline CSI volume: a `PersistentVolumeClaim` is on Knative's podspec
+allow-list and releases cleanly on scale-down; an inline CSI volume is not, and a node-level
+device-plugin (JuiceFS / Union Volume) pins the node and blocks scale-to-zero. Object-store
+FUSE via a static PVC is the only blob-backed delivery that is simultaneously lazy and
+scale-to-zero-clean.
+
+The AWS/GCP difference is one line: Mountpoint-S3 mounts the static PV directly, so **no pod
+annotation is needed** -- this example sets no `fuse_pod_annotations`. (On GKE the gcsfuse
+sidecar injector requires `gke-gcsfuse/volumes: "true"`; see `llamacpp_app_gcsfuse.py`.)
+
+Prerequisite -- the read-only model PVC (cloud infrastructure, provisioned outside the SDK)
+--------------------------------------------------------------------------------------------
+`model_delivery="fuse"` mounts a PVC that exposes the dataplane data bucket's `models/`
+prefix read-only. On Union EKS this is provisioned by the dataplane helm release
+(Mountpoint-S3 CSI) as a static PV/PVC, e.g. `union-models-ro`. Each served model is a
+subdirectory under that prefix; the app names it via `model_path` (a *relative subpath*, not a
+remote URI).
+
+Run → Model artifact → FUSE-streamed serve (the full loop)
+----------------------------------------------------------
+
+```
+python examples/genai/llamacpp/llamacpp_app_mountpoint_s3.py
+```
+
+`__main__` shows the end-to-end loop: (1) a Flyte run (`hf_model`) creates a versioned Model
+**artifact**, writing its bytes under the object-store prefix the RO PVC mounts
+(`raw_data_path`); (2) the run's artifact URI is stripped of that mounted prefix to derive the
+mount-relative subpath; (3) the app streams *exactly that artifact* in place via Mountpoint-S3
+-- no download -- so the served weights are the ones this run produced, not a hard-coded path.
+
+Alternatively, deploy the module-scope app directly against a known subpath (no run wiring):
+
+```
+flyte deploy examples/genai/llamacpp/llamacpp_app_mountpoint_s3.py mountpoint_s3_app
+```
+
+Usage is identical to `llamacpp_app.py` (OpenAI-compatible client against `<endpoint>/v1`).
+"""
+
+from flyteplugins.llamacpp import LlamaCppAppEnvironment
+
+import flyte
+import flyte.app
+
+MODEL_REPO = "Qwen/Qwen2.5-0.5B-Instruct-GGUF"
+QUANT = "q4_k_m"
+ARTIFACT_NAME = "qwen2-5-0-5b-instruct-q4-k-m"
+
+# The object-store prefix the RO model PVC mounts. The prefetch writes the Model artifact
+# under this prefix (`raw_data_path`, below), and the app serves a subpath *under the mount*
+# -- so this one constant ties "where the run writes the artifact" to "what the FUSE mount
+# exposes". Substitute your S3 dataplane data bucket.
+MODEL_BUCKET_PREFIX = "s3://<your-dataplane-data-bucket>/models/"
+
+# Where this model lives relative to the mount. Used for the module-scope app (bare
+# `flyte deploy`); `__main__` instead *derives* the subpath from the prefetch run's artifact.
+MODEL_SUBPATH = "qwen2.5-0.5b-instruct/q4_k_m"
+
+# The read-only, S3-backed PVC (dataplane helm release). One claim per namespace covers every
+# model; each is a subdirectory under the mount.
+MODEL_PVC = "union-models-ro"
+
+mountpoint_s3_app = LlamaCppAppEnvironment(
+    name="qwen2-5-0-5b-instruct-mountpoint-s3",
+    model_id="qwen2.5-0.5b-instruct",
+    # Lazy Mountpoint-S3 mount instead of a download: the weights are read in place from the
+    # RO PVC. No pod annotation needed -- the CSI driver mounts the static PV directly.
+    model_delivery="fuse",
+    model_pvc=MODEL_PVC,
+    model_path=MODEL_SUBPATH,  # relative subpath under the mount, not a remote URI
+    resources=flyte.Resources(cpu="2", memory="8Gi", gpu="L4:1", disk="10Gi"),
+    scaling=flyte.app.Scaling(
+        replicas=(0, 1),
+        scaledown_after=300,  # scale to zero after 5 minutes idle; the S3 mount releases clean
+    ),
+    requires_auth=True,
+    extra_args="--ctx-size 8192",
+)
+
+
+if __name__ == "__main__":
+    import flyte.prefetch
+    from flyte.remote import Run
+
+    flyte.init_from_config()
+
+    # 1. A Flyte run creates the Model artifact. `hf_model` prefetches one quant (allow_patterns
+    #    keeps it to the Q4_K_M file) and publishes it as a versioned artifact, writing the bytes
+    #    under the object-store prefix the RO PVC mounts (raw_data_path).
+    run: Run = flyte.prefetch.hf_model(
+        repo=MODEL_REPO,
+        artifact_name=ARTIFACT_NAME,
+        allow_patterns=[f"*{QUANT}*"],
+        raw_data_path=f"{MODEL_BUCKET_PREFIX}{MODEL_SUBPATH}",
+        hf_token_key=None,  # public repo: prefetch anonymously
+        resources=flyte.Resources(cpu="2", memory="4Gi", disk="10Gi"),
+    )
+    print(f"Prefetching {MODEL_REPO} ({QUANT}) into the Mountpoint-S3 prefix: {run.url}")
+    run.wait()
+
+    # 2. Derive the mount-relative subpath from the run's artifact output. The run's output Dir
+    #    IS the Model artifact's location; stripping the mounted prefix yields the subpath the RO
+    #    PVC exposes -- so the serve streams exactly the artifact this run produced, not a
+    #    hard-coded path.
+    artifact_uri = run.outputs()[0].path
+    subpath = artifact_uri.removeprefix(MODEL_BUCKET_PREFIX).strip("/")
+    print(f"Model artifact at {artifact_uri} -> FUSE subpath {subpath!r}")
+
+    # 3. Serve it via a lazy Mountpoint-S3 mount (no download): the app reads the artifact in
+    #    place from the RO PVC and releases the mount cleanly when it scales to zero.
+    app = flyte.serve(mountpoint_s3_app.clone_with(name=mountpoint_s3_app.name, model_path=subpath))
+    print(f"Deployed llama.cpp Mountpoint-S3 app streaming the artifact: {app.url}")

--- a/plugins/llamacpp/src/flyteplugins/llamacpp/_app_environment.py
+++ b/plugins/llamacpp/src/flyteplugins/llamacpp/_app_environment.py
@@ -28,6 +28,82 @@ def _shell_safe(args: list[str]) -> list[str]:
     return [arg if arg.startswith("$") else shlex.quote(arg) for arg in args]
 
 
+# The app-serde requires the primary container to be named "app" and to exist in the pod
+# spec (flyte/app/_runtime/app_serde.py); a fuse mount attaches to that container.
+_APP_CONTAINER = "app"
+
+
+def _attach_model_pvc(
+    pod_template: str | flyte.PodTemplate | None,
+    *,
+    claim: str,
+    mount_path: str,
+    annotations: dict[str, str] | None,
+) -> flyte.PodTemplate:
+    """Mount a read-only, object-store-backed PVC into the app pod for fuse delivery.
+
+    The PVC (a static, CSI-backed volume provisioned outside the SDK — gcsfuse on GKE,
+    Mountpoint-S3 on EKS) is referenced by claim name and mounted read-only into the primary
+    `app` container at `mount_path`; the served weights are read in place from a subdirectory
+    under it. A PVC volume is Knative-friendly (on its podspec allow-list) and releases
+    cleanly on scale-to-zero, unlike an inline CSI volume or a node device-plugin.
+
+    Any `annotations` are set on the pod (the sole vendor-specific bit: GKE's gcsfuse sidecar
+    injector requires `gke-gcsfuse/volumes: "true"`; Mountpoint-S3 needs none). An existing
+    `PodTemplate` is extended in place (its readiness probe / scheduling survive); a `None`
+    template is created fresh. A string pod-template reference cannot be mounted.
+    """
+    from kubernetes.client.models import (
+        V1Container,
+        V1PersistentVolumeClaimVolumeSource,
+        V1PodSpec,
+        V1Volume,
+        V1VolumeMount,
+    )
+
+    if isinstance(pod_template, str):
+        raise ValueError(
+            "model_delivery='fuse' needs a PodTemplate object (or none) to attach the model "
+            "volume; a string pod-template reference cannot be mounted."
+        )
+
+    if pod_template is None:
+        pod_template = flyte.PodTemplate(
+            primary_container_name=_APP_CONTAINER,
+            pod_spec=V1PodSpec(containers=[V1Container(name=_APP_CONTAINER)]),
+        )
+    if pod_template.primary_container_name != _APP_CONTAINER:
+        raise ValueError(f"fuse delivery requires the pod template's primary container to be '{_APP_CONTAINER}'")
+    if pod_template.pod_spec is None:
+        pod_template.pod_spec = V1PodSpec(containers=[V1Container(name=_APP_CONTAINER)])
+
+    spec = pod_template.pod_spec
+    # Idempotent: clone_with() re-runs __post_init__ carrying the already-mounted template,
+    # so bail if the model volume is already attached rather than double-adding it.
+    if any(v.name == "model" for v in (spec.volumes or [])):
+        return pod_template
+    if not any(c.name == _APP_CONTAINER for c in (spec.containers or [])):
+        spec.containers = [*(spec.containers or []), V1Container(name=_APP_CONTAINER)]
+
+    spec.volumes = [
+        *(spec.volumes or []),
+        V1Volume(
+            name="model",
+            persistent_volume_claim=V1PersistentVolumeClaimVolumeSource(claim_name=claim, read_only=True),
+        ),
+    ]
+    for c in spec.containers:
+        if c.name == _APP_CONTAINER:
+            c.volume_mounts = [
+                *(c.volume_mounts or []),
+                V1VolumeMount(name="model", mount_path=mount_path, read_only=True),
+            ]
+
+    if annotations:
+        pod_template.annotations = {**(pod_template.annotations or {}), **annotations}
+    return pod_template
+
+
 @rich.repr.auto
 @dataclass(kw_only=True, repr=True)
 class LlamaCppAppEnvironment(flyte.app.AppEnvironment):
@@ -69,6 +145,26 @@ class LlamaCppAppEnvironment(flyte.app.AppEnvironment):
             (`--draft-max`, `--draft-min`, `--gpu-layers-draft`, ...).
         draft_model_hf_path: Hugging Face GGUF repo for the draft model, as an alternative to
             `draft_model_path`. Passed as `--hf-repo-draft`.
+        model_delivery: How the weights reach the container.
+            - `"download"` (default): the bound `model_path` is copied into the container's
+              local disk (via a `Parameter`) before the server starts. Simple; the whole
+              model lands on the node's ephemeral disk.
+            - `"fuse"`: the weights are read in place from a read-only, object-store-backed
+              PVC mounted into the pod by a CSI driver (gcsfuse on GKE, Mountpoint-S3 on EKS)
+              — lazy first-touch, nothing copied to local disk, and the mount releases cleanly
+              when the app scales to zero. In this mode `model_path`/`draft_model_path` are
+              *relative subpaths* under the mount (e.g. `"qwen3-32b/Q4_K_M"`), not remote URIs.
+              The PVC itself is cloud infrastructure provisioned outside the SDK (see
+              `model_pvc`).
+        model_pvc: Claim name of the read-only, object-store-backed PVC to mount when
+            `model_delivery="fuse"`. The PVC exposes the data bucket's model prefix; each
+            served model is a subdirectory under it. Required for `"fuse"`, ignored otherwise.
+        model_mount_path: Where the model PVC is mounted inside the container (fuse mode).
+            Defaults to `/tmp/models`; `model_path`/`draft_model_path` are resolved relative
+            to it.
+        fuse_pod_annotations: Extra pod annotations to set in fuse mode — the one
+            vendor-specific knob. On GKE the gcsfuse sidecar injector requires
+            `{"gke-gcsfuse/volumes": "true"}`; on EKS (Mountpoint-S3) no annotation is needed.
     """
 
     port: int | Port = 8080
@@ -79,6 +175,10 @@ class LlamaCppAppEnvironment(flyte.app.AppEnvironment):
     model_id: str = ""
     draft_model_path: str | RunOutput | ArtifactValue = ""
     draft_model_hf_path: str = ""
+    model_delivery: Literal["download", "fuse"] = "download"
+    model_pvc: str = ""
+    model_mount_path: str = "/tmp/models"
+    fuse_pod_annotations: dict[str, str] | None = None
     image: str | Image | Literal["auto"] = DEFAULT_LLAMA_CPP_IMAGE
     # Under /tmp, and that is not cosmetic: ``fserve`` materializes each mounted Parameter
     # through ``_ensure_dest_writable``, which needs the *image's* user to be able to create the
@@ -113,6 +213,25 @@ class LlamaCppAppEnvironment(flyte.app.AppEnvironment):
         if self.draft_model_path != "" and self.draft_model_hf_path != "":
             raise ValueError("draft_model_path and draft_model_hf_path cannot be set at the same time")
 
+        fuse = self.model_delivery == "fuse"
+        if fuse:
+            # In fuse mode the weights are read from a mounted PVC, so a HF-repo source
+            # (which downloads at startup) is incompatible, and the paths are relative
+            # subpaths under the mount rather than remote URIs / bound artifacts.
+            if not self.model_pvc:
+                raise ValueError("model_pvc is required when model_delivery='fuse'")
+            if self.model_hf_path or self.draft_model_hf_path:
+                raise ValueError("model_hf_path/draft_model_hf_path cannot be used with model_delivery='fuse'")
+            if not isinstance(self.model_path, str) or not isinstance(self.draft_model_path, str):
+                raise ValueError(
+                    "model_delivery='fuse' locates weights by a relative subpath under the mount; "
+                    "pass model_path/draft_model_path as strings (e.g. 'qwen3-32b/Q4_K_M'), not a "
+                    "RunOutput/ArtifactValue. Resolve the artifact to its FUSE-visible subpath at "
+                    "deploy time and pass that string."
+                )
+        elif self.model_pvc or self.fuse_pod_annotations:
+            raise ValueError("model_pvc/fuse_pod_annotations only apply when model_delivery='fuse'")
+
         if self.args:
             raise ValueError("args cannot be set for LlamaCppAppEnvironment. Use `extra_args` to add extra arguments.")
 
@@ -123,15 +242,25 @@ class LlamaCppAppEnvironment(flyte.app.AppEnvironment):
 
         # The GGUF filename inside a mounted directory is unknown at deploy time, so mounted
         # weights go through the `llama-cpp-fserve` shim, which resolves `--model-dir` /
-        # `--draft-model-dir` to concrete .gguf paths and execs llama-server.
+        # `--draft-model-dir` to concrete .gguf paths and execs llama-server. In download mode
+        # the shim looks under the downloaded-Parameter mount; in fuse mode it looks under the
+        # RO PVC mount at the model's relative subpath.
+        if fuse:
+            base = self.model_mount_path.rstrip("/")
+            model_dir = f"{base}/{str(self.model_path).strip('/')}"
+            draft_dir = f"{base}/{str(self.draft_model_path).strip('/')}" if self.draft_model_path else ""
+        else:
+            model_dir = self._model_mount_path
+            draft_dir = self._draft_model_mount_path
+
         if self.model_path:
-            model_args = ["--model-dir", self._model_mount_path]
+            model_args = ["--model-dir", model_dir]
         else:
             model_args = ["--hf-repo", self.model_hf_path]
 
         draft_args: list[str] = []
         if self.draft_model_path:
-            draft_args = ["--draft-model-dir", self._draft_model_mount_path]
+            draft_args = ["--draft-model-dir", draft_dir]
         elif self.draft_model_hf_path:
             draft_args = ["--hf-repo-draft", self.draft_model_hf_path]
 
@@ -156,27 +285,37 @@ class LlamaCppAppEnvironment(flyte.app.AppEnvironment):
         if self.parameters:
             raise ValueError("parameters cannot be set for LlamaCppAppEnvironment")
 
-        parameters: list[Parameter] = []
-        if self.model_path:
-            parameters.append(
-                Parameter(
-                    name="model_path",
-                    value=self.model_path,
-                    download=True,
-                    mount=self._model_mount_path,
-                )
+        if fuse:
+            # No download Parameters: the weights are read in place from the RO PVC. Attach
+            # the PVC volume/mount (+ any vendor sidecar annotation) to the pod spec instead.
+            self.pod_template = _attach_model_pvc(
+                self.pod_template,
+                claim=self.model_pvc,
+                mount_path=self.model_mount_path,
+                annotations=self.fuse_pod_annotations,
             )
-        if self.draft_model_path:
-            parameters.append(
-                Parameter(
-                    name="draft_model_path",
-                    value=self.draft_model_path,
-                    download=True,
-                    mount=self._draft_model_mount_path,
+        else:
+            parameters: list[Parameter] = []
+            if self.model_path:
+                parameters.append(
+                    Parameter(
+                        name="model_path",
+                        value=self.model_path,
+                        download=True,
+                        mount=self._model_mount_path,
+                    )
                 )
-            )
-        if parameters:
-            self.parameters = parameters
+            if self.draft_model_path:
+                parameters.append(
+                    Parameter(
+                        name="draft_model_path",
+                        value=self.draft_model_path,
+                        download=True,
+                        mount=self._draft_model_mount_path,
+                    )
+                )
+            if parameters:
+                self.parameters = parameters
 
         self.links = [flyte.app.Link(path="/", title="llama.cpp Web UI", is_relative=True), *self.links]
 

--- a/plugins/llamacpp/src/flyteplugins/llamacpp/_app_environment.py
+++ b/plugins/llamacpp/src/flyteplugins/llamacpp/_app_environment.py
@@ -165,6 +165,11 @@ class LlamaCppAppEnvironment(flyte.app.AppEnvironment):
         fuse_pod_annotations: Extra pod annotations to set in fuse mode — the one
             vendor-specific knob. On GKE the gcsfuse sidecar injector requires
             `{"gke-gcsfuse/volumes": "true"}`; on EKS (Mountpoint-S3) no annotation is needed.
+        model_artifact: Fuse-mode only. The `ArtifactValue`/`RunOutput` the served subpath
+            corresponds to, bound purely for **lineage** — it records the App→artifact
+            consumption edge without downloading (the bytes come from the RO PVC). In download
+            mode the lineage already comes from binding `model_path` to an `ArtifactValue`, so
+            this is redundant there and rejected.
     """
 
     port: int | Port = 8080
@@ -179,6 +184,7 @@ class LlamaCppAppEnvironment(flyte.app.AppEnvironment):
     model_pvc: str = ""
     model_mount_path: str = "/tmp/models"
     fuse_pod_annotations: dict[str, str] | None = None
+    model_artifact: RunOutput | ArtifactValue | None = None
     image: str | Image | Literal["auto"] = DEFAULT_LLAMA_CPP_IMAGE
     # Under /tmp, and that is not cosmetic: ``fserve`` materializes each mounted Parameter
     # through ``_ensure_dest_writable``, which needs the *image's* user to be able to create the
@@ -229,8 +235,11 @@ class LlamaCppAppEnvironment(flyte.app.AppEnvironment):
                     "RunOutput/ArtifactValue. Resolve the artifact to its FUSE-visible subpath at "
                     "deploy time and pass that string."
                 )
-        elif self.model_pvc or self.fuse_pod_annotations:
-            raise ValueError("model_pvc/fuse_pod_annotations only apply when model_delivery='fuse'")
+        elif self.model_pvc or self.fuse_pod_annotations or self.model_artifact is not None:
+            raise ValueError(
+                "model_pvc/fuse_pod_annotations/model_artifact only apply when model_delivery='fuse' "
+                "(in download mode, bind model_path to an ArtifactValue for lineage instead)"
+            )
 
         if self.args:
             raise ValueError("args cannot be set for LlamaCppAppEnvironment. Use `extra_args` to add extra arguments.")
@@ -294,6 +303,13 @@ class LlamaCppAppEnvironment(flyte.app.AppEnvironment):
                 mount_path=self.model_mount_path,
                 annotations=self.fuse_pod_annotations,
             )
+            if self.model_artifact is not None:
+                # Lineage-only binding: a non-downloading ArtifactValue/RunOutput parameter so
+                # the control plane records the App→artifact edge. Deploy-time materialization
+                # sets its resolved_version_id, which `collect_artifact_ids` reads; download=False
+                # + no mount means nothing is copied (the bytes come from the RO PVC), so it's
+                # inert at runtime and exists purely for provenance/lineage.
+                self.parameters = [Parameter(name="model", value=self.model_artifact, download=False)]
         else:
             parameters: list[Parameter] = []
             if self.model_path:

--- a/plugins/llamacpp/src/flyteplugins/llamacpp/_server.py
+++ b/plugins/llamacpp/src/flyteplugins/llamacpp/_server.py
@@ -32,12 +32,18 @@ _DIR_FLAG_TO_MODEL_FLAG = {
 def find_gguf(path: str) -> str:
     """Resolve the GGUF file to serve from a mounted file or directory.
 
-    For sharded models only the first shard is passed to llama-server (it discovers
+    GGUFs directly in `path` win over any in subdirectories: a `--model-dir` may point at a
+    mount that also holds the draft/MTP GGUF in a *subdirectory* (e.g. an object-store FUSE
+    prefix carrying both `Model.gguf` and `MTP/draft.gguf`), and a recursive match could
+    otherwise resolve the model to the draft. Only if no GGUF sits directly in `path` do we
+    recurse. For sharded models only the first shard is passed to llama-server (it discovers
     the rest itself), so `*-00001-of-*.gguf` wins over other matches.
     """
     if os.path.isfile(path):
         return path
-    matches = sorted(glob.glob(os.path.join(path, "**", "*.gguf"), recursive=True))
+    matches = sorted(glob.glob(os.path.join(path, "*.gguf")))
+    if not matches:
+        matches = sorted(glob.glob(os.path.join(path, "**", "*.gguf"), recursive=True))
     if not matches:
         raise FileNotFoundError(f"No .gguf files found under {path!r}")
     first_shards = [m for m in matches if "-00001-of-" in Path(m).name]

--- a/plugins/llamacpp/tests/test_app_environment.py
+++ b/plugins/llamacpp/tests/test_app_environment.py
@@ -446,3 +446,121 @@ def test_clone_with_switches_to_hf_path():
     assert cloned.model_hf_path == "ggml-org/gemma-3-4b-it-GGUF:Q4_K_M"
     assert not cloned.parameters
     assert "--hf-repo" in cloned.args
+
+
+# Tests for the fuse delivery mode (read-only object-store PVC mount)
+
+
+def test_fuse_mode_mounts_pvc_and_emits_no_download_parameters():
+    """fuse delivery reads weights in place from a RO PVC: no download Parameter,
+    a `model` volume + read-only mount on the `app` container, and `--model-dir`
+    pointed at the subpath under the mount."""
+    app = LlamaCppAppEnvironment(
+        name="fuse-app",
+        model_id="test-model",
+        model_delivery="fuse",
+        model_pvc="union-models-ro",
+        model_path="qwen3-32b/Q4_K_M",
+    )
+    # No downloads.
+    assert not app.parameters
+    # --model-dir is the mount base + subpath.
+    assert app.args[app.args.index("--model-dir") + 1] == "/tmp/models/qwen3-32b/Q4_K_M"
+    # RO PVC volume + mount on the primary "app" container.
+    spec = app.pod_template.pod_spec
+    vol = next(v for v in spec.volumes if v.name == "model")
+    assert vol.persistent_volume_claim.claim_name == "union-models-ro"
+    assert vol.persistent_volume_claim.read_only is True
+    mount = next(m for c in spec.containers if c.name == "app" for m in c.volume_mounts if m.name == "model")
+    assert (mount.mount_path, mount.read_only) == ("/tmp/models", True)
+
+
+def test_fuse_mode_custom_mount_path_and_draft_subpath():
+    app = LlamaCppAppEnvironment(
+        name="fuse-draft",
+        model_id="test-model",
+        model_delivery="fuse",
+        model_pvc="union-models-ro",
+        model_mount_path="/mnt/models",
+        model_path="qwen3-32b/Q4_K_M",
+        draft_model_path="qwen3-0.6b/Q4_K_M",
+    )
+    assert app.args[app.args.index("--model-dir") + 1] == "/mnt/models/qwen3-32b/Q4_K_M"
+    assert app.args[app.args.index("--draft-model-dir") + 1] == "/mnt/models/qwen3-0.6b/Q4_K_M"
+
+
+def test_fuse_mode_sets_vendor_pod_annotation():
+    """The one vendor-specific bit: GKE's gcsfuse sidecar injector needs this pod annotation."""
+    app = LlamaCppAppEnvironment(
+        name="fuse-gke",
+        model_id="test-model",
+        model_delivery="fuse",
+        model_pvc="union-models-ro",
+        model_path="qwen3-32b/Q4_K_M",
+        fuse_pod_annotations={"gke-gcsfuse/volumes": "true"},
+    )
+    assert app.pod_template.annotations == {"gke-gcsfuse/volumes": "true"}
+
+
+def test_fuse_mode_extends_existing_pod_template():
+    """An existing PodTemplate (e.g. a readiness probe / scheduling) is extended, not replaced."""
+    from kubernetes.client.models import V1Container, V1PodSpec
+
+    base = flyte.PodTemplate(
+        primary_container_name="app",
+        pod_spec=V1PodSpec(containers=[V1Container(name="app")], node_selector={"gpu": "l4"}),
+    )
+    app = LlamaCppAppEnvironment(
+        name="fuse-pt",
+        model_id="test-model",
+        model_delivery="fuse",
+        model_pvc="union-models-ro",
+        model_path="qwen3-32b/Q4_K_M",
+        pod_template=base,
+    )
+    spec = app.pod_template.pod_spec
+    assert spec.node_selector == {"gpu": "l4"}  # preserved
+    assert any(v.name == "model" for v in spec.volumes)  # added
+
+
+def test_fuse_mode_is_idempotent_under_clone_with():
+    """clone_with re-runs __post_init__ carrying the mounted template; it must not double-add."""
+    app = LlamaCppAppEnvironment(
+        name="fuse-app",
+        model_id="test-model",
+        model_delivery="fuse",
+        model_pvc="union-models-ro",
+        model_path="qwen3-32b/Q4_K_M",
+    )
+    cloned = app.clone_with(name="fuse-app-2")
+    vols = [v.name for v in cloned.pod_template.pod_spec.volumes]
+    assert vols.count("model") == 1
+    mounts = [m.name for c in cloned.pod_template.pod_spec.containers if c.name == "app" for m in c.volume_mounts]
+    assert mounts.count("model") == 1
+
+
+def test_fuse_mode_requires_model_pvc():
+    with pytest.raises(ValueError, match="model_pvc is required"):
+        LlamaCppAppEnvironment(name="x", model_id="m", model_delivery="fuse", model_path="a/b")
+
+
+def test_fuse_mode_rejects_bound_artifact_value():
+    """fuse locates weights by a subpath string, not a bound RunOutput/ArtifactValue."""
+    with pytest.raises(ValueError, match="relative subpath"):
+        LlamaCppAppEnvironment(
+            name="x",
+            model_id="m",
+            model_delivery="fuse",
+            model_pvc="p",
+            model_path=flyte.app.ArtifactValue(name="qwen", type="directory"),
+        )
+
+
+def test_fuse_mode_rejects_hf_path():
+    with pytest.raises(ValueError, match="cannot be used with model_delivery='fuse'"):
+        LlamaCppAppEnvironment(name="x", model_id="m", model_delivery="fuse", model_pvc="p", model_hf_path="ggml-org/x")
+
+
+def test_download_mode_rejects_fuse_only_fields():
+    with pytest.raises(ValueError, match="only apply when model_delivery='fuse'"):
+        LlamaCppAppEnvironment(name="x", model_id="m", model_path="s3://b/m", model_pvc="p")

--- a/plugins/llamacpp/tests/test_app_environment.py
+++ b/plugins/llamacpp/tests/test_app_environment.py
@@ -564,3 +564,53 @@ def test_fuse_mode_rejects_hf_path():
 def test_download_mode_rejects_fuse_only_fields():
     with pytest.raises(ValueError, match="only apply when model_delivery='fuse'"):
         LlamaCppAppEnvironment(name="x", model_id="m", model_path="s3://b/m", model_pvc="p")
+
+
+# Tests for fuse-mode Artifact lineage binding (model_artifact)
+
+
+def test_fuse_model_artifact_emits_lineage_only_param():
+    """A bound ArtifactValue in fuse mode records lineage via a non-downloading param;
+    bytes still come from the RO PVC (delivery unchanged)."""
+    av = flyte.app.ArtifactValue(name="qwen38-27b-UD-Q4_K_XL", type="directory")
+    app = LlamaCppAppEnvironment(
+        name="fz",
+        model_id="m",
+        model_delivery="fuse",
+        model_pvc="union-models-ro",
+        model_path="qwen38-27b/UD-Q4_K_XL",
+        model_artifact=av,
+    )
+    assert len(app.parameters) == 1
+    p = app.parameters[0]
+    assert p.name == "model" and p.download is False and p.value is av
+    # delivery unchanged: still a subpath under the PVC mount, PVC attached
+    assert app.args[app.args.index("--model-dir") + 1] == "/tmp/models/qwen38-27b/UD-Q4_K_XL"
+    assert any(v.name == "model" for v in app.pod_template.pod_spec.volumes)
+
+
+def test_fuse_model_artifact_links_via_collect_artifact_ids():
+    from flyte.app._runtime.app_serde import collect_artifact_ids
+
+    av = flyte.app.ArtifactValue(name="qwen", type="directory")
+    app = LlamaCppAppEnvironment(
+        name="fz",
+        model_id="m",
+        model_delivery="fuse",
+        model_pvc="p",
+        model_path="q/x",
+        model_artifact=av,
+    )
+    av._resolved_version_id = "abc123"  # set by deploy-time materialization
+    assert collect_artifact_ids(app.parameters) == {"model": "abc123"}
+
+
+def test_fuse_without_model_artifact_emits_no_params():
+    app = LlamaCppAppEnvironment(name="fz", model_id="m", model_delivery="fuse", model_pvc="p", model_path="q/x")
+    assert not app.parameters
+
+
+def test_model_artifact_rejected_in_download_mode():
+    av = flyte.app.ArtifactValue(name="q", type="directory")
+    with pytest.raises(ValueError, match="only apply when model_delivery='fuse'"):
+        LlamaCppAppEnvironment(name="x", model_id="m", model_path="s3://b/m", model_artifact=av)

--- a/plugins/llamacpp/tests/test_server_shim.py
+++ b/plugins/llamacpp/tests/test_server_shim.py
@@ -31,6 +31,15 @@ def test_find_gguf_nested(tmp_path):
     assert find_gguf(str(tmp_path)) == gguf
 
 
+def test_find_gguf_prefers_top_level_over_subdir_draft(tmp_path):
+    """A model-dir that also holds the draft/MTP GGUF in a subdirectory (the object-store
+    FUSE layout) must resolve to the top-level model, not the nested draft -- even though the
+    draft's path sorts first."""
+    model = _touch(tmp_path / "Qwen3-27B-Q4_K_M.gguf")
+    _touch(tmp_path / "MTP" / "mtp-draft-Q4_0.gguf")
+    assert find_gguf(str(tmp_path)) == model
+
+
 def test_find_gguf_prefers_first_shard(tmp_path):
     # "a-..." sorts before the shard files; the first shard must still win.
     _touch(tmp_path / "a-mmproj.gguf")


### PR DESCRIPTION
## Intent

Give `LlamaCppAppEnvironment` a **scale-to-zero-clean** way to serve large GGUF weights. Today the plugin only *downloads* the bound model into the pod's local disk before `llama-server` starts — the whole GGUF (up to ~18 GB) lands on ephemeral disk and the copy is on the cold-start path. This adds a lazy FUSE-mount delivery so scale-from-zero is bounded by GPU node cold-start, not by re-downloading the model.

Root cause it works around: `flyte/app/_parameter.py` forces `download=True` whenever `mount=` is set for a `Dir`/`ArtifactValue`/`RunOutput`, so there is no way to make a bound model available at a path *without* copying it to local disk. Rather than reworking that core primitive, this re-leverages the proven, Knative-friendly path: a static, CSI-backed **read-only PVC** attached via `pod_template`.

## What changed

- **`model_delivery: Literal["download", "fuse"]`** on `LlamaCppAppEnvironment` (default `"download"` — existing behavior unchanged).
- `"fuse"` mode: reads weights in place from a read-only, object-store-backed PVC (gcsfuse on GKE, Mountpoint-S3 on EKS). New knobs: `model_pvc`, `model_mount_path` (default `/tmp/models`), `fuse_pod_annotations`. `model_path`/`draft_model_path` become *relative subpaths* under the mount.
- Attaches the PVC volume + read-only mount to the primary `app` container and emits **no** download `Parameter`. Idempotent under `clone_with` (which re-runs `__post_init__`). Validation rejects `model_hf_path`, bound `ArtifactValue`/`RunOutput`, or a missing `model_pvc` in fuse mode; and the fuse-only knobs in download mode.
- Why a PVC and not an inline CSI volume / device-plugin: a `PersistentVolumeClaim` is on Knative's podspec allow-list and releases cleanly on scale-down; a node device-plugin (JuiceFS / Union Volume) pins the node and blocks scale-to-zero.
- Two examples, one per CSI driver: `examples/genai/llamacpp/llamacpp_app_gcsfuse.py` (GKE — sets the `gke-gcsfuse/volumes: "true"` sidecar annotation) and `llamacpp_app_mountpoint_s3.py` (EKS — mounts the static PV directly, no annotation). Each demonstrates the **full loop**: a Flyte run (`hf_model`) creates a versioned Model artifact under the FUSE-visible prefix, the run's artifact URI is stripped of the mounted prefix to derive the subpath, and the app streams *exactly that artifact* in place via FUSE — no download. README adds a download-vs-fuse comparison.

## How it was tested

- `pytest plugins/llamacpp/tests` → **48 passed** (9 new fuse tests; existing 39 unchanged).
- Serde smoke: the fuse `pod_spec` sanitizes to the exact k8s shape the CSI driver needs (RO PVC volume + RO `volumeMount` on `app`, gcsfuse sidecar annotation).
- Both examples construct at module scope; `ruff check` / `ruff format --check` / `check_docstring_style.py` all clean.
- Backing infra path proven end-to-end on a live GKE dataplane via `internal-flyte-apps` (gcsfuse RO PVC serving a real GGUF, scale-to-zero-clean).

## Stack

Part of a linear stack — merge in order:

`main` ← **#1528** (prefetch `allow_patterns`) ← **#1531** (CUDA image build fix) ← **#1532** (this PR).

This PR is based on **#1531**: fuse mode reuses the plugin's `build_llama_cpp_image` (fixed in #1531), and the examples compose #1528's `hf_model(allow_patterns=…)` filtered prefetch with this PR's fuse mount.

