### PR TITLE
fix: sign tracked-run uploads for as long as the PUT may take

### DIFF
--- a/src/flyte/_persistence/_remote_upload.py
+++ b/src/flyte/_persistence/_remote_upload.py
@@ -13,14 +13,12 @@ from __future__ import annotations
 import hashlib
 import typing
 from base64 import b64encode
-from datetime import timedelta
 
 if typing.TYPE_CHECKING:
     from flyteidl2.common import identifier_pb2
 
     from flyte.remote._client._protocols import DataProxyService
 
-_UPLOAD_EXPIRES_IN = timedelta(seconds=60)
 
 # Artifact kind -> stored filename. The kind doubles as the caller-facing vocabulary
 # (the old dataproxy ArtifactType INPUTS/OUTPUTS enum values are gone).
@@ -92,6 +90,14 @@ async def upload_tracked_run_artifact(
         content_length=len(data),
         add_content_md5_metadata=True,
     )
+    # Use the same derived lifetime as file uploads (`flyte.remote._data`) rather than a fixed
+    # 60s. These bytes go out through the very same `_put_signed_url_with_retry`, whose retry
+    # budget alone can outlast a 60s signature -- the failure mode that FLYTE-SDK-5F / 4B / 6C /
+    # 7G / 7H / 7K were, fixed for file uploads in #1363 but never applied to this call site.
+    # Importing it here (rather than at module scope) keeps this module's cold-path import
+    # discipline and picks up the FLYTE_UPLOAD_EXPIRES_IN override for free.
+    from flyte.remote._data import _UPLOAD_EXPIRES_IN
+
     req.expires_in.FromTimedelta(_UPLOAD_EXPIRES_IN)
     try:
         resp, cluster = await dataproxy.create_tracked_run_upload_location(req)

--- a/tests/persistence/test_remote_upload.py
+++ b/tests/persistence/test_remote_upload.py
@@ -19,6 +19,13 @@ from flyte.errors import RuntimeSystemError
 _RUN_ID = identifier_pb2.RunIdentifier(org="o", project="p", domain="d", name="local-x")
 
 
+def _data_module():
+    """Import `flyte.remote._data` lazily, the way the upload helper itself does."""
+    from flyte.remote import _data
+
+    return _data
+
+
 def _make_dataproxy(headers: dict | None = None, cluster: str = ""):
     dataproxy = MagicMock()
     dataproxy.create_tracked_run_upload_location = AsyncMock(
@@ -72,7 +79,7 @@ async def test_upload_tracked_run_artifact_success():
     assert req.content_md5 == hashlib.md5(data).digest()
     assert req.content_length == len(data)
     assert req.add_content_md5_metadata is True
-    assert req.expires_in.ToTimedelta().total_seconds() == 60
+    assert req.expires_in.ToTimedelta() == _data_module()._UPLOAD_EXPIRES_IN
 
     client.put.assert_awaited_once()
     put_call = client.put.await_args
@@ -232,3 +239,40 @@ async def test_put_bytes_retries_on_network_error():
         )
 
     assert client.put.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_tracked_run_signed_url_outlives_the_put_it_authorizes():
+    """The signed URL must stay valid at least as long as the PUT it authorizes.
+
+    Tracked-run metadata goes out through the very same `_put_signed_url_with_retry` as
+    file uploads, which allows a full `FLYTE_UPLOAD_TIMEOUT` per attempt and then retries.
+    This call site used to mint its URL with a hardcoded 60s lifetime, so the signature
+    could lapse ten times over before a single attempt even timed out -- the failure the
+    file-upload path was fixed for in #1363 (FLYTE-SDK-5F / 4B / 6C / 7G / 7H / 7K).
+
+    Pinning the derived constant instead of a literal is the point: it is what stops the
+    two paths that share one PUT helper from drifting apart again, and it carries the
+    FLYTE_UPLOAD_EXPIRES_IN override to this path for free.
+    """
+    data_mod = _data_module()
+    dataproxy = _make_dataproxy()
+    _, ctx = _mock_http_client([httpx.Response(200)])
+
+    with patch("httpx.AsyncClient", return_value=ctx):
+        await upload_tracked_run_artifact(
+            dataproxy,
+            kind="inputs",
+            run_id=_RUN_ID,
+            action_name="a0",
+            attempt=None,
+            data=b"serialized-proto-bytes",
+        )
+
+    req = dataproxy.create_tracked_run_upload_location.await_args[0][0]
+    signed_for = req.expires_in.ToTimedelta().total_seconds()
+
+    assert signed_for == data_mod._UPLOAD_EXPIRES_IN.total_seconds()
+    assert signed_for >= data_mod._UPLOAD_TIMEOUT_SECONDS, (
+        f"signed URL lives {signed_for}s but one PUT attempt may run for {data_mod._UPLOAD_TIMEOUT_SECONDS}s"
+    )


