### PR TITLE
fix: mirror sys.path entries reached through a symlinked root

### DIFF
--- a/src/flyte/_run.py
+++ b/src/flyte/_run.py
@@ -4,7 +4,6 @@ import asyncio
 import contextvars
 import os
 import pathlib
-import sys
 import uuid
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Sequence, Tuple, Union, cast
@@ -34,7 +33,6 @@ from flyte.syncify import syncify
 
 # ``flyte.storage.join`` is imported lazily inside the one method that needs it so
 # ``import flyte`` does not eagerly pull fsspec/obstore/etc. into the startup path.
-from ._constants import FLYTE_SYS_PATH
 from ._sentry import track_operation
 
 if TYPE_CHECKING:
@@ -489,12 +487,9 @@ class _Runner:
 
         # These paths will be appended to sys.path at runtime.
         if cfg.sync_local_sys_paths:
-            root_dir_abs = pathlib.Path(cfg.root_dir).resolve()
-            env[FLYTE_SYS_PATH] = ":".join(
-                f"./{pathlib.Path(p).relative_to(root_dir_abs)}"
-                for p in sys.path
-                if pathlib.Path(p).is_relative_to(root_dir_abs)
-            )
+            from ._utils import local_sys_paths_env
+
+            env.update(local_sys_paths_env(cfg.root_dir))
 
         # TODO: Remove once the actions service is the default and this env var is no longer needed.
         if os.getenv("_U_USE_ACTIONS") == "1":

--- a/src/flyte/_utils/module_loader.py
+++ b/src/flyte/_utils/module_loader.py
@@ -164,6 +164,28 @@ def _load_module_from_file(file_path: Path) -> str | None:
         raise flyte.errors.ModuleLoadError(f"Failed to load module from {file_path}: {e}") from e
 
 
+def _relative_sys_path_entry(path: str, root_dir: Path, resolved_root: Path) -> str | None:
+    """Spell `path` relative to `root_dir`, or return None when it does not live under the root.
+
+    A path that is already a literal subpath is used as-is. Resolving those would follow symlinks that
+    legitimately point outside the root — `.venv/bin` is the canonical case — and drop them, the same
+    constraint `_code_bundle._utils._rebase_under_source` documents.
+
+    Only a path that is *not* a literal subpath is resolved, which is what catches a root reached through
+    a symlink: on macOS `/tmp` is a symlink to `/private/tmp`, so the root resolves to `/private/tmp/proj`
+    while `sys.path` still carries `/tmp/proj/pkg`. Both writers record entries with `abspath`
+    (`_initialize.py` for the root itself, `_load_module_from_file` for a loaded module's directory), and
+    `abspath` does not resolve symlinks, so comparing them against a resolved root matched nothing.
+    """
+    p = Path(path)
+    if p.is_relative_to(root_dir):
+        return f"./{p.relative_to(root_dir)}"
+    try:
+        return f"./{p.resolve().relative_to(resolved_root)}"
+    except (ValueError, OSError):
+        return None
+
+
 def local_sys_paths_env(root_dir: Path) -> dict[str, str]:
     """
     Mirror the local `sys.path` entries that live under `root_dir` as the `FLYTE_SYS_PATH` env var.
@@ -172,12 +194,22 @@ def local_sys_paths_env(root_dir: Path) -> dict[str, str]:
     at runtime, where the code bundle is extracted into the working directory. This is what lets a task or app
     module import its sibling files (`from _agent import ...`) when it was loaded from a subdirectory of the
     root directory.
+
+    An entry that does not live under the root is skipped rather than reported: it has no meaning once the
+    bundle is extracted somewhere else. Entries are de-duplicated because the same directory can reach us
+    under two spellings (`/tmp/proj/pkg` and `/private/tmp/proj/pkg`) that rewrite to one relative path.
     """
-    root_dir_abs = Path(root_dir).resolve()
-    value = ":".join(
-        f"./{Path(path).relative_to(root_dir_abs)}" for path in sys.path if Path(path).is_relative_to(root_dir_abs)
-    )
-    return {FLYTE_SYS_PATH: value}
+    root_dir_abs = Path(os.path.abspath(root_dir))
+    resolved_root = root_dir_abs.resolve()
+    entries: List[str] = []
+    for path in sys.path:
+        if not path:
+            # The conventional "current directory" entry; `adjust_sys_path` re-adds it at runtime.
+            continue
+        entry = _relative_sys_path_entry(path, root_dir_abs, resolved_root)
+        if entry is not None and entry not in entries:
+            entries.append(entry)
+    return {FLYTE_SYS_PATH: ":".join(entries)}
 
 
 def adjust_sys_path(additional_paths: List[str] | None = None):

