### PR TITLE
fix: report a missing file in an image definition as the user error it is (FLYTE-SDK-8B)

### DIFF
--- a/src/flyte/_image.py
+++ b/src/flyte/_image.py
@@ -563,6 +563,41 @@ class _DockerLines(Layer):
         hasher.update("".join(self.lines).encode("utf-8"))
 
 
+def _update_hash_for_layer(layer: Layer, hasher: hashlib._Hash, ignore: Optional[Any]) -> None:
+    """
+    Fold one layer into the image hash, reporting a bad image definition the way the layer itself would.
+
+    Layers that hash file contents read those files here, unguarded. Every one of them also declares a
+    `validate()` carrying a clear, user-facing message for the mistake that makes such a read fail: a lock
+    file, manifest or source folder that is not there. Those messages almost never get to run.
+    `ImageBuildEngine.build` asks `image_exists()` for the tag before it calls `image.validate()`, and
+    computing that tag is what performs these reads, so the unguarded read always loses the race. A user who
+    names a file that does not exist gets a bare `FileNotFoundError` out of the hashing internals instead of
+    the sentence the layer wrote for them (FLYTE-SDK-8B).
+
+    Ask the layer to diagnose itself, and rewrite the error only when it actually objects. A read that fails
+    while the layer considers its own definition fine is not a mistake in the image spec, so it keeps its
+    original exception and stays reportable.
+    """
+    try:
+        layer.update_hash(hasher, ignore=ignore)
+    except OSError as read_error:
+        from flyte.errors import ImageBuildError
+
+        try:
+            layer.validate()
+        except ImageBuildError:
+            # The layer already speaks in the right error type; let its message through unchanged.
+            raise
+        except Exception as bad_definition:
+            # `validate()` predates this path and still raises plain ValueError / FileNotFoundError.
+            # Restate it as a user error so it reads clearly and is not filed as an SDK crash.
+            raise ImageBuildError(str(bad_definition)) from read_error
+        # The layer is satisfied with its own definition, so this is not a bad image spec.
+        # Leave the original error alone -- it still deserves a crash report.
+        raise
+
+
 @rich.repr.auto
 @dataclass(frozen=True, repr=True)
 class Env(Layer):
@@ -1251,7 +1286,7 @@ class Image:
             filehash_update(self.dockerfile, hasher)
         if self._layers:
             for layer in self._layers:
-                layer.update_hash(hasher, ignore=ignore)
+                _update_hash_for_layer(layer, hasher, ignore)
         return hasher.hexdigest()
 
     @property

--- a/tests/flyte/test_image.py
+++ b/tests/flyte/test_image.py
@@ -1185,3 +1185,133 @@ def test_default_image_dev_mode_pypi_fallback(monkeypatch):
         pkg for layer in image._layers if isinstance(layer, PipPackages) for pkg in (layer.packages or ())
     )
     assert "flyte<2.3.7" in pip_packages, f"expected 'flyte<2.3.7' in pip layers, got {pip_packages}"
