### PR TITLE
feat(pod): add PodTemplate.allow_object_store_volume for read-only object-store mounts

### DIFF
--- a/src/flyte/_pod.py
+++ b/src/flyte/_pod.py
@@ -32,6 +32,10 @@ _FUSE_DEVICE_PATH = "/dev/fuse"
 # default (device-plugin) path of ``PodTemplate.allow_fuse()`` uses.
 _FUSE_DEVICE_RESOURCE = "smarter-devices/fuse"
 
+# Default volume name for ``PodTemplate.allow_object_store_volume()`` (override to
+# attach more than one object-store volume to a pod).
+_OBJECT_STORE_VOLUME_NAME = "object-store"
+
 # Every capability helper stamps ``flyte.org/capability-<name>: "true"`` on the
 # resulting template so the requested grant is auditable on the pod itself
 # (admission controllers and humans can match on the annotation) regardless of
@@ -158,6 +162,56 @@ class PodTemplate(object):
         `allowPrivilegeEscalation: false` pre-set).
         """
         return _apply_fuse(self, privileged=privileged)
+
+    def allow_object_store_volume(
+        self,
+        *,
+        claim_name: str,
+        mount_path: str,
+        read_only: bool = True,
+        sub_path: Optional[str] = None,
+        name: str = _OBJECT_STORE_VOLUME_NAME,
+        annotations: Optional[Dict[str, str]] = None,
+    ) -> PodTemplate:
+        """
+        Return a copy of this template with a read-only, **object-store-backed** volume
+        mounted into the primary container — for reading data (e.g. model weights)
+        straight from a cloud object store via its CSI driver (gcsfuse on GKE,
+        Mountpoint-S3 on EKS), with **no privileges**.
+
+        This is the object-store sibling of `allow_fuse()` (in-pod FUSE via the device
+        plugin) and `flyteplugins.union.io.allow_volumes()` (the broker CSI), but it
+        grants *nothing*: it references a pre-provisioned `PersistentVolumeClaim`
+        (`claim_name`) backing the object store and mounts it at `mount_path`. Unlike
+        `allow_fuse()` it needs **no** `CAP_SYS_ADMIN`, **no** `/dev/fuse`, and **no**
+        device plugin — the CSI driver runs the FUSE process out-of-pod, so the mount is
+        Knative-friendly and releases cleanly on scale-to-zero. The PVC is cloud
+        infrastructure provisioned outside the SDK; access is bounded by the pod's own
+        service-account IAM.
+
+        Args:
+            claim_name: Name of the pre-provisioned PVC backing the object store.
+            mount_path: Where to mount it in the primary container.
+            read_only: Mount read-only (default `True`; serving reads weights).
+            sub_path: Optional subdirectory of the PVC to mount instead of its root.
+            name: Volume name in the pod spec (override to attach more than one).
+            annotations: Extra pod annotations — the one vendor-specific knob. On GKE the
+                gcsfuse sidecar injector requires `{"gke-gcsfuse/volumes": "true"}`; on EKS
+                (Mountpoint-S3) none are needed.
+
+        The original template is never mutated; existing volumes, mounts, sidecars,
+        labels, annotations, and security-context fields are preserved. Re-applying with
+        the same `name` is idempotent.
+        """
+        return _apply_object_store_volume(
+            self,
+            claim_name=claim_name,
+            mount_path=mount_path,
+            read_only=read_only,
+            sub_path=sub_path,
+            name=name,
+            annotations=annotations,
+        )
 
     def allow_nested_sandboxing(self) -> PodTemplate:
         """
@@ -353,6 +407,48 @@ def _apply_fuse(pod_template: PodTemplate, *, privileged: bool = False) -> PodTe
 
     _add_sys_admin(primary)  # the mount(2) syscall needs it on both paths
     _stamp_capability(pt, "fuse")
