### PR TITLE
examples: queue resource cap example

### DIFF
--- a/examples/queues/README.md
+++ b/examples/queues/README.md
@@ -5,14 +5,20 @@ configuration shapes the behavior of bursts of work. Each example targets one
 of the queues declared in the cluster config; the examples assume the
 following queues exist with these limits:
 
-| Queue           | MaxActionConcurrency | MaxRunConcurrency | MaxDepth | Used by                    |
-| --------------- | -------------------- | ----------------- | -------- | -------------------------- |
-| `serial-1`      | 1                    | —                 | —        | `serial_one.py`            |
-| `small-3`       | 3                    | —                 | —        | `small_concurrency.py`     |
-| `depth-limited` | —                    | —                 | 5        | `depth_backpressure.py`    |
-| `bulk-a`        | 2                    | —                 | —        | `multi_queue.py`           |
-| `bulk-b`        | 4                    | —                 | —        | `multi_queue.py`           |
-| `runs-1`        | —                    | 1                 | —        | `serial_runs.py`           |
+| Queue           | MaxActionConcurrency | MaxRunConcurrency | MaxDepth | MaxResources   | Used by                    |
+| --------------- | -------------------- | ----------------- | -------- | -------------- | -------------------------- |
+| `serial-1`      | 1                    | —                 | —        | —              | `serial_one.py`            |
+| `small-3`       | 3                    | —                 | —        | —              | `small_concurrency.py`     |
+| `depth-limited` | —                    | —                 | 5        | —              | `depth_backpressure.py`    |
+| `bulk-a`        | 2                    | —                 | —        | —              | `multi_queue.py`           |
+| `bulk-b`        | 4                    | —                 | —        | —              | `multi_queue.py`           |
+| `runs-1`        | —                    | 1                 | —        | —              | `serial_runs.py`           |
+| `caps-mem`      | —                    | —                 | —        | `memory=600Mi` | `resource_cap.py`          |
+| `caps-tiny`     | —                    | —                 | —        | `memory=64Mi`  | `resource_cap.py`          |
+
+A `—` in a limit column means unset, which is *unlimited* — not zero. That
+matters most for `MaxResources`: a queue that names no resource caps nothing,
+while an explicit `0` on a dimension forbids every request on it.
 
 Targeting a queue from your code is one parameter on the task decorator:
 
@@ -31,14 +37,19 @@ pool and only the workload that should be capped is pinned to a queue.
 
 ## Running the examples
 
-All four examples are runnable with `flyte run`:
+All of the examples are runnable with `flyte run`:
 
 ```bash
 flyte run examples/queues/serial_one.py main
 flyte run examples/queues/small_concurrency.py main
 flyte run examples/queues/depth_backpressure.py main
 flyte run examples/queues/multi_queue.py main
+flyte run examples/queues/resource_cap.py main      # held on the memory cap
+flyte run examples/queues/resource_cap.py too_big   # too large to ever fit
 ```
+
+`resource_cap.py` needs its two queues to actually carry `max_resources`;
+its docstring shows how to create them and what each half should look like.
 
 Each example prints `START` and `END` lines with timestamps on every step so
 you can read the log and confirm the expected overlap pattern.

