### PR TITLE
fix: accept dry_run in flyte.deploy, deprecate dryrun

### DIFF
--- a/src/flyte/_deploy.py
+++ b/src/flyte/_deploy.py
@@ -6,6 +6,7 @@ import hashlib
 import os
 import pathlib
 import sys
+import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
 
@@ -686,17 +687,18 @@ def plan_deploy(*envs: Environment, version: Optional[str] = None) -> List[Deplo
 @syncify
 async def deploy(
     *envs: Environment,
-    dryrun: bool = False,
+    dry_run: bool = False,
     version: str | None = None,
     interactive_mode: bool | None = None,
     copy_style: CopyFiles = "loaded_modules",
+    dryrun: bool | None = None,
 ) -> List[Deployment]:
     """
     Deploy the given environment or list of environments.
 
     Args:
         envs: Environment or list of environments to deploy.
-        dryrun: dryrun mode, if True, the deployment will not be applied to the control plane.
+        dry_run: dry run mode, if True, the deployment will not be applied to the control plane.
         version: version of the deployment, if None, the version will be computed from the code bundle.
             TODO: Support for interactive_mode
         interactive_mode: Optional, can be forced to True or False.
@@ -704,16 +706,27 @@ async def deploy(
               considered interactive mode, while scripts are not. This is used to determine how the code bundle is
               created.
         copy_style: Copy style to use when running the task
+        dryrun: Deprecated alias for `dry_run`, kept for backwards compatibility. Use `dry_run` instead.
 
     Returns:
         Deployment object containing the deployed environments and tasks.
     """
+    if dryrun is not None:
+        # FutureWarning rather than DeprecationWarning: this body runs on the syncify background thread, so the
+        # warning cannot be attributed to the caller's module and a DeprecationWarning would be filtered out.
+        warnings.warn(
+            "flyte.deploy(dryrun=...) is deprecated, use flyte.deploy(dry_run=...) instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        # If the two disagree, err on the side of not deploying.
+        dry_run = dry_run or dryrun
     if interactive_mode:
         raise NotImplementedError("Interactive mode not yet implemented for deployment")
     deployment_plans = plan_deploy(*envs, version=version)
     deployments = []
     for deployment_plan in deployment_plans:
-        deployments.append(apply(deployment_plan, copy_style=copy_style, dryrun=dryrun))
+        deployments.append(apply(deployment_plan, copy_style=copy_style, dryrun=dry_run))
     return await asyncio.gather(*deployments)
 
 

--- a/src/flyte/cli/_deploy.py
+++ b/src/flyte/cli/_deploy.py
@@ -144,7 +144,7 @@ class DeployEnvCommand(click.RichCommand):
         with common.cli_status(obj.output_format, "Deploying...", no_progress=obj.no_progress):
             deployment = flyte.deploy(
                 self.env,
-                dryrun=self.deploy_args.dry_run,
+                dry_run=self.deploy_args.dry_run,
                 copy_style=self.deploy_args.copy_style,
                 version=self.deploy_args.version,
             )
@@ -216,7 +216,7 @@ class DeployEnvRecursiveCommand(click.Command):
         with common.cli_status(obj.output_format, "Deploying...", no_progress=obj.no_progress):
             deployments = flyte.deploy(
                 *all_envs,
-                dryrun=self.deploy_args.dry_run,
+                dry_run=self.deploy_args.dry_run,
                 copy_style=self.deploy_args.copy_style,
                 version=self.deploy_args.version,
             )

--- a/tests/flyte/test_deploy.py
+++ b/tests/flyte/test_deploy.py
@@ -4,6 +4,7 @@ import inspect
 import pathlib
 import sys
 import types
+import warnings
 from dataclasses import replace
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -697,3 +698,51 @@ async def test_deploy_task_without_triggers_emits_no_trigger_count(monkeypatch):
         await _deploy_task(task, context, dryrun=False)
 
     count_mock.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        ({}, False),
+        ({"dry_run": False}, False),
+        ({"dry_run": True}, True),
+    ],
+)
+def test_deploy_dry_run_is_forwarded(kwargs, expected):
+    """`flyte.deploy` takes `dry_run`, matching `flyte.with_runcontext`, `flyte.with_servecontext` and `flyte.build`."""
+    env = flyte.TaskEnvironment(name="dry_run_env")
+    apply_mock = AsyncMock(return_value=Mock())
+
+    with (
+        patch("flyte._deploy.plan_deploy", return_value=[Mock()]),
+        patch("flyte._deploy.apply", new=apply_mock),
+        warnings.catch_warnings(),
+    ):
+        warnings.simplefilter("error", FutureWarning)
+        flyte.deploy(env, **kwargs)
+
+    assert apply_mock.call_args.kwargs["dryrun"] is expected
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        ({"dryrun": True}, True),
+        ({"dryrun": False}, False),
+        ({"dry_run": True, "dryrun": False}, True),
+        ({"dry_run": False, "dryrun": True}, True),
+    ],
+)
+def test_deploy_dryrun_alias_is_deprecated(kwargs, expected):
+    """The old `dryrun` spelling still works but warns; if both are given, either one requests a dry run."""
+    env = flyte.TaskEnvironment(name="dryrun_alias_env")
+    apply_mock = AsyncMock(return_value=Mock())
+
+    with (
+        patch("flyte._deploy.plan_deploy", return_value=[Mock()]),
+        patch("flyte._deploy.apply", new=apply_mock),
+        pytest.warns(FutureWarning, match=r"use flyte\.deploy\(dry_run=\.\.\.\)"),
+    ):
+        flyte.deploy(env, **kwargs)
+
+    assert apply_mock.call_args.kwargs["dryrun"] is expected


