### PR TITLE
fix: clamp Backoff.compute_delay to the cap instead of overflowing

### DIFF
--- a/src/flyte/_retry.py
+++ b/src/flyte/_retry.py
@@ -65,7 +65,17 @@ class Backoff:
         """
         if n < 0:
             raise ValueError(f"Retry index n must be >= 0, got {n}")
-        delay = self.base * (self.factor**n)
+        try:
+            delay = self.base * (self.factor**n)
+        except OverflowError:
+            # `base * factor**n` leaves the float/timedelta range long before the retry
+            # index does: n=43 already overflows for base=10s, factor=2.0. Overflowing
+            # means the uncapped delay is far past the cap, so the cap is the answer.
+            # __post_init__ requires a cap whenever factor > 1.0, and factor == 1.0
+            # cannot overflow, so a cap is always present here.
+            if self.cap is None:
+                raise
+            return self.cap
         if self.cap is not None and delay > self.cap:
             return self.cap
         return delay

--- a/tests/user_api/test_retry_strategy.py
+++ b/tests/user_api/test_retry_strategy.py
@@ -58,6 +58,32 @@ def test_backoff_with_factor_and_cap():
     assert b.compute_delay(20) == timedelta(minutes=5)
 
 
+def test_backoff_large_n_stays_capped():
+    # `base * factor**n` overflows the timedelta range around n=43 for this policy.
+    # The cap exists to bound growth, so every n past it must still return the cap
+    # rather than raising OverflowError.
+    b = Backoff(base=timedelta(seconds=10), factor=2.0, cap=timedelta(minutes=5))
+    for n in (43, 50, 100, 1_000, 100_000):
+        assert b.compute_delay(n) == timedelta(minutes=5)
+
+
+def test_backoff_capped_across_full_retry_count():
+    # RetryStrategy(count=100) is a supported configuration, and the local controller
+    # calls compute_delay(attempt_num - 1) for every attempt, so the whole range has
+    # to be computable.
+    b = Backoff(base=timedelta(seconds=1), factor=2.0, cap=timedelta(minutes=1))
+    delays = [b.compute_delay(n) for n in range(100)]
+    assert delays[0] == timedelta(seconds=1)
+    assert all(d <= timedelta(minutes=1) for d in delays)
+    assert delays[-1] == timedelta(minutes=1)
+
+
+def test_backoff_constant_factor_large_n():
+    # factor == 1.0 needs no cap and must not overflow either.
+    b = Backoff(base=timedelta(seconds=2))
+    assert b.compute_delay(1_000_000) == timedelta(seconds=2)
+
+
 def test_backoff_zero_base():
     b = Backoff(base=timedelta(0))
     assert b.compute_delay(0) == timedelta(0)


### PR DESCRIPTION
## Why

`Backoff` requires a `cap` whenever `factor > 1.0`, and says exactly why:

```python
if self.factor > 1.0 and self.cap is None:
    raise ValueError("Backoff.cap is required when factor > 1.0 to prevent unbounded growth")
```

`compute_delay` then computed the unbounded product *before* comparing it to that cap, so the growth the cap is there to prevent happened anyway and overflowed the `timedelta` range:

```python
delay = self.base * (self.factor**n)      # overflows here
if self.cap is not None and delay > self.cap:
    return self.cap
return delay
```

Using the policy from the `RetryStrategy` docstring:

```python
b = Backoff(base=timedelta(seconds=10), factor=2.0, cap=timedelta(minutes=5))
b.compute_delay(20)   # 0:05:00  — capped, fine
b.compute_delay(43)   # OverflowError: days=1628906115; must have magnitude <= 999999999
```

The documented formula is `min(base * factor**n, cap)`, and `min` against a 5-minute cap cannot exceed 5 minutes. The first failing index is low enough to hit in practice — n=43 for the above, n=42 for `base=30s, factor=2.0, cap=1h`.

## Impact

`RetryStrategy(count=100)` is a supported configuration (asserted in `test_retry_strategy_high_count`), and the local controller calls `compute_delay` once per attempt:

```python
# src/flyte/_internal/controllers/_local_controller.py:281
backoff = user_backoff.compute_delay(attempt_num - 1).total_seconds()
```

So a task with a high retry count and exponential backoff retried normally for 43 attempts and then raised `OverflowError` on attempt 44 — from inside the failure-handling path, so the retry loop itself is what broke. The remaining ~56 attempts were lost, and the traceback pointed at `timedelta` arithmetic with nothing to connect it to the retry policy.

## What changed

`compute_delay` catches the overflow and returns the cap. `__post_init__` guarantees a cap whenever `factor > 1.0`, and `factor == 1.0` cannot overflow, so a cap is always present on that path; the bare `raise` is defensive and unreachable.

Behaviour for every non-overflowing `n` is byte-for-byte unchanged — the fix only adds a branch that previously raised.

## Tests

Three tests added to `tests/user_api/test_retry_strategy.py`:

- `test_backoff_large_n_stays_capped` — n = 43, 50, 100, 1_000, 100_000 all return the cap
- `test_backoff_capped_across_full_retry_count` — the whole `count=100` range is computable and stays under the cap
- `test_backoff_constant_factor_large_n` — guards the `factor == 1.0` path, which needs no cap

The first two fail on `main` with `OverflowError` and pass with this change. Existing coverage stopped at `n=20`, just under the threshold.

## Checks

- `make fmt` — clean
- `make mypy` — `Success: no issues found in 870 source files`
- `make check-docstrings` — `523 files clean`
- `make unit_test` — no new failures

Fixes flyteorg/flyte#7990
