### PR TITLE
feat: export Documentation from flyte

### DIFF
--- a/src/flyte/__init__.py
+++ b/src/flyte/__init__.py
@@ -13,6 +13,7 @@ from ._condition import ConditionWebhook, new_condition
 from ._context import ctx
 from ._custom_context import custom_context, get_custom_context
 from ._deploy import build_images, deploy
+from ._doc import Documentation
 from ._environment import Environment
 from ._excepthook import custom_excepthook
 from ._group import group
@@ -74,6 +75,7 @@ __all__ = [
     "Cron",
     "Device",
     "DeviceClass",
+    "Documentation",
     "Environment",
     "FixedRate",
     "Image",

--- a/tests/flyte/test_doc.py
+++ b/tests/flyte/test_doc.py
@@ -1,0 +1,16 @@
+import flyte
+from flyte._doc import Documentation as _Documentation
+from flyte._doc import extract_docstring
+
+
+def test_documentation_is_exported():
+    assert flyte.Documentation is _Documentation
+    assert "Documentation" in flyte.__all__
+
+
+def test_extract_docstring():
+    def f():
+        """Trains a model."""
+
+    assert extract_docstring(f) == flyte.Documentation(description="Trains a model.")
+    assert extract_docstring(None) == flyte.Documentation(description="")


### PR DESCRIPTION
## What

Exports `Documentation` from `flyte` and adds it to `__all__`.

`@env.task(docs=...)` (`TaskEnvironment.task`) and `TaskTemplate.docs` are typed `Optional[Documentation]`, but the class lives in the private module `flyte._doc` and has never been exported. Users can only reach it with `from flyte._doc import Documentation`, which goes against CONTRIBUTING's rule that users should never need to import an underscore module. The Union docs had written `from flyte import Documentation`, which fails with `ImportError` on 2.7.2.

## Changes

- `src/flyte/__init__.py`: `from ._doc import Documentation`, and `"Documentation"` in `__all__`, in the existing order.
- `tests/flyte/test_doc.py`: the export is the same class as `flyte._doc.Documentation` and is listed in `__all__`. Also tests `extract_docstring`.

## Checks

- `ruff check` and `ruff format --check` on the changed files: pass.
- `pytest tests/flyte/test_doc.py`: 2 passed.
- `make check-import-profile` fails, **but it fails identically on unmodified `main` (1e949304)**: the only difference is `flyte._observe`, so the recorded baseline in `import_profiles/` looks stale. This change adds no module to the import set, because `flyte._doc` is already imported through `flyte._task`. I haven't regenerated the baseline here, since that's unrelated to this PR.

## Worth knowing: `docs` does not reach the deployed description

While checking this, I found that `docs=` has no effect on the description a deployed task shows in the UI:

- `_deploy._get_documentation_entity` builds the `DocumentationEntity` from `task_template.interface.docstring` only.
- The one place that reads `task.docs` is the CLI: `cli/_run.py:604` uses it as the `flyte run ... --help` text.

Reproduced on flyte 2.7.2:

| Task | `_get_documentation_entity(task).short_description` |
|---|---|
| docstring only | the docstring |
| `docs=Documentation("Explicit…")` + docstring | the docstring (`docs` ignored) |
| `docs=Documentation("Explicit…")`, no docstring | `''` |

The parameter's own docstring ("The documentation for the task, if not provided the function docstring will be used") implies `docs` should take precedence. If that's the intent, `_get_documentation_entity` could prefer `task_template.docs.description` when it's set. I've left behaviour unchanged here, so this PR stays a pure export. Happy to follow up if you want it wired through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VShQvRszqYH5tU7cxTZ32h