### PR TITLE
fix: report a malformed auth env var against the variable that carried it

### DIFF
--- a/src/flyte/config/_internal.py
+++ b/src/flyte/config/_internal.py
@@ -30,7 +30,16 @@ def _as_argv(v: typing.Any) -> typing.Optional[typing.List[str]]:
         else:
             if isinstance(parsed, list):
                 return [str(x) for x in parsed]
-    return shlex.split(s)
+    try:
+        return shlex.split(s)
+    except ValueError as e:
+        # An unbalanced quote or a trailing escape. shlex says only what is wrong
+        # ("No closing quotation"), so add what a good value looks like; the caller
+        # adds which environment variable carried it.
+        raise ValueError(
+            f"{e}. Provide either a shell-quoted command line (mint-token --audience flyte) "
+            f'or a JSON array of arguments (["mint-token", "--audience", "flyte"]).'
+        ) from e
 
 
 def _as_str_list(v: typing.Any) -> typing.Optional[typing.List[str]]:

--- a/src/flyte/config/_reader.py
+++ b/src/flyte/config/_reader.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import yaml
 
 from flyte._logging import logger
+from flyte.errors import InitializationError
 
 # This is the default config file name for flyte
 FLYTECTL_CONFIG_ENV_VAR = "FLYTECTL_CONFIG"
@@ -68,7 +69,25 @@ class YamlConfigEntry(object):
                     f"{env} and {other_env} configure the same setting but are set to different "
                     f"values; using {env}. Unset {other_env} to remove the ambiguity."
                 )