--- a/tests/flyte/utils/test_module_loader.py
+++ b/tests/flyte/utils/test_module_loader.py
@@ -7,7 +7,8 @@ import click
 import pytest
 
 import flyte.errors
-from flyte._utils.module_loader import load_python_modules
+from flyte._constants import FLYTE_SYS_PATH
+from flyte._utils.module_loader import load_python_modules, local_sys_paths_env
 
 
 @pytest.fixture
@@ -366,3 +367,82 @@ def test_load_python_modules_single_file_wraps_runtime_error(tmp_path):
     assert "workflow.py" in msg
     assert "RuntimeError" in msg
     assert "union.sandbox" in msg
+
+
+def _symlinked_root(tmp_path: Path) -> tuple[Path, Path]:
+    """Build `real/` plus a `link -> real` symlink, mirroring macOS's /tmp -> /private/tmp."""
+    real = tmp_path / "real"
+    real.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(real, target_is_directory=True)
+    return real, link
+
+
+def _sys_paths_for(root_dir: Path, entries: list[str]) -> list[str]:
+    """Run local_sys_paths_env over an explicit sys.path so ambient entries cannot affect the result."""
+    with patch.object(sys, "path", list(entries)):
+        value = local_sys_paths_env(root_dir)[FLYTE_SYS_PATH]
+    return [p for p in value.split(":") if p]
+
+
+@pytest.mark.parametrize("root_spelling", ["real", "link"])
+def test_local_sys_paths_env_keeps_entry_reached_through_a_symlinked_root(tmp_path, root_spelling):
+    """A sys.path entry spelled through a symlink to the root must still be mirrored.
+
+    The root was resolved while the sys.path entries were not, so on a symlinked root nothing
+    matched and `_F_SYS_PATH` shipped empty. Nothing raised — the task or app simply lost the
+    path it needed to import its sibling modules and failed inside the container with a
+    ModuleNotFoundError. Both writers record entries with `abspath`, which does not resolve
+    symlinks: `_initialize.py` for the root itself and `_load_module_from_file` for a loaded
+    module's directory. Same root cause as FLYTE-SDK-7E, on the silent side.
+    """
+    real, link = _symlinked_root(tmp_path)
+    (real / "pkg").mkdir()
+    root_dir = real if root_spelling == "real" else link
+
+    assert _sys_paths_for(root_dir, [str(link / "pkg")]) == ["./pkg"]
+
+
+def test_local_sys_paths_env_keeps_a_symlink_inside_the_root_unresolved(tmp_path):
+    """A symlink under the root pointing outside it must keep its in-root spelling.
+
+    `.venv/lib -> /usr/lib/...` is the canonical case: resolving it would push the path outside
+    the root and drop it. Only entries that are *not* already literal subpaths get resolved, the
+    same constraint `_code_bundle._utils._rebase_under_source` documents. This passes before and
+    after the fix by design — it is a regression guard, not a repro.
+    """
+    root = tmp_path / "proj"
+    root.mkdir()
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    (root / ".venv").symlink_to(outside, target_is_directory=True)
+
+    assert _sys_paths_for(root, [str(root / ".venv")]) == ["./.venv"]
+
+
+def test_local_sys_paths_env_skips_entries_outside_the_root(tmp_path):
+    """An entry that is nowhere under the root has no meaning once the bundle is extracted."""
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "pkg").mkdir()
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+
+    assert _sys_paths_for(root, [str(outside), str(root / "pkg")]) == ["./pkg"]
+
+
+def test_local_sys_paths_env_deduplicates_two_spellings_of_one_directory(tmp_path):
+    """Rewriting makes `/tmp/proj/pkg` and `/private/tmp/proj/pkg` collapse to one relative entry."""
+    real, link = _symlinked_root(tmp_path)
+    (real / "pkg").mkdir()
+
+    assert _sys_paths_for(real, [str(link / "pkg"), str(real / "pkg")]) == ["./pkg"]
+
+
+def test_local_sys_paths_env_skips_the_empty_current_directory_entry(tmp_path):
+    """`sys.path` carries '' for the current directory; `adjust_sys_path` re-adds it at runtime."""
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "pkg").mkdir()
+
+    assert _sys_paths_for(root, ["", str(root / "pkg")]) == ["./pkg"]