--- a/examples/queues/resource_cap.py
+++ b/examples/queues/resource_cap.py
@@ -1,74 +1,28 @@
 """
 Queue resource caps: holding work on the summed request vector, not a count.
 
-`caps-mem` is configured with `maxResources: {memory: 600Mi}` and NO integer
-caps, so the only thing that can hold an action is its memory request. Each
-step asks for 200Mi, so three fit and the rest wait for a predecessor to
-finish — the same shape as small_concurrency.py, measured in memory instead
-of actions.
-
-Run it:
+`main` submits six 200Mi steps to `caps-mem`, which caps memory at 600Mi and
+carries no integer caps. Three run at a time; the rest wait for a predecessor
+to release its request.
 
     flyte run examples/queues/resource_cap.py main
 
-Expected timing for `count=6, sleep_seconds=4` and 600Mi / 200Mi = 3:
-ceil(6/3) * 4s = 8s wall time. Under ~6s means the cap is not being enforced;
-far over ~12s means the queue is under-scheduling (a held action should be
-re-picked the tick after its predecessor's demand is released, ~1s).
-
-Watch it from the leasor while it runs:
-
-    curl -s localhost:10254/debug/leasor/queues | jq '.queues[]
-      | select(.Name=="caps-mem") | {max_resources, in_flight, Depth, ActiveActions}'
-
-    curl -s localhost:10254/metrics | grep -E \
-      'queue_resource_(max|in_flight)|schedule_skip_total.*queue_at_resource_cap'
-
-`in_flight.MemoryBytes` should sit at 629145600 (3 x 200Mi) while the queue is
-saturated, never above it, and `schedule_skip_total{reason=queue_at_resource_cap}`
-should climb while actions are waiting. Both return to zero when the run ends.
-
----
-
-`too_big` is the other half: one 200Mi step on `caps-tiny`, whose cap is
-64Mi. That action cannot fit even an idle queue, so waiting cannot help — the
-leasor fails it immediately instead of holding it forever:
+`too_big` submits one 200Mi step to `caps-tiny`, capped at 64Mi. It cannot fit
+even an idle queue, so the leasor fails it as UNSCHEDULABLE before dispatch
+rather than holding it for room that can never appear. The terminal lands on
+the child (`oversized`), not the parent, and no pod is ever created for it.
 
     flyte run examples/queues/resource_cap.py too_big
 
-Expect the action to fail in seconds with UNSCHEDULABLE and a message naming
-both the request and the cap, and `unschedulable_total{reason="queue_cap"}`
-to tick once. It must NOT sit in Unassigned.
-
-Note that it is the CHILD (`oversized`) that carries the UNSCHEDULABLE
-terminal — the run fails because its child did, so do not go looking for that
-error on the parent. No pod is ever created for the child: it is refused
-before dispatch, which is the point.
-
----
-
-Creating the queues these examples need
----------------------------------------
-
-The wall-time and hold expectations above assume `caps-mem` caps memory at
-600Mi and `caps-tiny` at 64Mi. Retune either and the arithmetic changes with
-it — the shape to expect is `ceil(count / (cap // request))` waves.
-
-The two queues must exist and carry those caps before either half of this
-example demonstrates anything:
+Both queues must exist and carry those caps first:
 
     flyte create queue caps-mem --run-concurrency 100 --action-concurrency 100 \
         --max-resources memory=600Mi
     flyte create queue caps-tiny --run-concurrency 100 --action-concurrency 100 \
         --max-resources memory=64Mi
 
-`--max-resources` takes NAME=QUANTITY and repeats per resource, e.g.
-`--max-resources gpu=8 --max-resources memory=512Gi`. To retune a cap later,
-`flyte update queue caps-mem --edit` shows `max_resources` as a mapping;
-setting it to `{}` there removes the cap entirely.
-
-Until a queue actually carries a cap, both examples still run — they simply
-demonstrate nothing, because an unconfigured cap admits everything.
+To watch a cap hold work while the example runs, use the queue dashboard:
+`flyte get queue caps-mem --watch`.
 """
 
 import asyncio
@@ -77,10 +31,8 @@ from functools import partial
 
 import flyte
 
