### PR TITLE
fix: reject a gpu resource that is not one of its declared forms

### DIFF
--- a/src/flyte/_resources.py
+++ b/src/flyte/_resources.py
@@ -450,14 +450,28 @@ class Resources:
             elif isinstance(self.gpu, str):
                 if self.gpu not in get_args(Accelerators):
                     raise ValueError(f"gpu must be one of {Accelerators}, got {self.gpu}")
+            elif not isinstance(self.gpu, Device):
+                # Anything else is silently carried by `get_device` and only fails much
+                # later, in serialization, as an AttributeError against whatever was
+                # passed -- a crash in SDK frames rather than a report about the task
+                # definition. A `(device, quantity)` tuple is the common way to land
+                # here: it is what the accelerator string decomposes into, and what
+                # `get_device` used to be documented as returning.
+                raise ValueError(
+                    "gpu must be an accelerator string such as 'A100:4', a device count, or a "
+                    "GPU()/TPU()/Device() instance, got "
+                    f"{type(self.gpu).__name__}: {self.gpu!r}"
+                )
 
     def get_device(self) -> Optional[Device]:
         """
-        Get the accelerator string for the task.
+        Get the accelerator device for the task.
 
         Returns:
-            If GPUs are requested, return a tuple of the device name, and potentially a partition string.
-            Default cloud provider labels typically use the following values: `1g.5gb`, `2g.10gb`, etc.
+            A `Device` carrying the quantity, device class and -- for an accelerator string or an
+            explicit `GPU()`/`TPU()`/`Device()` -- the device name and partition. `None` when no
+            accelerator is requested, which includes `gpu=0`. Partition values follow the default
+            cloud provider labels, typically `1g.5gb`, `2g.10gb`, etc.
         """
         if self.gpu is None:
             return None

--- a/tests/user_api/test_resources.py
+++ b/tests/user_api/test_resources.py
@@ -553,3 +553,56 @@ def test_resources_gpu_positive_still_serializes_a_gpu_entry():
     assert proto is not None
     gpu_entries = [e for e in proto.requests if e.name == tasks_pb2.Resources.ResourceName.GPU]
     assert [e.value for e in gpu_entries] == ["2"]
+
+
+@pytest.mark.parametrize(
+    "bad_gpu",
+    [
+        pytest.param(("A100", 4), id="tuple"),
+        pytest.param(["A100", 4], id="list"),
+        pytest.param({"device": "A100", "quantity": 4}, id="dict"),
+        pytest.param(4.0, id="float"),
+    ],
+)
+def test_resources_rejects_a_gpu_that_is_not_a_declared_form(bad_gpu):
+    """`gpu` is typed `Union[Accelerators, int, Device, None]`, but __post_init__ only
+    ever checked the int and str arms. Anything else was carried untouched by
+    `get_device`, whose `Optional[Device]` annotation then lied, and the request died
+    much later inside serialization as `AttributeError: 'tuple' object has no attribute
+    'quantity'` -- SDK frames, no mention of the task definition that caused it.
+
+    A `(device, quantity)` tuple is the likely way to land here: it is what an
+    accelerator string decomposes into, and what `get_device` was documented as
+    returning.
+    """
+    with pytest.raises(ValueError, match="gpu must be an accelerator string"):
+        Resources(gpu=bad_gpu)
+
+
+@pytest.mark.parametrize(
+    "good_gpu",
+    [
+        pytest.param("A100:4", id="accelerator-string"),
+        pytest.param(2, id="count"),
+        pytest.param(0, id="zero-count"),
+        pytest.param(None, id="unset"),
+        pytest.param(GPU("A100", 4), id="GPU()"),
+        pytest.param(TPU("V6E", "1x1"), id="TPU()"),
+        pytest.param(Device(quantity=2, device_class="GPU"), id="Device()"),
+    ],
+)
+def test_resources_accepts_every_declared_gpu_form(good_gpu):
+    """The guard must not narrow the accepted surface -- `gpu=0` in particular still
+    means "no accelerator" rather than raising."""
+    assert Resources(gpu=good_gpu).gpu == good_gpu
+
+
+def test_get_device_returns_a_device_for_every_accepted_form():
+    """The `Optional[Device]` annotation is now true of every value that gets past
+    __post_init__, which is what the serializer relies on."""
+    for good_gpu in ("A100:4", 2, GPU("A100", 4), TPU("V6E", "1x1")):
+        device = Resources(gpu=good_gpu).get_device()
+        assert isinstance(device, Device), f"{good_gpu!r} produced {type(device).__name__}"
+
+    for absent in (0, None):
+        assert Resources(gpu=absent).get_device() is None


