### PR TITLE
fix: add V5E to TPUType so TPU v5e is reachable

### DIFF
--- a/src/flyte/_resources.py
+++ b/src/flyte/_resources.py
@@ -35,8 +35,11 @@ H200Parts = Literal["1g.18gb", "1g.35gb", "2g.35gb", "3g.71gb", "4g.71gb", "7g.1
 Partitions for NVIDIA H200 GPU (141GB HBM3e).
 """
 
-TPUType = Literal["V5P", "V6E"]
+TPUType = Literal["V5E", "V5P", "V6E"]
 V5EParts = Literal["1x1", "2x2", "2x4", "4x4", "4x8", "8x8", "8x16", "16x16"]
+"""
+Slices for Google Cloud TPU v5e.
+"""
 
 V5PParts = Literal[
     "2x2x1", "2x2x2", "2x4x4", "4x4x4", "4x4x8", "4x8x8", "8x8x8", "8x8x16", "8x16x16", "16x16x16", "16x16x24"
@@ -298,12 +301,12 @@ def GPU(
     return Device(device=device, quantity=quantity, partition=partition, device_class="GPU")
 
 
-def TPU(device: TPUType, partition: V5PParts | V6EParts | None = None):
+def TPU(device: TPUType, partition: V5EParts | V5PParts | V6EParts | None = None):
     """
     Create a TPU device instance.
 
     Args:
-        device: Device type (e.g., "V5P", "V6E").
+        device: Device type (e.g., "V5E", "V5P", "V6E").
         partition: Partition of the TPU (e.g., "1x1", "2x2", ...).
 
     Returns:

--- a/tests/user_api/test_resources.py
+++ b/tests/user_api/test_resources.py
@@ -244,6 +244,9 @@ def test_gpu_invalid_quantity():
 @pytest.mark.parametrize(
     "tpu_type,partition",
     [
+        ("V5E", "1x1"),
+        ("V5E", "2x2"),
+        ("V5E", "8x16"),
         ("V5P", "2x2x1"),
         ("V5P", "2x2x2"),
         ("V5P", "4x4x4"),
@@ -551,3 +554,25 @@ def test_resources_gpu_positive_still_serializes_a_gpu_entry():
     assert proto is not None
     gpu_entries = [e for e in proto.requests if e.name == tasks_pb2.Resources.ResourceName.GPU]
     assert [e.value for e in gpu_entries] == ["2"]
+
+
+def test_tpu_v5e_is_a_valid_type():
+    # ACCELERATOR_DEVICE_MAP already carries a v5e node label, so the constructor
+    # has to admit the type that reaches it.
+    assert "V5E" in get_args(TPUType)
+
+
+def test_tpu_invalid_partition_v5e():
+    # This branch existed but was unreachable while V5E was absent from TPUType.
+    with pytest.raises(ValueError, match="Invalid partition for V5E"):
+        TPU(device="V5E", partition="3x3")  # type: ignore
+
+
+def test_tpu_v5e_serializes_to_the_v5e_node_label():
+    from flyte._internal.runtime.resources_serde import get_proto_extended_resources
+
+    extended = get_proto_extended_resources(Resources(gpu=TPU(device="V5E", partition="2x2")))
+
+    assert extended is not None
+    assert extended.gpu_accelerator.device == "tpu-v5-lite-podslice"
+    assert extended.gpu_accelerator.partition_size == "2x2"

--- a/tests/user_api/test_resources.py
+++ b/tests/user_api/test_resources.py
@@ -623,6 +623,8 @@ def test_tpu_v5e_serializes_to_the_v5e_node_label():
     assert extended is not None
     assert extended.gpu_accelerator.device == "tpu-v5-lite-podslice"
     assert extended.gpu_accelerator.partition_size == "2x2"
+
+
 @pytest.mark.parametrize(
     "bad_gpu",
     [


### PR DESCRIPTION
## Why

TPU v5e is wired up everywhere except the type that gates the constructor.

`ACCELERATOR_DEVICE_MAP` already carries its node label, right next to the two generations that do work:

```python
"V5E": "tpu-v5-lite-podslice",
"V5P": "tpu-v5p-slice",
"V6E": "tpu-v6e-slice",
```

and `_resources.py` already defines the slice shapes and a branch to validate them:

```python
V5EParts = Literal["1x1", "2x2", "2x4", "4x4", "4x8", "8x8", "8x16", "16x16"]
...
elif partition is not None and device == "V5E":
    if partition not in get_args(V5EParts):
        raise ValueError(f"Invalid partition for V5E: ...")
```

But `TPUType` listed only two of the three:

```python
TPUType = Literal["V5P", "V6E"]
```

So `TPU()` rejected the device at its first guard, the `elif device == "V5E"` branch below it was unreachable, and `V5EParts` was exported and documented but unusable:

```python
TPU(device="V5E", partition="2x2")
# ValueError: Invalid TPU type: V5E. Must be one of ('V5P', 'V6E')
```

## What confirms the direction

Nothing downstream needed changing. Building the device directly — going around the constructor — already serialized correctly before this patch:

```
Device(device="V5E", device_class="TPU", quantity=1, partition="2x2")
  -> gpu_accelerator { device: "tpu-v5-lite-podslice" partition_size: "2x2" device_class: GOOGLE_TPU }
```

which is structurally identical to what V5P and V6E produce. The whole stack already handles v5e; only the literal was blocking it. That rules out the other possible reading — deleting `V5EParts` and the dead branch — since that would contradict `ACCELERATOR_DEVICE_MAP` at the layer that actually talks to the backend.

## What changed

- `V5E` added to `TPUType`
- `V5EParts` admitted in the `partition` type hint (previously `V5PParts | V6EParts | None`)
- `V5EParts` given the docstring its two siblings already have
- `V5E` named in the `Args:` example, which listed only `"V5P", "V6E"`

The previously-dead partition validation now actually runs:

```python
TPU(device="V5E", partition="3x3")
# ValueError: Invalid partition for V5E: 3x3. Must be one of ('1x1', '2x2', ...)
```

V5P and V6E are untouched, and an unknown device is still rejected.

## Tests

`test_tpu_all_types_with_partitions` is extended with three V5E cases alongside the existing V5P/V6E ones, plus three new tests:

- `test_tpu_v5e_is_a_valid_type`
- `test_tpu_invalid_partition_v5e` — covers the branch that could not previously execute
- `test_tpu_v5e_serializes_to_the_v5e_node_label` — pins `tpu-v5-lite-podslice`

All six fail on `main` and pass with this change.

## Checks

- `make fmt` — clean
- `make mypy` — `Success: no issues found in 870 source files`
- `make check-docstrings` — `523 files clean`
- `codespell` — clean
- `make unit_test` — no new failures

Fixes flyteorg/flyte#7996