### PR DESCRIPTION
## What

`local_sys_paths_env` mirrors the local `sys.path` entries under the project root into `_F_SYS_PATH`, so a task or app module can import its sibling files (`from _agent import ...`) once the code bundle is extracted in the container. It compares each entry against a **resolved** root:

```python
root_dir_abs = Path(root_dir).resolve()
value = ":".join(
    f"./{Path(path).relative_to(root_dir_abs)}"
    for path in sys.path
    if Path(path).is_relative_to(root_dir_abs)
)
```

The entries themselves are never resolved, and both writers record them with `abspath`, which normalizes but does not follow symlinks — `_initialize.py:352` for the root itself, `_load_module_from_file` for a loaded module's directory. So whenever the root is reached through a symlink the two spellings never match. On macOS `/tmp` is a symlink to `/private/tmp`: the root resolves to `/private/tmp/proj` while `sys.path` still carries `/tmp/proj/pkg`.

**Nothing raises.** `is_relative_to` guards the `relative_to`, so the entry is simply dropped and `_F_SYS_PATH` ships empty. The task or app then loses the path it needed and fails inside the container with a `ModuleNotFoundError` on a sibling import — the exact failure this env var exists to prevent.

A repro against `main` shows the entry is dropped under **both** spellings of the root, so passing the real path is not a workaround:

```
sys.path entry as the SDK records it : /private/var/folders/.../tmpXXXX/link/pkg
  [DROP] root spelled through symlink     -> _F_SYS_PATH=''
  [DROP] root spelled as real path        -> _F_SYS_PATH=''
```

## Why this shape

This is the silent half of the same path-containment bug [FLYTE-SDK-7E](https://unionai.sentry.io/issues/?query=FLYTE-SDK-7E) / #1441 fixes for the code bundle, at a site that PR does not touch. The fix takes the same approach as its `_rebase_under_source`: **a literal subpath is kept as-is, and only a path that is not a literal subpath is resolved.**

That ordering is the whole point and is not incidental — resolving everything would follow a symlink that legitimately points *outside* the root (`.venv/lib -> /usr/lib/...` is the canonical case), push the path out of the root, and drop it. That is why `create_bundle` deliberately keeps those unresolved.

## Also in this PR

- **Folds the third copy of this logic into the shared helper.** #1539 extracted `local_sys_paths_env` out of `_deploy.py` and added an `app_serde.py` caller, but left the `flyte run` copy at `_run.py:492` inline, where it carried the same bug independently. All three paths (`flyte deploy`, `flyte run`, app serialization) now go through one implementation.
- **De-duplicates entries.** With the fix, `/tmp/proj/pkg` and `/private/tmp/proj/pkg` can both be on `sys.path` and rewrite to the same relative path.
- **Skips the empty `''` entry explicitly** (the conventional "current directory"); `adjust_sys_path` re-adds it at runtime. This preserves existing behaviour, where `Path('')` became `Path('.')` and was filtered out.

## Tests

Two of the five new tests are genuine repros — they fail on clean `main` with the production symptom (`[]` instead of `['./pkg']`) and pass here:

```
FAILED test_local_sys_paths_env_keeps_entry_reached_through_a_symlinked_root[real]
FAILED test_local_sys_paths_env_keeps_entry_reached_through_a_symlinked_root[link]
```

The other three pass on both sides **by design** — they are regression guards, not repros. `..._keeps_a_symlink_inside_the_root_unresolved` in particular pins the `.venv` constraint above, so a later "just resolve everything" simplification fails loudly.

## Notes for the reviewer

- **No Sentry issue.** The client-side failure is a silent drop, and the resulting `ModuleNotFoundError` happens in the container, outside the four `capture_exception` extents — so this class cannot appear in Sentry by construction. Filed under `sentry-fix` because it came out of the Sentry fix-site audit and is the sibling of #1441.
- `make fmt`, `ruff check`, `mypy`, `ty`, and `check-docstrings` are all clean on the changed files. The 4 pre-existing `tests/flyte/test_deploy.py` failures in my sandbox (`Protocol message TaskMetadata has no "cache_max_age" field`) reproduce identically on clean `main` — stale local protobufs, not this diff.