### PR DESCRIPTION
## What

`Resources.gpu` is typed `Union[Accelerators, int, Device, None]`, but `__post_init__` only ever checked the `int` and `str` arms. Anything else passes validation, is carried untouched by `get_device` — whose `Optional[Device]` annotation then lies — and kills the request much later, inside serialization:

```python
Resources(gpu=("A100", 4))    # accepted
...
AttributeError: 'tuple' object has no attribute 'quantity'
#   at resources_serde.py, _get_gpu_resource_entry(device.quantity)
```

The crash lands in SDK frames and names neither the field nor the task definition that caused it, at a point far from the mistake.

A `(device, quantity)` tuple is the likely way to land here: it is exactly what an accelerator string decomposes into, and what `get_device` was **documented as returning** ("return a tuple of the device name, and potentially a partition string"). That stale docstring is corrected here too, since it is what points users at a tuple in the first place.

## The fix

`__post_init__` rejects anything that is not an accelerator string, a device count, or a `Device`, naming the accepted forms:

```
gpu must be an accelerator string such as 'A100:4', a device count, or a
GPU()/TPU()/Device() instance, got tuple: ('A100', 4)
```

The accepted surface is unchanged — verified explicitly for `"A100:4"`, an int count, `gpu=0`, `None`, `GPU()`, `TPU()` and a bare `Device()`. **`gpu=0` in particular still means "no accelerator"** rather than raising, preserving #1547 / flyteorg/flyte#7995.

With the guard in place the `Optional[Device]` annotation on `get_device` is true of every value that gets past the constructor, which is what the serializer already assumed.

## Provenance and reachability

Found by auditing what landed on main since the last Sentry-triage run — #1554 added the A2 accelerator, and re-running the `Accelerators` ↔ `_DeviceClassType` invariant over all 145 literals (clean) surfaced the adjacent "two validators, opposite answers" case: `Resources(gpu=("A2", 2))` is accepted while `Resources(gpu="A2:2")` raises.

**No Sentry issue is attached, but unlike most audit findings this one is capture-reachable**: `get_proto_resources` runs under `cli/_deploy.py`'s `@capture_errors` during `flyte deploy`, and `AttributeError` is not filtered by `_sentry._is_user_error`, so today this reports as an SDK crash. Not currently in the corpus — presumably because nobody has hit it yet rather than because it cannot fire.

This is the third instance of the same family: a value the constructor accepts that only fails once it reaches the serializer. The other two are flyteorg/flyte#7995 (`gpu=0`, fixed) and flyteorg/flyte#7991 (`disk=` / `shm=` KeyError, still open).

## Deliberately out of scope

`memory=4` and `disk=10` fail the same way, with an opaque `TypeError: bad argument type for built-in operation` from serialization. They are left alone because they raise a design question this PR should not settle unilaterally — whether `memory=4` should be rejected or coerced to `"4Gi"`. Happy to follow up either way.

## Testing

- 4 new rejection cases (tuple, list, dict, float) and 7 acceptance cases covering every declared form.
- A test pinning that `get_device()` returns a real `Device` for every accepted form and `None` for `gpu=0` / `None`.
- Verified the 4 rejection tests fail on `origin/main` while the acceptance guards pass either way.
- `tests/user_api/test_resources.py`: 88 passed. Full `tests/user_api tests/internal tests/flyte` sweep: no failure present that is not also present on clean `origin/main` (remaining failures are the known S3/network/keyring/roundtrip set).
- `make fmt`, `make mypy`, `make ty`, `make check-docstrings` all clean.