+
+
+# ---------------------------------------------------------------------------
+# FLYTE-SDK-8B: the image tag is computed before the image is validated, so a
+# file named in the image spec that does not exist crashed in the hashing
+# internals instead of reporting the layer's own message.
+# ---------------------------------------------------------------------------
+
+
+def test_hash_digest_reports_missing_uvlock_as_image_build_error(tmp_path):
+    """A uv.lock that does not exist is a mistake in the image spec.
+
+    `UVProject.validate()` has said so clearly since it was written, but
+    `ImageBuildEngine.build` asks `image_exists()` for the tag before it calls
+    `image.validate()`, and computing the tag reads the lock file. So the user got
+    `FileNotFoundError: [Errno 2] No such file or directory: '.../does-not-exist.lock'`
+    out of `filehash_update` and the careful message never ran.
+
+    Reproduces FLYTE-SDK-8B.
+    """
+    from flyte.errors import ImageBuildError
+
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[project]\nname = 'test-project'\n")
+    missing_lock = tmp_path / "does-not-exist.lock"
+
+    image = Image.from_debian_base(registry="localhost", name="img").with_uv_project(
+        pyproject_file=pyproject, uvlock=missing_lock
+    )
+    with pytest.raises(ImageBuildError, match=r"UVLock file .* does not exist"):
+        image._get_hash_digest()
+
+
+def test_uri_reports_missing_uvlock_as_image_build_error(tmp_path):
+    """The same through `.uri`, which is the property `image_exists()` actually reads."""
+    from flyte.errors import ImageBuildError
+
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[project]\nname = 'test-project'\n")
+
+    image = Image.from_debian_base(registry="localhost", name="img").with_uv_project(
+        pyproject_file=pyproject, uvlock=tmp_path / "nope.lock"
+    )
+    with pytest.raises(ImageBuildError, match=r"UVLock file .* does not exist"):
+        _ = image.uri
+
+
+def test_hash_digest_reports_missing_poetry_lock_as_image_build_error(tmp_path):
+    """PoetryProject has the same guarded/unguarded split."""
+    from flyte.errors import ImageBuildError
+
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[tool.poetry]\nname = 'test-project'\n")
+
+    image = Image.from_debian_base(registry="localhost", name="img").with_poetry_project(
+        pyproject_file=pyproject, poetry_lock=tmp_path / "nope.lock"
+    )
+    with pytest.raises(ImageBuildError, match=r"poetry.lock file .* does not exist"):
+        image._get_hash_digest()
+
+
+def test_hash_digest_reports_missing_pixi_lock_as_image_build_error(tmp_path):
+    """PixiProject too."""
+    from flyte.errors import ImageBuildError
+
+    manifest = tmp_path / "pixi.toml"
+    manifest.write_text("[project]\nname = 'test-project'\n")
+
+    image = Image.from_debian_base(registry="localhost", name="img").with_pixi_project(
+        manifest_file=manifest, pixi_lock=tmp_path / "nope.lock"
+    )
+    with pytest.raises(ImageBuildError, match=r"Pixi lock file .* does not exist"):
+        image._get_hash_digest()
+
+
+def test_hash_digest_leaves_copy_config_to_validate(tmp_path):
+    """Scope marker: `CopyConfig` is not part of this bug and is not changed.
+
+    It hashes through `update_hasher_for_source`, which skips paths that do not
+    exist on purpose (so a symlink to nowhere does not break a build). A missing
+    source folder is therefore a silent no-op here rather than a crash, and stays
+    the business of `CopyConfig.validate()`, which `ImageBuildEngine.build` still
+    calls before building and which already reports it as an ImageBuildError
+    (FLYTE-SDK-4D). Only the layers that read a named file directly, through
+    `filehash_update`, could raise from the hash path at all.
+    """
+    from flyte.errors import ImageBuildError
+
+    image = Image.from_debian_base(registry="localhost", name="img").with_source_folder(
+        src=tmp_path / "not-there", dst="/app"
+    )
+    image._get_hash_digest()  # does not raise
+    with pytest.raises(ImageBuildError, match=r"Source folder .* does not exist"):
+        image.validate()
+
+
+def test_hash_digest_keeps_reporting_a_read_failure_the_layer_is_happy_with(tmp_path, monkeypatch):
+    """Narrowness guard: only a layer that objects to its own definition gets its
+    error rewritten. A read that fails while `validate()` passes is not a bad image
+    spec, so the original exception must propagate untouched and stay reportable."""
+    from flyte._image import UVProject
+
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[project]\nname = 'test-project'\n")
+    uvlock = tmp_path / "uv.lock"
+    uvlock.write_text("# lock\n")
+
+    image = Image.from_debian_base(registry="localhost", name="img").with_uv_project(
+        pyproject_file=pyproject, uvlock=uvlock
+    )
+
+    def boom(self, hasher, ignore=None):
+        raise OSError(5, "Input/output error")
+
+    monkeypatch.setattr(UVProject, "update_hash", boom)
+    with pytest.raises(OSError, match="Input/output error"):
+        image._get_hash_digest()
+
+
+def test_hash_digest_still_succeeds_when_every_file_is_present(tmp_path):
+    """The happy path is unchanged and still deterministic."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[project]\nname = 'test-project'\n")
+    uvlock = tmp_path / "uv.lock"
+    uvlock.write_text("# lock\n")
+
+    image = Image.from_debian_base(registry="localhost", name="img").with_uv_project(
+        pyproject_file=pyproject, uvlock=uvlock
+    )
+    assert image._get_hash_digest() == image._get_hash_digest()


### PR DESCRIPTION
## What

When a hash-time file read fails, ask the layer to diagnose itself and report its own message, instead of letting a bare `FileNotFoundError` out of the hashing internals.

## Why

A user pointed `with_uv_project(uvlock=...)` at a lock file that does not exist. What they got:

```
FileNotFoundError: [Errno 2] No such file or directory:
    '/Users/…/insights-vehicles-data/does-not-exist.lock'
```

raised from `flyte._utils.file_handling.filehash_update`, and filed against the SDK as a crash.

What the SDK already had ready for them, written long ago in `UVProject.validate()`:

```
UVLock file /Users/…/insights-vehicles-data/does-not-exist.lock does not exist
```

That message never runs. `ImageBuildEngine.build` asks `image_exists()` for the image tag **before** it calls `image.validate()`:

```python
elif image_uri := await cls.image_exists(image):   # ← needs _final_tag → _get_hash_digest → update_hash
    ...
# Validate the image before building
image.validate()                                   # ← too late, the read already blew up
```

and computing that tag is precisely what reads the files. The unguarded read in `update_hash()` always wins the race, so the careful message loses every time.

This is not one layer's problem. `UVProject`, `PoetryProject`, `PixiProject` and `UVScript` each declare a `validate()` with a clear sentence for a missing file, and each reads those same files unguarded in `update_hash()`. `CopyConfig.validate()` raising `ImageBuildError` was itself a Sentry fix (FLYTE-SDK-4D) — the same ordering keeps part of that one from being reached too.

## The change

```python
try:
    layer.update_hash(hasher, ignore=ignore)
except OSError as read_error:
    try:
        layer.validate()
    except ImageBuildError:
        raise                                        # already the right type and message
    except Exception as bad_definition:
        raise ImageBuildError(str(bad_definition)) from read_error
    raise                                            # layer is happy — not a bad spec, keep reporting
```

Two properties worth stating, because they are what make this narrow:

- **It cannot hide an SDK bug.** The error is only rewritten when the layer itself objects to its own definition. If `validate()` passes, the original exception propagates untouched and stays reportable.
- **It adds no new validation.** Nothing is checked that was not already checked; the existing checks just get to run before the crash instead of after it. In particular it does **not** validate user paths at image-definition time — image definitions are module-level code that also runs inside the container, where the developer's file is absent. This is strictly the build-time read path.

`ImageBuildError` is a `RuntimeUserError`, so the result is also filtered out of Sentry rather than being counted as an SDK crash.

## Scope

`CopyConfig` is deliberately untouched. It hashes through `update_hasher_for_source`, which skips non-existent paths on purpose (so a symlink to nowhere does not break a build), so a missing source folder is a silent no-op here rather than a crash, and stays the business of `validate()`. Only layers that read a named file directly through `filehash_update` could raise from this path at all. There is a test pinning that.

## Noticed, not changed

`_get_hash_digest` also calls `filehash_update(self.dockerfile, hasher)` unguarded, and `Image.validate()` does not check `self.dockerfile` at all — so `with_dockerfile()` pointed at a missing file has the same shape with no existing message to reuse. No Sentry evidence for it, and inventing a new validation message is a different change, so it is left alone.

## Tests

Seven tests in `tests/flyte/test_image.py`: uv / poetry / pixi missing lock files through `_get_hash_digest()`, the uv case through `.uri` (the property `image_exists()` actually reads), the `CopyConfig` scope marker, the narrowness guard (read fails + `validate()` passes ⇒ original `OSError` survives), and an unchanged-happy-path determinism check.

Verified they fail for the right reason: reverting only the wiring and keeping the helper defined, the four behavioural tests fail with the production error at `file_handling.py:20` while the guards keep passing.

`tests/flyte/test_image.py`: 93 passed. `make fmt`, `ruff check`, `mypy`, `ty check` and `make check-docstrings` all clean.

fixes FLYTE-SDK-8B

- https://unionai.sentry.io/issues/7724710190/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
