### PR TITLE
fix: apply the session's TLS trust to object-store uploads

### DIFF
--- a/src/flyte/remote/_data.py
+++ b/src/flyte/remote/_data.py
@@ -1,6 +1,7 @@
 import asyncio
 import hashlib
 import os
+import ssl
 import typing
 import uuid
 from base64 import b64encode
@@ -149,11 +150,60 @@ def _redact_signed_url(url: str) -> str:
     return f"{base}?<redacted>" if sep else base
 
 
+# httpx accepts either a bool or a ready-made SSLContext for `verify`.
+_VerifyT = typing.Union[bool, ssl.SSLContext]
+
+
+@lru_cache(maxsize=4)
+def _ssl_context_from_ca_file(ca_cert_file_path: str) -> ssl.SSLContext:
+    """Build an SSLContext trusting exactly `ca_cert_file_path`, once per path.
+
+    Cached because `upload_dir` fans every file out concurrently and parsing a
+    CA bundle per PUT is pure overhead -- the bundle is fixed for a session.
+    """
+    return ssl.create_default_context(cafile=ca_cert_file_path)
+
+
+def _resolve_upload_verify(verify: _VerifyT) -> _VerifyT:
+    """Apply the session's configured TLS trust to object-store uploads.
+
+    `verify=True` means "use the default trust store", and for httpx that is
+    certifi alone -- it never sees `admin.caCertFilePath`. That splits the
+    control plane and the object store across two different trust stores, so a
+    private or intercepting CA configured for one is invisible to the other and
+    uploads fail with CERTIFICATE_VERIFY_FAILED even though the control plane
+    connected fine.
+
+    Only an explicit `ca_cert_file_path` carries over. `insecure_skip_verify`
+    resolves to the *control plane's own* chain (`_bootstrap_ssl_from_server`),
+    which is not a trust anchor for the object store's host, so it maps to "do
+    not verify" -- what the flag asks for -- rather than to those bytes.
+
+    A caller passing its own bool or SSLContext keeps it.
+    """
+    if verify is not True:
+        return verify
+
+    try:
+        session_config = get_client().session_config
+    except InitializationError:
+        # Uploads always run initialized; a caller poking at this directly should
+        # get httpx's default rather than an unrelated error.
+        return True
+
+    ca_cert_file_path = (session_config.auth_kwargs or {}).get("ca_cert_file_path")
+    if ca_cert_file_path:
+        return _ssl_context_from_ca_file(ca_cert_file_path)
+    if session_config.insecure_skip_verify:
+        return False
+    return True
+
+
 async def _put_signed_url_with_retry(
     source: typing.Union[Path, bytes],
     signed_url: str,
     extra_headers: dict,
-    verify: bool,
+    verify: _VerifyT,
     max_retries: int = 3,
     min_backoff_sec: float = 0.5,
     max_backoff_sec: float = 30.0,
@@ -183,6 +233,8 @@ async def _put_signed_url_with_retry(
     # upload; in-memory metadata artifacts have no path.
     desc = "metadata artifact" if is_bytes else str(source)
     short_desc = "metadata artifact" if is_bytes else typing.cast(Path, source).name
+
+    verify = _resolve_upload_verify(verify)
 
     retry_attempt = 0
     last_error: str | Exception | None = None
@@ -318,7 +370,7 @@ async def _upload_with_retry(
     fp: Path,
     signed_url: str,
     extra_headers: dict,
-    verify: bool,
+    verify: _VerifyT,
     max_retries: int = 3,
     min_backoff_sec: float = 0.5,
     max_backoff_sec: float = 30.0,
@@ -337,7 +389,9 @@ async def _upload_with_retry(
         fp: Path to file to upload
         signed_url: Pre-signed URL for upload
         extra_headers: Headers including Content-MD5, Content-Length
-        verify: Whether to verify SSL certificates
+        verify: SSL verification for the PUT. True (default) uses the trust
+            configured for the session; see `_resolve_upload_verify`. A bool or
+            SSLContext passed explicitly is used as-is.
         max_retries: Maximum retry attempts (default: 3)
         min_backoff_sec: Initial backoff delay (default: 0.5)
         max_backoff_sec: Maximum exponential backoff delay (default: 30.0)
@@ -363,7 +417,7 @@ async def _upload_with_retry(
 async def _upload_single_file(
     cfg: CommonInit,
     fp: Path,
-    verify: bool = True,
+    verify: _VerifyT = True,
     basedir: str | None = None,
     fname: str | None = None,
     content_type: str | None = None,
@@ -374,7 +428,8 @@ async def _upload_single_file(
     Args:
         cfg: Configuration containing project and domain information.
         fp: Path to the file to upload.
-        verify: Whether to verify SSL certificates.
+        verify: SSL verification for the upload. True (default) uses the trust
+            configured for the session; see `_resolve_upload_verify`.
         basedir: Optional base directory prefix for the remote path.
         fname: Optional file name for the remote path.
         content_type: Optional MIME type to store on the object, so that a browser
@@ -467,14 +522,15 @@ async def _upload_single_file(
 
 @syncify
 async def upload_file(
-    fp: Path, verify: bool = True, fname: str | None = None, content_type: str | None = None
+    fp: Path, verify: _VerifyT = True, fname: str | None = None, content_type: str | None = None
 ) -> Tuple[str, str]:
     """
     Uploads a file to a remote location and returns the remote URI.
 
     Args:
         fp: The file path to upload.
-        verify: Whether to verify the certificate for HTTPS requests.
+        verify: SSL verification for the upload. True (default) uses the trust
+            configured for the session (`admin.caCertFilePath` when set).
         fname: Optional file name for the remote path.
         content_type: Optional MIME type to store on the uploaded object, so browsers
             render it inline (used for artifact cards) rather than downloading it.
@@ -490,13 +546,14 @@ async def upload_file(
 
 
 @syncify
-async def upload_dir(dir_path: Path, verify: bool = True, prefix: str | None = None) -> str:
+async def upload_dir(dir_path: Path, verify: _VerifyT = True, prefix: str | None = None) -> str:
     """
     Uploads a directory to a remote location and returns the remote URI.
 
     Args:
         dir_path: The directory path to upload.
-        verify: Whether to verify the certificate for HTTPS requests.
+        verify: SSL verification for the upload. True (default) uses the trust
+            configured for the session (`admin.caCertFilePath` when set).
 
     Returns:
         The remote URI of the uploaded directory.

--- a/tests/flyte/remote/test_upload_tls.py
+++ b/tests/flyte/remote/test_upload_tls.py
@@ -1,0 +1,99 @@
+"""The trust configured for the session has to reach object-store uploads too.
+
+`verify=True` used to mean "certifi", which left the control plane and the object
+store on two different trust stores: `admin.caCertFilePath` fixed the first and was
+invisible to the second, so uploads failed with CERTIFICATE_VERIFY_FAILED on a
+connection the control plane had just made successfully.
+"""
+
+import ssl
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import certifi
+import httpx
+import pytest
+
+from flyte.errors import InitializationError
+from flyte.remote._data import (
+    _UPLOAD_TIMEOUT,
+    _resolve_upload_verify,
+    _ssl_context_from_ca_file,
+    _upload_with_retry,
+)
+
+
+def _session(*, ca_cert_file_path=None, insecure_skip_verify=False):
+    auth_kwargs = {"ca_cert_file_path": ca_cert_file_path} if ca_cert_file_path else {}
+    return MagicMock(auth_kwargs=auth_kwargs, insecure_skip_verify=insecure_skip_verify)
+
+
+def _patch_session(session):
+    return patch("flyte.remote._data.get_client", return_value=MagicMock(session_config=session))
+
+
+def test_ca_cert_file_path_reaches_uploads():
+    with _patch_session(_session(ca_cert_file_path=certifi.where())):
+        resolved = _resolve_upload_verify(True)
+    assert isinstance(resolved, ssl.SSLContext)
+    # Trusting exactly that bundle, not silently falling back to something else.
+    assert len(resolved.get_ca_certs()) == len(ssl.create_default_context(cafile=certifi.where()).get_ca_certs())
+
+
+def test_ca_context_is_cached_per_path():
+    """upload_dir fans out per file; the bundle must be parsed once, not per PUT."""
+    assert _ssl_context_from_ca_file(certifi.where()) is _ssl_context_from_ca_file(certifi.where())
+
+
+def test_insecure_skip_verify_does_not_verify():
+    """The bootstrapped chain anchors the control plane's host, not the object store's."""
+    with _patch_session(_session(insecure_skip_verify=True)):
+        assert _resolve_upload_verify(True) is False
+
+
+def test_ca_cert_file_path_wins_over_skip_verify():
+    """Matches _platform_to_client_kwargs, where ca_cert_file_path takes precedence."""
+    with _patch_session(_session(ca_cert_file_path=certifi.where(), insecure_skip_verify=True)):
+        assert isinstance(_resolve_upload_verify(True), ssl.SSLContext)
+
+
+def test_plain_session_keeps_httpx_default():
+    with _patch_session(_session()):
+        assert _resolve_upload_verify(True) is True
+
+
+@pytest.mark.parametrize("explicit", [False, ssl.create_default_context()])
+def test_explicit_verify_is_untouched(explicit):
+    """A caller who passed their own value should not have it overridden."""
+    with _patch_session(_session(ca_cert_file_path=certifi.where())) as get_client:
+        assert _resolve_upload_verify(explicit) is explicit
+        get_client.assert_not_called()
+
+
+def test_uninitialized_client_falls_back_to_default():
+    with patch(
+        "flyte.remote._data.get_client",
+        side_effect=InitializationError("ClientNotInitializedError", "user", "nope"),
+    ):
+        assert _resolve_upload_verify(True) is True
+
+
+@pytest.mark.asyncio
+async def test_upload_passes_resolved_context_to_httpx(tmp_path):
+    """End of the wire: the context reaches the client that makes the PUT."""
+    f = tmp_path / "bundle.tar.gz"
+    f.write_bytes(b"fake bundle content")
+
+    with patch("flyte.remote._data.httpx.AsyncClient") as mock_cls:
+        client = AsyncMock()
+        client.put.return_value = httpx.Response(200)
+        ctx = AsyncMock()
+        ctx.__aenter__.return_value = client
+        ctx.__aexit__.return_value = False
+        mock_cls.return_value = ctx
+
+        with _patch_session(_session(ca_cert_file_path=certifi.where())):
+            await _upload_with_retry(f, "https://signed.url/upload", {}, verify=True)
+
+    kwargs = mock_cls.call_args.kwargs
+    assert isinstance(kwargs["verify"], ssl.SSLContext)
+    assert kwargs["timeout"] == _UPLOAD_TIMEOUT


### PR DESCRIPTION
## Problem

`flyte run` fails at code-bundle upload behind a TLS-inspecting corporate proxy, **even though the control plane connects fine**:

```
Failed to upload fast<hash>.tar.gz after 3 retries: ConnectError:
[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
self-signed certificate in certificate chain (_ssl.c:1082)
```

The two planes resolved trust from different places:

| | Client | Trust source |
|---|---|---|
| Control plane | pyqwest / rustls | honors `ca_cert_file_path`; `tls_include_system_certs` otherwise |
| Uploads | `httpx.AsyncClient(verify=verify)` (`_data.py`) | bare `bool`, never wired to `PlatformConfig` |

With `verify=True`, httpx 0.28's `create_ssl_context` falls through to `ssl.create_default_context(cafile=certifi.where())` — certifi alone. So a private or intercepting CA set via `admin.caCertFilePath` fixed the control plane and stayed invisible to the object store, and there was **no supported way to configure trust for the data path** (only the undocumented `SSL_CERT_FILE`, which httpx happens to read).

## Fix

Resolve `verify=True` against the active session before building the client:

- **`ca_cert_file_path`** → builds the `SSLContext` used for the PUT. Cached per path, since `upload_dir` fans out per file and reparsing the bundle per PUT is pure overhead.
- **`insecure_skip_verify`** → maps to "do not verify" rather than to the bootstrapped bytes. `_bootstrap_ssl_from_server` pins the *control plane's* chain, which is not a trust anchor for the object store's host. This is the one judgment call in the PR — happy to drop it and keep the change to `ca_cert_file_path` only if you'd rather not widen what that flag does.
- An explicitly passed `bool` or `SSLContext` is left untouched, so callers of `upload_file` / `upload_dir` keep their behavior. Annotations widen `bool` → `bool | ssl.SSLContext`.
- An uninitialized client still gets httpx's default.

## Testing

`tests/flyte/remote/test_upload_tls.py` — 9 cases covering each branch plus the end-to-end assertion that the context reaches the client making the PUT.

- `pytest tests/flyte/remote/` → 641 passed
- `ruff check` / `ruff format --check` → clean
- `mypy` and `ty` on the changed file → clean

## Notes for reviewers

- No change to control-plane behavior; `_session.py` is untouched.
- The reported customer case  is unblocked today with `export SSL_CERT_FILE=<bundle>`. This PR makes `admin.caCertFilePath` cover both planes so a single documented config option is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUgT21VhSRKEqoMf7NVgXv