### PR TITLE
feat: triggers without automation + flyte.run(trigger) to fire on demand

### DIFF
--- a/examples/triggers/manual.py
+++ b/examples/triggers/manual.py
@@ -1,0 +1,104 @@
+"""Triggers without automation: a named, pre-bound launch configuration.
+
+A `Trigger` does not have to be scheduled. Leave `automation` unset and the
+trigger becomes a saved launch configuration for the task -- default inputs,
+queue, env vars, notifications -- that nothing fires on its own. It is fired
+on demand only (from the UI, or via the API), which makes it a convenient way
+to publish a handful of "blessed" ways to run a task without re-typing inputs.
+
+Try it (see the env vars below for where notifications are delivered):
+
+    SLACK_WEBHOOK_URL=... NOTIFICATION_EMAIL=... flyte deploy examples/triggers/manual.py env
+    flyte get trigger
+
+`report_on_demand` deploys with two such triggers, `quick-report` and
+`full-report`, alongside a regular scheduled one. Fire either manual trigger
+from the task's Triggers tab in the UI, or from Python with `flyte.run` (see
+`programmatic.py`). The run starts with the trigger's bound inputs, env vars
+and notifications.
+"""
+
+import os
+from datetime import datetime
+
+import flyte
+import flyte.notify
+from flyte.models import ActionPhase
+
+env = flyte.TaskEnvironment(name="manual_trigger_example")
+
+# Where notifications go. Read from the deploying shell so no credentials land
+# in the example:
+#
+#     SLACK_WEBHOOK_URL=https://hooks.slack.com/services/... \
+#     NOTIFICATION_EMAIL=you@example.com \
+#     flyte deploy examples/triggers/manual.py env
+#
+# webhook.site is handy for seeing the Slack payload if you have no webhook yet.
+SLACK_WEBHOOK = os.environ.get("SLACK_WEBHOOK_URL", "https://webhook.site/")
+REPORT_RECIPIENTS = (os.environ.get("NOTIFICATION_EMAIL", "<EMAIL>"),)
+
+# No `automation=`: nothing schedules these. Each is just a named set of
+# inputs plus what to do when the run ends.
+#
+# Trigger inputs override the task's own defaults (`region="all"`, `days=7`
+# below) for every run fired through the trigger. Inputs the trigger does not
+# mention keep the task default, so `quick-report` still gets `as_of=None`.
+quick_report = flyte.Trigger(
+    name="quick-report",
+    inputs={"region": "us-east", "days": 1},
+    description="Yesterday only, for a fast sanity check",
+    # A quick check only needs to shout when something goes wrong.
+    notifications=flyte.notify.Slack(
+        on_phase=(ActionPhase.FAILED, ActionPhase.TIMED_OUT),
+        webhook_url=SLACK_WEBHOOK,
+        message=":x: quick-report {{.Run.Name}} ended in {{.Phase}}: {{.Error}}",
+    ),
+)
+
+full_report = flyte.Trigger(
+    name="full-report",
+    inputs={"region": "all", "days": 30},
+    description="The full monthly report",
+    env_vars={"REPORT_VERBOSE": "1"},
+    # The monthly report is worth an email on success and a Slack ping on failure.
+    notifications=(
+        flyte.notify.Email(
+            on_phase=ActionPhase.SUCCEEDED,
+            recipients=REPORT_RECIPIENTS,
+            subject="Monthly report {{.Run.Name}} is ready",
+            body="The full report finished.\nRun: {{.Run.Name}}\nProject/Domain: {{.Run.Project}}/{{.Run.Domain}}",
+        ),
+        flyte.notify.Slack(
+            on_phase=ActionPhase.FAILED,
+            webhook_url=SLACK_WEBHOOK,
+            message=":rotating_light: full-report {{.Run.Name}} failed: {{.Error}}",
+        ),
+    ),
+)
+
+# A scheduled trigger can sit next to the manual ones on the same task. Only a
+# schedule can bind `flyte.TriggerTime`, since a manual trigger has no fire time.
+nightly = flyte.Trigger(
+    name="nightly",
+    automation=flyte.Cron("0 2 * * *"),
+    inputs={"as_of": flyte.TriggerTime, "region": "all", "days": 1},
+    notifications=flyte.notify.Slack(
+        on_phase=ActionPhase.FAILED,
+        webhook_url=SLACK_WEBHOOK,
+        message=":rotating_light: nightly report {{.Run.Name}} failed: {{.Error}}",
+    ),
+)
+
+
+@env.task(triggers=(quick_report, full_report, nightly))
+async def report_on_demand(region: str = "all", days: int = 7, as_of: datetime | None = None) -> str:
+    as_of = as_of or datetime.now()
+    msg = f"report for region={region!r} over the last {days} day(s), as of {as_of.isoformat()}"
+    print(msg)
+    return msg
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    flyte.deploy(env)

