### PR TITLE
docs(wandb): correct Raises in download_wandb_run_dir and download_wandb_sweep_dirs

### DIFF
--- a/plugins/wandb/src/flyteplugins/wandb/__init__.py
+++ b/plugins/wandb/src/flyteplugins/wandb/__init__.py
@@ -370,8 +370,10 @@ def download_wandb_run_dir(
         Local path where files were downloaded.
 
     Raises:
-        `RuntimeError`: If no `run_id` provided and no active run in context.
-        `wandb.errors.CommError`: If run not found in wandb cloud.
+        `RuntimeError`: If no `run_id` is provided and there is no active run in context,
+            if authentication fails, if the run can't be found in wandb cloud or you don't
+            have access to it, or if downloading or exporting the run's files fails. The
+            underlying wandb error, where there is one, is the exception's cause.
 
     Note:
         There may be a brief delay between when files are written locally and
@@ -492,8 +494,12 @@ def download_wandb_sweep_dirs(
         List of local paths where run data was downloaded.
 
     Raises:
-        RuntimeError: If no sweep_id provided and no active sweep in context.
-        wandb.errors.CommError: If sweep not found in wandb cloud.
+        RuntimeError: If no sweep_id is provided and there is no active sweep in context,
+            if entity and project are not set, if authentication fails, if the sweep can't
+            be found in wandb cloud or you don't have access to it, or if every run fails
+            to download. The underlying wandb error, where there is one, is the exception's
+            cause. If only some runs fail, a warning is logged and the paths that succeeded
+            are returned.
     """
     # Determine sweep_id
     if sweep_id is None:


### PR DESCRIPTION
## What

The `Raises:` sections of `download_wandb_run_dir()` and `download_wandb_sweep_dirs()` say they raise `wandb.errors.CommError` when the run or sweep isn't found. Neither does. Both catch `AuthenticationError` and `CommError` from the wandb API and raise `RuntimeError(...) from` the wandb error, and `plugins/wandb/tests/test_download_errors.py` asserts `RuntimeError`.

This PR lists what actually raises. It also says that `download_wandb_sweep_dirs()` raises only when every run fails to download: partial failures are logged, and the paths that succeeded are returned.

Docstring only; no behaviour change.

## Why it matters

These docstrings generate the W&B API reference on union.ai/docs, so the wrong exception is published there. A hand-written docs page repeated it; that page is fixed separately in unionai/unionai-docs#1596.

## Checks

- `ruff check` and `ruff format --check`: clean
- `make check-docstrings`: 528 files clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VShQvRszqYH5tU7cxTZ32h

