### PR TITLE
fix: run/serve a file whose absolute path is outside the current directory

### DIFF
--- a/src/flyte/cli/_common.py
+++ b/src/flyte/cli/_common.py
@@ -297,6 +297,24 @@ def key_value_callback(_: Any, param: str, values: List[str]) -> Optional[Dict[s
     return result
 
 
+def relative_to_cwd(path: Path) -> Path:
+    """Spell `path` relative to the current directory when it lies inside it.
+
+    Absolute paths under the current directory read better as relative ones, so the CLI shortens
+    them for display and for the module names it derives from them. A path *outside* the current
+    directory has no relative spelling: `Path.relative_to` raises `ValueError: ... is not in the
+    subpath of ...` rather than producing a `../` form. Such a path is returned unchanged, which is
+    what every caller wants -- an absolute path is always a usable spelling.
+
+    Relative paths are returned unchanged too. `is_relative_to` compares them literally against an
+    absolute cwd and always says no, so they never had a shortened form to begin with.
+    """
+    cwd = Path.cwd()
+    if path.is_absolute() and path.is_relative_to(cwd):
+        return path.relative_to(cwd)
+    return path
+
+
 class ObjectsPerFileGroup(GroupBase):
     """
     Group that creates a command for each object in a python file.
@@ -395,9 +413,7 @@ class FileGroup(GroupBase):
 
             # files that are in the current directory or subdirectories of the
             # current directory should be displayed as relative paths
-            self._files = [
-                str(Path(f).relative_to(Path.cwd())) if Path(f).is_relative_to(Path.cwd()) else f for f in _files
-            ]
+            self._files = [os.fspath(relative_to_cwd(Path(f))) for f in _files]
         return self._files
 
     def list_commands(self, ctx):

--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -568,8 +568,7 @@ class TaskPerFileGroup(common.ObjectsPerFileGroup):
     """
 
     def __init__(self, filename: Path, run_args: RunArguments, *args, **kwargs):
-        if filename.is_absolute():
-            filename = filename.relative_to(Path.cwd())
+        filename = common.relative_to_cwd(filename)
         super().__init__(*(filename, *args), **kwargs)
         self.run_args = run_args
 

--- a/src/flyte/cli/_serve.py
+++ b/src/flyte/cli/_serve.py
@@ -281,8 +281,7 @@ class AppPerFileGroup(common.ObjectsPerFileGroup):
     """
 
     def __init__(self, filename: Path, serve_args: ServeArguments, *args, **kwargs):
-        if filename.is_absolute():
-            filename = filename.relative_to(Path.cwd())
+        filename = common.relative_to_cwd(filename)
         super().__init__(*(filename, *args), **kwargs)
         self.serve_args = serve_args
 

--- a/tests/flyte/cli/test_path_outside_cwd.py
+++ b/tests/flyte/cli/test_path_outside_cwd.py
@@ -1,0 +1,73 @@
+"""Tests for addressing a task/app file by a path that lies outside the current directory."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from flyte.cli._common import FileGroup, relative_to_cwd
+
+
+@pytest.fixture()
+def outside(tmp_path, monkeypatch):
+    """A source directory and a *separate* working directory, neither inside the other."""
+    src = tmp_path / "project"
+    src.mkdir()
+    (src / "task.py").write_text("x = 1\n")
+    cwd = tmp_path / "elsewhere"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    return src
+
+
+def test_relative_to_cwd_shortens_a_path_inside_the_current_directory(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    inside = Path(os.getcwd()) / "pkg" / "task.py"
+    assert relative_to_cwd(inside) == Path("pkg/task.py")
+
+
+def test_relative_to_cwd_keeps_a_path_outside_the_current_directory(outside):
+    """The bug: `Path.relative_to` raises for a path with no relative spelling under cwd."""
+    absolute = (outside / "task.py").resolve()
+    assert relative_to_cwd(absolute) == absolute
+
+
+def test_relative_to_cwd_keeps_a_relative_path(outside):
+    """A relative path is already as short as it gets; `is_relative_to` always rejects it."""
+    assert relative_to_cwd(Path("../project/task.py")) == Path("../project/task.py")
+
+
+def test_file_group_lists_outside_paths_as_absolute(outside):
+    """FileGroup deliberately emits absolute paths for files it cannot spell relatively.
+
+    This is what feeds the per-file groups below, so the two halves have to agree: whatever
+    `files` emits must be something the group constructors accept.
+    """
+    files = FileGroup(name="g", directory=outside).files
+    assert files == [os.fspath((outside / "task.py"))]
+
+
+def test_file_group_shortens_paths_inside_the_current_directory(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "task.py").write_text("x = 1\n")
+    assert FileGroup(name="g", directory=tmp_path).files == ["task.py"]
+
+
+def test_task_per_file_group_accepts_a_path_outside_the_current_directory(outside):
+    """`flyte run /abs/path/outside/cwd/task.py` used to die with 'is not in the subpath of'."""
+    from flyte.cli._run import RunArguments, TaskPerFileGroup
+
+    target = outside / "task.py"
+    grp = TaskPerFileGroup(filename=target, run_args=RunArguments(), name=str(target))
+    assert grp.filename == target
+
+
+def test_app_per_file_group_accepts_a_path_outside_the_current_directory(outside):
+    """Same defect on the `flyte serve` side."""
+    from flyte.cli._serve import AppPerFileGroup, ServeArguments
+
+    target = outside / "task.py"
+    grp = AppPerFileGroup(filename=target, serve_args=ServeArguments(), name=str(target))
+    assert grp.filename == target


### PR DESCRIPTION
## The bug

`flyte run` and `flyte serve` cannot open a file by absolute path unless that file happens to live under the current directory:

```
$ cd ~
$ flyte run /work/proj/task.py hello
╭─ Error ─────────────────────────────────────────────────────────╮
│ Error invoking command: '/work/proj/task.py' is not in the      │
│ subpath of '/home/me'                                           │
╰─────────────────────────────────────────────────────────────────╯
```

`TaskPerFileGroup.__init__` (and its `flyte serve` twin `AppPerFileGroup.__init__`) shortens an absolute filename for display with a bare `relative_to`:

```python
if filename.is_absolute():
    filename = filename.relative_to(Path.cwd())   # ValueError when not under cwd
```

`Path.relative_to` does not produce a `../` form — it raises `ValueError: ... is not in the subpath of ...`.

## Why it is a two-halves bug, not just a missing guard

The **listing** half of the same feature already handles this correctly. `FileGroup.files` guards the identical conversion and deliberately keeps absolute paths for files it cannot spell relatively:

```python
# files that are in the current directory or subdirectories of the
# current directory should be displayed as relative paths
str(Path(f).relative_to(Path.cwd())) if Path(f).is_relative_to(Path.cwd()) else f
```

So the two halves disagree, six lines apart in the same package — and `flyte run <dir-outside-cwd>` walks straight into the disagreement: `files` hands the group an absolute path *by design*, and the group then rejects it.

## The fix

Hoist the guarded conversion into `common.relative_to_cwd` and use it at all three sites, so there is one spelling of this rule instead of a correct copy and two broken ones.

The shortening was only ever cosmetic. `ObjectsPerFileGroup.objs` loads the module via `spec_from_file_location(..., self.filename)` and `os.path.dirname(os.path.abspath(self.filename))` — both fine with an absolute path — and `_module.py` already wraps its own `relative_to` in `try/except ValueError` for exactly the not-under-source-dir case.

## Verification

Repro'd end to end against a real CLI invocation, before and after, from a cwd outside the project:

| case | before | after |
|---|---|---|
| `flyte run /abs/outside/task.py --help` | `ValueError` | lists `hello` |
| `flyte run /abs/outside` → pick a file | `ValueError` | lists `hello` |
| `flyte serve /abs/outside/myapp.py --help` | `ValueError` | lists `app` |
| `flyte run ../rel/task.py --help` (control) | works | works |
| `flyte run /abs/under/cwd/task.py --help` (control) | works | works |

A relative `../` path was never affected — `is_absolute()` is false, so the branch never ran — and that stays true.

Of the seven tests, the two `*_accepts_a_path_outside_the_current_directory` cases fail on unpatched code with the exact production `ValueError`; the other five are **regression guards that pass on both sides by design**, pinning the behaviour this change must not alter (in-cwd paths still shorten, relative paths still pass through, `FileGroup` still lists outside paths as absolute).

Local gate: `make fmt` clean, `ruff check` clean, `ty` clean, `mypy` clean on the changed files (the 4 remaining `pydantic_monty` errors are pre-existing on `main`), `check-docstrings` 523 files clean, and `tests/flyte/cli` + `tests/cli` = **520 passed**.

## No Sentry issue

Found by a code audit, not from the corpus, and it is **not Sentry-reachable**: `InvokeBaseMixin.invoke` converts the `ValueError` into a `click.ClickException`, which `_sentry._is_user_error` filters. The command is simply unusable while never reporting anything. Same standing as #1537 and #1546 — reachability decides whether an issue can *appear* in Sentry, not whether the defect is worth fixing.