--- a/examples/triggers/programmatic.py
+++ b/examples/triggers/programmatic.py
@@ -1,0 +1,75 @@
+"""Fire a deployed trigger from Python with `flyte.run`.
+
+A trigger is a saved launch configuration for a task: inputs, env vars, queue,
+notifications. Scheduled and artifact triggers fire on their own; a trigger
+with no automation (see `manual.py`) only fires when something asks for it.
+Either kind can be fired on demand by fetching it and passing it to
+`flyte.run`, exactly like a task:
+
+    trigger = flyte.remote.Trigger.get(name="full-report", task_name=...)
+    run = flyte.run(trigger)            # everything the trigger was deployed with
+    run = flyte.run(trigger, days=3)    # override one input, keep the rest
+
+The run is created *as* the trigger: the platform records the trigger as its
+origin (same as a scheduled fire), and the run carries the trigger's inputs,
+env vars, queue and notification rules. Keyword arguments override individual
+inputs; anything left out keeps the value the trigger was deployed with.
+`flyte.with_runcontext(...)` layers further overrides (env vars, queue, run
+name, ...) on top of the trigger's run spec.
+
+Try it, after deploying `manual.py`:
+
+    flyte deploy examples/triggers/manual.py env
+    python examples/triggers/programmatic.py
+"""
+
+import flyte
+import flyte.remote
+
+TASK_NAME = "manual_trigger_example.report_on_demand"
+
+
+def fire_as_deployed() -> flyte.remote.Run:
+    """Fire `full-report` with exactly what it was deployed with (region="all", days=30)."""
+    trigger = flyte.remote.Trigger.get(name="full-report", task_name=TASK_NAME)
+    return flyte.run(trigger)
+
+
+def fire_with_overrides() -> flyte.remote.Run:
+    """Override one input; `region` keeps the trigger's value, `days` becomes 3."""
+    trigger = flyte.remote.Trigger.get(name="full-report", task_name=TASK_NAME)
+    return flyte.run(trigger, days=3)
+
+
+def fire_with_runcontext() -> flyte.remote.Run:
+    """Layer run-level overrides on top of the trigger's run spec.
+
+    The trigger's own env vars and notification rules are kept; `EXTRA_FLAG` is added and
+    the run gets a fixed name. Anything `with_runcontext` sets wins over the trigger's value.
+    """
+    trigger = flyte.remote.Trigger.get(name="quick-report", task_name=TASK_NAME)
+    return flyte.with_runcontext(env_vars={"EXTRA_FLAG": "1"}, name="quick-report-from-python").run(trigger)
+
+
+def fire_every_trigger_on_task() -> list[flyte.remote.Run]:
+    """Triggers from `listall()` can be fired too; their details are fetched on demand.
+
+    Scheduled triggers (`nightly` here) fire just fine off-schedule: the platform stamps the
+    run start time, and any `flyte.TriggerTime` input is filled from it.
+    """
+    runs = []
+    for trigger in flyte.remote.Trigger.listall(task_name=TASK_NAME):
+        runs.append(flyte.run(trigger))
+    return runs
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+
+    run = fire_with_overrides()
+    print(f"fired full-report with days=3: {run.url}")
+    run.wait()
+    print(f"phase={run.phase} inputs={run.inputs()} outputs={run.outputs()}")
+
+    run = fire_with_runcontext()
+    print(f"fired quick-report with run-context overrides: {run.url}")

--- a/src/flyte/_internal/runtime/trigger_serde.py
+++ b/src/flyte/_internal/runtime/trigger_serde.py
@@ -183,7 +183,13 @@ async def to_task_trigger(
     if kickoff_arg_name is not None:
         context_kvs.append(literals_pb2.KeyValuePair(key=KICKOFF_TIME_INPUT_ARG_CONTEXT_KEY, value=kickoff_arg_name))
 
-    if isinstance(t.automation, OnArtifact):
+    if t.automation is None:
+        # No automation: the trigger is a named launch configuration that is only fired on
+        # demand (UI / API). Nothing schedules it, so there is no kickoff-time or artifact binding.
+        automation_spec = common_pb2.TriggerAutomationSpec(
+            type=common_pb2.TriggerAutomationSpecType.TYPE_NONE,
+        )
+    elif isinstance(t.automation, OnArtifact):
         # Note the contrast with the schedule branch below, which stashes the kickoff-time input
         # arg name under KICKOFF_TIME_INPUT_ARG_CONTEXT_KEY (see convert.py): a scheduled trigger
         # has to, because the offloaded inputs blob is written once and cannot carry the per-fire

--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -43,6 +43,8 @@ if TYPE_CHECKING:
     from flyte.notify import NamedRule, Notification
     from flyte.remote import Run
     from flyte.remote._task import LazyEntity
+    from flyte.remote._trigger import Trigger as RemoteTrigger
+    from flyte.remote._trigger import TriggerDetails
 
     from ._code_bundle import CopyFiles
     from ._internal.imagebuild.image_builder import ImageCache
@@ -672,15 +674,19 @@ class _Runner:
         run_id: Any,
         project_id: Any,
         offloaded_input_data: Any = None,
+        trigger_name: Any = None,
     ) -> Run:
         """Upload inputs and create the run. The single network call site for remote submission.
 
         Consumes an already-built `run_spec` (see `_apply_overrides`), raw proto `inputs`
         (`flyteidl2.task.Inputs`), and a task by reference (`task_id`) or by value
-        (`task_spec`); shared by `_run_remote` and `rerun`. `offloaded_input_data`
+        (`task_spec`); shared by `_run_remote`, `_run_trigger` and `rerun`. `offloaded_input_data`
         (`flyteidl2.common.OffloadedInputData`) references already-offloaded inputs (e.g. the
         source run's inputs.pb on a rerun whose inputs can't be re-downloaded) and skips the
-        upload; exactly one of `proto_inputs` / `offloaded_input_data` is used.
+        upload; exactly one of `proto_inputs` / `offloaded_input_data` is used. `trigger_name`
+        (`flyteidl2.common.TriggerName`) fires the run *as* that trigger: it replaces `task_id`
+        on the create-run request (the server resolves the trigger's pinned task itself and
+        records the trigger as the run's origin); `task_id` is still used to upload the inputs.
         """
         from connectrpc.code import Code
         from connectrpc.errors import ConnectError
@@ -737,8 +743,11 @@ class _Runner:
                 offloaded_input_data=offloaded_input_data,
                 run_spec=run_spec,
             )
-            # Reference an already-registered task by id; otherwise send the full spec.
-            if task_id is not None:
+            # `task` is a oneof: fire as a trigger, else reference an already-registered task by
+            # id, else send the full spec.
+            if trigger_name is not None:
+                create_req.trigger_name.CopyFrom(trigger_name)
+            elif task_id is not None:
                 create_req.task_id.CopyFrom(task_id)
             else:
                 create_req.task_spec.CopyFrom(task_spec)
@@ -871,6 +880,147 @@ class _Runner:
                 self.code_bundle = _code_bundle
 
         return DryRun(_task_spec=task_spec, _inputs=inputs, _code_bundle=code_bundle)
