### PR TITLE
fix: bind Artifact overrides when firing a trigger with flyte.run(trigger, ...)

### DIFF
--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -887,7 +887,8 @@ class _Runner:
 
         The trigger is a saved launch configuration: its registered inputs and `RunSpec` (env
         vars, queue, notifications, ...) are the floor. Keyword inputs override individual
-        trigger inputs; `with_runcontext(...)` overrides layer on top of the trigger's run spec.
+        trigger inputs (a `flyte.remote.Artifact` binds as its stored literal, exactly as when
+        running a task); `with_runcontext(...)` overrides layer on top of the trigger's run spec.
         The run is created *as* the trigger, so the platform records it as trigger-fired, exactly
         like a scheduled fire. Inputs are resolved client-side (the server only restores a
         trigger's inputs when it fires with nothing else set), so an inline-registered trigger
@@ -901,7 +902,10 @@ class _Runner:
         from flyte.remote._trigger import Trigger as RemoteTrigger
         from flyte.remote._trigger import TriggerDetails
 
-        from ._internal.runtime.convert import KICKOFF_TIME_INPUT_ARG_CONTEXT_KEY, convert_from_native_to_inputs
+        from ._internal.runtime.convert import (
+            KICKOFF_TIME_INPUT_ARG_CONTEXT_KEY,
+            convert_from_native_to_inputs_binding_artifacts,
+        )
 
         if args:
             raise ValueError(
@@ -967,13 +971,16 @@ class _Runner:
                     f"{trigger_name.task_name!r}. Known inputs: {known}."
                 )
             # Only the overridden inputs are converted; the rest keep the trigger's literals.
+            # Same binding path as _run_remote, so a `flyte.remote.Artifact` override lands as its
+            # stored literal (coerced to the declared type, provenance stamp intact) instead of
+            # reaching the type engine as a foreign object.
             reduced_iface = NativeInterface(
                 inputs={k: v for k, v in iface.inputs.items() if k in kwargs},
                 outputs={},
                 _remote_defaults=iface._remote_defaults,
             )
-            converted = await convert_from_native_to_inputs(
-                reduced_iface, custom_context=self._custom_context, **kwargs
+            converted = await convert_from_native_to_inputs_binding_artifacts(
+                reduced_iface, (), kwargs, custom_context=self._custom_context
             )
             assert base_inputs is not None
             overrides = {lit.name: lit.value for lit in converted.proto_inputs.literals}

--- a/tests/flyte/test_run_trigger.py
+++ b/tests/flyte/test_run_trigger.py
@@ -220,6 +220,43 @@ async def test_run_trigger_override_adds_input_the_trigger_never_bound():
 
 
 @pytest.mark.asyncio
+async def test_run_trigger_artifact_override_binds_stored_literal():
+    """A `flyte.remote.Artifact` keyword override binds as the artifact's stored literal, with
+    its artifact_id stamp intact, the same way it does for flyte.run(task, ...)."""
+    from flyteidl2.artifact import artifact_pb2
+    from flyteidl2.core import artifact_id_pb2
+
+    from flyte.remote import Artifact
+    from flyte.types import TypeEngine
+
+    mock_client, _run_service, mock_dataproxy = _mock_client()
+    await _init_for_testing(client=mock_client, project="p", domain="d", org="o")
+    trigger = _trigger_details(inline_inputs={"region": _str("all"), "days": _int(30)})
+
+    version_id = artifact_id_pb2.ArtifactVersionId(
+        key=artifact_id_pb2.ArtifactKey(org="o", project="p", domain="d", name="region_pick"), version="3"
+    )
+    stored = _str("eu")
+    stored.artifact_id.CopyFrom(version_id)
+    artifact = Artifact(
+        pb2=artifact_pb2.Artifact(
+            artifact_id=artifact_pb2.ArtifactIdentifier(
+                name=artifact_pb2.ArtifactName(org="o", project="p", domain="d", name="region_pick"), version="3"
+            ),
+            spec=artifact_pb2.ArtifactSpec(value=stored, type=TypeEngine.to_literal_type(str)),
+        )
+    )
+
+    with _patched_task_get(_task_details()):
+        await flyte.run.aio(trigger, region=artifact)
+
+    uploaded = _literals(mock_dataproxy.upload_inputs.call_args[0][0].inputs)
+    assert uploaded["days"] == _int(30)
+    assert uploaded["region"].scalar.primitive.string_value == "eu"
+    assert uploaded["region"].artifact_id == version_id
+
+
+@pytest.mark.asyncio
 async def test_run_trigger_explicit_kickoff_input_drops_marker():
     """Passing the TriggerTime-bound input explicitly removes the kickoff marker so the runtime
     does not overwrite the value with run_start_time; otherwise the marker is kept."""


### PR DESCRIPTION
## Why

`flyte.run(trigger, model=<flyte.remote.Artifact>)` raises `TypeTransformerFailedError: Expected value of type File but got Artifact(...)`. `_run_trigger` converts keyword overrides with `convert_from_native_to_inputs`, which does no artifact binding, while `_run_remote` uses `convert_from_native_to_inputs_binding_artifacts`.

Firing an artifact trigger by hand is the main case: no new version is being published, so the caller has to pass the `flyte.TriggeredArtifact` input themselves, and the natural thing to pass is the `Artifact` object. Found by the docsy review on unionai/unionai-docs#1578, which documents exactly this flow.

## What

- `_run_trigger` now uses the same binding path as `_run_remote`, so an `Artifact` override lands as its stored literal, coerced to the declared input type, with its `artifact_id` provenance stamp intact.
- Regression test `test_run_trigger_artifact_override_binds_stored_literal`. It fails on `main` with the error above and passes with the fix.

The docs PR states this needs flyte 2.7.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZb1h3fcHSSjdVGA1FsRYc
