### PR TITLE
fix: map disk to ephemeral-storage and skip shm in pod_spec_from_resources

### DIFF
--- a/src/flyte/_resources.py
+++ b/src/flyte/_resources.py
@@ -509,24 +509,31 @@ def pod_spec_from_resources(
         if resources is None:
             return None
 
+        # Maps a `Resources` field onto its container resource key. `shm` is deliberately
+        # absent: shared memory is a volume, surfaced through `ExtendedResources` rather
+        # than as a key under container resources, so it is skipped here along with any
+        # other field that has no container-level equivalent.
         resources_map = {
             "cpu": "cpu",
             "memory": "memory",
             "gpu": k8s_gpu_resource_key,
-            "ephemeral_storage": "ephemeral-storage",
+            "disk": "ephemeral-storage",
         }
 
         k8s_pod_resources = {}
 
         _check_resource_is_singular(resources)
         for resource in fields(resources):
+            k8s_resource_name = resources_map.get(resource.name)
+            if k8s_resource_name is None:
+                continue
             resource_value = getattr(resources, resource.name)
             if resource_value is not None:
                 if resource.name == "gpu":
                     device = resources.get_device()
                     if device is not None:
                         resource_value = str(device.quantity)
-                k8s_pod_resources[resources_map[resource.name]] = resource_value
+                k8s_pod_resources[k8s_resource_name] = resource_value
 
         return k8s_pod_resources
 

--- a/tests/user_api/test_resources.py
+++ b/tests/user_api/test_resources.py
@@ -567,6 +567,8 @@ def test_pod_spec_from_resources_disk_in_requests_and_limits():
     resources = pod_spec.containers[0].resources
     assert resources.requests == {"cpu": 1, "ephemeral-storage": "10Gi"}
     assert resources.limits == {"cpu": 2, "ephemeral-storage": "20Gi"}
+
+
 def test_resources_gpu_zero_has_no_device():
     # __post_init__ accepts any count >= 0, so gpu=0 means "no accelerator" and must
     # report the same absent device as an unset gpu rather than raising.

--- a/tests/user_api/test_resources.py
+++ b/tests/user_api/test_resources.py
@@ -16,6 +16,7 @@ from flyte._resources import (
     NeuronType,
     Resources,
     TPUType,
+    pod_spec_from_resources,
 )
 
 
@@ -521,3 +522,47 @@ def test_habana_gaudi_type_accelerators_synchronization():
     assert not missing_in_habana_gaudi_type, (
         f"Habana Gaudi types in Accelerators but missing in HABANA_GAUDIType: {missing_in_habana_gaudi_type}"
     )
+
+
+def test_pod_spec_from_resources_maps_disk_to_ephemeral_storage():
+    # `disk` is the v2 name for what k8s calls `ephemeral-storage`; the serde path
+    # maps it onto Resources.ResourceName.EPHEMERAL_STORAGE, so the pod spec has to
+    # agree.
+    pod_spec = pod_spec_from_resources(requests=Resources(cpu=1, memory="1Gi", disk="10Gi"))
+
+    requests = pod_spec.containers[0].resources.requests
+    assert requests == {"cpu": 1, "memory": "1Gi", "ephemeral-storage": "10Gi"}
+
+
+def test_pod_spec_from_resources_skips_shm():
+    # Shared memory is a volume surfaced through ExtendedResources, not a container
+    # resource key, so it must not appear under requests/limits -- and must not raise.
+    pod_spec = pod_spec_from_resources(requests=Resources(cpu=1, memory="1Gi", shm="2Gi"))
+
+    requests = pod_spec.containers[0].resources.requests
+    assert requests == {"cpu": 1, "memory": "1Gi"}
+
+
+def test_pod_spec_from_resources_all_fields():
+    pod_spec = pod_spec_from_resources(
+        requests=Resources(cpu=2, memory="4Gi", gpu="A100:4", disk="50Gi", shm="1Gi"),
+    )
+
+    requests = pod_spec.containers[0].resources.requests
+    assert requests == {
+        "cpu": 2,
+        "memory": "4Gi",
+        "nvidia.com/gpu": "4",
+        "ephemeral-storage": "50Gi",
+    }
+
+
+def test_pod_spec_from_resources_disk_in_requests_and_limits():
+    pod_spec = pod_spec_from_resources(
+        requests=Resources(cpu=1, disk="10Gi"),
+        limits=Resources(cpu=2, disk="20Gi"),
+    )
+
+    resources = pod_spec.containers[0].resources
+    assert resources.requests == {"cpu": 1, "ephemeral-storage": "10Gi"}
+    assert resources.limits == {"cpu": 2, "ephemeral-storage": "20Gi"}


### PR DESCRIPTION
## Why

`pod_spec_from_resources` walks every field of `Resources` and looks each one up in an unguarded dict:

```python
resources_map = {
    "cpu": "cpu",
    "memory": "memory",
    "gpu": k8s_gpu_resource_key,
    "ephemeral_storage": "ephemeral-storage",   # no such field on Resources
}
...
k8s_pod_resources[resources_map[resource.name]] = resource_value
```

`Resources` declares `cpu, memory, gpu, disk, shm`. The map is keyed on `ephemeral_storage` — the flytekit v1 name for what v2 calls `disk` — and has no entry for `shm`, so either field raises:

```python
pod_spec_from_resources(requests=Resources(cpu=1, disk="10Gi"))  # KeyError: 'disk'
pod_spec_from_resources(requests=Resources(cpu=1, shm="2Gi"))    # KeyError: 'shm'
```

`ephemeral_storage` was the only occurrence of that spelling left in `src/`.

## Impact

The function is public — exported from `flyte.extend` and in its `__all__` — and the Ray plugin calls it for every head/worker group that sets resources (`plugins/ray/src/flyteplugins/ray/task.py:86`). Going through the plugin's own `_build_node_pod_template`:

```
before:  ray worker, disk  -> KeyError: 'disk'
         ray worker, shm   -> KeyError: 'shm'
after:   ray worker, disk  -> {'cpu': 1, 'memory': '1Gi', 'ephemeral-storage': '10Gi'}
         ray worker, shm   -> {'cpu': 1, 'memory': '1Gi'}
```

So a Ray task requesting ephemeral disk — ordinary for a shuffle- or spill-heavy job — failed before submitting anything. Both fields are documented on `Resources`, and `shm` is documented as "useful for ML data loading", squarely Ray's use case.

## What changed

The serde path already settles what both fields mean, so the mapping isn't a judgement call:

- `disk` → `ResourceName.EPHEMERAL_STORAGE` via `_get_disk_resource_entry` (`resources_serde.py:80`), i.e. the `ephemeral-storage` container key.
- `shm` → `ExtendedResources.shared_memory` mounted at `/dev/shm` via `get_proto_extended_resources` (`resources_serde.py:96`). That's a volume, not a container resource key, so it must not appear under `requests`/`limits`.

This keys `disk` to `ephemeral-storage`, drops the stale `ephemeral_storage` entry, and skips fields with no entry in the map — which leaves `shm` out of container resources where it belongs, and makes a future `Resources` field a silent skip rather than a crash.

`cpu`, `memory`, and `gpu` behaviour is unchanged, including the `nvidia.com/gpu` key and the requests/limits mirroring.

## Tests

Four tests added to `tests/user_api/test_resources.py` — the function had no coverage at all:

- `test_pod_spec_from_resources_maps_disk_to_ephemeral_storage`
- `test_pod_spec_from_resources_skips_shm`
- `test_pod_spec_from_resources_all_fields` — cpu + memory + gpu + disk + shm together
- `test_pod_spec_from_resources_disk_in_requests_and_limits`

All four fail on `main` with the exact `KeyError`s and pass with this change.

## Checks

- `make fmt` — clean
- `make mypy` — `Success: no issues found in 870 source files`
- `make check-docstrings` — `523 files clean`
- `codespell` — clean
- `make unit_test` — no new failures
- Ray plugin suite — 15 passed

Fixes flyteorg/flyte#7991