+
+    @requires_initialization
+    async def _run_trigger(self, trigger: RemoteTrigger | TriggerDetails, *args: Any, **kwargs: Any) -> Run:
+        """Fire a deployed trigger on demand, returning the new `Run`.
+
+        The trigger is a saved launch configuration: its registered inputs and `RunSpec` (env
+        vars, queue, notifications, ...) are the floor. Keyword inputs override individual
+        trigger inputs; `with_runcontext(...)` overrides layer on top of the trigger's run spec.
+        The run is created *as* the trigger, so the platform records it as trigger-fired, exactly
+        like a scheduled fire. Inputs are resolved client-side (the server only restores a
+        trigger's inputs when it fires with nothing else set), so an inline-registered trigger
+        launches with its inputs too, not just an offloaded one.
+        """
+        from flyteidl2.core import literals_pb2
+        from flyteidl2.task import common_pb2 as task_common_pb2
+
+        import flyte.errors
+        from flyte.remote._task import Task
+        from flyte.remote._trigger import Trigger as RemoteTrigger
+        from flyte.remote._trigger import TriggerDetails
+
+        from ._internal.runtime.convert import KICKOFF_TIME_INPUT_ARG_CONTEXT_KEY, convert_from_native_to_inputs
+
+        if args:
+            raise ValueError(
+                "Trigger inputs can only be overridden by keyword (flyte.run(trigger, x=1)): every input left "
+                "out keeps the value the trigger was deployed with, so positional arguments are ambiguous."
+            )
+        if self._dry_run:
+            raise ValueError("dry_run is not supported when running a trigger.")
+        if get_client() is None:
+            raise flyte.errors.InitializationError(
+                "ClientNotInitializedError",
+                "user",
+                "flyte.run requires client to be initialized. "
+                "Call flyte.init() with a valid endpoint/api-key before using this function"
+                "or Call flyte.init_from_config() with a valid path to the config file",
+            )
+
+        details: TriggerDetails
+        if isinstance(trigger, RemoteTrigger):
+            # A listed trigger carries no spec; fetch the details once.
+            details = trigger.details or await TriggerDetails.get.aio(name=trigger.name, task_name=trigger.task_name)
+        else:
+            details = trigger
+        trigger_name = details.pb2.id.name
+        spec = details.pb2.spec
+
+        # The trigger is pinned to one task version; fetch it for the interface (keyword conversion)
+        # and the cache metadata the upload path consults.
+        task = await Task.get(
+            name=trigger_name.task_name,
+            project=trigger_name.project,
+            domain=trigger_name.domain,
+            version=spec.task_version,
+        ).fetch.aio()
+
+        # Inputs. Three cases: inline literals (backend without input offloading), offloaded
+        # literals (read back only when something has to be merged into them), or none.
+        proto_inputs: task_common_pb2.Inputs | None = None
+        offloaded_input_data = None
+        base_inputs: task_common_pb2.Inputs | None = None
+        match spec.WhichOneof("input_wrapper"):
+            case "inputs":
+                base_inputs = spec.inputs
+            case "offloaded_input_data":
+                if kwargs:
+                    from ._internal.runtime.io import load_inputs
+
+                    base_inputs = (await load_inputs(spec.offloaded_input_data.uri)).proto_inputs
+                else:
+                    offloaded_input_data = spec.offloaded_input_data
+            case _:
+                base_inputs = task_common_pb2.Inputs()
+
+        if kwargs:
+            from flyte.models import NativeInterface
+
+            iface = task.interface
+            unknown = sorted(set(kwargs) - set(iface.inputs))
+            if unknown:
+                known = ", ".join(iface.inputs) or "<none>"
+                raise ValueError(
+                    f"Unknown input(s) {unknown} for trigger {trigger_name.name!r} on task "
+                    f"{trigger_name.task_name!r}. Known inputs: {known}."
+                )
+            # Only the overridden inputs are converted; the rest keep the trigger's literals.
+            reduced_iface = NativeInterface(
+                inputs={k: v for k, v in iface.inputs.items() if k in kwargs},
+                outputs={},
+                _remote_defaults=iface._remote_defaults,
+            )
+            converted = await convert_from_native_to_inputs(
+                reduced_iface, custom_context=self._custom_context, **kwargs
+            )
+            assert base_inputs is not None
+            overrides = {lit.name: lit.value for lit in converted.proto_inputs.literals}
+            merged = [
+                task_common_pb2.NamedLiteral(name=lit.name, value=overrides.pop(lit.name, lit.value))
+                for lit in base_inputs.literals
+            ]
+            # An input the trigger never bound (left to the task default) still has to land.
+            merged += [task_common_pb2.NamedLiteral(name=name, value=v) for name, v in overrides.items()]
+            # Context: the trigger's registered context (custom_context, and the kickoff-time input
+            # marker on scheduled triggers) is the floor; this call's custom_context wins per key.
+            context = {kv.key: kv.value for kv in base_inputs.context}
+            context.update({kv.key: kv.value for kv in converted.proto_inputs.context})
+            # The runtime fills the kickoff-time input from run_start_time whenever the marker is
+            # present. An explicit value for that input must win, so drop the marker.
+            if context.get(KICKOFF_TIME_INPUT_ARG_CONTEXT_KEY) in kwargs:
+                del context[KICKOFF_TIME_INPUT_ARG_CONTEXT_KEY]
+            proto_inputs = task_common_pb2.Inputs(
+                literals=merged,
+                context=[literals_pb2.KeyValuePair(key=k, value=v) for k, v in context.items()],
+            )
+        elif base_inputs is not None:
+            proto_inputs = task_common_pb2.Inputs()
+            proto_inputs.CopyFrom(base_inputs)
+            if self._custom_context:
+                context = {kv.key: kv.value for kv in proto_inputs.context}
+                context.update(self._custom_context)
+                del proto_inputs.context[:]
+                proto_inputs.context.extend(literals_pb2.KeyValuePair(key=k, value=v) for k, v in context.items())
+
+        # Run spec: the trigger's registered spec is the floor (that is what a scheduled fire
+        # uses); runner overrides merge on top, provenance is per-run.
+        spawn_parent = self._resolve_spawn_parent()
+        relation = (spawn_parent, "spawn") if spawn_parent is not None else None
+        run_spec = self._apply_overrides(spec.run_spec, relation=relation)
+
+        run_id, project_id = self._resolve_run_target(trigger_name.project, trigger_name.domain, trigger_name.org)
+        return await self._submit_remote(
+            task_spec=task.pb2.spec,
+            task_id=task.pb2.task_id,
+            proto_inputs=proto_inputs,
+            offloaded_input_data=offloaded_input_data,
+            run_spec=run_spec,
+            run_id=run_id,
+            project_id=project_id,
+            trigger_name=trigger_name,
+        )
 
     @requires_storage
     @requires_initialization
