### PR TITLE
fix: don't report a disk quota as an SDK crash (FLYTE-SDK-8D)

### DIFF
--- a/src/flyte/_sentry.py
+++ b/src/flyte/_sentry.py
@@ -234,7 +234,12 @@ def _is_non_connect_endpoint_response(exc: BaseException) -> bool:
     return bool(content_type and content_type.group("received").strip().lower().startswith("text/"))
 
 
-_USER_ENVIRONMENT_OSERROR_ERRNOS: frozenset[int] = frozenset({errno.ENOSPC})
+# EDQUOT is not defined on every platform CPython builds for (Windows has no such errno), and where it
+# does exist its value is not portable -- 122 on Linux, 69 on macOS and the BSDs. Look it up rather than
+# hard-coding it, and drop it when the platform has no such thing, so importing this module cannot fail.
+_USER_ENVIRONMENT_OSERROR_ERRNOS: frozenset[int] = frozenset(
+    code for code in (errno.ENOSPC, getattr(errno, "EDQUOT", None)) if code is not None
+)
 
 
 def _is_user_environment_oserror(exc: BaseException) -> bool:
@@ -244,6 +249,17 @@ def _is_user_environment_oserror(exc: BaseException) -> bool:
     during `flyte deploy` bundle uploads when the user's machine is out of disk
     (FLYTE-SDK-32). Disk-full is a user environment problem, not something the
     SDK can fix, so it shouldn't be reported as a crash.
+
+    EDQUOT ("Disk quota exceeded") is the same condition reported by a filesystem
+    that rations space per user instead of running out of it globally -- the usual
+    shape on NFS, and on the shared or managed home directories common in HPC and
+    university clusters. FLYTE-SDK-8D is `tarfile.copyfileobj` hitting it while
+    `create_bundle` writes the code-bundle tarball. The user has to free space or
+    get their quota raised either way; neither is something the SDK can fix.
+
+    Kept to those two. The neighbouring errnos are not the same story: EACCES,
+    EPERM and EROFS can equally mean the SDK wrote somewhere it should not have,
+    and EMFILE / ENFILE would hide a file-descriptor leak of our own.
     """
     if not isinstance(exc, OSError):
         return False

--- a/tests/flyte/test_sentry.py
+++ b/tests/flyte/test_sentry.py
@@ -298,6 +298,42 @@ def test_capture_exception_skips_oserror_no_space_left():
     init_mock.assert_not_called()
 
 
+def test_capture_exception_skips_oserror_disk_quota_exceeded():
+    """FLYTE-SDK-8D: OSError(EDQUOT) from tarfile.copyfileobj while `create_bundle`
+    writes the code-bundle tarball. A per-user quota is the same user environment
+    problem as a globally full disk, just reported by a filesystem that rations
+    space instead of running out of it."""
+    err = OSError(errno.EDQUOT, "Disk quota exceeded", "/home/user/.cache/flyte-tmp/bundle.tar.gz")
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()
+
+
+def test_capture_exception_skips_disk_quota_via_cause_chain():
+    """The quota failure is reachable when the bundle writer wraps it."""
+    from flyte.errors import RuntimeSystemError
+
+    try:
+        raise OSError(errno.EDQUOT, "Disk quota exceeded", "/home/user/bundle.tar.gz")
+    except OSError as e:
+        err = RuntimeSystemError("Unknown", "Failed to build code bundle")
+        err.__cause__ = e
+
+    with mock.patch.object(_sentry, "init") as init_mock:
+        _sentry.capture_exception(err)
+    init_mock.assert_not_called()
+
+
+def test_user_environment_errno_set_survives_a_platform_without_edquot():
+    """Windows has no EDQUOT. The set is built with a guarded lookup so importing
+    `flyte._sentry` cannot fail there, and ENOSPC must still be covered."""
+    assert errno.ENOSPC in _sentry._USER_ENVIRONMENT_OSERROR_ERRNOS
+    assert all(isinstance(code, int) for code in _sentry._USER_ENVIRONMENT_OSERROR_ERRNOS)
+    # Neighbouring errnos stay reportable: they can equally mean an SDK bug.
+    for code in (errno.EACCES, errno.EPERM, errno.EMFILE):
+        assert code not in _sentry._USER_ENVIRONMENT_OSERROR_ERRNOS
+
+
 def test_capture_exception_skips_gaierror():
     """FLYTE-SDK-6Z: `socket.gaierror` while resolving the configured endpoint is a
     stale endpoint / VPN / resolver problem, not an SDK bug."""


### PR DESCRIPTION
## What

Filter `OSError(EDQUOT)` — "Disk quota exceeded" — out of Sentry, alongside the `ENOSPC` that has been filtered since FLYTE-SDK-32.

## Why

```
OSError: [Errno 122] Disk quota exceeded
  culprit: tarfile in copyfileobj
  release: 2.7.2
```

`create_bundle` writes the code-bundle tarball to local disk during `flyte deploy`. On a filesystem that rations space **per user** rather than running out of it globally, that write fails with `EDQUOT` instead of `ENOSPC` — the usual shape on NFS, and on the shared or managed home directories common in HPC and university clusters.

It is the same condition and the same remedy as disk-full: free some space, or get the quota raised. Neither is something the SDK can do anything about, and `ENOSPC` was filtered on exactly that reasoning. The only reason `EDQUOT` still reports is that it is a different number.

## The change

```python
_USER_ENVIRONMENT_OSERROR_ERRNOS: frozenset[int] = frozenset(
    code for code in (errno.ENOSPC, getattr(errno, "EDQUOT", None)) if code is not None
)
```

The guarded lookup is not decoration. `EDQUOT` does not exist on Windows — CPython's `errnomodule.c` defines these constants under `#ifdef` — so a direct `errno.EDQUOT` would raise `AttributeError` at **import** of `flyte._sentry` there, which would be a considerably worse bug than the one being fixed. And where it does exist its value is not portable: 122 on Linux, 69 on macOS and the BSDs. Both sides of the comparison come from the same machine, so looking it up is also the only correct way to match.

## Why only this errno

Tested the predicate across the whole corpus first: 73 unresolved issues contain exactly four `OSError`-family events, with errnos 98 (`EADDRINUSE`, PKCE bind — covered by #1199), 2 (`FileNotFoundError`, FLYTE-SDK-8B), no-errno (`libgomp.so.1` missing in a user image), and this one. Adding `EDQUOT` silences FLYTE-SDK-8D and nothing else.

The neighbouring errnos are deliberately left out, and the docstring says why: `EACCES`, `EPERM` and `EROFS` can equally mean the SDK wrote somewhere it should not have, and `EMFILE` / `ENFILE` would hide a file-descriptor leak of our own.

## Tests

Three tests in `tests/flyte/test_sentry.py`: the direct `EDQUOT`, the same through a `RuntimeSystemError` cause chain (how the bundle writer wraps it), and a guard that the errno set still contains `ENOSPC`, holds only ints, and excludes `EACCES` / `EPERM` / `EMFILE` — which also pins the Windows-safe construction.

`tests/flyte/test_sentry.py`: 82 passed. `make fmt`, `ruff check`, `mypy`, `ty check` and `make check-docstrings` all clean.

fixes FLYTE-SDK-8D

- https://unionai.sentry.io/issues/7725254893/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