### PR DESCRIPTION
## What

`upload_tracked_run_artifact` minted its pre-signed upload URL with a **hardcoded 60s** lifetime:

```python
_UPLOAD_EXPIRES_IN = timedelta(seconds=60)
...
req.expires_in.FromTimedelta(_UPLOAD_EXPIRES_IN)
```

…and then handed that URL to `flyte.remote._data._put_signed_url_with_retry` — the *same* helper file uploads use, which allows a full `FLYTE_UPLOAD_TIMEOUT` (**600s** by default) per attempt, and then retries with backoff on top of that.

So a single PUT attempt could run **ten times longer than the signature authorizing it**. When it does, the object store answers with a plain authorization failure and the upload dies as `RuntimeSystemError: Upload failed for inputs.pb`.

## Why this call site

This is exactly the defect #1363 fixed for file uploads (FLYTE-SDK-5F, 4B, 6C, 7G, 7H, 7K — all now resolved). That PR derived the lifetime from the upload timeout plus a margin, clamped to the control plane's `upload.maxExpiresIn`:

```python
_UPLOAD_EXPIRES_IN_SECONDS = float(os.environ.get(
    "FLYTE_UPLOAD_EXPIRES_IN",
    min(_UPLOAD_TIMEOUT_SECONDS + _UPLOAD_EXPIRES_MARGIN_SECONDS, _UPLOAD_EXPIRES_CAP_SECONDS),
))
```

…but only wired it into `flyte/remote/_data.py`. `_persistence/_remote_upload.py` shares the PUT helper while keeping its own literal, so `flyte run --tracked` still signs `inputs.pb` / `outputs.pb` / `report.html` for 60s.

Reusing the derived constant also:
- brings the `FLYTE_UPLOAD_EXPIRES_IN` escape hatch to this path (it silently did nothing here), and
- makes the expiry error message truthful — it quotes the requested lifetime, and on this path it was quoting `_data`'s 900s while the URL actually lived 60s.

The import is function-local, matching this module's existing cold-path import discipline (it already imports `get_extra_headers_for_protocol` the same way).

## Not a Sentry issue — found by auditing #1363's call sites

Worth stating plainly so the diff isn't read as fixing reported events: **this path cannot appear in Sentry.** Tracked-run reporting is best-effort — failures are logged and swallowed unless `--tracked-strict` is set, and they then surface as `TrackedRunReportingError`, a plain `RuntimeError` that is not a `RuntimeSystemError` and so is never captured by `cli/_run.py`.

It was found by grepping the other callers of the function #1363 touched, rather than from the issue corpus. The user-visible effect is silently degraded tracked-run reporting (missing inputs/outputs/report artifacts), not a crash report.

## Test

Both assertions fail on clean `main` with the exact production numbers (`assert 60.0 == 900.0`) and pass here.

The regression test pins the **derived constant** rather than a literal, and separately asserts the signature outlives one PUT attempt:

```python
assert signed_for == data_mod._UPLOAD_EXPIRES_IN.total_seconds()
assert signed_for >= data_mod._UPLOAD_TIMEOUT_SECONDS
```

That second assertion is the point: it is what stops two paths sharing one PUT helper from drifting apart again. The pre-existing `== 60` assertion in `test_upload_tracked_run_artifact_success` is updated for the same reason.

`tests/persistence/` — 115 passed. ruff format + check, mypy, `ty`, and `check_docstring_style.py` all clean.