### PR TITLE
fix(deploy): propagate --image to tasks in every environment, not just the first

### DIFF
--- a/src/flyte/_deploy.py
+++ b/src/flyte/_deploy.py
@@ -520,7 +520,19 @@ async def _deploy_task_env(context: DeploymentContext) -> DeployedTaskEnvironmen
 
 
 @requires_initialization
-async def apply(deployment_plan: DeploymentPlan, copy_style: CopyFiles, dryrun: bool = False) -> Deployment:
+async def apply(
+    deployment_plan: DeploymentPlan,
+    copy_style: CopyFiles,
+    dryrun: bool = False,
+    image_cache: ImageCache | None = None,
+) -> Deployment:
+    """
+    Args:
+        image_cache: Pre-built image cache to serialize into this plan's tasks. `deploy` passes a
+            cache merged across *all* plans in the same invocation so that a task calling into a
+            sibling environment can still resolve that environment's image at runtime (see
+            `_build_images_for_plans`). When None, images are built for this plan alone.
+    """
     import flyte.errors
 
     from ._code_bundle import build_code_bundle
@@ -529,7 +541,8 @@ async def apply(deployment_plan: DeploymentPlan, copy_style: CopyFiles, dryrun: 
 
     cfg = get_init_config()
 
-    image_cache = await _build_images(deployment_plan, cfg.images, copy_style)
+    if image_cache is None:
+        image_cache = await _build_images(deployment_plan, cfg.images, copy_style)
 
     # Collect all `Environment.include` files across envs in the plan. They are
     # resolved to absolute paths anchored at each env's declaring file and
@@ -724,9 +737,17 @@ async def deploy(
     if interactive_mode:
         raise NotImplementedError("Interactive mode not yet implemented for deployment")
     deployment_plans = plan_deploy(*envs, version=version)
+    cfg = get_init_config()
+    # Build every plan's images up front and share one merged cache across all of them. Independent
+    # environments land in separate plans, but a task in one environment can call a task in another,
+    # and that child's image is resolved at runtime from the cache transported in the *parent's*
+    # container args. A per-plan cache leaves the sibling env missing from that lookup, which
+    # silently falls back to the default image (flyteorg/flyte:...) instead of the env's real image
+    # -- notably dropping a `flyte deploy --image <uri>` override on every env but the first.
+    image_cache = await _build_images_for_plans(deployment_plans, cfg.images, copy_style)
     deployments = []
     for deployment_plan in deployment_plans:
-        deployments.append(apply(deployment_plan, copy_style=copy_style, dryrun=dry_run))
+        deployments.append(apply(deployment_plan, copy_style=copy_style, dryrun=dry_run, image_cache=image_cache))
     return await asyncio.gather(*deployments)
 
 
@@ -753,12 +774,31 @@ async def build_images(
     Returns:
         ImageCache containing the built images.
     """
-    from ._internal.imagebuild.image_builder import ImageCache
-
     cfg = get_init_config()
     images = cfg.images if cfg else {}
-    deployment_plans = plan_deploy(*envs)
-    caches = [await _build_images(plan, images, copy_style, seed_cache=seed_cache) for plan in deployment_plans]
+    return await _build_images_for_plans(plan_deploy(*envs), images, copy_style, seed_cache=seed_cache)
+
+
+async def _build_images_for_plans(
+    deployment_plans: List[DeploymentPlan],
+    image_refs: Dict[str, str] | None = None,
+    copy_style: "CopyFiles" = "loaded_modules",
+    seed_cache: ImageCache | None = None,
+) -> ImageCache:
+    """
+    Build images for several deployment plans and merge the results into a single ImageCache.
+
+    The merged cache is what makes cross-environment task calls work: every environment deployed in
+    the same invocation is resolvable from any task's serialization context, whether or not the
+    environments are linked by `depends_on` (independent environments are planned separately).
+    """
+    from ._internal.imagebuild.image_builder import ImageCache
+
+    # Plans hold disjoint environments, so build them concurrently -- `deploy` used to get this
+    # parallelism for free by gathering over per-plan `apply` calls.
+    caches = await asyncio.gather(
+        *(_build_images(plan, image_refs, copy_style, seed_cache=seed_cache) for plan in deployment_plans)
+    )
     if len(caches) == 1:
         return caches[0]
 

--- a/tests/flyte/test_deploy.py
+++ b/tests/flyte/test_deploy.py
@@ -715,6 +715,8 @@ def test_deploy_dry_run_is_forwarded(kwargs, expected):
 
     with (
         patch("flyte._deploy.plan_deploy", return_value=[Mock()]),
+        patch("flyte._deploy.get_init_config", return_value=Mock(images={})),
+        patch("flyte._deploy._build_images_for_plans", new=AsyncMock(return_value=ImageCache(image_lookup={}))),
         patch("flyte._deploy.apply", new=apply_mock),
         warnings.catch_warnings(),
     ):
@@ -740,6 +742,8 @@ def test_deploy_dryrun_alias_is_deprecated(kwargs, expected):
 
     with (
         patch("flyte._deploy.plan_deploy", return_value=[Mock()]),
+        patch("flyte._deploy.get_init_config", return_value=Mock(images={})),
+        patch("flyte._deploy._build_images_for_plans", new=AsyncMock(return_value=ImageCache(image_lookup={}))),
         patch("flyte._deploy.apply", new=apply_mock),
         pytest.warns(FutureWarning, match=r"use flyte\.deploy\(dry_run=\.\.\.\)"),
     ):

--- a/tests/flyte/test_deploy_image_cache.py
+++ b/tests/flyte/test_deploy_image_cache.py
@@ -126,3 +126,104 @@ def test_ambient_image_cache_returns_transported_cache_in_pod():
 
     with patch("flyte._run.internal_ctx", return_value=fake_ctx):
         assert _ambient_image_cache() is cache
+
+
+# ---------------------------------------------------------------------------
+# Cross-environment image resolution: independent envs are planned separately,
+# but must still share one image cache so a task can call into a sibling env.
+# ---------------------------------------------------------------------------
+
+
+CLI_IMAGE = "my.registry.example.com/custom:v1"
+
+
+@pytest.mark.asyncio
+async def test_build_images_for_plans_merges_cli_image_across_independent_envs():
+    """`flyte deploy --image <uri>` must reach every env, not just the first plan's.
+
+    Independent environments (no `depends_on` link) each land in their own DeploymentPlan, so a
+    per-plan image cache only ever knows about its own env.
+    """
+    from flyte._deploy import _build_images_for_plans, plan_deploy
+
+    flyte.init()
+    parent = TaskEnvironment(name="xenv-parent")
+    sibling = TaskEnvironment(name="xenv-sibling", resources=flyte.Resources(cpu="0.5"))
+    cloned = parent.clone_with(name="xenv-cloned", image="auto")
+
+    plans = plan_deploy(parent, sibling, cloned)
+    assert [list(p.envs) for p in plans] == [["xenv-parent"], ["xenv-sibling"], ["xenv-cloned"]]
+
+    merged = await _build_images_for_plans(plans, {"default": CLI_IMAGE})
+
+    assert merged.image_lookup == {
+        "xenv-parent": CLI_IMAGE,
+        "xenv-sibling": CLI_IMAGE,
+        "xenv-cloned": CLI_IMAGE,
+    }
+
+
+@pytest.mark.asyncio
+async def test_deploy_gives_every_plan_the_merged_image_cache():
+    """Every deployed env's SerializationContext sees all envs deployed in the same invocation.
+
+    The parent's container args carry this cache into the pod, and a child task in another env has
+    its image resolved from it at runtime. Before this, the sibling env was absent from the
+    parent's cache and silently fell back to the default flyteorg image.
+    """
+    import pathlib
+    from unittest.mock import Mock
+
+    from flyte._internal.runtime.task_serde import lookup_image_in_cache
+
+    flyte.init()
+    parent = TaskEnvironment(name="merged-parent")
+    sibling = TaskEnvironment(name="merged-sibling", resources=flyte.Resources(cpu="0.5"))
+
+    @sibling.task
+    async def child(x: int) -> int:
+        return x
+
+    @parent.task
+    async def root(x: int) -> int:
+        return await child(x=x)
+
+    fake_bundle = Mock()
+    fake_bundle.computed_version = "bundle-v1"
+
+    fake_cfg = Mock()
+    fake_cfg.root_dir = pathlib.Path("/tmp")
+    fake_cfg.images = {"default": CLI_IMAGE}
+    fake_cfg.project, fake_cfg.domain, fake_cfg.org = "p", "d", "o"
+
+    seen = []
+
+    def _fake_get_deployer(_env_type):
+        async def _deployer(context):
+            seen.append(context.serialization_context)
+            deployed = Mock()
+            deployed.get_name.return_value = context.environment.name
+            return deployed
+
+        return _deployer
+
+    with (
+        patch("flyte._initialize.is_initialized", return_value=True),
+        patch("flyte._deploy.get_init_config", return_value=fake_cfg),
+        patch("flyte._code_bundle._includes.collect_env_include_files", return_value=[]),
+        patch("flyte._code_bundle.build_code_bundle", new=AsyncMock(return_value=fake_bundle)),
+        patch("flyte._deployer.get_deployer", new=_fake_get_deployer),
+    ):
+        await flyte.deploy.aio(parent, sibling, dry_run=True)
+
+    # Two independent envs -> two plans -> two deployer invocations, both with the merged cache.
+    assert len(seen) == 2
+    for sc in seen:
+        assert sc.image_cache.image_lookup == {
+            "merged-parent": CLI_IMAGE,
+            "merged-sibling": CLI_IMAGE,
+        }
+
+    # The parent's context can now resolve the sibling env's task image to the --image override
+    # instead of silently falling back to the default flyteorg image.
+    assert lookup_image_in_cache(seen[0], child.parent_env_name, child.image) == CLI_IMAGE


### PR DESCRIPTION
## Problem

`flyte deploy --image <image> --recursive <module>` propagates the image correctly when the module defines a single `TaskEnvironment`:

```python
env = flyte.TaskEnvironment(name="test-environment")

@env.task
async def example_task(x: int) -> int:
    return x

@env.task
async def another_example_task(y: int) -> list[int]:
    return list(await asyncio.gather(*[example_task(x=x) for x in range(y)]))
```

But as soon as a second environment is involved — either a `clone_with` override or a plain second `TaskEnvironment` — the nested task runs on `ghcr.io/flyteorg/flyte:py3.11-v2.7.1` instead of the `--image` value:

```python
env = flyte.TaskEnvironment(name="test-environment")
med = flyte.TaskEnvironment(name="medium-environment", resources=flyte.Resources(cpu="0.5"))

@med.task
async def example_task(x: int) -> int:      # <-- runs on the default image
    return x

@env.task
async def another_example_task(y: int) -> list[int]:
    return list(await asyncio.gather(*[example_task(x=x) for x in range(y)]))
```

There is no error — just the wrong image.

## Root cause

1. `plan_deploy` puts every environment not reachable through `depends_on` into **its own `DeploymentPlan`**. Two independent envs → two plans.
2. `apply` called `_build_images` per plan, so each plan got an `ImageCache` containing **only its own env**.
3. That cache is serialized into the pod's `--image-cache` container arg (`_task.py`), and at runtime a parent task resolves a *child* task's container image from it via `lookup_image_in_cache(sc, child_env_name, child_image)` (`task_serde.py`).
4. For a child in a sibling env the lookup misses. The fallback branch

   ```python
   if image._ref_name is None and (not serialize_context.image_cache or len(image._layers) == 0):
       return image.uri
   ```

   returns `image.uri` — and on a released flyte wheel the default `Image.from_debian_base()` has **zero layers**, so the miss silently resolves to the unbuilt default image rather than raising `MissingEnvironment`.

Reproduced locally: for the snippet above, `plan_deploy` yields 3 plans whose caches are `{'test-environment': ...}`, `{'medium-environment': ...}`, `{'overrides': ...}` — each blind to the others.

## Fix

Build every plan's images up front in `deploy` and hand **all** plans the merged cache, so any env deployed in the same invocation is resolvable from any task's serialization context — with or without a `depends_on` link.

- Extracted `_build_images_for_plans`, which is the merge `build_images` already performed, and made it build plans **concurrently** (`deploy` previously got that parallelism for free by gathering over per-plan `apply` calls).
- `apply` takes an optional pre-built `image_cache`; when omitted it builds for its plan alone, so standalone callers are unchanged.

Note the merged cache now feeds the deployment version hash. That is correct rather than churn: the cache is part of the container args, so a changed sibling image genuinely *is* a changed deployment. Version stays stable while sibling image URIs do.

This does not remove the `depends_on` requirement for envs deployed in *separate* invocations — that case still raises the existing actionable `MissingEnvironment` error.

One behavior change worth calling out: `deploy` now reads `get_init_config()` itself, so `flyte.deploy(...)` on an uninitialized client raises `InitializationError` from `deploy` rather than from the `apply` call it delegates to. Same exception type, same guidance, marginally earlier.

## Tests

Two regression tests in `tests/flyte/test_deploy_image_cache.py`:

- `test_build_images_for_plans_merges_cli_image_across_independent_envs` — asserts three independently-planned envs (including a `clone_with` one) all land in one cache carrying the `--image` override.
- `test_deploy_gives_every_plan_the_merged_image_cache` — drives `flyte.deploy(...)` end to end and asserts every deployed env's `SerializationContext` sees all envs, and that the parent's context resolves the sibling task's image to the `--image` override instead of the default.

Rebased onto `main` to pick up #1573 (`dry_run`, with the deprecated `dryrun` alias). The two `test_deploy.py` dry-run tests isolate `deploy` by patching `plan_deploy`/`apply`; they now also patch `get_init_config` and `_build_images_for_plans`, since `deploy` gained that collaborator.

Verified: full `tests/flyte` + `tests/cli` suite passes (4363 passed, 9 skipped), plus `make mypy`, `make ty`, `make fmt`. The two failures in that run — `test_keyring_store::test_retrieve_degrades_when_keyring_not_installed` and `test_int_image_builder::test_real_build` — are pre-existing and environmental (keyring installed locally; no container registry configured); both fail identically on `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwQixBcyR5va6BC75jaQx3