-        return transform(v) if transform else v
+        if transform is None:
+            return v
+        try:
+            return transform(v)
+        except InitializationError:
+            raise
+        except Exception as e:
+            # An env var can only carry a string, so any parsing a setting needs happens
+            # in `transform` -- and a malformed value would otherwise escape as whatever
+            # the parser raises (`shlex.split` on an unbalanced quote raises a bare
+            # `ValueError: No closing quotation`), naming neither the variable nor the
+            # setting. Note the file path swallows a bad value instead; that asymmetry is
+            # deliberate here, since an env var the caller explicitly set should not be
+            # silently ignored only to fail later as an auth error.
+            raise InitializationError(
+                "InvalidConfigurationError",
+                "user",
+                f"{env} could not be parsed as a value for the `{self.switch}` setting: {e} (got {v!r})",
+            ) from e
 
     def read_from_file(
         self, cfg: "ConfigFile", transform: typing.Optional[typing.Callable] = None

--- a/tests/flyte/config/test_reader.py
+++ b/tests/flyte/config/test_reader.py
@@ -2,11 +2,18 @@ import io
 import logging
 import pathlib
 
+import pytest
 from rich.console import Console
 from rich.logging import RichHandler
 
 from flyte._logging import logger
-from flyte.config._reader import read_file_if_exists
+from flyte.config._reader import ConfigEntry, YamlConfigEntry, read_file_if_exists
+from flyte.errors import InitializationError
+
+
+def _boom(_value):
+    """Stand-in for a transform whose parser raises without naming its source."""
+    raise ValueError("No closing quotation")
 
 
 def test_read_file_if_exists_debug_log_renders_under_rich_markup(tmp_path: pathlib.Path) -> None:
@@ -40,3 +47,60 @@ def test_read_file_if_exists_debug_log_renders_under_rich_markup(tmp_path: pathl
     finally:
         logger.removeHandler(handler)
         logger.setLevel(prior_level)
+
+
+class TestEnvTransformFailure:
+    """A malformed env var must name itself.
+
+    An env var can only ever carry a string, so whatever parsing a setting needs
+    happens in the entry's `transform`. When that parsing fails, the parser's own
+    exception says nothing about where the value came from -- `shlex.split` on an
+    unbalanced quote raises a bare `ValueError: No closing quotation`. The read
+    must turn it into a classified error naming the variable and the setting.
+
+    The file path deliberately keeps swallowing a bad value: this is only about a
+    variable the caller explicitly set, which must not be silently ignored and
+    then resurface later as an auth failure.
+    """
+
+    def test_transform_failure_names_the_env_var_and_the_setting(self, monkeypatch) -> None:
+        entry = ConfigEntry(YamlConfigEntry("admin.command", list), transform=_boom)
+        monkeypatch.setenv("FLYTE_ADMIN_COMMAND", "whatever")
+
+        with pytest.raises(InitializationError) as exc:
+            entry.read()
+
+        message = str(exc.value)
+        assert "FLYTE_ADMIN_COMMAND" in message
+        assert "admin.command" in message
+        assert "'whatever'" in message, "the rejected value belongs in the message"
+
+    def test_alias_is_reported_when_the_alias_carried_the_value(self, monkeypatch) -> None:
+        """The message must name the variable actually set, not the preferred one."""
+        entry = ConfigEntry(YamlConfigEntry("admin.command", list, aliases=("FLYTE_AUTH_COMMAND",)), transform=_boom)
+        monkeypatch.delenv("FLYTE_AUTH_COMMAND", raising=False)
+        monkeypatch.setenv("FLYTE_ADMIN_COMMAND", "whatever")
+
+        with pytest.raises(InitializationError, match="FLYTE_ADMIN_COMMAND"):
+            entry.read()
+
+    def test_already_classified_error_passes_through_unchanged(self, monkeypatch) -> None:
+        """A transform that has already done the classifying keeps its own message."""
+        sentinel = InitializationError("MineNotYours", "user", "a better message")
+
+        def _raise_classified(_v):
+            raise sentinel
+
+        entry = ConfigEntry(YamlConfigEntry("admin.command", list), transform=_raise_classified)
+        monkeypatch.setenv("FLYTE_ADMIN_COMMAND", "whatever")
+
+        with pytest.raises(InitializationError) as exc:
+            entry.read()
+
+        assert exc.value is sentinel
+
+    def test_a_good_value_is_untouched(self, monkeypatch) -> None:
+        entry = ConfigEntry(YamlConfigEntry("admin.command", list), transform=lambda v: v.split())
+        monkeypatch.setenv("FLYTE_ADMIN_COMMAND", "uctl get-token")
+
+        assert entry.read() == ["uctl", "get-token"]

--- a/tests/user_api/test_init_in_cluster_env_auth.py
+++ b/tests/user_api/test_init_in_cluster_env_auth.py
@@ -112,6 +112,29 @@ class TestAuthOverridesFromEnv:
         with pytest.raises(InitializationError, match="FLYTE_AUTH_COMMAND"):
             _auth_overrides_from_env()
 
+    def test_unbalanced_quote_is_reported_against_the_env_var(self, clean_env):
+        """A typo in the command line must not escape as a bare `ValueError: No closing
+        quotation` from shlex, which names neither the variable nor what a good value
+        looks like. The same value reaches `PlatformConfig.auto` on the CLI path, where
+        it aborts the command before any of its own error handling runs."""
+        clean_env.setenv("FLYTE_AUTH_TYPE", "ExternalCommand")
+        clean_env.setenv("FLYTE_AUTH_COMMAND", 'mint-token --claim "team = data')
+
+        with pytest.raises(InitializationError) as exc:
+            _auth_overrides_from_env()
+
+        message = str(exc.value)
+        assert "FLYTE_AUTH_COMMAND" in message
+        assert "No closing quotation" in message, "keep shlex's account of what is wrong"
+        assert "JSON array" in message, "and say what a good value looks like"
+
+    def test_unbalanced_quote_in_proxy_command_is_reported_too(self, clean_env):
+        """PROXY_COMMAND shares the transform, so it must share the treatment."""
+        clean_env.setenv("FLYTE_AUTH_PROXY_COMMAND", "get-proxy-token --quiet '")
+
+        with pytest.raises(InitializationError, match="FLYTE_AUTH_PROXY_COMMAND"):
+            _auth_overrides_from_env()
+
 
 class TestPreferredAndDerivedNames:
     """`admin.authType` is really an auth setting, not an "admin" one, so the entries


### PR DESCRIPTION
## What

`Credentials.COMMAND` / `Credentials.PROXY_COMMAND` (`FLYTE_AUTH_COMMAND`, `FLYTE_AUTH_PROXY_COMMAND`, and the derived `FLYTE_ADMIN_COMMAND` / `FLYTE_ADMIN_PROXYCOMMAND`) are normalized through `shlex.split`, which raises a bare `ValueError` on an unbalanced quote or a trailing escape. Nothing catches it:

```
$ FLYTE_AUTH_TYPE=ExternalCommand \
  FLYTE_AUTH_COMMAND='mint-token --claim "team = data' \
  flyte deploy ...
ValueError: No closing quotation
```

The message names neither the variable, the setting, nor what a good value looks like — and because `config.auto()` runs in the CLI group callback, this aborts the command before any of its own error handling runs, so the user gets a raw traceback.

## The fix

`read_from_env` turns **any** transform failure into an `InitializationError` naming the variable that actually carried the value (preferred alias or derived name, whichever was set) and the setting it configures. `_as_argv` contributes the accepted forms to shlex's account of what is wrong:

```
FLYTE_AUTH_COMMAND could not be parsed as a value for the `admin.command` setting:
No closing quotation. Provide either a shell-quoted command line (mint-token
--audience flyte) or a JSON array of arguments (["mint-token", "--audience",
"flyte"]). (got 'mint-token --claim "team = data')
```

An already-classified `InitializationError` from a transform passes through unchanged, so a transform that has done its own classifying keeps its message.

## Why the env and file halves stay asymmetric

`read_from_file` wraps its own `transform` call in `except Exception: ...` and falls through to the next source. That is right for a shared config file, but wrong for a variable the caller set explicitly — silently ignoring it just moves the failure to the first RPC, where it surfaces as an `AuthenticationError` naming nothing. This PR only changes the env half; the file half is untouched.

## Provenance and reachability

Found by auditing what landed on main since the last Sentry-triage run, per the "a feature PR is the highest-probability moment for a latent bug" heuristic — #1536 introduced `_as_argv` and the `shlex.split` call two days ago, and its tests cover the balanced-quote happy path (`mint-token --claim 'team = data'`) but not the malformed one.

**No Sentry issue is attached, and this is not Sentry-reachable**: `config.auto()` runs in the `main.py` group callback at click parse time, which sits outside all four `capture_exception` extents. It is reported here as a real, user-visible defect in brand-new surface rather than as a filter gap. `InitializationError` is filtered by `_sentry._is_user_error` regardless, so the classification is also correct if this ever does become reachable.

## Testing

- 4 new tests in `tests/flyte/config/test_reader.py` for the generic reader contract (names the variable + setting + rejected value; reports the variable actually set rather than the preferred one; passes an already-classified error through; leaves a good value untouched).
- 2 new tests in `tests/user_api/test_init_in_cluster_env_auth.py` for the end-to-end `FLYTE_AUTH_COMMAND` / `FLYTE_AUTH_PROXY_COMMAND` messages.
- Verified the two behavioural tests fail on `origin/main` with the exact production error (`ValueError: No closing quotation`) while the guards pass either way.
- `tests/cli tests/flyte/config tests/flyte/git`: 483 passed. `tests/user_api`: the 8 failures are pre-existing on clean `origin/main` (stale local `flyteidl2`) — identical set before and after this change.
- `make fmt`, `make mypy`, `make ty`, `make check-docstrings` all clean.