### PR TITLE
feat(llamacpp): factor build_fserve_command for reuse outside the App

### DIFF
--- a/examples/genai/llamacpp/README.md
+++ b/examples/genai/llamacpp/README.md
@@ -77,3 +77,8 @@ The same prefetched model can reach the server two ways, set by `model_delivery`
   `--jinja` for tool-calling, `--flash-attn`). See the
   [llama-server docs](https://github.com/ggml-org/llama.cpp/tree/master/tools/server).
 - **Speculative decoding.** Point `draft_model_hf_path` at a small draft GGUF (see the plugin README).
+- **Serving shape: task-pod sidecar.** Besides the standalone scale-to-zero App above, you can
+  run llama.cpp as a **native sidecar in a Flyte task pod** for batch/pipeline inference against
+  a co-located model — see [`llamacpp_sidecar.py`](llamacpp_sidecar.py). It builds the server
+  command with the plugin's `build_fserve_command` (the same argv the App runs), so both shapes
+  stay in lockstep.

--- a/examples/genai/llamacpp/llamacpp_sidecar.py
+++ b/examples/genai/llamacpp/llamacpp_sidecar.py
@@ -1,0 +1,123 @@
+"""
+Serve a GGUF model with llama.cpp as a **native sidecar in a Flyte task pod** -- for
+batch/pipeline inference against a co-located model, as opposed to the standalone,
+scale-to-zero Flyte App in `llamacpp_app.py`.
+
+The task pod runs two containers:
+  * `primary` -- the client task; it calls the local server on `localhost`.
+  * `llama`   -- a llama.cpp server (llama-server via the `llama-cpp-fserve` shim) started
+                 with the plugin's `build_fserve_command` -- the *same* argv
+                 `LlamaCppAppEnvironment` runs. Both serving shapes assemble the command the
+                 one way, so tuning/flags stay identical.
+
+The server is a **native sidecar**: an init container with `restart_policy="Always"`, so
+Kubernetes starts it before the primary and SIGTERMs it when the primary exits (the pod
+reaches a terminal state instead of hanging with a forever-running plain container).
+
+Self-contained: the sidecar loads the model straight from HuggingFace (`--hf-repo` via
+`model_hf_path`), so there is no model volume to provision. To serve a mounted model instead
+(object-store FUSE), pass `model_dir=<mount>/<subpath>` to `build_fserve_command` and attach
+the PVC to the pod (see `llamacpp_app_gcsfuse.py`).
+
+Sidecar container images must be string image URIs (`V1Container.image`), not `flyte.Image`
+objects (only the task environment's own image is Flyte-built), so `__main__` builds the
+llama.cpp image first with `flyte.build` and passes its URI.
+
+Run:
+    python examples/genai/llamacpp/llamacpp_sidecar.py --prompt "Write a haiku about GPUs."
+"""
+
+from __future__ import annotations
+
+from flyteplugins.llamacpp import build_fserve_command, build_llama_cpp_image
+
+import flyte
+
+MODEL_HF = "Qwen/Qwen2.5-0.5B-Instruct-GGUF:q4_k_m"  # public repo, small enough for CPU
+MODEL_ID = "qwen2.5-0.5b-instruct"
+SERVER_PORT = 8080
+
+# CPU-only so the example needs no GPU. The image carries llama-server + the
+# `llama-cpp-fserve` shim (it installs `flyteplugins-llamacpp`).
+SERVE_IMAGE = build_llama_cpp_image(name="llama-cpp-sidecar", cuda=False)
+
+# The client task's own image (Flyte-built): just needs an OpenAI client.
+CLIENT_IMAGE = flyte.Image.from_debian_base(name="llamacpp-sidecar-client", install_flyte=True).with_pip_packages(
+    "openai"
+)
+
+
+def _pod_template(serve_image_uri: str) -> flyte.PodTemplate:
+    """primary (client) + a llama.cpp server as a native sidecar."""
+    from kubernetes.client.models import V1Container, V1PodSpec
+
+    # The same llama-cpp-fserve argv the App runs; build_fserve_command returns shell-safe
+    # tokens meant to be joined into one shell string (how fserve execs llama-server), so
+    # wrap them in `sh -c`.
+    server_cmd = build_fserve_command(model_id=MODEL_ID, port=SERVER_PORT, model_hf_path=MODEL_HF)
+    llama_sidecar = V1Container(
+        name="llama",
+        image=serve_image_uri,
+        restart_policy="Always",  # native sidecar: started before, torn down with, the primary
+        command=["/bin/sh", "-c", " ".join(server_cmd)],
+    )
+    return flyte.PodTemplate(
+        primary_container_name="primary",
+        pod_spec=V1PodSpec(
+            containers=[V1Container(name="primary")],
+            init_containers=[llama_sidecar],
+        ),
+    )
+
+
+def _build_env(serve_image_uri: str) -> flyte.TaskEnvironment:
+    return flyte.TaskEnvironment(
+        name="llamacpp-sidecar",
+        image=CLIENT_IMAGE,
+        pod_template=_pod_template(serve_image_uri),
+        resources=flyte.Resources(cpu="2", memory="6Gi"),
+    )
+
+
+def chat(prompt: str) -> str:
+    """Call the local llama.cpp sidecar (OpenAI-compatible) once it is ready."""
+    import time
+
+    from openai import OpenAI
+
+    client = OpenAI(base_url=f"http://localhost:{SERVER_PORT}/v1", api_key="sk-noauth")
+    # Wait for the sidecar to finish loading the model (cold HF download on first start).
+    for _ in range(150):
+        try:
+            client.models.list()
+            break
+        except Exception:
+            time.sleep(2)
+    else:
+        raise RuntimeError("llama.cpp sidecar did not become ready")
+
+    resp = client.chat.completions.create(
+        model=MODEL_ID, messages=[{"role": "user", "content": prompt}], max_tokens=256
+    )
+    return resp.choices[0].message.content or ""
+
+
+if __name__ == "__main__":
+    import argparse
+    import asyncio
+
+    p = argparse.ArgumentParser(description="llama.cpp as a Flyte task-pod sidecar.")
+    p.add_argument("--prompt", default="Write a haiku about GPUs.")
+    args = p.parse_args()
+
+    flyte.init_from_config()
+
+    # Sidecar images must be string URIs, so build the llama.cpp image and use its URI.
+    built = asyncio.run(flyte.build.aio(SERVE_IMAGE))
+    print(f"llama.cpp sidecar image: {built.uri}")
+
+    env = _build_env(built.uri)
+    run = flyte.run(env.task(chat), prompt=args.prompt)
+    print(f"Run: {run.url}")
+    run.wait()
+    print(run.outputs())

--- a/plugins/llamacpp/src/flyteplugins/llamacpp/__init__.py
+++ b/plugins/llamacpp/src/flyteplugins/llamacpp/__init__.py
@@ -1,4 +1,9 @@
-__all__ = ["DEFAULT_LLAMA_CPP_IMAGE", "LlamaCppAppEnvironment", "build_llama_cpp_image"]
+__all__ = [
+    "DEFAULT_LLAMA_CPP_IMAGE",
+    "LlamaCppAppEnvironment",
+    "build_fserve_command",
+    "build_llama_cpp_image",
+]
 
-from flyteplugins.llamacpp._app_environment import LlamaCppAppEnvironment
+from flyteplugins.llamacpp._app_environment import LlamaCppAppEnvironment, build_fserve_command
 from flyteplugins.llamacpp._image import DEFAULT_LLAMA_CPP_IMAGE, build_llama_cpp_image

--- a/plugins/llamacpp/src/flyteplugins/llamacpp/_app_environment.py
+++ b/plugins/llamacpp/src/flyteplugins/llamacpp/_app_environment.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import shlex
+from collections.abc import Iterable
 from dataclasses import dataclass, field, replace
 from typing import Any, Literal, Optional, Union
 
@@ -26,6 +27,58 @@ def _shell_safe(args: list[str]) -> list[str]:
     environment *before* joining, and quoting would turn the marker into a literal.
     """
     return [arg if arg.startswith("$") else shlex.quote(arg) for arg in args]
+
+
+def build_fserve_command(
+    *,
+    model_id: str,
+    port: int,
+    model_dir: str | None = None,
+    model_hf_path: str | None = None,
+    draft_model_dir: str | None = None,
+    draft_model_hf_path: str | None = None,
+    extra_args: Iterable[str] = (),
+    host: str = "0.0.0.0",
+) -> list[str]:
+    """Build the shell-safe `llama-cpp-fserve` argv that serves a GGUF model with llama.cpp.
+
+    This is exactly the command `LlamaCppAppEnvironment` runs, exposed for serving shapes that
+    are not a Flyte App -- e.g. a llama.cpp server running as a native sidecar in a task pod.
+    The `llama-cpp-fserve` shim resolves a `--model-dir`/`--draft-model-dir` (a directory whose
+    concrete `.gguf` filename is unknown until runtime) to a file and execs llama-server.
+
+    Provide the model as either a mounted directory (`model_dir`, resolved by the shim) or a
+    HuggingFace repo (`model_hf_path`, which llama-server downloads at startup) -- exactly one.
+    The optional speculative-decoding draft is the same, via `draft_model_dir` /
+    `draft_model_hf_path` (at most one). `extra_args` are appended verbatim (e.g. `--ctx-size`,
+    `--flash-attn`); if they already carry `--host`, the default host bind is skipped.
+    """
+    extra = list(extra_args)
+    if bool(model_dir) == bool(model_hf_path):
+        raise ValueError("exactly one of model_dir or model_hf_path must be provided")
+    if draft_model_dir and draft_model_hf_path:
+        raise ValueError("provide at most one of draft_model_dir or draft_model_hf_path")
+    model_args = ["--model-dir", model_dir] if model_dir else ["--hf-repo", model_hf_path]
+    if draft_model_dir:
+        draft_args = ["--draft-model-dir", draft_model_dir]
+    elif draft_model_hf_path:
+        draft_args = ["--hf-repo-draft", draft_model_hf_path]
+    else:
+        draft_args = []
+    host_args = [] if "--host" in extra else ["--host", host]
+    return _shell_safe(
+        [
+            "llama-cpp-fserve",
+            *model_args,
+            "--alias",
+            model_id,
+            *host_args,
+            "--port",
+            str(port),
+            *draft_args,
+            *extra,
+        ]
+    )
 
 
 # The app-serde requires the primary container to be named "app" and to exist in the pod
@@ -262,33 +315,16 @@ class LlamaCppAppEnvironment(flyte.app.AppEnvironment):
             model_dir = self._model_mount_path
             draft_dir = self._draft_model_mount_path
 
-        if self.model_path:
-            model_args = ["--model-dir", model_dir]
-        else:
-            model_args = ["--hf-repo", self.model_hf_path]
-
-        draft_args: list[str] = []
-        if self.draft_model_path:
-            draft_args = ["--draft-model-dir", draft_dir]
-        elif self.draft_model_hf_path:
-            draft_args = ["--hf-repo-draft", self.draft_model_hf_path]
-
-        # llama-server binds 127.0.0.1 by default, which is unreachable from outside the
-        # container.
-        host_args = [] if "--host" in extra_args else ["--host", "0.0.0.0"]
-
-        self.args = _shell_safe(
-            [
-                "llama-cpp-fserve",
-                *model_args,
-                "--alias",
-                self.model_id,
-                *host_args,
-                "--port",
-                str(self.get_port().port),
-                *draft_args,
-                *extra_args,
-            ]
+        # llama-server binds 127.0.0.1 by default (unreachable from outside the container), so
+        # build_fserve_command adds --host 0.0.0.0 unless extra_args override it.
+        self.args = build_fserve_command(
+            model_id=self.model_id,
+            port=self.get_port().port,
+            model_dir=model_dir if self.model_path else None,
+            model_hf_path=self.model_hf_path or None,
+            draft_model_dir=draft_dir if self.draft_model_path else None,
+            draft_model_hf_path=self.draft_model_hf_path or None,
+            extra_args=extra_args,
         )
 
         if self.parameters:

--- a/plugins/llamacpp/tests/test_app_environment.py
+++ b/plugins/llamacpp/tests/test_app_environment.py
@@ -614,3 +614,53 @@ def test_model_artifact_rejected_in_download_mode():
     av = flyte.app.ArtifactValue(name="q", type="directory")
     with pytest.raises(ValueError, match="only apply when model_delivery='fuse'"):
         LlamaCppAppEnvironment(name="x", model_id="m", model_path="s3://b/m", model_artifact=av)
+
+
+# Tests for build_fserve_command (reusable llama-cpp-fserve argv, for non-App shapes)
+
+
+def test_build_fserve_command_model_dir_with_draft():
+    from flyteplugins.llamacpp import build_fserve_command
+
+    cmd = build_fserve_command(
+        model_id="qwen38-27b",
+        port=8081,
+        model_dir="/tmp/models/q/UD-Q4_K_XL",
+        draft_model_dir="/tmp/models/q/UD-Q4_K_XL/MTP",
+        extra_args=["--ctx-size", "131072"],
+    )
+    assert cmd[0] == "llama-cpp-fserve"
+    assert cmd[cmd.index("--model-dir") + 1] == "/tmp/models/q/UD-Q4_K_XL"
+    assert cmd[cmd.index("--draft-model-dir") + 1] == "/tmp/models/q/UD-Q4_K_XL/MTP"
+    assert cmd[cmd.index("--alias") + 1] == "qwen38-27b"
+    assert cmd[cmd.index("--port") + 1] == "8081"
+    assert cmd[cmd.index("--host") + 1] == "0.0.0.0"  # default host bind added
+    assert cmd[-2:] == ["--ctx-size", "131072"]
+
+
+def test_build_fserve_command_hf_repo_and_host_override():
+    from flyteplugins.llamacpp import build_fserve_command
+
+    cmd = build_fserve_command(
+        model_id="m", port=8080, model_hf_path="ggml-org/x:Q4_K_M", extra_args=["--host", "1.2.3.4"]
+    )
+    assert "--hf-repo" in cmd and "--model-dir" not in cmd
+    assert cmd.count("--host") == 1  # not double-added when extra_args carries --host
+
+
+def test_build_fserve_command_requires_exactly_one_model_source():
+    from flyteplugins.llamacpp import build_fserve_command
+
+    with pytest.raises(ValueError, match="exactly one of model_dir or model_hf_path"):
+        build_fserve_command(model_id="m", port=8080)
+    with pytest.raises(ValueError, match="exactly one of model_dir or model_hf_path"):
+        build_fserve_command(model_id="m", port=8080, model_dir="/d", model_hf_path="r")
+
+
+def test_app_environment_args_match_build_fserve_command():
+    """The AppEnvironment builds its argv via build_fserve_command; they must agree."""
+    from flyteplugins.llamacpp import build_fserve_command
+
+    app = LlamaCppAppEnvironment(name="a", model_id="m", model_path="s3://b/model")
+    expected = build_fserve_command(model_id="m", port=8080, model_dir="/tmp/flyte/model", extra_args=[])
+    assert app.args == expected


### PR DESCRIPTION
Extract the llama-cpp-fserve argv builder out of LlamaCppAppEnvironment.__post_init__
into a public build_fserve_command(), and have the App call it. This makes the exact
command the App runs reusable for other serving shapes that are not a Flyte App --
notably a llama.cpp server running as a native sidecar in a task pod -- so both shapes
stay in lockstep instead of re-deriving the argv. Behavior for the App is unchanged
(the argv is identical); adds unit tests including an equivalence check.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

Signed-off-by: Michael Hotan <mike@union.ai>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>