-# One environment for everything. The 200Mi request is all both halves need:
-# three of them fit caps-mem's 600Mi, and a single one already exceeds
-# caps-tiny's 64Mi. A second environment would only add a task the entrypoint's
-# deploy does not cover, and a pod k3d may not have room for.
+# One environment for both halves: three 200Mi requests fit caps-mem's 600Mi,
+# and a single one already exceeds caps-tiny's 64Mi.
 env = flyte.TaskEnvironment(
     name="queues_resource_cap",
     resources=flyte.Resources(memory="200Mi"),

--- a/examples/queues/resource_cap.py
+++ b/examples/queues/resource_cap.py
@@ -1,0 +1,123 @@
+"""
+Queue resource caps: holding work on the summed request vector, not a count.
+
+`caps-mem` is configured with `maxResources: {memory: 600Mi}` and NO integer
+caps, so the only thing that can hold an action is its memory request. Each
+step asks for 200Mi, so three fit and the rest wait for a predecessor to
+finish — the same shape as small_concurrency.py, measured in memory instead
+of actions.
+
+Run it:
+
+    flyte run examples/queues/resource_cap.py main
+
+Expected timing for `count=6, sleep_seconds=4` and 600Mi / 200Mi = 3:
+ceil(6/3) * 4s = 8s wall time. Under ~6s means the cap is not being enforced;
+far over ~12s means the queue is under-scheduling (a held action should be
+re-picked the tick after its predecessor's demand is released, ~1s).
+
+Watch it from the leasor while it runs:
+
+    curl -s localhost:10254/debug/leasor/queues | jq '.queues[]
+      | select(.Name=="caps-mem") | {max_resources, in_flight, Depth, ActiveActions}'
+
+    curl -s localhost:10254/metrics | grep -E \
+      'queue_resource_(max|in_flight)|schedule_skip_total.*queue_at_resource_cap'
+
+`in_flight.MemoryBytes` should sit at 629145600 (3 x 200Mi) while the queue is
+saturated, never above it, and `schedule_skip_total{reason=queue_at_resource_cap}`
+should climb while actions are waiting. Both return to zero when the run ends.
+
+---
+
+`too_big` is the other half: one 200Mi step on `caps-tiny`, whose cap is
+64Mi. That action cannot fit even an idle queue, so waiting cannot help — the
+leasor fails it immediately instead of holding it forever:
+
+    flyte run examples/queues/resource_cap.py too_big
+
+Expect the action to fail in seconds with UNSCHEDULABLE and a message naming
+both the request and the cap, and `unschedulable_total{reason="queue_cap"}`
+to tick once. It must NOT sit in Unassigned.
+
+Note that it is the CHILD (`oversized`) that carries the UNSCHEDULABLE
+terminal — the run fails because its child did, so do not go looking for that
+error on the parent. No pod is ever created for the child: it is refused
+before dispatch, which is the point.
+
+---
+
+Creating the queues these examples need
+---------------------------------------
+
+The wall-time and hold expectations above assume `caps-mem` caps memory at
+600Mi and `caps-tiny` at 64Mi. Retune either and the arithmetic changes with
+it — the shape to expect is `ceil(count / (cap // request))` waves.
+
+The two queues must exist and carry those caps before either half of this
+example demonstrates anything:
+
+    flyte create queue caps-mem --run-concurrency 100 --action-concurrency 100 \
+        --max-resources memory=600Mi
+    flyte create queue caps-tiny --run-concurrency 100 --action-concurrency 100 \
+        --max-resources memory=64Mi
+
+`--max-resources` takes NAME=QUANTITY and repeats per resource, e.g.
+`--max-resources gpu=8 --max-resources memory=512Gi`. To retune a cap later,
+`flyte update queue caps-mem --edit` shows `max_resources` as a mapping;
+setting it to `{}` there removes the cap entirely.
+
+Until a queue actually carries a cap, both examples still run — they simply
+demonstrate nothing, because an unconfigured cap admits everything.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+from functools import partial
+
+import flyte
+
+# One environment for everything. The 200Mi request is all both halves need:
+# three of them fit caps-mem's 600Mi, and a single one already exceeds
+# caps-tiny's 64Mi. A second environment would only add a task the entrypoint's
+# deploy does not cover, and a pod k3d may not have room for.
+env = flyte.TaskEnvironment(
+    name="queues_resource_cap",
+    resources=flyte.Resources(memory="200Mi"),
+)
+
+
+# 200Mi against a 600Mi cap: three at a time.
+@env.task(queue="caps-mem")
+async def step(i: int, sleep_seconds: int) -> str:
+    started = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    print(f"[caps-mem] step {i} START at {started}", flush=True)
+    await asyncio.sleep(sleep_seconds)
+    finished = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    print(f"[caps-mem] step {i} END   at {finished}", flush=True)
+    return f"step {i} done"
+
+
+@env.task
+async def main(count: int = 6, sleep_seconds: int = 4) -> list[str]:
+    return list(flyte.map(partial(step, sleep_seconds=sleep_seconds), list(range(count))))
+
+
+# 200Mi against a 64Mi cap: impossible, not merely blocked. The leasor fails
+# this before it is ever dispatched, so the task body never runs.
+@env.task(queue="caps-tiny")
+async def oversized() -> str:
+    return "this should never run"
+
+
+@env.task
+async def too_big() -> str:
+    return await oversized()
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(main, count=6, sleep_seconds=4)
+    print(run.name)
+    print(run.url)
+    run.wait()


### PR DESCRIPTION
Adds `examples/queues/resource_cap.py`, covering a queue's `max_resources` cap the way the other examples here cover the integer limits.

`main` submits six 200Mi actions to a queue capped at 600Mi: three run at a time, in two waves. `too_big` submits one 200Mi action to a queue capped at 64Mi, which cannot fit even an idle queue, so it is failed as UNSCHEDULABLE before dispatch rather than held for room that can never appear.

The docstring carries the expected timing for each half, the commands to watch it from the scheduler while it runs, and how to create the two queues.