### PR DESCRIPTION
## Summary

`flyte.deploy` is the only public API that spells the dry-run flag `dryrun`. Everything else uses `dry_run`:

| Call | Before | After |
|---|---|---|
| `flyte.deploy(...)` | `dryrun` | `dry_run` (`dryrun` deprecated) |
| `flyte.with_runcontext(...)` | `dry_run` | unchanged |
| `flyte.with_servecontext(...)` | `dry_run` | unchanged |
| `flyte.build(...)` | `dry_run` | unchanged |
| `flyte deploy` CLI | `--dry-run` / `--dryrun` | unchanged |

On 2.7.2, `flyte.deploy(env, dry_run=True)` raises `TypeError: deploy() got an unexpected keyword argument 'dry_run'`. The user docs have already tripped over this.

## Changes

- `flyte.deploy` now takes `dry_run: bool = False`.
- `dryrun` is still accepted as a deprecated keyword. It emits a `FutureWarning` and maps onto `dry_run`. If both are passed, either one being `True` requests a dry run, so disagreement errs toward not deploying.
- The `flyte deploy` CLI now calls `flyte.deploy(dry_run=...)`, so it no longer triggers the warning.
- Internal helpers (`apply`, `_deploy_task`, `DeploymentContext`, code bundling) keep their `dryrun` names. Only the public signature changes.

### Why `FutureWarning` and not `DeprecationWarning`

`@syncify` runs the coroutine body on a background-loop thread, so the warning can't be attributed to the caller's module. Under Python's default filters, a `DeprecationWarning` raised there is silently dropped. A plain-script check confirmed this: the `DeprecationWarning` probe printed nothing, and the `FutureWarning` was shown.

## Tests

- New tests in `tests/flyte/test_deploy.py` check that `dry_run` is forwarded to `apply` with no warning, that `dryrun` still works and warns, and how the two combine when both are passed.
- `uv run pytest tests/flyte/test_deploy.py tests/cli`: all pass (35 and 462).
- `ruff format --check`, `ruff check`, `mypy`, `ty check` and `make check-docstrings` are clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VaXxQs8r2Ca5ELNfAVVPQQ
