### PR TITLE
Env-var control of in-cluster auth mode (ExternalCommand without EAGER_API_KEY)

### DIFF
--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -555,6 +555,46 @@ async def init_from_api_key(
     )
 
 
+def _auth_overrides_from_env() -> dict[str, typing.Any]:
+    """Read the auth-mode config entries from the environment only.
+
+    Returns the subset of ``auth_type`` / ``command`` / ``proxy_command`` that is
+    set, in ``init``/``create_remote_controller`` kwarg form. This is the
+    no-config-file escape hatch for clusters that mint their own tokens: setting
+
+        FLYTE_ADMIN_AUTHTYPE=ExternalCommand
+        FLYTE_ADMIN_COMMAND="/usr/local/bin/mint-token --audience flyte"
+
+    as default env vars on the task pod makes in-cluster init authenticate by
+    running that command, with no api key issued to the pod at all.
+
+    ``ConfigEntry.read()`` with no config file consults only the environment, so
+    this stays free of the file-resolution walk (including its ``git rev-parse``
+    subprocess) that is wasted work inside a task pod.
+    """
+    from flyte.config import _internal
+
+    overrides: dict[str, typing.Any] = {}
+    if auth_type := _internal.Credentials.AUTH_MODE.read():
+        overrides["auth_type"] = auth_type
+    if command := _internal.Credentials.COMMAND.read():
+        overrides["command"] = command
+    if proxy_command := _internal.Credentials.PROXY_COMMAND.read():
+        overrides["proxy_command"] = proxy_command
+
+    if overrides.get("auth_type") == "ExternalCommand" and not overrides.get("command"):
+        # Otherwise this surfaces as an AuthenticationError from the interceptor on
+        # the first RPC, long after init, naming neither env var.
+        raise InitializationError(
+            "MissingExternalCommand",
+            "user",
+            f"{_internal.Credentials.AUTH_MODE.yaml_entry.get_env_name()}=ExternalCommand requires the token "
+            f"command to be set in {_internal.Credentials.COMMAND.yaml_entry.get_env_name()} "
+            f"(a shell-quoted command line, or a JSON array of arguments).",
+        )
+    return overrides
+
+
 @syncify
 async def init_in_cluster(
     org: str | None = None,
@@ -564,6 +604,46 @@ async def init_in_cluster(
     endpoint: str | None = None,
     insecure: bool = False,
 ) -> dict[str, typing.Any]:
+    """
+    Initialize the Flyte system from inside a task pod, and return the kwargs used to build
+    the controller that enqueues and watches child actions.
+
+    Credentials are resolved in this order:
+
+    1. An explicit `api_key` argument.
+    2. A mounted config file, when the pod has `UCTL_CONFIG` or `FLYTECTL_CONFIG` set.
+    3. Auth env vars set on the pod (see below).
+    4. The api key injected by the control plane (`_UNION_EAGER_API_KEY` / `EAGER_API_KEY`).
+
+    Deployments that do not want to hand task pods a long-lived API key can skip issuing one
+    entirely and set the standard credentials config env vars as default env vars on the pod:
+
+    ```
+    FLYTE_ADMIN_AUTHTYPE=ExternalCommand
+    FLYTE_ADMIN_COMMAND="/usr/local/bin/mint-token --audience flyte"
+    ```
+
+    `FLYTE_ADMIN_COMMAND` takes a shell-quoted command line or a JSON array of arguments; the
+    command's stdout is used as the access token and is re-run whenever the token needs
+    refreshing. Setting `FLYTE_ADMIN_AUTHTYPE` disables the injected-api-key fallback, so the
+    two can never disagree. The endpoint still comes from the injected `_U_EP_OVERRIDE`, and can
+    also be set explicitly with `FLYTE_ADMIN_ENDPOINT`. `FLYTE_ADMIN_PROXYCOMMAND` configures a
+    token command for an authenticating proxy in front of Flyte, independently of the auth type.
+
+    Note: the opt-in Rust controller (`_F_USE_RUST_CONTROLLER=1`) reads the injected api key
+    directly and does not support these env vars.
+
+    Args:
+        org: Optional org override; defaults to the `_U_ORG_NAME` env var.
+        project: Optional project override; defaults to the `FLYTE_INTERNAL_EXECUTION_PROJECT` env var.
+        domain: Optional domain override; defaults to the `FLYTE_INTERNAL_EXECUTION_DOMAIN` env var.
+        api_key: Optional api key, taking precedence over every env-var and config-file source.
+        endpoint: Optional endpoint override, taking precedence over `_U_EP_OVERRIDE`.
+        insecure: Whether to use a plaintext channel.
+
+    Returns:
+        The kwargs used to initialize the client, to be spread into `create_remote_controller`.
+    """
     from flyte._utils import str2bool
 
     PROJECT_NAME = "FLYTE_INTERNAL_EXECUTION_PROJECT"
@@ -617,14 +697,36 @@ async def init_in_cluster(
     org = org or os.getenv(ORG_NAME)
     project = project or os.getenv(PROJECT_NAME)
     domain = domain or os.getenv(DOMAIN_NAME)
-    api_key = api_key or os.getenv(_UNION_EAGER_API_KEY_ENV_VAR) or os.getenv(EAGER_API_KEY)
+
+    # Auth supplied entirely through env vars. A deployment that does not want to
+    # issue eager API keys to task pods can instead set FLYTE_ADMIN_AUTHTYPE (plus
+    # FLYTE_ADMIN_COMMAND for ExternalCommand) as default env vars on the pod. An
+    # explicit auth type wins over the injected key so the two can never fight:
+    # once it is set we do not even look at EAGER_API_KEY / _UNION_EAGER_API_KEY.
+    auth_overrides = _auth_overrides_from_env()
+    if api_key is None and "auth_type" not in auth_overrides:
+        api_key = os.getenv(_UNION_EAGER_API_KEY_ENV_VAR) or os.getenv(EAGER_API_KEY)
 
     remote_kwargs: dict[str, typing.Any] = {"insecure": insecure}
     if api_key:
         logger.info("Using api key from environment")
         remote_kwargs["api_key"] = api_key
+        if auth_overrides:
+            # An api key is a self-contained ClientSecret credential (it decodes to
+            # endpoint + client id + secret), so honoring both is not possible.
+            logger.warning(
+                f"Ignoring env-var auth override {sorted(auth_overrides)} because an api key was supplied explicitly."
+            )
     else:
-        ep = endpoint or os.environ.get(ENDPOINT_OVERRIDE, "host.docker.internal:8090")
+        from flyte.config import _internal
+
+        remote_kwargs.update(auth_overrides)
+        ep = (
+            endpoint
+            or os.environ.get(ENDPOINT_OVERRIDE)
+            or _internal.Platform.URL.read()
+            or "host.docker.internal:8090"
+        )
         remote_kwargs["endpoint"] = ep
         if not insecure:
             if "localhost" in ep or "docker" in ep:

--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -558,8 +558,8 @@ async def init_from_api_key(
 def _auth_overrides_from_env() -> dict[str, typing.Any]:
     """Read the auth-mode config entries from the environment only.
 
-    Returns the subset of ``auth_type`` / ``command`` / ``proxy_command`` that is
-    set, in ``init``/``create_remote_controller`` kwarg form. This is the
+    Returns the subset of `auth_type` / `command` / `proxy_command` that is
+    set, in `init`/`create_remote_controller` kwarg form. This is the
     no-config-file escape hatch for clusters that mint their own tokens: setting
 
         FLYTE_AUTH_TYPE=ExternalCommand
@@ -568,10 +568,10 @@ def _auth_overrides_from_env() -> dict[str, typing.Any]:
     as default env vars on the task pod makes in-cluster init authenticate by
     running that command, with no api key issued to the pod at all. The names
     derived from the config keys (FLYTE_ADMIN_AUTHTYPE, FLYTE_ADMIN_COMMAND) are
-    still accepted; ``get_env_name`` reports the preferred one.
+    still accepted; `get_env_name` reports the preferred one.
 
-    ``ConfigEntry.read()`` with no config file consults only the environment, so
-    this stays free of the file-resolution walk (including its ``git rev-parse``
+    `ConfigEntry.read()` with no config file consults only the environment, so
+    this stays free of the file-resolution walk (including its `git rev-parse`
     subprocess) that is wasted work inside a task pod.
     """
     from flyte.config import _internal

--- a/src/flyte/_initialize.py
+++ b/src/flyte/_initialize.py
@@ -562,11 +562,13 @@ def _auth_overrides_from_env() -> dict[str, typing.Any]:
     set, in ``init``/``create_remote_controller`` kwarg form. This is the
     no-config-file escape hatch for clusters that mint their own tokens: setting
 
-        FLYTE_ADMIN_AUTHTYPE=ExternalCommand
-        FLYTE_ADMIN_COMMAND="/usr/local/bin/mint-token --audience flyte"
+        FLYTE_AUTH_TYPE=ExternalCommand
+        FLYTE_AUTH_COMMAND="/usr/local/bin/mint-token --audience flyte"
 
     as default env vars on the task pod makes in-cluster init authenticate by
-    running that command, with no api key issued to the pod at all.
+    running that command, with no api key issued to the pod at all. The names
+    derived from the config keys (FLYTE_ADMIN_AUTHTYPE, FLYTE_ADMIN_COMMAND) are
+    still accepted; ``get_env_name`` reports the preferred one.
 
     ``ConfigEntry.read()`` with no config file consults only the environment, so
     this stays free of the file-resolution walk (including its ``git rev-parse``
@@ -619,16 +621,21 @@ async def init_in_cluster(
     entirely and set the standard credentials config env vars as default env vars on the pod:
 
     ```
-    FLYTE_ADMIN_AUTHTYPE=ExternalCommand
-    FLYTE_ADMIN_COMMAND="/usr/local/bin/mint-token --audience flyte"
+    FLYTE_AUTH_TYPE=ExternalCommand
+    FLYTE_AUTH_COMMAND="/usr/local/bin/mint-token --audience flyte"
     ```
 
-    `FLYTE_ADMIN_COMMAND` takes a shell-quoted command line or a JSON array of arguments; the
+    `FLYTE_AUTH_COMMAND` takes a shell-quoted command line or a JSON array of arguments; the
     command's stdout is used as the access token and is re-run whenever the token needs
-    refreshing. Setting `FLYTE_ADMIN_AUTHTYPE` disables the injected-api-key fallback, so the
+    refreshing. Setting `FLYTE_AUTH_TYPE` disables the injected-api-key fallback, so the
     two can never disagree. The endpoint still comes from the injected `_U_EP_OVERRIDE`, and can
-    also be set explicitly with `FLYTE_ADMIN_ENDPOINT`. `FLYTE_ADMIN_PROXYCOMMAND` configures a
-    token command for an authenticating proxy in front of Flyte, independently of the auth type.
+    also be set explicitly with `FLYTE_ADMIN_ENDPOINT` (the endpoint is a platform setting, not
+    an auth one, so it keeps the derived name). `FLYTE_AUTH_PROXY_COMMAND` configures a token
+    command for an authenticating proxy in front of Flyte, independently of the auth type.
+
+    `FLYTE_AUTH_TYPE` / `FLYTE_AUTH_COMMAND` / `FLYTE_AUTH_PROXY_COMMAND` are the preferred
+    names; the ones derived from the config keys (`FLYTE_ADMIN_AUTHTYPE`, `FLYTE_ADMIN_COMMAND`,
+    `FLYTE_ADMIN_PROXYCOMMAND`) remain accepted.
 
     Note: the opt-in Rust controller (`_F_USE_RUST_CONTROLLER=1`) reads the injected api key
     directly and does not support these env vars.
@@ -699,8 +706,8 @@ async def init_in_cluster(
     domain = domain or os.getenv(DOMAIN_NAME)
 
     # Auth supplied entirely through env vars. A deployment that does not want to
-    # issue eager API keys to task pods can instead set FLYTE_ADMIN_AUTHTYPE (plus
-    # FLYTE_ADMIN_COMMAND for ExternalCommand) as default env vars on the pod. An
+    # issue eager API keys to task pods can instead set FLYTE_AUTH_TYPE (plus
+    # FLYTE_AUTH_COMMAND for ExternalCommand) as default env vars on the pod. An
     # explicit auth type wins over the injected key so the two can never fight:
     # once it is set we do not even look at EAGER_API_KEY / _UNION_EAGER_API_KEY.
     auth_overrides = _auth_overrides_from_env()

--- a/src/flyte/_internal/controllers/remote/__init__.py
+++ b/src/flyte/_internal/controllers/remote/__init__.py
@@ -32,28 +32,27 @@ def create_remote_controller(
     from ._client import ControllerClient
     from ._controller import RemoteController
 
+    # Keep this set in sync with `_initialize._initialize_client`: the controller and the
+    # SDK client are built from the same kwargs (see `init_in_cluster`), so an auth field
+    # dropped here authenticates the client but leaves the controller unable to enqueue.
+    auth_kwargs: dict = {
+        "insecure": insecure,
+        "insecure_skip_verify": insecure_skip_verify,
+        "ca_cert_file_path": ca_cert_file_path,
+        "client_id": client_id,
+        "client_credentials_secret": client_credentials_secret,
+        "scopes": scopes,
+        "auth_type": auth_type,
+        "command": command,
+        "proxy_command": proxy_command,
+        "http_proxy_url": http_proxy_url,
+        "client_config": client_config,
+    }
+
     if endpoint:
-        client_coro = ControllerClient.for_endpoint(
-            endpoint,
-            insecure=insecure,
-            insecure_skip_verify=insecure_skip_verify,
-            ca_cert_file_path=ca_cert_file_path,
-            client_id=client_id,
-            client_credentials_secret=client_credentials_secret,
-            scopes=scopes,
-            auth_type=auth_type,
-        )
+        client_coro = ControllerClient.for_endpoint(endpoint, **auth_kwargs)
     elif api_key:
-        client_coro = ControllerClient.for_api_key(
-            api_key,
-            insecure=insecure,
-            insecure_skip_verify=insecure_skip_verify,
-            ca_cert_file_path=ca_cert_file_path,
-            client_id=client_id,
-            client_credentials_secret=client_credentials_secret,
-            scopes=scopes,
-            auth_type=auth_type,
-        )
+        client_coro = ControllerClient.for_api_key(api_key, **auth_kwargs)
 
     controller = RemoteController(
         client_coro=client_coro,

--- a/src/flyte/config/_internal.py
+++ b/src/flyte/config/_internal.py
@@ -1,4 +1,58 @@
+import json
+import re
+import shlex
+import typing
+
 from flyte.config._reader import ConfigEntry, YamlConfigEntry
+
+
+def _as_argv(v: typing.Any) -> typing.Optional[typing.List[str]]:
+    """Normalize a config value that must end up as an argv list.
+
+    YAML already yields a list, and that is passed through untouched. An
+    environment variable can only ever carry a string, so accept both a JSON
+    array (``["uctl", "get-token"]``) and a plain shell-quoted command line
+    (``uctl get-token --audience foo``), which is what people reach for first.
+    Without this, ``FLYTE_ADMIN_COMMAND`` reached the external-command
+    authenticator as a bare string and ``create_subprocess_exec(*cmd)`` spread
+    it one character per argument.
+    """
+    if v is None or isinstance(v, list):
+        return v
+    s = str(v).strip()
+    if not s:
+        return None
+    if s.startswith("["):
+        try:
+            parsed = json.loads(s)
+        except json.JSONDecodeError:
+            pass
+        else:
+            if isinstance(parsed, list):
+                return [str(x) for x in parsed]
+    return shlex.split(s)
+
+
+def _as_str_list(v: typing.Any) -> typing.Optional[typing.List[str]]:
+    """Normalize a config value that must end up as a list of strings.
+
+    Same reasoning as `_as_argv`, but for value lists (scopes) rather than an
+    argv: accept a JSON array or a comma/whitespace separated string.
+    """
+    if v is None or isinstance(v, list):
+        return v
+    s = str(v).strip()
+    if not s:
+        return None
+    if s.startswith("["):
+        try:
+            parsed = json.loads(s)
+        except json.JSONDecodeError:
+            pass
+        else:
+            if isinstance(parsed, list):
+                return [str(x) for x in parsed]
+    return [p for p in re.split(r"[,\s]+", s) if p]
 
 
 class Platform(object):
@@ -13,12 +67,12 @@ class Platform(object):
 
 class Credentials(object):
     SECTION = "credentials"
-    COMMAND = ConfigEntry(YamlConfigEntry("admin.command", list))
+    COMMAND = ConfigEntry(YamlConfigEntry("admin.command", list), transform=_as_argv)
     """
     This command is executed to return a token using an external process.
     """
 
-    PROXY_COMMAND = ConfigEntry(YamlConfigEntry("admin.proxyCommand", list))
+    PROXY_COMMAND = ConfigEntry(YamlConfigEntry("admin.proxyCommand", list), transform=_as_argv)
     """
     This command is executed to return a token for authorization with a proxy
      in front of Flyte using an external process.
@@ -42,20 +96,22 @@ class Credentials(object):
     password from a mounted environment variable.
     """
 
-    SCOPES = ConfigEntry(YamlConfigEntry("admin.scopes", list))
+    SCOPES = ConfigEntry(YamlConfigEntry("admin.scopes", list), transform=_as_str_list)
     """
     This setting can be used to manually pass in scopes into authenticator flows - eg.) for Auth0 compatibility
     """
 
     AUTH_MODE = ConfigEntry(YamlConfigEntry("admin.authType"))
     """
-    The auth mode defines the behavior used to request and refresh credentials. The currently supported modes include:
-    - 'standard' or 'Pkce': This uses the pkce-enhanced authorization code flow by opening a browser window to initiate
+    The auth mode defines the behavior used to request and refresh credentials. The value must be one of the
+    `flyte.remote._client.auth.AuthType` literals:
+    - 'Pkce' (default): the pkce-enhanced authorization code flow, which opens a browser window to initiate
             credentials access.
-    - "DeviceFlow": This uses the Device Authorization Flow
-    - 'basic', 'client_credentials' or 'clientSecret': This uses symmetric key auth in which the end user enters a
-            client id and a client secret and public key encryption is used to facilitate authentication.
-    - None: No auth will be attempted.
+    - 'DeviceFlow': the Device Authorization Flow, for hosts without a browser.
+    - 'ClientSecret': symmetric key auth, in which a client id and a client secret are exchanged for a token.
+    - 'ExternalCommand': `COMMAND` is executed and its stdout is used as the access token. Use this to plug in an
+            external token minter (see the `admin.command` entry).
+    - 'Passthrough': auth metadata is supplied per-call by the caller.
     """
 
 

--- a/src/flyte/config/_internal.py
+++ b/src/flyte/config/_internal.py
@@ -67,15 +67,21 @@ class Platform(object):
 
 class Credentials(object):
     SECTION = "credentials"
-    COMMAND = ConfigEntry(YamlConfigEntry("admin.command", list), transform=_as_argv)
+    COMMAND = ConfigEntry(YamlConfigEntry("admin.command", list, aliases=("FLYTE_AUTH_COMMAND",)), transform=_as_argv)
     """
     This command is executed to return a token using an external process.
+
+    Env var: `FLYTE_AUTH_COMMAND` (the derived `FLYTE_ADMIN_COMMAND` is still accepted).
     """
 
-    PROXY_COMMAND = ConfigEntry(YamlConfigEntry("admin.proxyCommand", list), transform=_as_argv)
+    PROXY_COMMAND = ConfigEntry(
+        YamlConfigEntry("admin.proxyCommand", list, aliases=("FLYTE_AUTH_PROXY_COMMAND",)), transform=_as_argv
+    )
     """
     This command is executed to return a token for authorization with a proxy
      in front of Flyte using an external process.
+
+    Env var: `FLYTE_AUTH_PROXY_COMMAND` (the derived `FLYTE_ADMIN_PROXYCOMMAND` is still accepted).
     """
 
     CLIENT_ID = ConfigEntry(YamlConfigEntry("admin.clientId"))
@@ -101,8 +107,10 @@ class Credentials(object):
     This setting can be used to manually pass in scopes into authenticator flows - eg.) for Auth0 compatibility
     """
 
-    AUTH_MODE = ConfigEntry(YamlConfigEntry("admin.authType"))
+    AUTH_MODE = ConfigEntry(YamlConfigEntry("admin.authType", aliases=("FLYTE_AUTH_TYPE",)))
     """
+    Env var: `FLYTE_AUTH_TYPE` (the derived `FLYTE_ADMIN_AUTHTYPE` is still accepted).
+
     The auth mode defines the behavior used to request and refresh credentials. The value must be one of the
     `flyte.remote._client.auth.AuthType` literals:
     - 'Pkce' (default): the pkce-enhanced authorization code flow, which opens a browser window to initiate

--- a/src/flyte/config/_internal.py
+++ b/src/flyte/config/_internal.py
@@ -11,10 +11,10 @@ def _as_argv(v: typing.Any) -> typing.Optional[typing.List[str]]:
 
     YAML already yields a list, and that is passed through untouched. An
     environment variable can only ever carry a string, so accept both a JSON
-    array (``["uctl", "get-token"]``) and a plain shell-quoted command line
-    (``uctl get-token --audience foo``), which is what people reach for first.
-    Without this, ``FLYTE_ADMIN_COMMAND`` reached the external-command
-    authenticator as a bare string and ``create_subprocess_exec(*cmd)`` spread
+    array (`["uctl", "get-token"]`) and a plain shell-quoted command line
+    (`uctl get-token --audience foo`), which is what people reach for first.
+    Without this, `FLYTE_ADMIN_COMMAND` reached the external-command
+    authenticator as a bare string and `create_subprocess_exec(*cmd)` spread
     it one character per argument.
     """
     if v is None or isinstance(v, list):

--- a/src/flyte/config/_reader.py
+++ b/src/flyte/config/_reader.py
@@ -27,20 +27,47 @@ class YamlConfigEntry(object):
 
     switch: str
     config_value_type: typing.Type = str
+    aliases: typing.Tuple[str, ...] = ()
 
-    def get_env_name(self) -> str:
+    def get_derived_env_name(self) -> str:
+        """The name mechanically derived from the switch: `FLYTE_{SECTION}_{OPTION}`, upper cased."""
         var_name = self.switch.upper().replace(".", "_")
         return f"FLYTE_{var_name}"
 
+    def get_env_name(self) -> str:
+        """The preferred, user-facing name: the first declared alias, else the derived name.
+
+        This is the name to put in docs and error messages.
+        """
+        return self.aliases[0] if self.aliases else self.get_derived_env_name()
+
+    def env_names(self) -> typing.Tuple[str, ...]:
+        """Every accepted name for this entry, most-preferred first."""
+        return (*self.aliases, self.get_derived_env_name())
+
     def read_from_env(self, transform: typing.Optional[typing.Callable] = None) -> typing.Optional[typing.Any]:
         """
-        Reads the config entry from environment variable, the structure of the env var is current
-        `FLYTE_{SECTION}_{OPTION}` all upper cased. We will change this in the future.
+        Reads the config entry from the environment.
+
+        The name is derived from the switch as `FLYTE_{SECTION}_{OPTION}`, all upper cased.
+        An entry may also declare `aliases`: hand-written names that take precedence over the
+        derived one. That lets a setting be documented under a better name than its config key
+        spells -- `admin.authType` is really an auth setting, not an "admin" one -- without
+        breaking anyone already setting the derived name.
+
+        The first name that is set wins. A lower-precedence name set to a different value is
+        reported rather than silently discarded.
         """
-        env = self.get_env_name()
-        v = os.environ.get(env, None)
-        if v is None:
+        set_names = [(name, os.environ[name]) for name in self.env_names() if name in os.environ]
+        if not set_names:
             return None
+        env, v = set_names[0]
+        for other_env, other_v in set_names[1:]:
+            if other_v != v:
+                logger.warning(
+                    f"{env} and {other_env} configure the same setting but are set to different "
+                    f"values; using {env}. Unset {other_env} to remove the ambiguity."
+                )
         return transform(v) if transform else v
 
     def read_from_file(

--- a/tests/user_api/test_init_in_cluster_env_auth.py
+++ b/tests/user_api/test_init_in_cluster_env_auth.py
@@ -1,0 +1,192 @@
+"""Tests for env-var-driven auth in `init_in_cluster`.
+
+A deployment that does not issue eager API keys to task pods can instead set the
+standard credentials config env vars as default env vars on the pod:
+
+    FLYTE_ADMIN_AUTHTYPE=ExternalCommand
+    FLYTE_ADMIN_COMMAND="/usr/local/bin/mint-token --audience flyte"
+
+The explicit auth type must win over any injected `EAGER_API_KEY` /
+`_UNION_EAGER_API_KEY`, and the resulting kwargs must reach BOTH the SDK client
+(via `init`) and the controller (via `create_remote_controller`) — the controller
+is what enqueues and watches child actions.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from flyte._initialize import _auth_overrides_from_env, init_in_cluster
+from flyte.errors import InitializationError
+
+AUTH_ENV_VARS = (
+    "FLYTE_ADMIN_AUTHTYPE",
+    "FLYTE_ADMIN_COMMAND",
+    "FLYTE_ADMIN_PROXYCOMMAND",
+    "FLYTE_ADMIN_ENDPOINT",
+)
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Start from a pod with no config file, no api key and no auth env vars."""
+    for var in (
+        "UCTL_CONFIG",
+        "FLYTECTL_CONFIG",
+        "_UNION_EAGER_API_KEY",
+        "EAGER_API_KEY",
+        "_U_EP_OVERRIDE",
+        *AUTH_ENV_VARS,
+    ):
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
+
+class TestAuthOverridesFromEnv:
+    def test_empty_when_nothing_set(self, clean_env):
+        assert _auth_overrides_from_env() == {}
+
+    def test_command_is_shell_split(self, clean_env):
+        clean_env.setenv("FLYTE_ADMIN_AUTHTYPE", "ExternalCommand")
+        clean_env.setenv("FLYTE_ADMIN_COMMAND", "/usr/local/bin/mint-token --audience flyte")
+
+        assert _auth_overrides_from_env() == {
+            "auth_type": "ExternalCommand",
+            "command": ["/usr/local/bin/mint-token", "--audience", "flyte"],
+        }
+
+    def test_command_accepts_json_array(self, clean_env):
+        """A JSON array is the unambiguous form for arguments containing spaces."""
+        clean_env.setenv("FLYTE_ADMIN_AUTHTYPE", "ExternalCommand")
+        clean_env.setenv("FLYTE_ADMIN_COMMAND", '["mint-token", "--claim", "team = data"]')
+
+        assert _auth_overrides_from_env()["command"] == ["mint-token", "--claim", "team = data"]
+
+    def test_quoted_argument_survives_shell_split(self, clean_env):
+        clean_env.setenv("FLYTE_ADMIN_AUTHTYPE", "ExternalCommand")
+        clean_env.setenv("FLYTE_ADMIN_COMMAND", "mint-token --claim 'team = data'")
+
+        assert _auth_overrides_from_env()["command"] == ["mint-token", "--claim", "team = data"]
+
+    def test_proxy_command_is_picked_up(self, clean_env):
+        clean_env.setenv("FLYTE_ADMIN_PROXYCOMMAND", "get-proxy-token --quiet")
+
+        assert _auth_overrides_from_env() == {"proxy_command": ["get-proxy-token", "--quiet"]}
+
+    def test_external_command_without_command_is_loud(self, clean_env):
+        """Otherwise this only surfaces as an AuthenticationError from the auth
+        interceptor on the first RPC, naming neither env var."""
+        clean_env.setenv("FLYTE_ADMIN_AUTHTYPE", "ExternalCommand")
+
+        with pytest.raises(InitializationError, match="FLYTE_ADMIN_COMMAND"):
+            _auth_overrides_from_env()
+
+
+class TestInitInClusterEnvAuth:
+    @pytest.mark.asyncio
+    async def test_external_command_env_vars_reach_client_and_controller(self, clean_env):
+        clean_env.setenv("_U_EP_OVERRIDE", "dns:///example.com:443")
+        clean_env.setenv("FLYTE_ADMIN_AUTHTYPE", "ExternalCommand")
+        clean_env.setenv("FLYTE_ADMIN_COMMAND", "mint-token --audience flyte")
+
+        with patch("flyte._initialize.init", new_callable=AsyncMock) as mock_init:
+            controller_kwargs = await init_in_cluster.aio()
+
+        # Returned kwargs are spread into create_remote_controller by the runtime.
+        assert controller_kwargs["auth_type"] == "ExternalCommand"
+        assert controller_kwargs["command"] == ["mint-token", "--audience", "flyte"]
+        assert controller_kwargs["endpoint"] == "dns:///example.com:443"
+        assert "api_key" not in controller_kwargs
+
+        # ...and the same settings configure the SDK client.
+        init_kwargs = mock_init.aio.await_args.kwargs
+        assert init_kwargs["auth_type"] == "ExternalCommand"
+        assert init_kwargs["command"] == ["mint-token", "--audience", "flyte"]
+
+    @pytest.mark.asyncio
+    async def test_explicit_auth_type_beats_injected_api_key(self, clean_env):
+        """The whole point of the knob: a cluster that still injects an eager API
+        key must not silently keep using it once ExternalCommand is configured."""
+        clean_env.setenv("_U_EP_OVERRIDE", "dns:///example.com:443")
+        clean_env.setenv("_UNION_EAGER_API_KEY", "legacy-composite-token")
+        clean_env.setenv("EAGER_API_KEY", "another-token")
+        clean_env.setenv("FLYTE_ADMIN_AUTHTYPE", "ExternalCommand")
+        clean_env.setenv("FLYTE_ADMIN_COMMAND", "mint-token")
+
+        with patch("flyte._initialize.init", new_callable=AsyncMock) as mock_init:
+            controller_kwargs = await init_in_cluster.aio()
+
+        assert "api_key" not in controller_kwargs
+        assert mock_init.aio.await_args.kwargs.get("api_key") is None
+
+    @pytest.mark.asyncio
+    async def test_endpoint_falls_back_to_config_env_var(self, clean_env):
+        """Deployments that drop the api key also lose the endpoint it decodes to.
+        `_U_EP_OVERRIDE` is what the backend injects; `FLYTE_ADMIN_ENDPOINT` is the
+        user-settable equivalent for the same reason the auth vars are."""
+        clean_env.setenv("FLYTE_ADMIN_ENDPOINT", "dns:///byo.example.com:443")
+        clean_env.setenv("FLYTE_ADMIN_AUTHTYPE", "ExternalCommand")
+        clean_env.setenv("FLYTE_ADMIN_COMMAND", "mint-token")
+
+        with patch("flyte._initialize.init", new_callable=AsyncMock):
+            controller_kwargs = await init_in_cluster.aio()
+
+        assert controller_kwargs["endpoint"] == "dns:///byo.example.com:443"
+
+    @pytest.mark.asyncio
+    async def test_injected_api_key_still_wins_when_no_auth_type_set(self, clean_env):
+        """No auth env vars -> unchanged legacy behavior."""
+        clean_env.setenv("_UNION_EAGER_API_KEY", "legacy-composite-token")
+
+        with patch("flyte._initialize.init", new_callable=AsyncMock):
+            controller_kwargs = await init_in_cluster.aio()
+
+        assert controller_kwargs["api_key"] == "legacy-composite-token"
+        assert "auth_type" not in controller_kwargs
+
+    @pytest.mark.asyncio
+    async def test_explicit_api_key_arg_wins_over_env_auth(self, clean_env):
+        clean_env.setenv("FLYTE_ADMIN_AUTHTYPE", "ExternalCommand")
+        clean_env.setenv("FLYTE_ADMIN_COMMAND", "mint-token")
+
+        with patch("flyte._initialize.init", new_callable=AsyncMock):
+            controller_kwargs = await init_in_cluster.aio(api_key="explicit-key")
+
+        assert controller_kwargs["api_key"] == "explicit-key"
+        assert "auth_type" not in controller_kwargs
+
+
+class TestControllerForwardsAuth:
+    @pytest.mark.asyncio
+    async def test_create_remote_controller_forwards_external_command(self):
+        """The controller is the half of in-cluster init that enqueues and watches
+        child actions. Dropping `command` here left `auth_type=ExternalCommand`
+        with nothing to run, which only surfaced as an AuthenticationError on the
+        controller's first RPC."""
+        from flyte._internal.controllers.remote import create_remote_controller
+
+        captured: dict = {}
+
+        async def fake_for_endpoint(endpoint, **kwargs):
+            captured["endpoint"] = endpoint
+            captured.update(kwargs)
+            return object()
+
+        with (
+            patch(
+                "flyte._internal.controllers.remote._client.ControllerClient.for_endpoint",
+                staticmethod(fake_for_endpoint),
+            ),
+            patch("flyte._internal.controllers.remote._controller.RemoteController") as mock_controller,
+        ):
+            create_remote_controller(
+                endpoint="dns:///example.com:443",
+                auth_type="ExternalCommand",
+                command=["mint-token", "--audience", "flyte"],
+            )
+            # Awaiting the captured coroutine is what actually builds the client.
+            await mock_controller.call_args.kwargs["client_coro"]
+
+        assert captured["endpoint"] == "dns:///example.com:443"
+        assert captured["auth_type"] == "ExternalCommand"
+        assert captured["command"] == ["mint-token", "--audience", "flyte"]

--- a/tests/user_api/test_init_in_cluster_env_auth.py
+++ b/tests/user_api/test_init_in_cluster_env_auth.py
@@ -3,8 +3,8 @@
 A deployment that does not issue eager API keys to task pods can instead set the
 standard credentials config env vars as default env vars on the pod:
 
-    FLYTE_ADMIN_AUTHTYPE=ExternalCommand
-    FLYTE_ADMIN_COMMAND="/usr/local/bin/mint-token --audience flyte"
+    FLYTE_AUTH_TYPE=ExternalCommand
+    FLYTE_AUTH_COMMAND="/usr/local/bin/mint-token --audience flyte"
 
 The explicit auth type must win over any injected `EAGER_API_KEY` /
 `_UNION_EAGER_API_KEY`, and the resulting kwargs must reach BOTH the SDK client
@@ -12,6 +12,8 @@ The explicit auth type must win over any injected `EAGER_API_KEY` /
 is what enqueues and watches child actions.
 """
 
+import contextlib
+import logging
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -19,12 +21,41 @@ import pytest
 from flyte._initialize import _auth_overrides_from_env, init_in_cluster
 from flyte.errors import InitializationError
 
+# Both spellings of each auth entry: the preferred FLYTE_AUTH_* names and the
+# names derived from the config keys, which stay accepted for back-compat.
 AUTH_ENV_VARS = (
+    "FLYTE_AUTH_TYPE",
+    "FLYTE_AUTH_COMMAND",
+    "FLYTE_AUTH_PROXY_COMMAND",
     "FLYTE_ADMIN_AUTHTYPE",
     "FLYTE_ADMIN_COMMAND",
     "FLYTE_ADMIN_PROXYCOMMAND",
     "FLYTE_ADMIN_ENDPOINT",
 )
+
+
+@contextlib.contextmanager
+def captured_flyte_warnings():
+    """Collect WARNING records off flyte's logger.
+
+    `caplog` cannot see them (the logger does not propagate to root) and `capsys`
+    cannot either (its handler holds the sys.stderr from import time, so the write
+    happens at fd level). Attaching a handler is independent of both.
+    """
+    from flyte._logging import logger as flyte_logger
+
+    records: list[str] = []
+
+    class _Collect(logging.Handler):
+        def emit(self, record):
+            records.append(record.getMessage())
+
+    handler = _Collect(level=logging.WARNING)
+    flyte_logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        flyte_logger.removeHandler(handler)
 
 
 @pytest.fixture
@@ -47,8 +78,8 @@ class TestAuthOverridesFromEnv:
         assert _auth_overrides_from_env() == {}
 
     def test_command_is_shell_split(self, clean_env):
-        clean_env.setenv("FLYTE_ADMIN_AUTHTYPE", "ExternalCommand")
-        clean_env.setenv("FLYTE_ADMIN_COMMAND", "/usr/local/bin/mint-token --audience flyte")
+        clean_env.setenv("FLYTE_AUTH_TYPE", "ExternalCommand")
+        clean_env.setenv("FLYTE_AUTH_COMMAND", "/usr/local/bin/mint-token --audience flyte")
 
         assert _auth_overrides_from_env() == {
             "auth_type": "ExternalCommand",
@@ -57,37 +88,95 @@ class TestAuthOverridesFromEnv:
 
     def test_command_accepts_json_array(self, clean_env):
         """A JSON array is the unambiguous form for arguments containing spaces."""
-        clean_env.setenv("FLYTE_ADMIN_AUTHTYPE", "ExternalCommand")
-        clean_env.setenv("FLYTE_ADMIN_COMMAND", '["mint-token", "--claim", "team = data"]')
+        clean_env.setenv("FLYTE_AUTH_TYPE", "ExternalCommand")
+        clean_env.setenv("FLYTE_AUTH_COMMAND", '["mint-token", "--claim", "team = data"]')
 
         assert _auth_overrides_from_env()["command"] == ["mint-token", "--claim", "team = data"]
 
     def test_quoted_argument_survives_shell_split(self, clean_env):
-        clean_env.setenv("FLYTE_ADMIN_AUTHTYPE", "ExternalCommand")
-        clean_env.setenv("FLYTE_ADMIN_COMMAND", "mint-token --claim 'team = data'")
+        clean_env.setenv("FLYTE_AUTH_TYPE", "ExternalCommand")
+        clean_env.setenv("FLYTE_AUTH_COMMAND", "mint-token --claim 'team = data'")
 
         assert _auth_overrides_from_env()["command"] == ["mint-token", "--claim", "team = data"]
 
     def test_proxy_command_is_picked_up(self, clean_env):
-        clean_env.setenv("FLYTE_ADMIN_PROXYCOMMAND", "get-proxy-token --quiet")
+        clean_env.setenv("FLYTE_AUTH_PROXY_COMMAND", "get-proxy-token --quiet")
 
         assert _auth_overrides_from_env() == {"proxy_command": ["get-proxy-token", "--quiet"]}
 
     def test_external_command_without_command_is_loud(self, clean_env):
         """Otherwise this only surfaces as an AuthenticationError from the auth
         interceptor on the first RPC, naming neither env var."""
-        clean_env.setenv("FLYTE_ADMIN_AUTHTYPE", "ExternalCommand")
+        clean_env.setenv("FLYTE_AUTH_TYPE", "ExternalCommand")
 
-        with pytest.raises(InitializationError, match="FLYTE_ADMIN_COMMAND"):
+        with pytest.raises(InitializationError, match="FLYTE_AUTH_COMMAND"):
             _auth_overrides_from_env()
+
+
+class TestPreferredAndDerivedNames:
+    """`admin.authType` is really an auth setting, not an "admin" one, so the entries
+    declare `FLYTE_AUTH_*` aliases that take precedence over the name derived from the
+    config key. The derived names keep working: they are public surface that predates
+    this feature, and are what the config-file path has always documented."""
+
+    def test_preferred_name_is_what_docs_and_errors_report(self):
+        from flyte.config import _internal
+
+        assert _internal.Credentials.AUTH_MODE.yaml_entry.get_env_name() == "FLYTE_AUTH_TYPE"
+        assert _internal.Credentials.COMMAND.yaml_entry.get_env_name() == "FLYTE_AUTH_COMMAND"
+        assert _internal.Credentials.PROXY_COMMAND.yaml_entry.get_env_name() == "FLYTE_AUTH_PROXY_COMMAND"
+
+    def test_entry_without_alias_still_derives_its_name(self):
+        """Only the auth entries are aliased; the rest of the scheme is untouched."""
+        from flyte.config import _internal
+
+        assert _internal.Platform.URL.yaml_entry.get_env_name() == "FLYTE_ADMIN_ENDPOINT"
+        assert _internal.Credentials.CLIENT_ID.yaml_entry.get_env_name() == "FLYTE_ADMIN_CLIENTID"
+
+    def test_derived_name_still_accepted(self, clean_env):
+        clean_env.setenv("FLYTE_ADMIN_AUTHTYPE", "ExternalCommand")
+        clean_env.setenv("FLYTE_ADMIN_COMMAND", "mint-token --audience flyte")
+
+        assert _auth_overrides_from_env() == {
+            "auth_type": "ExternalCommand",
+            "command": ["mint-token", "--audience", "flyte"],
+        }
+
+    def test_preferred_name_wins_over_derived(self, clean_env):
+        clean_env.setenv("FLYTE_AUTH_COMMAND", "preferred-token")
+        clean_env.setenv("FLYTE_ADMIN_COMMAND", "derived-token")
+
+        assert _auth_overrides_from_env()["command"] == ["preferred-token"]
+
+    def test_conflicting_values_are_reported(self, clean_env):
+        """Silently discarding one of two disagreeing settings is how a migration
+        goes wrong without anyone noticing."""
+        clean_env.setenv("FLYTE_AUTH_COMMAND", "preferred-token")
+        clean_env.setenv("FLYTE_ADMIN_COMMAND", "derived-token")
+
+        with captured_flyte_warnings() as warnings:
+            assert _auth_overrides_from_env()["command"] == ["preferred-token"]
+
+        assert len(warnings) == 1
+        assert "FLYTE_AUTH_COMMAND" in warnings[0]
+        assert "FLYTE_ADMIN_COMMAND" in warnings[0]
+
+    def test_agreeing_values_are_not_reported(self, clean_env):
+        clean_env.setenv("FLYTE_AUTH_COMMAND", "same-token")
+        clean_env.setenv("FLYTE_ADMIN_COMMAND", "same-token")
+
+        with captured_flyte_warnings() as warnings:
+            assert _auth_overrides_from_env()["command"] == ["same-token"]
+
+        assert warnings == []
 
 
 class TestInitInClusterEnvAuth:
     @pytest.mark.asyncio
     async def test_external_command_env_vars_reach_client_and_controller(self, clean_env):
         clean_env.setenv("_U_EP_OVERRIDE", "dns:///example.com:443")
-        clean_env.setenv("FLYTE_ADMIN_AUTHTYPE", "ExternalCommand")
-        clean_env.setenv("FLYTE_ADMIN_COMMAND", "mint-token --audience flyte")
+        clean_env.setenv("FLYTE_AUTH_TYPE", "ExternalCommand")
+        clean_env.setenv("FLYTE_AUTH_COMMAND", "mint-token --audience flyte")
 
         with patch("flyte._initialize.init", new_callable=AsyncMock) as mock_init:
             controller_kwargs = await init_in_cluster.aio()
@@ -110,8 +199,8 @@ class TestInitInClusterEnvAuth:
         clean_env.setenv("_U_EP_OVERRIDE", "dns:///example.com:443")
         clean_env.setenv("_UNION_EAGER_API_KEY", "legacy-composite-token")
         clean_env.setenv("EAGER_API_KEY", "another-token")
-        clean_env.setenv("FLYTE_ADMIN_AUTHTYPE", "ExternalCommand")
-        clean_env.setenv("FLYTE_ADMIN_COMMAND", "mint-token")
+        clean_env.setenv("FLYTE_AUTH_TYPE", "ExternalCommand")
+        clean_env.setenv("FLYTE_AUTH_COMMAND", "mint-token")
 
         with patch("flyte._initialize.init", new_callable=AsyncMock) as mock_init:
             controller_kwargs = await init_in_cluster.aio()
@@ -125,8 +214,8 @@ class TestInitInClusterEnvAuth:
         `_U_EP_OVERRIDE` is what the backend injects; `FLYTE_ADMIN_ENDPOINT` is the
         user-settable equivalent for the same reason the auth vars are."""
         clean_env.setenv("FLYTE_ADMIN_ENDPOINT", "dns:///byo.example.com:443")
-        clean_env.setenv("FLYTE_ADMIN_AUTHTYPE", "ExternalCommand")
-        clean_env.setenv("FLYTE_ADMIN_COMMAND", "mint-token")
+        clean_env.setenv("FLYTE_AUTH_TYPE", "ExternalCommand")
+        clean_env.setenv("FLYTE_AUTH_COMMAND", "mint-token")
 
         with patch("flyte._initialize.init", new_callable=AsyncMock):
             controller_kwargs = await init_in_cluster.aio()
@@ -146,8 +235,8 @@ class TestInitInClusterEnvAuth:
 
     @pytest.mark.asyncio
     async def test_explicit_api_key_arg_wins_over_env_auth(self, clean_env):
-        clean_env.setenv("FLYTE_ADMIN_AUTHTYPE", "ExternalCommand")
-        clean_env.setenv("FLYTE_ADMIN_COMMAND", "mint-token")
+        clean_env.setenv("FLYTE_AUTH_TYPE", "ExternalCommand")
+        clean_env.setenv("FLYTE_AUTH_COMMAND", "mint-token")
 
         with patch("flyte._initialize.init", new_callable=AsyncMock):
             controller_kwargs = await init_in_cluster.aio(api_key="explicit-key")


### PR DESCRIPTION
## Problem

A customer does not want the control plane issuing eager API keys to their task pods. They mint their own, more narrowly scoped tokens and want the SDK to authenticate with `ExternalCommand`, which we already support and prototyped with them.

`init_in_cluster` resolved credentials in this order:

1. an explicit `api_key=` argument
2. a mounted config file, if the pod has `UCTL_CONFIG` / `FLYTECTL_CONFIG` set
3. the injected `_UNION_EAGER_API_KEY` / `EAGER_API_KEY`

So the only way to opt out of the injected key was to mount a config file. There was no env-var-only route — even though every credentials config entry already derives an env var (`admin.authType` → `FLYTE_ADMIN_AUTHTYPE`).

Two things were also quietly broken along the way, and both had to be fixed for the env-var route to work end to end.

## What this does

A task pod can now carry:

```
FLYTE_AUTH_TYPE=ExternalCommand
FLYTE_AUTH_COMMAND="/usr/local/bin/mint-token --audience flyte"
```

and authenticate by running that command, with no API key issued to it at all.

- `FLYTE_AUTH_COMMAND` takes a shell-quoted command line, or a JSON array when an argument contains spaces. Its stdout is the access token, re-run on refresh.
- **Setting `FLYTE_AUTH_TYPE` disables the injected-key fallback outright** rather than layering on top of it, so a cluster still injecting a key mid-migration cannot have the two silently disagree.
- The endpoint still comes from the injected `_U_EP_OVERRIDE`, and now also accepts `FLYTE_ADMIN_ENDPOINT` — dropping the API key drops the endpoint it used to decode to.
- `FLYTE_AUTH_PROXY_COMMAND` is picked up independently of the auth type.
- An explicit `api_key=` argument still wins, and logs that it is ignoring the env vars instead of doing so quietly.
- `ExternalCommand` with no command raises at init, rather than deferring to an `AuthenticationError` on the first RPC that names neither env var.

The entries are read via `ConfigEntry.read()` with no config file, which consults only the environment. That deliberately keeps the pod off `resolve_config_path`, whose `git rev-parse` subprocess is wasted work in a task pod.

## Two bugs fixed on the way

**`FLYTE_ADMIN_COMMAND` was unusable even on the existing config-file path.** `ConfigEntry` applied no transform to env values, so a `list`-typed entry came back as the raw string and `asyncio.create_subprocess_exec(*self._cmd)` spread it *one argument per character*. Same shape for the proxy command and scopes. YAML already yields a list and is unaffected; the new transforms are idempotent on that path.

**`create_remote_controller` accepted `command` and threw it away.** It took `command`, `proxy_command`, `http_proxy_url` and `client_config` and never forwarded them to `ControllerClient`. Since `init_in_cluster` builds the SDK client and the controller from the same kwargs, `auth_type="ExternalCommand"` would have authenticated the client correctly while leaving the controller holding the auth mode with nothing to run — surfacing only as `AuthenticationError: Command cannot be empty for command authenticator` on the controller's first RPC. The controller is what enqueues and watches child actions, so eager tasks would have failed at the point of spawning work rather than at init.

`rpc_retries` is deliberately still not forwarded there: the controller has never installed the retry interceptor, and adding it would change retry behavior rather than fix a drop.

## On the env var names

These names are normally *derived*, not chosen: `get_env_name()` does `FLYTE_{SWITCH_UPPERCASED}`, so `admin.authType` → `FLYTE_ADMIN_AUTHTYPE`. That spelling leaks flyte-1 `flyteadmin` naming into something a customer has to type into a pod spec, and `read_from_env`'s docstring already called the scheme provisional.

Renaming outright would cost more than the wart. The scheme's one real virtue is that env var and config key are derivable from each other both ways; changing 2 of the 11 `admin.*` entries leaves no rule, just a lookup table with exceptions. The derived names are also public surface predating this feature — they are what the config-file path has always used.

So the preferred name is now explicit rather than implicit. `YamlConfigEntry` takes an `aliases` tuple checked ahead of the derived name; `get_env_name()` reports the preferred one (docs, error messages) and `env_names()` gives the precedence order.

| setting | preferred | still accepted |
|---|---|---|
| `admin.authType` | `FLYTE_AUTH_TYPE` | `FLYTE_ADMIN_AUTHTYPE` |
| `admin.command` | `FLYTE_AUTH_COMMAND` | `FLYTE_ADMIN_COMMAND` |
| `admin.proxyCommand` | `FLYTE_AUTH_PROXY_COMMAND` | `FLYTE_ADMIN_PROXYCOMMAND` |

Nothing that worked before stops working. When two names for one setting disagree the higher-precedence one wins and the conflict is logged rather than dropped silently — that ambiguity is how a migration goes wrong quietly; identical values are not reported.

Scoped deliberately to the three auth entries this feature documents. `FLYTE_ADMIN_ENDPOINT` keeps its derived name, since the endpoint is a platform setting rather than an auth one. Renaming the rest of the `admin.*` family is the scheme-wide change the code comment anticipates and wants its own discussion.

## Known gap

The opt-in Rust controller (`_F_USE_RUST_CONTROLLER=1`) reads the injected API key directly and does not honor these vars. Anyone on it cannot drop the key yet. Called out in the `init_in_cluster` docstring.

## Testing

- 18 new tests in `tests/user_api/test_init_in_cluster_env_auth.py` covering parsing (shlex, JSON array, quoted args), precedence (explicit auth type beats the injected key; explicit `api_key` beats the env vars; no env vars means unchanged legacy behavior), the endpoint fallback, the loud-failure case, the controller forwarding, and the alias mechanism (preferred name wins, derived name still honored, conflicts reported, non-aliased entries unchanged).
- Verified end to end that the env vars produce an `AsyncCommandAuthenticator` which runs the command and returns its stdout as the token.
- Full suite failure set is byte-identical before and after this change. `ruff` and `mypy` clean.

Note for reviewers running tests inside a Flyte task pod: `_U_EP_OVERRIDE` and `_UNION_EAGER_API_KEY` are live in that environment and leak into several tests, including a pre-existing one in `test_init_in_cluster_fallback.py`. Unset them for a clean run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUo1yWWgg9hxxgni4hm8XR
