### PR TITLE
feat(cli): add --version to flyte run

### DIFF
--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -129,6 +129,18 @@ class RunArguments:
             )
         },
     )
+    version: str | None = field(
+        default=None,
+        metadata={
+            "click.option": click.Option(
+                ["--version"],
+                type=str,
+                default=None,
+                help="Version to use for the run. If not provided, it is computed from the code bundle. "
+                "Required with --copy-style none. Not used with deployed-task: use env.task:version there.",
+            )
+        },
+    )
     root_dir: str | None = field(
         default=None,
         metadata={
@@ -428,6 +440,7 @@ Missing required parameter(s): {", ".join(f"--{p[0]} (type: {p[1]})" for p in mi
             status.step(f"Launching {'local' if self.run_args.local else 'remote'} execution...")
             execution_context = flyte.with_runcontext(
                 copy_style=self.run_args.copy_style,
+                version=self.run_args.version,
                 mode="local" if self.run_args.local else "remote",
                 name=self.run_args.name,
                 raw_data_path=self.run_args.raw_data_path,
@@ -494,6 +507,7 @@ Missing required parameter(s): {", ".join(f"--{p[0]} (type: {p[1]})" for p in mi
 
             execution_context = flyte.with_runcontext(
                 copy_style=self.run_args.copy_style,
+                version=self.run_args.version,
                 mode="local",
                 name=self.run_args.name,
                 raw_data_path=self.run_args.raw_data_path,
@@ -735,6 +749,11 @@ Missing required parameter(s): {", ".join(f"--{p[0]} (type: {p[1]})" for p in mi
         )
         if self.run_args.tracked or self.run_args.tracked_strict:
             raise click.UsageError("--tracked/--report-strict are not supported for deployed tasks")
+        if self.run_args.version:
+            raise click.UsageError(
+                "--version sets the version of code run from a file. To run a specific version of a "
+                "deployed task, use the env.task:version syntax."
+            )
         self._validate_required_params(ctx)
         # Main entry point remains very thin
         asyncio.run(self._execute_and_render(ctx, config))

--- a/src/flyte/cli/_run.py
+++ b/src/flyte/cli/_run.py
@@ -137,7 +137,7 @@ class RunArguments:
                 type=str,
                 default=None,
                 help="Version to use for the run. If not provided, it is computed from the code bundle. "
-                "Required with --copy-style none. Not used with deployed-task: use env.task:version there.",
+                "Required with `--copy-style none`. Not used with `deployed-task`: use `env.task:version` there.",
             )
         },
     )
@@ -749,11 +749,6 @@ Missing required parameter(s): {", ".join(f"--{p[0]} (type: {p[1]})" for p in mi
         )
         if self.run_args.tracked or self.run_args.tracked_strict:
             raise click.UsageError("--tracked/--report-strict are not supported for deployed tasks")
-        if self.run_args.version:
-            raise click.UsageError(
-                "--version sets the version of code run from a file. To run a specific version of a "
-                "deployed task, use the env.task:version syntax."
-            )
         self._validate_required_params(ctx)
         # Main entry point remains very thin
         asyncio.run(self._execute_and_render(ctx, config))
@@ -937,6 +932,13 @@ class TaskFiles(common.FileGroup):
             return python_script
 
         if cmd_name == RUN_REMOTE_CMD:
+            # Checked here, before anything loads config or fetches the task: a deployed task's version
+            # comes from env.task:version, and --version would otherwise be silently ignored.
+            if run_args.version:
+                raise click.UsageError(
+                    "--version sets the version of code run from a file. To run a specific version of a "
+                    "deployed task, use the env.task:version syntax."
+                )
             return RemoteTaskGroup(
                 name=cmd_name,
                 run_args=run_args,

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -125,6 +125,57 @@ def test_run_queue_defaults_to_none_in_runcontext(runner, monkeypatch):
     assert captured.get("queue") is None
 
 
+def test_run_command_has_version_option():
+    option_names = {decl for p in run.params for decl in p.opts}
+    assert "--version" in option_names
+
+
+def test_run_arguments_version_from_dict():
+    from flyte.cli._run import RunArguments
+
+    assert RunArguments.from_dict({"version": "v1.0.0"}).version == "v1.0.0"
+    assert RunArguments.from_dict({}).version is None
+
+
+def test_run_version_passed_to_runcontext(runner, monkeypatch):
+    captured = {}
+    _patch_with_runcontext(monkeypatch, captured)
+
+    cmd = ["--version", "v1.0.0", "--local", str(HELLO_WORLD_PY), "say_hello", "--name", "World"]
+    result = runner.invoke(run, cmd)
+    assert result.exit_code == 0, result.output
+    assert captured.get("version") == "v1.0.0"
+
+
+def test_run_version_defaults_to_none_in_runcontext(runner, monkeypatch):
+    captured = {}
+    _patch_with_runcontext(monkeypatch, captured)
+
+    cmd = ["--local", str(HELLO_WORLD_PY), "say_hello", "--name", "World"]
+    result = runner.invoke(run, cmd)
+    assert result.exit_code == 0, result.output
+    assert captured.get("version") is None
+
+
+def test_run_copy_style_none_needs_version(runner):
+    """`with_runcontext` requires a version for copy_style='none'; the CLI can now supply one."""
+    base = ["--copy-style", "none", "--local", str(HELLO_WORLD_PY), "say_hello", "--name", "World"]
+
+    without = runner.invoke(run, base)
+    assert without.exit_code != 0
+    assert "Version is required when copy_style is 'none'" in without.output
+
+    with_version = runner.invoke(run, ["--version", "v1.0.0", *base])
+    assert with_version.exit_code == 0, with_version.output
+
+
+def test_run_version_rejected_for_deployed_task(runner):
+    cmd = ["--version", "v1.0.0", "deployed-task", "my_env.my_task"]
+    result = runner.invoke(run, cmd)
+    assert result.exit_code != 0
+    assert "env.task:version" in result.output
+
+
 def test_run_max_action_concurrency_rejects_negative(runner):
     result = runner.invoke(run, ["--max-action-concurrency", "-1", str(HELLO_WORLD_PY), "say_hello"])
     assert result.exit_code != 0


### PR DESCRIPTION
## What

Adds `--version` to `flyte run`, passed through to `flyte.with_runcontext(version=...)`.

## Why

- Python callers can set a run's version with `with_runcontext(version=...)`. The CLI couldn't.
- `with_runcontext` raises `ValueError("Version is required when copy_style is 'none'")` whenever `copy_style="none"` has no version. So `flyte run --copy-style none` failed every time, in local mode too:
  ```
  $ flyte run --local --copy-style none my_example.py my_task --name World
  ✕ Execution failed: Version is required when copy_style is 'none'
  ```

## Equivalence with the programmatic path

`flyte run <file> <task>` builds its runner with the same `flyte.with_runcontext(...)` a Python caller uses, then calls `run.aio(task, ...)`. This change passes `version=` into that call, so `_Runner` receives exactly what `with_runcontext(version=...)` would give it. Inside the runner, `version` is used the same way for both:

- **Remote runs of a local task** (`_build_task_spec_from_template`) and **hybrid runs** (`_run_hybrid`) use `self._version or code_bundle.computed_version` as the task version.
- **Local runs** (`_run_local`) use `"na"`, so `version` is ignored there. The `copy_style="none"` check in `with_runcontext` still applies, which is why local runs need it too.

Two details:

- **Both file-run call sites pass it**, the direct run and the TUI path. Otherwise `--version` would silently do nothing in the TUI.
- **`deployed-task` does not use it.** `_run_remote` takes a fetched task's version from the task itself (`task.pb2.task_id.version`), so `--version` there would be silently ignored. It's rejected instead, pointing to `env.task:version`. The check runs in `TaskFiles.get_command`, before anything loads config or fetches the task: `RunRemoteTaskCommand.get_params` contacts the backend before `invoke` runs, so a check in `invoke` never fires when there is no config. The second commit fixes that; CI caught it.

## Tests

Six new tests in `tests/cli/test_run.py`:
- the option exists;
- `from_dict` parses it;
- it's passed to `with_runcontext`, and defaults to `None`;
- `--copy-style none` fails without `--version` and succeeds with it, through the real `with_runcontext`;
- it's rejected for `deployed-task`.

Results:
- `tests/cli`: 468 passed, both with a Flyte config and in a CI-like environment with none.
- `ruff check` and `ruff format --check`: pass.
- `make check-docstrings`: clean.
- `flyte gen docs --type json | python maint_tools/check_cli_json.py`: 57 commands described, all keys present.

Also run by hand with this branch's CLI:
- `flyte run --local --copy-style none --version v1.0.0 my_example.py my_task --name World` prints `Hello, World!`.
- The same without `--version` fails with the version error.
- `flyte run --version v1.0.0 deployed-task my_env.my_task` is rejected with the `env.task:version` hint.

## Noticed, not changed

`flyte run` offers `--copy-style custom`, but `with_runcontext` always rejects `"custom"` ("not yet supported through with_runcontext"), so that choice can never succeed from the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VShQvRszqYH5tU7cxTZ32h
