### PR TITLE
fix: normalize the Image DSL's path arguments consistently

### DIFF
--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -457,6 +457,10 @@ class Commands(Layer):
 class WorkDir(Layer):
     workdir: str
 
+    def __post_init__(self):
+        if not isinstance(self.workdir, str):
+            object.__setattr__(self, "workdir", str(self.workdir))
+
     def update_hash(self, hasher: hashlib._Hash, ignore: Optional[Any] = None):
         hasher.update(self.workdir.encode("utf-8"))
 
@@ -488,6 +492,11 @@ class CopyConfig(Layer):
             raise ValueError(f"Invalid path_type {self.path_type}, must be 0 (file) or 1 (directory)")
         if not isinstance(self.src, Path):
             object.__setattr__(self, "src", Path(self.src))
+        # `dst` is a path *inside the image*, so a caller naturally reaches for a Path here just as
+        # they do for `src`. Normalizing it keeps every consumer honest: `update_hash` calls
+        # `.encode()` on it, and the remote builder already compensates with `str(layer.dst)`.
+        if not isinstance(self.dst, str):
+            object.__setattr__(self, "dst", str(self.dst))
 
     def validate(self):
         # A missing / wrong-typed source path is a user mistake in the image spec
@@ -1273,7 +1282,7 @@ class Image:
             return f"{self.registry}/{self.name}:{tag}"
         return f"{self.name}:{tag}"
 
-    def with_workdir(self, workdir: str) -> Image:
+    def with_workdir(self, workdir: str | Path) -> Image:
         """
         Use this method to create a new image with the specified working directory
         This will override any existing working directory
@@ -1281,7 +1290,7 @@ class Image:
         Args:
             workdir: working directory to use
         """
-        new_image = self.clone(addl_layer=WorkDir(workdir=workdir))
+        new_image = self.clone(addl_layer=WorkDir(workdir=str(workdir)))
         return new_image
 
     def with_requirements(
@@ -1401,7 +1410,7 @@ class Image:
         new_image = self.clone(addl_layer=Env.from_dict(env_vars))
         return new_image
 
-    def with_source_folder(self, src: Path, dst: str = ".", copy_contents_only: bool = False) -> Image:
+    def with_source_folder(self, src: str | Path, dst: str | Path = ".", copy_contents_only: bool = False) -> Image:
         """
         Use this method to create a new image with the specified local directory layered on top of the current image.
         If dest is not specified, it will be copied to the working directory of the image
@@ -1415,12 +1424,14 @@ class Image:
         Returns:
             Image
         """
+        src = Path(src)
+        dst = str(dst)
         if not copy_contents_only:
             dst = str("./" + src.name) if dst == "." else dst
         new_image = self.clone(addl_layer=CopyConfig(path_type=1, src=src, dst=dst))
         return new_image
 
-    def with_source_file(self, src: typing.Union[Path, typing.List[Path]], dst: str = ".") -> Image:
+    def with_source_file(self, src: typing.Union[str, Path, typing.List[Path]], dst: str | Path = ".") -> Image:
         """
         Use this method to create a new image with the specified local file(s) layered on top of the current image.
         If dest is not specified, it will be copied to the working directory of the image
@@ -1432,6 +1443,7 @@ class Image:
         Returns:
             Image
         """
+        dst = str(dst)
         if isinstance(src, list):
             names = [p.name for p in src]
             duplicates = {name for name in names if names.count(name) > 1}
@@ -1442,9 +1454,9 @@ class Image:
                 )
             image = self
             for path in src:
-                image = image.clone(addl_layer=CopyConfig(path_type=0, src=path, dst=dst))
+                image = image.clone(addl_layer=CopyConfig(path_type=0, src=Path(path), dst=dst))
             return image