+    return pt
+
+
+def _apply_object_store_volume(
+    pod_template: PodTemplate,
+    *,
+    claim_name: str,
+    mount_path: str,
+    read_only: bool,
+    sub_path: Optional[str],
+    name: str,
+    annotations: Optional[Dict[str, str]],
+) -> PodTemplate:
+    """Augmentor behind `PodTemplate.allow_object_store_volume`: attach a PVC volume +
+    mount to the primary container (idempotent by volume name) and merge any
+    vendor-specific pod annotations. Grants no privilege — no cap, no device, no
+    hostPath — so it composes with `allow_nested_sandboxing()`."""
+    from kubernetes.client import V1PersistentVolumeClaimVolumeSource, V1Volume, V1VolumeMount
+
+    pt = _clone_with_primary(pod_template)
+    primary = _get_primary_container(pt)
+    assert pt.pod_spec is not None  # _clone_with_primary guarantees it
+
+    volumes = list(pt.pod_spec.volumes or [])
+    if not any(getattr(v, "name", None) == name for v in volumes):
+        volumes.append(
+            V1Volume(
+                name=name,
+                persistent_volume_claim=V1PersistentVolumeClaimVolumeSource(claim_name=claim_name, read_only=read_only),
+            )
+        )
+        pt.pod_spec.volumes = volumes
+
+    mounts = list(primary.volume_mounts or [])
+    if not any(getattr(m, "name", None) == name for m in mounts):
+        primary.volume_mounts = [
+            *mounts,
+            V1VolumeMount(name=name, mount_path=mount_path, read_only=read_only, sub_path=sub_path),
+        ]
+
+    if annotations:
+        pt.annotations = {**(pt.annotations or {}), **annotations}
     return pt
 
 

--- a/tests/user_api/test_pod_template.py
+++ b/tests/user_api/test_pod_template.py
@@ -405,3 +405,63 @@ class TestAllowNestedSandboxing:
         primary = next(c for c in pt.pod_spec.containers if c.name == "primary")
         assert "SYS_ADMIN" in primary.security_context.capabilities.add
         assert [c.name for c in pt.pod_spec.containers] == ["worker", "primary"]
+
+
+class TestAllowObjectStoreVolume:
+    """Read-only, object-store-backed PVC mount — no privilege (sibling of allow_fuse)."""
+
+    def test_attaches_readonly_pvc_volume_and_mount(self):
+        pt = PodTemplate().allow_object_store_volume(claim_name="union-models-ro", mount_path="/tmp/models")
+        vol = next(v for v in pt.pod_spec.volumes if v.name == "object-store")
+        assert vol.persistent_volume_claim.claim_name == "union-models-ro"
+        assert vol.persistent_volume_claim.read_only is True
+        primary = next(c for c in pt.pod_spec.containers if c.name == "primary")
+        mnt = next(m for m in primary.volume_mounts if m.name == "object-store")
+        assert (mnt.mount_path, mnt.read_only) == ("/tmp/models", True)
+
+    def test_grants_no_privilege(self):
+        pt = PodTemplate().allow_object_store_volume(claim_name="c", mount_path="/m")
+        primary = next(c for c in pt.pod_spec.containers if c.name == "primary")
+        # no CAP_SYS_ADMIN, no device resource, no /dev/fuse hostPath, no capability stamp
+        assert primary.security_context is None or primary.security_context.capabilities is None
+        assert primary.resources is None or "smarter-devices/fuse" not in (primary.resources.requests or {})
+        assert not any(getattr(v, "name", None) == "fuse-device" for v in (pt.pod_spec.volumes or []))
+        assert "flyte.org/capability-object-store" not in (pt.annotations or {})
+
+    def test_vendor_annotation_gke_gcsfuse(self):
+        pt = PodTemplate().allow_object_store_volume(
+            claim_name="c", mount_path="/m", annotations={"gke-gcsfuse/volumes": "true"}
+        )
+        assert pt.annotations == {"gke-gcsfuse/volumes": "true"}
+
+    def test_does_not_mutate_original(self):
+        original = PodTemplate()
+        original.allow_object_store_volume(claim_name="c", mount_path="/m")
+        assert original.pod_spec is None
+
+    def test_idempotent_by_name(self):
+        pt = (
+            PodTemplate()
+            .allow_object_store_volume(claim_name="c", mount_path="/m")
+            .allow_object_store_volume(claim_name="c", mount_path="/m")
+        )
+        assert [v.name for v in pt.pod_spec.volumes].count("object-store") == 1
+        primary = next(c for c in pt.pod_spec.containers if c.name == "primary")
+        assert [m.name for m in primary.volume_mounts].count("object-store") == 1
+
+    def test_sub_path_and_custom_name(self):
+        pt = PodTemplate().allow_object_store_volume(
+            claim_name="c", mount_path="/m", sub_path="models/qwen", name="model", read_only=False
+        )
+        vol = next(v for v in pt.pod_spec.volumes if v.name == "model")
+        assert vol.persistent_volume_claim.read_only is False
+        primary = next(c for c in pt.pod_spec.containers if c.name == "primary")
+        mnt = next(m for m in primary.volume_mounts if m.name == "model")
+        assert mnt.sub_path == "models/qwen" and mnt.read_only is False
+
+    def test_composes_with_allow_nested_sandboxing(self):
+        # no privilege → must not conflict with allowPrivilegeEscalation=false
+        a = PodTemplate().allow_object_store_volume(claim_name="c", mount_path="/m").allow_nested_sandboxing()
+        b = PodTemplate().allow_nested_sandboxing().allow_object_store_volume(claim_name="c", mount_path="/m")
+        assert any(v.name == "object-store" for v in a.pod_spec.volumes)
+        assert any(v.name == "object-store" for v in b.pod_spec.volumes)


