### PR TITLE
fix: treat Resources(gpu=0) as no accelerator instead of raising

### DIFF
--- a/src/flyte/_resources.py
+++ b/src/flyte/_resources.py
@@ -460,6 +460,11 @@ class Resources:
         if self.gpu is None:
             return None
         if isinstance(self.gpu, int):
+            # `gpu=0` is a valid way to say "no accelerator" -- __post_init__ accepts any
+            # count >= 0 -- and is what a computed count collapses to. `Device` requires a
+            # quantity of at least 1, so report it the same way an unset `gpu` is reported.
+            if self.gpu == 0:
+                return None
             return Device(quantity=self.gpu, device_class="GPU")
         if isinstance(self.gpu, str):
             device, portion = self.gpu.split(":")

--- a/tests/user_api/test_resources.py
+++ b/tests/user_api/test_resources.py
@@ -1,6 +1,7 @@
 from typing import get_args
 
 import pytest
+from flyteidl2.core import tasks_pb2
 
 from flyte._resources import (
     AMD_GPU,
@@ -521,3 +522,32 @@ def test_habana_gaudi_type_accelerators_synchronization():
     assert not missing_in_habana_gaudi_type, (
         f"Habana Gaudi types in Accelerators but missing in HABANA_GAUDIType: {missing_in_habana_gaudi_type}"
     )
+
+
+def test_resources_gpu_zero_has_no_device():
+    # __post_init__ accepts any count >= 0, so gpu=0 means "no accelerator" and must
+    # report the same absent device as an unset gpu rather than raising.
+    res = Resources(gpu=0)
+    assert res.gpu == 0
+    assert res.get_device() is None
+
+
+def test_resources_gpu_zero_serializes_without_a_gpu_entry():
+    from flyte._internal.runtime.resources_serde import get_proto_resources
+
+    proto = get_proto_resources(Resources(cpu=1, gpu=0))
+
+    assert proto is not None
+    names = [entry.name for entry in proto.requests]
+    assert tasks_pb2.Resources.ResourceName.GPU not in names
+    assert tasks_pb2.Resources.ResourceName.CPU in names
+
+
+def test_resources_gpu_positive_still_serializes_a_gpu_entry():
+    from flyte._internal.runtime.resources_serde import get_proto_resources
+
+    proto = get_proto_resources(Resources(cpu=1, gpu=2))
+
+    assert proto is not None
+    gpu_entries = [e for e in proto.requests if e.name == tasks_pb2.Resources.ResourceName.GPU]
+    assert [e.value for e in gpu_entries] == ["2"]


### PR DESCRIPTION
## Why

`Resources` accepts `gpu=0` and then fails on the way to the backend.

`__post_init__` validates the count as `>= 0`, and the suite pins that boundary — `test_resources_gpu_with_negative_int` asserts `-1` is rejected with exactly *"gpu must be greater than or equal to 0"*, which makes `0` the intended valid edge. But `get_device()` handed the count straight to `Device`, which requires `quantity >= 1`:

```python
if isinstance(self.gpu, int):
    return Device(quantity=self.gpu, device_class="GPU")   # Device demands >= 1
```

Two validators, opposite answers for the same value.

## Impact

This isn't limited to calling `get_device()` directly — it breaks the serialization path every task goes through. `_convert_resources_to_resource_entries` guards on `is not None`, and `0 is not None`:

```python
if resources.gpu is not None:
    device = resources.get_device()      # raises for gpu=0
```

```python
get_proto_resources(Resources(cpu=1, gpu=0))
# ValueError: GPU quantity must be at least 1
```

So a computed count is a trap:

```python
@env.task(resources=flyte.Resources(cpu=1, gpu=num_gpus))   # num_gpus == 0 for the CPU variant
async def train(): ...
```

The task builds cleanly, then fails at registration with a message naming neither the field the user set nor the value behind it.

## What changed

`get_device()` returns `None` for `gpu == 0`, which is what "no accelerator" already means downstream. Both `resources_serde` call sites already handle a `None` device (`_convert_resources_to_resource_entries` checks `if device is not None`, and `_get_gpu_extended_resource_entry` already returns `None` for any `int` gpu), so no GPU entry is emitted and nothing else moves:

```
gpu=0  ->  requests { name: CPU value: "1" }
gpu=1  ->  requests { name: CPU value: "1" }  requests { name: GPU value: "1" }
```

The alternative — rejecting `0` in `__post_init__` — would contradict the documented `>= 0` rule and break the existing boundary test, so it looks like the wrong direction.

## Tests

Three tests added to `tests/user_api/test_resources.py`:

- `test_resources_gpu_zero_has_no_device`
- `test_resources_gpu_zero_serializes_without_a_gpu_entry`
- `test_resources_gpu_positive_still_serializes_a_gpu_entry` — guards the positive path against regression

The first two fail on `main` with `ValueError: GPU quantity must be at least 1` and pass with this change; the third passes either way by design.

## Checks

- `make fmt` — clean
- `make mypy` — `Success: no issues found in 870 source files`
- `make check-docstrings` — `523 files clean`
- `codespell` — clean
- `make unit_test` — no new failures

Fixes flyteorg/flyte#7995
