### PR TITLE
Add support for A2 GPU accelerator

### DIFF
--- a/src/flyte/_resources.py
+++ b/src/flyte/_resources.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 PRIMARY_CONTAINER_DEFAULT_NAME = "primary"
 
 GPUType = Literal[
-    "A10", "A10G", "A100", "A100 80G", "B200", "H100", "H200", "L4", "L40s", "T4", "V100", "RTX PRO 6000", "GB10"
+    "A2", "A10", "A10G", "A100", "A100 80G", "B200", "H100", "H200", "L4", "L40s", "T4", "V100", "RTX PRO 6000", "GB10"
 ]
 GPUQuantity = Literal[1, 2, 3, 4, 5, 6, 7, 8]
 A100Parts = Literal["1g.5gb", "2g.10gb", "3g.20gb", "4g.20gb", "7g.40gb"]
@@ -57,6 +57,8 @@ AMD_GPUType = Literal["MI100", "MI210", "MI250", "MI250X", "MI300A", "MI300X", "
 HABANA_GAUDIType = Literal["Gaudi1"]
 
 Accelerators = Literal[
+    # A2
+    "A2:1",
     # A10
     "A10:1",
     "A10:2",
@@ -414,7 +416,7 @@ class Resources:
             - `Device`: Advanced config via `GPU()`, `TPU()`, or `Device()` for partitioning
               and custom device types. See `GPU`, `TPU`, `Device` for details.
 
-            Supported GPU types include T4, L4, L40s, A10, A10G, A100, A100 80G, B200, H100, H200, V100.
+            Supported GPU types include A2, T4, L4, L40s, A10, A10G, A100, A100 80G, B200, H100, H200, V100.
             GPU partitioning (MIG) is available on A100, A100 80G, H100, and H200.
         disk: Ephemeral disk storage as a string with Kubernetes units
             (e.g., `"10Gi"`, `"100Gi"`, `"1Ti"`). Automatically cleaned up when the task completes.

--- a/tests/user_api/test_resources.py
+++ b/tests/user_api/test_resources.py
@@ -164,6 +164,7 @@ def test_resources_with_various_gpu_combinations():
 @pytest.mark.parametrize(
     "gpu_type,quantity",
     [
+        ("A2", 1),
         ("A10", 1),
         ("A10G", 2),
         ("A100", 4),
@@ -368,6 +369,7 @@ def test_habana_gaudi_invalid_device():
 @pytest.mark.parametrize(
     "accelerator_string,expected_device,expected_quantity,expected_class",
     [
+        ("A2:1", "A2", 1, "GPU"),
         ("A100:4", "A100", 4, "GPU"),
         ("T4:1", "T4", 1, "GPU"),
         ("L4:2", "L4", 2, "GPU"),


### PR DESCRIPTION
We hit some errors attempting to run tasks with accelerator `A2:1`. There is a workaround of course but we figured it might be nice to add this here. The Nvidia A2 is a single GPU connected via PCI E.