@@ -1262,12 +1412,16 @@ class _Runner:
     @syncify  # type: ignore[arg-type]
     async def run(
         self,
-        task: TaskTemplate[P, R, F] | LazyEntity,
+        task: TaskTemplate[P, R, F] | LazyEntity | RemoteTrigger | TriggerDetails,
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> Run:
         """
         Run an async `@env.task` or `TaskTemplate` instance. The existing async context will be used.
+
+        A deployed trigger (`flyte.remote.Trigger.get(...)`) can be run too: the run is fired *as*
+        the trigger, with the trigger's registered inputs, env vars, queue and notifications.
+        Keyword arguments override individual trigger inputs. Remote mode only.
 
         Example:
         ```python
@@ -1283,9 +1437,10 @@ class _Runner:
         ```
 
         Args:
-            task: TaskTemplate instance `@env.task` or `TaskTemplate`
-            args: Arguments to pass to the Task
-            kwargs: Keyword arguments to pass to the Task
+            task: TaskTemplate instance `@env.task` or `TaskTemplate`, a fetched remote task, or a
+                deployed trigger (`flyte.remote.Trigger` / `TriggerDetails`)
+            args: Arguments to pass to the Task (not allowed for a trigger)
+            kwargs: Keyword arguments to pass to the Task (for a trigger: overrides of its inputs)
 
         Returns:
             A Run handle in every mode. Remote mode returns the platform run; local and
@@ -1293,11 +1448,13 @@ class _Runner:
             native results and whose `wait()` is an immediate no-op.
         """
         from flyte.remote._task import LazyEntity, TaskDetails
+        from flyte.remote._trigger import Trigger as RemoteTrigger
+        from flyte.remote._trigger import TriggerDetails
 
-        if isinstance(task, (LazyEntity, TaskDetails)) and self._mode != "remote":
-            raise ValueError("Remote task can only be run in remote mode.")
+        if isinstance(task, (LazyEntity, TaskDetails, RemoteTrigger, TriggerDetails)) and self._mode != "remote":
+            raise ValueError("Remote tasks and triggers can only be run in remote mode.")
 
-        if not isinstance(task, TaskTemplate) and not isinstance(task, (LazyEntity, TaskDetails)):
+        if not isinstance(task, (TaskTemplate, LazyEntity, TaskDetails, RemoteTrigger, TriggerDetails)):
             raise TypeError(f"On Flyte tasks can be run, not generic functions or methods '{type(task)}'.")
 
         # report mirrors a locally-orchestrated run onto the control plane as a tracked run —
@@ -1312,6 +1469,8 @@ class _Runner:
 
         try:
             if self._mode == "remote":
+                if isinstance(task, (RemoteTrigger, TriggerDetails)):
+                    return await self._run_trigger(task, *args, **kwargs)
                 return await self._run_remote(task, *args, **kwargs)
             task = cast(TaskTemplate, task)
             if self._mode == "hybrid":
@@ -1768,14 +1927,22 @@ def with_runcontext(
 
 
 @syncify
-async def run(task: TaskTemplate[P, R, F], *args: P.args, **kwargs: P.kwargs) -> Run:
+async def run(
+    task: TaskTemplate[P, R, F] | LazyEntity | RemoteTrigger | TriggerDetails, *args: P.args, **kwargs: P.kwargs
+) -> Run:
     """
-    Run a task with the given parameters
+    Run a task with the given parameters, or fire a deployed trigger on demand.
+
+    ```python
+    trigger = flyte.remote.Trigger.get(name="full-report", task_name="reports.report")
+    run = flyte.run(trigger)              # the trigger's inputs, env vars, queue, notifications
+    run = flyte.run(trigger, days=7)      # override one input, keep the rest
+    ```
 
     Args:
-        task: task to run
-        args: args to pass to the task
-        kwargs: kwargs to pass to the task
+        task: task to run, or a deployed trigger (`flyte.remote.Trigger.get(...)`)
+        args: args to pass to the task (not allowed for a trigger)
+        kwargs: kwargs to pass to the task (for a trigger: overrides of its registered inputs)
 
     Returns:
         Run | Result of the task

--- a/src/flyte/_trigger.py
+++ b/src/flyte/_trigger.py
@@ -755,11 +755,15 @@ class FixedRate:
 @dataclass(frozen=True)
 class Trigger:
     """
-    Specification for a scheduled trigger that can be associated with any Flyte task.
+    Specification for a trigger that can be associated with any Flyte task.
 
-    Triggers run tasks on a schedule (cron or fixed-rate). They are set only in the
-    `@env.task` decorator via the `triggers` parameter. The same `Trigger` object
-    can be associated with multiple tasks.
+    A trigger is a named, pre-bound launch configuration for a task (default inputs,
+    queue, env vars, notifications, ...). It may optionally carry an *automation*
+    that fires it on a schedule (`Cron`/`FixedRate`) or when a new artifact version
+    is published (`OnArtifact`). A trigger with no automation is fired only
+    on demand (for example from the UI or via the API). Triggers are set only in
+    the `@env.task` decorator via the `triggers` parameter. The same `Trigger`
+    object can be associated with multiple tasks.
 
     Predefined convenience constructors are available: `Trigger.hourly()`,
     `Trigger.daily()`, `Trigger.weekly()`, `Trigger.monthly()`, and
@@ -782,7 +786,9 @@ class Trigger:
 
     Args:
         name: Unique name for the trigger (required).
-        automation: Schedule type — `Cron(...)` or `FixedRate(...)` (required).
+        automation: What fires the trigger — `Cron(...)`, `FixedRate(...)` or
+            `OnArtifact(...)`. `None` (default) means the trigger has no automation
+            and is only fired on demand.
         description: Human-readable description (max 255 characters). Default `""`.
         auto_activate: Whether to activate the trigger automatically on deployment.
             Default `True`.
@@ -807,7 +813,7 @@ class Trigger:
     """
 
     name: str
-    automation: Union[Cron, FixedRate, OnArtifact]
+    automation: Union[Cron, FixedRate, OnArtifact, None] = None
     description: str = ""
     auto_activate: bool = True
     inputs: Dict[str, Any] | None = None
@@ -824,8 +830,6 @@ class Trigger:
     def __post_init__(self):
         if not self.name:
             raise ValueError("Trigger name cannot be empty")
-        if self.automation is None:
-            raise ValueError("Automation cannot be None")
         if self.inputs:
             artifact_args = [k for k, v in self.inputs.items() if v is TriggeredArtifact]
             if len(artifact_args) > 1:
@@ -838,10 +842,12 @@ class Trigger:
                     f"Trigger '{self.name}' binds TriggeredArtifact to input '{artifact_args[0]}' "
                     "but its automation is not OnArtifact."
                 )
-            if isinstance(self.automation, OnArtifact) and any(v is TriggerTime for v in self.inputs.values()):
+            if not isinstance(self.automation, (Cron, FixedRate)) and any(
+                v is TriggerTime for v in self.inputs.values()
+            ):
                 raise ValueError(
                     f"Trigger '{self.name}' uses TriggerTime, which is only available on "
-                    "schedule (Cron/FixedRate) triggers, not OnArtifact triggers."
+                    "schedule (Cron/FixedRate) triggers."
                 )
         if self.max_action_concurrency is not None and (
             self.max_action_concurrency < 0 or self.max_action_concurrency == 1

--- a/src/flyte/cli/_create.py
+++ b/src/flyte/cli/_create.py
@@ -599,9 +599,8 @@ def config(
 @click.option(
     "--schedule",
     type=str,
-    required=True,
-    help="Cron schedule for the trigger. Defaults to every minute.",
-    show_default=True,
+    default=None,
+    help="Cron schedule for the trigger. If omitted, the trigger has no automation and is only fired on demand.",
 )
 @click.option(
     "--description",
@@ -629,7 +628,7 @@ def trigger(
     cfg: common.CLIConfig,
     task_name: str,
     name: str,
-    schedule: str,
+    schedule: str | None = None,
     trigger_time_var: str = "trigger_time",
     auto_activate: bool = True,
     description: str = "",
@@ -645,7 +644,12 @@ def trigger(
     $ flyte create trigger my_task my_trigger --schedule "0 0 * * *"
     ```
 
-    This will create a trigger that runs every day at midnight.
+    This will create a trigger that runs every day at midnight. Omit `--schedule` to create a
+    trigger with no automation, which is only fired on demand:
+
+    ```bash
+    $ flyte create trigger my_task my_trigger
+    ```
     """
     from flyte.remote import Trigger
 
@@ -654,10 +658,11 @@ def trigger(
 
     trigger = flyte.Trigger(
         name=name,
-        automation=flyte.Cron(schedule),
+        automation=flyte.Cron(schedule) if schedule else None,
         description=description,
         auto_activate=auto_activate,
-        inputs={trigger_time_var: flyte.TriggerTime},  # Use the trigger time variable in inputs
+        # TriggerTime only exists on scheduled triggers; a no-automation trigger has no fire time.
+        inputs={trigger_time_var: flyte.TriggerTime} if schedule else None,
         env_vars=None,
         interruptible=None,
     )

--- a/src/flyte/remote/__init__.py
+++ b/src/flyte/remote/__init__.py
@@ -20,6 +20,7 @@ __all__ = [
     "TaskDetails",
     "TimeFilter",
     "Trigger",
+    "TriggerDetails",
     "User",
     "auth_metadata",
     "upload_dir",
@@ -38,5 +39,5 @@ from ._run import Run, RunDetails
 from ._secret import Secret, SecretTypes
 from ._settings import Settings
 from ._task import Task, TaskDetails
-from ._trigger import Trigger
+from ._trigger import Trigger, TriggerDetails
 from ._user import User

--- a/tests/flyte/internal/runtime/test_trigger_serde.py
+++ b/tests/flyte/internal/runtime/test_trigger_serde.py
@@ -239,6 +239,30 @@ class TestToTaskTrigger:
         assert result.automation_spec.schedule.cron.timezone == DEFAULT_TIMEZONE
 
     @pytest.mark.asyncio
+    async def test_trigger_without_automation(self):
+        """A trigger with no automation serializes as TYPE_NONE and still carries its run config."""
+        trigger = Trigger(name="manual", inputs={"x": 7}, queue="gpu", description="fire on demand")
+
+        task_inputs = interface_pb2.VariableMap(
+            variables=[
+                VariableEntry(
+                    key="x",
+                    value=interface_pb2.Variable(type=types_pb2.LiteralType(simple=types_pb2.SimpleType.INTEGER)),
+                )
+            ]
+        )
+
+        result = await to_task_trigger(trigger, "test_task", task_inputs, [])
+
+        assert result.name == "manual"
+        assert result.automation_spec.type == common_pb2.TriggerAutomationSpecType.TYPE_NONE
+        assert result.automation_spec.WhichOneof("automation") is None
+        assert result.spec.run_spec.queue == "gpu"
+        assert result.spec.description == "fire on demand"
+        assert [nl.name for nl in result.spec.inputs.literals] == ["x"]
+        assert result.spec.inputs.literals[0].value.scalar.primitive.integer == 7
+
+    @pytest.mark.asyncio
     async def test_fixed_rate_trigger(self):
         """Test FixedRate trigger conversion"""
         trigger = Trigger(

--- a/tests/flyte/test_run_trigger.py
+++ b/tests/flyte/test_run_trigger.py
@@ -1,0 +1,301 @@
+"""Unit tests for firing a deployed trigger on demand via flyte.run(trigger, ...).
+
+The run is created *as* the trigger (CreateRunRequest.trigger_name) with the trigger's registered
+inputs and RunSpec as the floor; keyword inputs override individual inputs and with_runcontext
+overrides layer on top of the run spec.
+"""
+
+import mock
+import pytest
+from flyteidl2.common import identifier_pb2
+from flyteidl2.common import run_pb2 as common_run_pb2
+from flyteidl2.core import literals_pb2
+from flyteidl2.dataproxy import dataproxy_service_pb2
+from flyteidl2.task import common_pb2 as task_common_pb2
+from flyteidl2.task import run_pb2
+from flyteidl2.trigger import trigger_definition_pb2, trigger_service_pb2
+from flyteidl2.workflow import run_definition_pb2, run_service_pb2
+from mock.mock import AsyncMock, MagicMock
+
+import flyte
+from flyte._initialize import _init_for_testing
+from flyte._internal.runtime.convert import KICKOFF_TIME_INPUT_ARG_CONTEXT_KEY, Inputs
+from flyte.remote._trigger import Trigger as RemoteTrigger
+from flyte.remote._trigger import TriggerDetails
+
+TASK_NAME = "env.report"
+TASK_VERSION = "v7"
+
+
+def _mock_client():
+    mock_client = MagicMock()
+    mock_run_service = AsyncMock()
+    mock_run_service.create_run.return_value = run_service_pb2.CreateRunResponse(
+        run=run_definition_pb2.Run(
+            action=run_definition_pb2.Action(
+                id=identifier_pb2.ActionIdentifier(name="a0", run=identifier_pb2.RunIdentifier(name="r-new"))
+            )
+        )
+    )
+    mock_client.run_service = mock_run_service
+    mock_dataproxy = AsyncMock()
+    mock_dataproxy.upload_inputs.return_value = dataproxy_service_pb2.UploadInputsResponse(
+        offloaded_input_data=common_run_pb2.OffloadedInputData(uri="s3://b/uploaded/inputs.pb", inputs_hash="h"),
+    )
+    mock_client.dataproxy_service = mock_dataproxy
+    return mock_client, mock_run_service, mock_dataproxy
+
+
+def _task_details():
+    """A fetched TaskDetails stand-in: string input `region`, int input `days`, version v7."""
+    from flyteidl2.core import identifier_pb2 as core_identifier_pb2
+    from flyteidl2.core import interface_pb2, tasks_pb2, types_pb2
+    from flyteidl2.task import task_definition_pb2
+
+    from flyte.remote._task import TaskDetails
+
+    iface = interface_pb2.TypedInterface(
+        inputs=interface_pb2.VariableMap(
+            variables=[
+                interface_pb2.VariableEntry(
+                    key="region",
+                    value=interface_pb2.Variable(type=types_pb2.LiteralType(simple=types_pb2.SimpleType.STRING)),
+                ),
+                interface_pb2.VariableEntry(
+                    key="days",
+                    value=interface_pb2.Variable(type=types_pb2.LiteralType(simple=types_pb2.SimpleType.INTEGER)),
+                ),
+            ]
+        )
+    )
+    tmpl = tasks_pb2.TaskTemplate(
+        id=core_identifier_pb2.Identifier(name=TASK_NAME, version=TASK_VERSION), interface=iface
+    )
+    pb2 = task_definition_pb2.TaskDetails(
+        task_id=task_definition_pb2.TaskIdentifier(
+            org="o", project="p", domain="d", name=TASK_NAME, version=TASK_VERSION
+        ),
+        spec=task_definition_pb2.TaskSpec(task_template=tmpl),
+    )
+    return TaskDetails(pb2=pb2)
+
+
+def _str(v: str) -> literals_pb2.Literal:
+    return literals_pb2.Literal(scalar=literals_pb2.Scalar(primitive=literals_pb2.Primitive(string_value=v)))
+
+
+def _int(v: int) -> literals_pb2.Literal:
+    return literals_pb2.Literal(scalar=literals_pb2.Scalar(primitive=literals_pb2.Primitive(integer=v)))
+
+
+def _trigger_details(*, inline_inputs=None, offloaded_uri=None, context=(), run_spec=None) -> TriggerDetails:
+    spec = trigger_definition_pb2.TriggerSpec(active=True, task_version=TASK_VERSION)
+    if inline_inputs is not None:
+        spec.inputs.CopyFrom(
+            task_common_pb2.Inputs(
+                literals=[task_common_pb2.NamedLiteral(name=k, value=v) for k, v in inline_inputs.items()],
+                context=[literals_pb2.KeyValuePair(key=k, value=v) for k, v in context],
+            )
+        )
+    if offloaded_uri is not None:
+        spec.offloaded_input_data.CopyFrom(common_run_pb2.OffloadedInputData(uri=offloaded_uri, inputs_hash="th"))
+    if run_spec is None:
+        run_spec = run_pb2.RunSpec(
+            envs=run_pb2.Envs(values=[literals_pb2.KeyValuePair(key="REPORT_VERBOSE", value="1")]),
+            notification_rules=run_pb2.InlineRuleList(rules=[run_pb2.InlineRule()]),
+        )
+    spec.run_spec.CopyFrom(run_spec)
+    return TriggerDetails(
+        pb2=trigger_definition_pb2.TriggerDetails(
+            id=identifier_pb2.TriggerIdentifier(
+                name=identifier_pb2.TriggerName(
+                    org="o", project="p", domain="d", name="full-report", task_name=TASK_NAME
+                )
+            ),
+            spec=spec,
+        )
+    )
+
+
+def _literals(inputs: task_common_pb2.Inputs) -> dict:
+    return {lit.name: lit.value for lit in inputs.literals}
+
+
+def _patched_task_get(task_details):
+    """Patch remote Task.get to return a lazy entity whose fetch yields `task_details`."""
+    lazy = MagicMock()
+    lazy.fetch = MagicMock()
+    lazy.fetch.aio = AsyncMock(return_value=task_details)
+    return mock.patch("flyte.remote._task.Task.get", return_value=lazy)
+
+
+@pytest.mark.asyncio
+async def test_run_trigger_fires_as_trigger_with_registered_inputs_and_runspec():
+    """No kwargs + inline inputs: the trigger's literals are uploaded verbatim, the run is created
+    with trigger_name (not task_id) and the trigger's run spec incl. notification rules."""
+    mock_client, mock_run_service, mock_dataproxy = _mock_client()
+    await _init_for_testing(client=mock_client, project="p", domain="d", org="o")
+    trigger = _trigger_details(inline_inputs={"region": _str("all"), "days": _int(30)})
+
+    with _patched_task_get(_task_details()) as task_get:
+        run = await flyte.run.aio(trigger)
+
+    assert run.name == "r-new"
+    task_get.assert_called_once_with(name=TASK_NAME, project="p", domain="d", version=TASK_VERSION)
+
+    upload_req = mock_dataproxy.upload_inputs.call_args[0][0]
+    assert upload_req.task_id.name == TASK_NAME and upload_req.task_id.version == TASK_VERSION
+    assert _literals(upload_req.inputs) == {"region": _str("all"), "days": _int(30)}
+
+    req: run_service_pb2.CreateRunRequest = mock_run_service.create_run.call_args[0][0]
+    assert req.WhichOneof("task") == "trigger_name"
+    assert req.trigger_name.name == "full-report" and req.trigger_name.task_name == TASK_NAME
+    assert req.trigger_name.project == "p" and req.trigger_name.domain == "d" and req.trigger_name.org == "o"
+    assert req.offloaded_input_data.uri == "s3://b/uploaded/inputs.pb"
+    # The runner adds its standard env (log levels, sys path); the trigger's env rides along.
+    assert {kv.key: kv.value for kv in req.run_spec.envs.values}["REPORT_VERBOSE"] == "1"
+    assert len(req.run_spec.notification_rules.rules) == 1
+
+
+@pytest.mark.asyncio
+async def test_run_trigger_offloaded_inputs_without_overrides_reuses_blob():
+    """Offloaded inputs + no kwargs: nothing is uploaded; the trigger's blob is referenced as-is."""
+    mock_client, mock_run_service, mock_dataproxy = _mock_client()
+    await _init_for_testing(client=mock_client, project="p", domain="d", org="o")
+    trigger = _trigger_details(offloaded_uri="s3://b/trigger/inputs.pb")
+
+    with _patched_task_get(_task_details()), mock.patch("flyte._internal.runtime.io.load_inputs") as load:
+        await flyte.run.aio(trigger)
+
+    load.assert_not_called()
+    mock_dataproxy.upload_inputs.assert_not_called()
+    req: run_service_pb2.CreateRunRequest = mock_run_service.create_run.call_args[0][0]
+    assert req.WhichOneof("task") == "trigger_name"
+    assert req.offloaded_input_data.uri == "s3://b/trigger/inputs.pb"
+    assert req.offloaded_input_data.inputs_hash == "th"
+
+
+@pytest.mark.asyncio
+async def test_run_trigger_offloaded_inputs_merge_overrides():
+    """Offloaded inputs + kwargs: the blob is read back, the override replaces one literal, the
+    rest keep the trigger's values, and the merged set is uploaded."""
+    mock_client, mock_run_service, mock_dataproxy = _mock_client()
+    await _init_for_testing(client=mock_client, project="p", domain="d", org="o")
+    trigger = _trigger_details(offloaded_uri="s3://b/trigger/inputs.pb")
+    stored = task_common_pb2.Inputs(
+        literals=[
+            task_common_pb2.NamedLiteral(name="region", value=_str("all")),
+            task_common_pb2.NamedLiteral(name="days", value=_int(30)),
+        ],
+        context=[literals_pb2.KeyValuePair(key="team", value="data")],
+    )
+
+    with (
+        _patched_task_get(_task_details()),
+        mock.patch("flyte._internal.runtime.io.load_inputs", new=AsyncMock(return_value=Inputs(stored))) as load,
+    ):
+        await flyte.run.aio(trigger, days=7)
+
+    load.assert_awaited_once_with("s3://b/trigger/inputs.pb")
+    upload_req = mock_dataproxy.upload_inputs.call_args[0][0]
+    assert _literals(upload_req.inputs) == {"region": _str("all"), "days": _int(7)}
+    # Trigger-registered context survives the merge.
+    assert {kv.key: kv.value for kv in upload_req.inputs.context} == {"team": "data"}
+    req: run_service_pb2.CreateRunRequest = mock_run_service.create_run.call_args[0][0]
+    assert req.WhichOneof("task") == "trigger_name"
+
+
+@pytest.mark.asyncio
+async def test_run_trigger_override_adds_input_the_trigger_never_bound():
+    """An input the trigger left to the task default can still be set by keyword."""
+    mock_client, _run_service, mock_dataproxy = _mock_client()
+    await _init_for_testing(client=mock_client, project="p", domain="d", org="o")
+    trigger = _trigger_details(inline_inputs={"region": _str("all")})
+
+    with _patched_task_get(_task_details()):
+        await flyte.run.aio(trigger, days=3)
+
+    upload_req = mock_dataproxy.upload_inputs.call_args[0][0]
+    assert _literals(upload_req.inputs) == {"region": _str("all"), "days": _int(3)}
+
+
+@pytest.mark.asyncio
+async def test_run_trigger_explicit_kickoff_input_drops_marker():
+    """Passing the TriggerTime-bound input explicitly removes the kickoff marker so the runtime
+    does not overwrite the value with run_start_time; otherwise the marker is kept."""
+    mock_client, _run_service, mock_dataproxy = _mock_client()
+    await _init_for_testing(client=mock_client, project="p", domain="d", org="o")
+    marker = ((KICKOFF_TIME_INPUT_ARG_CONTEXT_KEY, "region"),)
+
+    trigger = _trigger_details(inline_inputs={"days": _int(1)}, context=marker)
+    with _patched_task_get(_task_details()):
+        await flyte.run.aio(trigger, days=2)
+    ctx = {kv.key: kv.value for kv in mock_dataproxy.upload_inputs.call_args[0][0].inputs.context}
+    assert ctx == {KICKOFF_TIME_INPUT_ARG_CONTEXT_KEY: "region"}
+
+    with _patched_task_get(_task_details()):
+        await flyte.run.aio(trigger, region="explicit")
+    ctx = {kv.key: kv.value for kv in mock_dataproxy.upload_inputs.call_args[0][0].inputs.context}
+    assert KICKOFF_TIME_INPUT_ARG_CONTEXT_KEY not in ctx
+
+
+@pytest.mark.asyncio
+async def test_run_trigger_runcontext_overrides_layer_on_trigger_runspec():
+    """with_runcontext env vars / queue merge on top of the trigger's run spec; the trigger's
+    notification rules survive."""
+    mock_client, mock_run_service, _dataproxy = _mock_client()
+    await _init_for_testing(client=mock_client, project="p", domain="d", org="o")
+    trigger = _trigger_details(inline_inputs={"region": _str("all")})
+
+    with _patched_task_get(_task_details()):
+        await flyte.with_runcontext(env_vars={"EXTRA": "x"}, queue="gpu", name="named-run").run.aio(trigger)
+
+    req: run_service_pb2.CreateRunRequest = mock_run_service.create_run.call_args[0][0]
+    envs = {kv.key: kv.value for kv in req.run_spec.envs.values}
+    assert envs["REPORT_VERBOSE"] == "1" and envs["EXTRA"] == "x"
+    assert req.run_spec.queue == "gpu"
+    assert len(req.run_spec.notification_rules.rules) == 1
+    assert req.run_id.name == "named-run"
+    assert req.run_id.project == "p" and req.run_id.domain == "d" and req.run_id.org == "o"
+
+
+@pytest.mark.asyncio
+async def test_run_trigger_from_listed_trigger_fetches_details():
+    """A `flyte.remote.Trigger` from listall() carries no spec: details are fetched by name."""
+    mock_client, mock_run_service, _dataproxy = _mock_client()
+    await _init_for_testing(client=mock_client, project="p", domain="d", org="o")
+    details = _trigger_details(inline_inputs={"region": _str("all")})
+    listed = RemoteTrigger(pb2=details.trigger)
+    mock_client.trigger_service = AsyncMock()
+    mock_client.trigger_service.get_trigger_details.return_value = trigger_service_pb2.GetTriggerDetailsResponse(
+        trigger=details.pb2
+    )
+
+    with _patched_task_get(_task_details()):
+        await flyte.run.aio(listed)
+
+    get_req = mock_client.trigger_service.get_trigger_details.call_args.kwargs["request"]
+    assert get_req.name.name == "full-report" and get_req.name.task_name == TASK_NAME
+    req: run_service_pb2.CreateRunRequest = mock_run_service.create_run.call_args[0][0]
+    assert req.trigger_name.name == "full-report"
+
+
+@pytest.mark.asyncio
+async def test_run_trigger_rejects_positional_args_and_unknown_inputs():
+    mock_client, _run_service, _dataproxy = _mock_client()
+    await _init_for_testing(client=mock_client, project="p", domain="d", org="o")
+    trigger = _trigger_details(inline_inputs={"region": _str("all")})
+
+    with pytest.raises(ValueError, match="keyword"):
+        await flyte.run.aio(trigger, "positional")
+    with _patched_task_get(_task_details()), pytest.raises(ValueError, match="Unknown input"):
+        await flyte.run.aio(trigger, nope=1)
+
+
+@pytest.mark.asyncio
+async def test_run_trigger_requires_remote_mode():
+    mock_client, _run_service, _dataproxy = _mock_client()
+    await _init_for_testing(client=mock_client, project="p", domain="d", org="o")
+    trigger = _trigger_details(inline_inputs={})
+    with pytest.raises(ValueError, match="remote mode"):
+        await flyte.with_runcontext(mode="local").run.aio(trigger)

--- a/tests/user_api/test_triggers.py
+++ b/tests/user_api/test_triggers.py
@@ -145,10 +145,22 @@ def test_trigger_validation_empty_name():
         flyte.Trigger(name="", automation=flyte.Cron("0 * * * *"))
 
 
-def test_trigger_validation_none_automation():
-    """Test that automation cannot be None"""
-    with pytest.raises(ValueError, match="Automation cannot be None"):
-        flyte.Trigger(name="test", automation=None)
+def test_trigger_without_automation():
+    """A trigger with no automation is allowed: it is only fired on demand."""
+    t = flyte.Trigger(name="test", inputs={"x": 1})
+    assert t.automation is None
+    assert flyte.Trigger(name="explicit", automation=None).automation is None
+
+
+def test_trigger_without_automation_rejects_trigger_time():
+    """TriggerTime only makes sense on a schedule, so a no-automation trigger cannot bind it."""
+    with pytest.raises(ValueError, match="TriggerTime, which is only available on"):
+        flyte.Trigger(name="test", inputs={"start": flyte.TriggerTime})
+
+
+def test_trigger_without_automation_rejects_triggered_artifact():
+    with pytest.raises(ValueError, match="automation is not OnArtifact"):
+        flyte.Trigger(name="test", inputs={"model": flyte.TriggeredArtifact})
 
 
 def test_task_with_single_trigger():


### PR DESCRIPTION
Triggers no longer require an automation. A trigger without one is a named launch configuration (inputs, env vars, queue, notifications) that only fires on demand. `flyte.run(trigger, ...)` fires any deployed trigger from Python, as the trigger, so the run carries its registered config and is recorded as trigger-fired.

```python
import flyte
import flyte.notify
import flyte.remote
from flyte.models import ActionPhase

env = flyte.TaskEnvironment(name="reports")

# No automation: nothing schedules this, it is fired on demand.
full_report = flyte.Trigger(
    name="full-report",
    inputs={"region": "all", "days": 30},
    env_vars={"REPORT_VERBOSE": "1"},
    notifications=flyte.notify.Email(on_phase=ActionPhase.SUCCEEDED, recipients=("me@example.com",)),
)

@env.task(triggers=(full_report,))
async def report(region: str = "all", days: int = 7) -> str:
    return f"report for {region!r} over {days} day(s)"

# Fire it programmatically, with the trigger's inputs / env vars / notifications.
trigger = flyte.remote.Trigger.get(name="full-report", task_name=report.name)
run = flyte.run(trigger)            # region="all", days=30
run = flyte.run(trigger, days=3)    # override one input, keep the rest
```

Also: `flyte create trigger` no longer requires `--schedule`. Examples in `examples/triggers/manual.py` and `examples/triggers/programmatic.py`.