### PR DESCRIPTION
## Intent

Give serving/task pods a clean, declarative way to **read data straight from a cloud object store** (model weights, datasets) via its CSI driver — **without privileges**. Today this requires hand-rolled `pod_template` surgery (a PVC volume + volumeMount + the GKE gcsfuse annotation) per app; this makes it a first-class `PodTemplate` primitive.

## What changed

- **`PodTemplate.allow_object_store_volume(*, claim_name, mount_path, read_only=True, sub_path=None, name="object-store", annotations=None)`** — returns a copy with a read-only object-store-backed PVC mounted into the primary container.
- The **object-store sibling** of the existing volume helpers, distinguished by storage type:
  - `allow_fuse()` — in-pod FUSE via the device plugin (`smarter-devices/fuse` + `CAP_SYS_ADMIN`, node-pinned).
  - `flyteplugins.union.io.allow_volumes()` — Union broker CSI.
  - `allow_object_store_volume()` — cloud object-store CSI (gcsfuse / Mountpoint-S3).
- **Grants nothing**: no `CAP_SYS_ADMIN`, no `/dev/fuse`, no device plugin — the CSI driver runs the FUSE process out-of-pod, so the mount is **Knative-friendly and releases cleanly on scale-to-zero**. Access is bounded by the pod's own service-account IAM.
- **Cloud-agnostic**: the one vendor-specific knob (e.g. `{"gke-gcsfuse/volumes": "true"}` on GKE; none on EKS Mountpoint-S3) is passed via `annotations=`.
- Non-mutating, idempotent by volume name, composes with `allow_nested_sandboxing()` (no privilege conflict).

## How it was tested

- `pytest tests/user_api/test_pod_template.py` → **61 passed** (7 new: RO PVC + mount, no-privilege, vendor annotation, non-mutating, idempotent, sub_path/custom-name, composes-with-nested-sandboxing).
- Serde smoke: the resulting `pod_spec` sanitizes to the exact k8s shape a CSI-backed RO PVC needs.
- `ruff check` / `ruff format` / `check_docstring_style.py` clean.

## Follow-ups (separate PRs)

- Wire `ArtifactValue`/`RunOutput` binding + App→artifact lineage into the app layer (resolve URI at deploy → non-download param so `collect_artifact_ids` records the edge), so `model_path=ArtifactValue(...)` serves via this mount lineage-linked.
- Provision the bucket-rooted RO model PVC in the dataplane chart.