-        return self.clone(addl_layer=CopyConfig(path_type=0, src=src, dst=dst))
+        return self.clone(addl_layer=CopyConfig(path_type=0, src=Path(src), dst=dst))
 
     def with_code_bundle(
         self,
@@ -1480,7 +1492,7 @@ class Image:
     def with_uv_project(
         self,
         pyproject_file: str | Path,
-        uvlock: Path | None = None,
+        uvlock: str | Path | None = None,
         index_url: Optional[str] = None,
         extra_index_urls: Union[List[str], Tuple[str, ...], None] = None,
         pre: bool = False,
@@ -1515,6 +1527,8 @@ class Image:
         """
         if isinstance(pyproject_file, str):
             pyproject_file = Path(pyproject_file)
+        if isinstance(uvlock, str):
+            uvlock = Path(uvlock)
         # If uvlock is not provided, use the default uv.lock file in the same directory if it exists
         if uvlock is None:
             default_uvlock = pyproject_file.parent / "uv.lock"
@@ -1536,7 +1550,7 @@ class Image:
     def with_poetry_project(
         self,
         pyproject_file: str | Path,
-        poetry_lock: Path | None = None,
+        poetry_lock: str | Path | None = None,
         extra_args: Optional[str] = None,
         secret_mounts: Optional[SecretRequest] = None,
         project_install_mode: typing.Literal["dependencies_only", "install_project"] = "dependencies_only",
@@ -1568,6 +1582,8 @@ class Image:
         """
         if isinstance(pyproject_file, str):
             pyproject_file = Path(pyproject_file)
+        if isinstance(poetry_lock, str):
+            poetry_lock = Path(poetry_lock)
         new_image = self.clone(
             addl_layer=PoetryProject(
                 pyproject=pyproject_file,
@@ -1582,7 +1598,7 @@ class Image:
     def with_pixi_project(
         self,
         manifest_file: str | Path,
-        pixi_lock: Path | None = None,
+        pixi_lock: str | Path | None = None,
         environment: str = "default",
         extra_args: Optional[str] = None,
         secret_mounts: Optional[SecretRequest] = None,
@@ -1641,6 +1657,8 @@ class Image:
             # Mirror pixi's own manifest discovery: pixi.toml wins over pyproject.toml.
             pixi_toml = manifest_file / "pixi.toml"
             manifest_file = pixi_toml if pixi_toml.exists() else manifest_file / "pyproject.toml"
+        if isinstance(pixi_lock, str):
+            pixi_lock = Path(pixi_lock)
         # If pixi_lock is not provided, use the default pixi.lock file in the same directory if it exists
         if pixi_lock is None:
             default_pixi_lock = manifest_file.parent / "pixi.lock"

--- a/tests/flyte/test_image.py
+++ b/tests/flyte/test_image.py
@@ -1185,3 +1185,107 @@ def test_default_image_dev_mode_pypi_fallback(monkeypatch):
         pkg for layer in image._layers if isinstance(layer, PipPackages) for pkg in (layer.packages or ())
     )
     assert "flyte<2.3.7" in pip_packages, f"expected 'flyte<2.3.7' in pip layers, got {pip_packages}"
+
+
+def test_path_dst_is_normalized_to_str(tmp_path):
+    """A Path in a `dst` position must behave exactly like the equivalent str.
+
+    Reproduces FLYTE-SDK-8A: `CopyConfig.__post_init__` normalized `src` but not `dst`, so a
+    `Path` survived into `update_hash`, where `self.dst.encode("utf-8")` raised
+    `AttributeError: 'PosixPath' object has no attribute 'encode'` during `flyte deploy`'s
+    image-existence check — long after the call that introduced it.
+    """
+    src = tmp_path / "pkg"
+    src.mkdir()
+    (src / "mod.py").write_text("x = 1")
+
+    base = Image.from_debian_base(registry="localhost", name="test-image", flyte_version="0.2.0b14")
+
+    # The crash itself: hashing must survive a Path dst.
+    folder_layer = base.with_source_folder(src, dst=Path("/opt/code"))._layers[-1]
+    assert folder_layer.dst == "/opt/code"
+    assert isinstance(folder_layer.dst, str)
+    base.with_source_folder(src, dst=Path("/opt/code"))._get_hash_digest()
+
+    file_layer = base.with_source_file(src / "mod.py", dst=Path("/opt/code"))._layers[-1]
+    assert file_layer.dst == "/opt/code"
+    assert isinstance(file_layer.dst, str)
+    base.with_source_file(src / "mod.py", dst=Path("/opt/code"))._get_hash_digest()
+
+    # A Path dst must hash identically to the same dst spelled as a str.
+    assert (
+        base.with_source_folder(src, dst=Path("/opt/code"))._get_hash_digest()
+        == base.with_source_folder(src, dst="/opt/code")._get_hash_digest()
+    )
+
+
+def test_path_dst_does_not_flip_copy_semantics(tmp_path):
+    """`dst=Path(".")` must keep the copy-the-folder-itself default, not silently drop it.
+
+    The `dst == "."` test in `with_source_folder` compares against a str, so a `Path(".")` fell
+    through to the `copy_contents_only=True` behaviour without anyone asking for it.
+    """
+    src = tmp_path / "pkg"
+    src.mkdir()
+    (src / "mod.py").write_text("x = 1")
+
+    base = Image.from_debian_base(registry="localhost", name="test-image", flyte_version="0.2.0b14")
+
+    assert base.with_source_folder(src, dst=Path("."))._layers[-1].dst == "./pkg"
+    assert base.with_source_folder(src, dst=".")._layers[-1].dst == "./pkg"
+    assert base.with_source_folder(src, dst=Path("."), copy_contents_only=True)._layers[-1].dst == "."
+
+
+def test_str_src_is_normalized_to_path(tmp_path):
+    """`with_source_folder` must accept a str src, which `CopyConfig` already normalizes."""
+    src = tmp_path / "pkg"
+    src.mkdir()
+    (src / "mod.py").write_text("x = 1")
+
+    base = Image.from_debian_base(registry="localhost", name="test-image", flyte_version="0.2.0b14")
+    layer = base.with_source_folder(str(src))._layers[-1]
+    assert layer.src == src
+    assert layer.dst == "./pkg"
+
+
+def test_path_workdir_is_normalized_to_str():
+    """`WorkDir.update_hash` calls `.encode()` on `workdir` — the same shape as CopyConfig.dst."""
+    base = Image.from_debian_base(registry="localhost", name="test-image", flyte_version="0.2.0b14")
+
+    layer = base.with_workdir(Path("/opt/app"))._layers[-1]
+    assert layer.workdir == "/opt/app"
+    assert isinstance(layer.workdir, str)
+    assert base.with_workdir(Path("/opt/app"))._get_hash_digest() == base.with_workdir("/opt/app")._get_hash_digest()
+
+
+def test_lock_file_arguments_accept_str(tmp_path):
+    """The lock-file half of each project setter must accept a str like the manifest half does.
+
+    `with_uv_project` / `with_poetry_project` / `with_pixi_project` each coerce their first path
+    argument (`pyproject_file` / `manifest_file`) from a str but left the second (`uvlock` /
+    `poetry_lock` / `pixi_lock`) exactly as passed, so a str there reached `validate()` as
+    `AttributeError: 'str' object has no attribute 'exists'` — the same late, misattributed
+    failure as FLYTE-SDK-8A, from the opposite direction.
+    """
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "x"\nversion = "0.1"\n')
+    (tmp_path / "uv.lock").write_text("version = 1\n")
+    (tmp_path / "poetry.lock").write_text("x\n")
+    (tmp_path / "pixi.lock").write_text("x\n")
+    (tmp_path / "pixi.toml").write_text(
+        '[project]\nname = "p"\n[tool.pixi.workspace]\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n'
+    )
+
+    base = Image.from_debian_base(registry="localhost", name="test-image", flyte_version="0.2.0b14")
+    pyproject, manifest = tmp_path / "pyproject.toml", tmp_path / "pixi.toml"
+
+    cases = [
+        ("uvlock", lambda v: base.with_uv_project(str(pyproject), uvlock=v), tmp_path / "uv.lock"),
+        ("poetry_lock", lambda v: base.with_poetry_project(str(pyproject), poetry_lock=v), tmp_path / "poetry.lock"),
+        ("pixi_lock", lambda v: base.with_pixi_project(str(manifest), pixi_lock=v), tmp_path / "pixi.lock"),
+    ]
+    for name, build, lock in cases:
+        as_str, as_path = build(str(lock)), build(lock)
+        # Neither spelling may raise, and both must describe the same image.
+        as_str.validate()
+        as_path.validate()
+        assert as_str._get_hash_digest() == as_path._get_hash_digest(), name


### PR DESCRIPTION
fixes FLYTE-SDK-8A

The image builder's path arguments normalize inconsistently, so whether a `str` or a `Path` works
depends on which argument you happen to be filling. Both directions fail late, far from the call
that introduced the value.

## 1. A `Path` in a `dst` position — the reported crash

`FLYTE-SDK-8A` fired for the first time yesterday (release **2.7.2**, current) during a `flyte deploy`:

```
AttributeError: 'PosixPath' object has no attribute 'encode'
  cli/_deploy.py invoke -> _deploy.deploy -> _build_images -> _build.build
    -> image_builder.image_exists -> _image._final_tag -> _get_hash_digest
      -> CopyConfig.update_hash
```

The crashing frame's locals name the culprit exactly:

```python
self = CopyConfig(1, PosixPath('../../dbt_utsikt'), PosixPath('.'))
```

`CopyConfig.__post_init__` normalizes `src` into a `Path` but leaves `dst` exactly as passed:

```python
if not isinstance(self.src, Path):
    object.__setattr__(self, "src", Path(self.src))
# ...nothing for dst
```

so the `Path` is accepted in silence and only surfaces much later, at
`hasher.update(self.dst.encode("utf-8"))` — a traceback that names the hasher rather than the
`with_source_folder(...)` call that introduced the value.

**The same `Path` causes a second, silent bug.** `with_source_folder` decides copy semantics with
`dst == "."`, which a `Path(".")` fails:

```python
if not copy_contents_only:
    dst = str("./" + src.name) if dst == "." else dst
```

so `dst=Path(".")` quietly took the `copy_contents_only=True` path — copying the folder's *contents*
instead of the folder — without anyone asking for it. That one never raises.

## 2. A `str` in a lock-file position — the same gap, opposite direction

Auditing the rest of the DSL turned up the mirror image, three for three. Each project setter coerces
its **first** path argument from a `str` and leaves the **second** untouched:

```python
if isinstance(pyproject_file, str):
    pyproject_file = Path(pyproject_file)   # manifest half: coerced
# uvlock: not coerced
```

So the sibling argument in the *same signature* behaves differently:

| call | result on `main` |
|---|---|
| `with_uv_project(pyproject, uvlock="uv.lock")` | `AttributeError: 'str' object has no attribute 'exists'` |
| `with_poetry_project(pyproject, poetry_lock="poetry.lock")` | `AttributeError: 'str' object has no attribute 'exists'` |
| `with_pixi_project(manifest, pixi_lock="pixi.lock")` | `AttributeError: 'str' object has no attribute 'exists'` |
| the same three with a `Path` | fine |

## Why normalizing is the right fix

The rest of the codebase already assumes these are normalized and compensates for it:

- `remote_builder.py:465,475` — `dst=str(layer.dst)` at both call sites
- `with_dockerignore` — `DockerIgnore(path=str(path))` coerces at the call site
- `CodeBundleLayer.update_hash` — f-strings `dst`, so a `Path` happens to work there

`CopyConfig.update_hash` was the one unguarded consumer. `WorkDir.workdir` is the identical shape —
a str-annotated path field with a bare `.encode()` — and is normalized here too.

## Change

- `CopyConfig.__post_init__` normalizes `dst` the way it already normalizes `src`; `WorkDir` gains the
  same normalization.
- `with_source_folder` / `with_source_file` / `with_workdir` coerce at the boundary, so the
  `dst == "."` comparison sees a `str`.
- `with_uv_project` / `with_poetry_project` / `with_pixi_project` coerce their lock-file argument
  right beside the manifest argument they already coerce.
- Signatures widen to `str | Path` to state what was already accepted. Because coercion happens at the
  boundary, the narrow dataclass annotations stay true and **both `mypy` and `ty` verify this with no
  suppression**.

## Reachability

The FLYTE-SDK-8A crash is under `cli/_deploy.py`'s `@capture_errors`, and `AttributeError` is not
filtered by `_is_user_error` — which is why it reached Sentry as an SDK crash rather than a
user-facing message.

## Validation

Five regression tests, each verified to fail on unpatched `main` **with the production error** and
pass with the fix:

- `test_path_dst_is_normalized_to_str` — the reported `AttributeError`, folder + file layers, and that
  a `Path` dst hashes identically to the same dst as a `str`
- `test_path_dst_does_not_flip_copy_semantics` — `dst=Path(".")` keeps the copy-the-folder default
- `test_str_src_is_normalized_to_path` — a `str` src works, as `CopyConfig` already implied
- `test_path_workdir_is_normalized_to_str`
- `test_lock_file_arguments_accept_str` — all three lock arguments, str vs Path hashing identically

`make fmt`, `ruff check`, `mypy`, `ty` and `check-docstrings` are all clean. The image suites pass; the
only local failures are pre-existing on clean `main` (no docker daemon in the sandbox), verified by
running them against an unpatched tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)