### PR TITLE
feat(remote): fetch the code a run executed

### DIFF
--- a/src/flyte/_internal/runtime/task_serde.py
+++ b/src/flyte/_internal/runtime/task_serde.py
@@ -33,6 +33,10 @@ from .types_serde import transform_native_to_typed_interface
 _MAX_ENV_NAME_LENGTH = 63  # Maximum length for environment names
 _MAX_TASK_SHORT_NAME_LENGTH = 63  # Maximum length for task short names
 
+# Mirrors flyte._code_bundle.bundle._pickled_file_extension; duplicated to keep this module
+# import-light (task_serde is on the task-startup path).
+_PICKLED_FILE_EXTENSION = ".pkl.gz"
+
 
 def translate_task_to_wire(
     task: TaskTemplate,
@@ -456,11 +460,71 @@ def _get_k8s_pod(primary_container: tasks_pb2.Container, pod_template: PodTempla
     return tasks_pb2.K8sPod(pod_spec=pod_spec, metadata=metadata)
 
 
+def _bundle_from_args(args: typing.Sequence[str]) -> Optional[CodeBundle]:
+    """Parse the entrypoint arguments a task was launched with into a CodeBundle."""
+    pkl_path = None
+    tgz_path = None
+    dest_path: str = "."
+    version = ""
+    for i, v in enumerate(args):
+        if v == "--pkl":
+            # Extract the code bundle path from the argument
+            pkl_path = args[i + 1] if i + 1 < len(args) else None
+        elif v == "--tgz":
+            # Extract the code bundle path from the argument
+            tgz_path = args[i + 1] if i + 1 < len(args) else None
+        elif v == "--dest":
+            # Extract the destination path from the argument
+            dest_path = args[i + 1] if i + 1 < len(args) else "."
+        elif v == "--version":
+            # Extract the version from the argument
+            version = args[i + 1] if i + 1 < len(args) else ""
+    if pkl_path or tgz_path:
+        return CodeBundle(
+            destination=dest_path,
+            tgz=tgz_path,
+            pkl=pkl_path,
+            computed_version=version,
+        )
+    return None
+
+
+def _primary_container_args(k8s_pod: tasks_pb2.K8sPod, config: typing.Mapping[str, str] | None) -> typing.List[str]:
+    """
+    Args of the primary container of a K8sPod task target.
+
+    The primary container is named by `K8sPod.primary_container_name`, falling back to the task
+    config's `primary_container_name` key and finally to the first container in the spec — the
+    same resolution order the backend uses when it looks for a code bundle in a pod-template task.
+    """
+    from google.protobuf.json_format import MessageToDict
+
+    if not k8s_pod.HasField("pod_spec"):
+        return []
+    pod_spec = MessageToDict(k8s_pod.pod_spec)
+    containers = pod_spec.get("containers") or []
+    if not containers:
+        return []
+
+    name = k8s_pod.primary_container_name or (config or {}).get(_PRIMARY_CONTAINER_NAME_FIELD)
+    if name:
+        for c in containers:
+            if c.get("name") == name:
+                return list(c.get("args") or [])
+    return list(containers[0].get("args") or [])
+
+
 def extract_code_bundle(
     task_spec: task_definition_pb2.TaskSpec,
 ) -> Optional[CodeBundle]:
     """
     Extract the code bundle from the task spec.
+
+    The bundle is recovered from the arguments the task's entrypoint was launched with
+    (`--tgz` / `--pkl` / `--dest` / `--version`), for either a container or a K8sPod task target.
+    When those are absent — an image that bakes the code in, or a target this function cannot
+    introspect — the task template's `metadata.code_bundle_uri` is used as a last resort; it
+    carries the bundle's location but not its destination or version.
 
     Args:
         task_spec: The task spec to extract the code bundle from.
@@ -468,30 +532,27 @@ def extract_code_bundle(
     Returns:
         The extracted code bundle or None if not present.
     """
-    container = task_spec.task_template.container
+    template = task_spec.task_template
+
+    container = template.container
     if container and container.args:
-        pkl_path = None
-        tgz_path = None
-        dest_path: str = "."
-        version = ""
-        for i, v in enumerate(container.args):
-            if v == "--pkl":
-                # Extract the code bundle path from the argument
-                pkl_path = container.args[i + 1] if i + 1 < len(container.args) else None
-            elif v == "--tgz":
-                # Extract the code bundle path from the argument
-                tgz_path = container.args[i + 1] if i + 1 < len(container.args) else None
-            elif v == "--dest":
-                # Extract the destination path from the argument
-                dest_path = container.args[i + 1] if i + 1 < len(container.args) else "."
-            elif v == "--version":
-                # Extract the version from the argument
-                version = container.args[i + 1] if i + 1 < len(container.args) else ""
-        if pkl_path or tgz_path:
-            return CodeBundle(
-                destination=dest_path,
-                tgz=tgz_path,
-                pkl=pkl_path,
-                computed_version=version,
-            )
+        bundle = _bundle_from_args(container.args)
+        if bundle:
+            return bundle
+
+    if template.HasField("k8s_pod"):
+        bundle = _bundle_from_args(_primary_container_args(template.k8s_pod, template.config))
+        if bundle:
+            return bundle
+
+    uri = template.metadata.code_bundle_uri
+    if uri:
+        is_pkl = uri.split("?", 1)[0].split("#", 1)[0].lower().endswith(_PICKLED_FILE_EXTENSION)
+        return CodeBundle(
+            destination=".",
+            tgz=None if is_pkl else uri,
+            pkl=uri if is_pkl else None,
+            computed_version="",
+        )
+
     return None

--- a/src/flyte/cli/_get.py
+++ b/src/flyte/cli/_get.py
@@ -1,5 +1,7 @@
 import asyncio
 import datetime as dt
+import tarfile
+import tempfile
 from pathlib import Path
 from typing import Any, Tuple, Union
 
@@ -552,6 +554,101 @@ def secret(
         console.print(common.format("Secret", [remote.Secret.get(name, cluster_pool=cluster_pool)], "json"))
     else:
         console.print(common.format("Secrets", remote.Secret.listall(cluster_pool=cluster_pool), cfg.output_format))
+
+
+@get.command(cls=common.CommandBase)
+@click.argument("run_name", type=str, required=True)
+@click.argument("action_name", type=str, required=False)
+@click.option(
+    "--dest",
+    "-o",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Directory to download the code into. Without it, the code is only listed, not kept.",
+)
+@click.option(
+    "--no-extract",
+    is_flag=True,
+    default=False,
+    help="Keep the downloaded archive instead of unpacking it. Requires `--dest`.",
+)
+@click.option(
+    "--attempt", "-a", type=int, default=None, help="Attempt to fetch the code for, defaults to the latest attempt."
+)
+@click.pass_obj
+def code(
+    cfg: common.CLIConfig,
+    run_name: str,
+    action_name: str | None = None,
+    project: str | None = None,
+    domain: str | None = None,
+    dest: Path | None = None,
+    no_extract: bool = False,
+    attempt: int | None = None,
+):
+    """
+    Get the code a run executed — the source shown in the console's "Code" tab.
+
+    Without `--dest` the bundle is listed and then discarded:
+
+    ```bash
+    $ flyte get code my_run
+    ```
+
+    With `--dest` the source is unpacked there and kept:
+
+    ```bash
+    $ flyte get code my_run --dest ./my_run_code
+    ```
+
+    If only the run name is given, the code of the run's root action is fetched. Pass an action
+    name to fetch the code of a specific action inside the run, which may have been packaged
+    separately:
+
+    ```bash
+    $ flyte get code my_run my_action
+    ```
+
+    Tasks that run from code baked into their image have no bundle to download.
+    """
+    if no_extract and dest is None:
+        raise click.BadParameter("`--no-extract` only makes sense together with `--dest`.")
+
+    cfg.init(project=project, domain=domain)
+    console = common.get_console()
+
+    obj: Union[remote.Action, remote.Run]
+    if action_name:
+        obj = remote.Action.get(run_name=run_name, name=action_name)
+    else:
+        obj = remote.Run.get(name=run_name)
+
+    if dest is not None:
+        path = obj.download_code(dest=dest, extract=not no_extract, attempt=attempt)
+        console.print(
+            common.get_panel(
+                "Code",
+                f"[green bold]Downloaded to[/green bold] {path}",
+                cfg.output_format,
+            )
+        )
+        return
+
+    # No destination: fetch into a scratch directory purely to report what the bundle holds.
+    with tempfile.TemporaryDirectory() as tmp:
+        archive = obj.download_code(dest=Path(tmp), extract=False, attempt=attempt)
+        if tarfile.is_tarfile(archive):
+            with tarfile.open(archive) as tar:
+                listing = "\n".join(sorted(m.name for m in tar.getmembers() if m.isfile()))
+        else:
+            listing = f"[yellow]{archive.name} is a pickled bundle, there are no source files to list.[/yellow]"
+        console.print(
+            common.get_panel(
+                "Code",
+                f"[green bold]{archive.name}[/green bold]\n{listing}\n\nPass `--dest <dir>` to download it.",
+                cfg.output_format,
+            )
+        )
 
 
 @get.command(cls=common.CommandBase)

--- a/src/flyte/remote/_action.py
+++ b/src/flyte/remote/_action.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import pathlib
 from collections import UserDict
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -37,7 +38,8 @@ from flyte import types
 from flyte._initialize import ensure_client, get_client, get_init_config
 from flyte._interface import default_output_name
 from flyte._utils.helpers import action_phase_name
-from flyte.models import ActionPhase
+from flyte.models import ActionPhase, CodeBundle
+from flyte.remote._code import download_code_bundle
 from flyte.remote._common import TimeFilter, ToJSONMixin, time_filtering
 from flyte.remote._logs import Logs
 from flyte.syncify import syncify
@@ -598,6 +600,58 @@ class Action(ToJSONMixin):
             download.raise_for_status()
             return download.text
 
+    @syncify
+    async def download_code(
+        self,
+        dest: str | pathlib.Path | None = None,
+        extract: bool = True,
+        attempt: int | None = None,
+    ) -> pathlib.Path:
+        """
+        Download the code this action ran — the source shown in the console's "Code" tab.
+
+        The code is whatever `flyte run` / `flyte deploy` packaged and uploaded for this task: a
+        tarball of the source tree, or a cloudpickle of the task when it was launched from a
+        notebook or REPL. Tasks that run from code baked into their image carry no bundle, and
+        raise.
+
+        ```python
+        action = flyte.remote.Action.get(run_name="my-run", name="n0")
+        src = action.download_code(dest="./n0-code")
+        print((src / "workflows" / "main.py").read_text())
+        ```
+
+        Args:
+            dest: Directory to download into, created if missing. Defaults to a directory named
+                after the run, under the current working directory.
+            extract: Unpack the tarball into `dest`. Set False to keep the archive as-is.
+                Pickled bundles are never unpacked.
+            attempt: Attempt to fetch the bundle for. Defaults to the latest attempt.
+
+        Returns:
+            The directory the source was extracted into, or the path of the downloaded archive
+            when `extract` is False or the bundle is a pickle.
+        """
+        details = await self.details()
+        bundle = details.code_bundle
+        if bundle is None:
+            raise RuntimeError(
+                f"No code bundle is associated with action '{self.name}' in run '{self.run_name}'. "
+                "The task ran from code baked into its image rather than from an uploaded bundle."
+            )
+
+        if attempt is None:
+            attempt = details.attempts
+
+        dest = pathlib.Path(dest) if dest is not None else pathlib.Path.cwd() / self.run_name
+        return await download_code_bundle(
+            bundle,
+            dest,
+            action_id=self.action_id,
+            attempt=attempt,
+            extract=extract,
+        )
+
     async def details(self) -> ActionDetails:
         """
         Get the details of the action. This is a placeholder for getting the action details.
@@ -985,6 +1039,18 @@ class ActionDetails(ToJSONMixin):
         Get the action ID.
         """
         return self.pb2.id
+
+    @property
+    def code_bundle(self) -> CodeBundle | None:
+        """
+        The code bundle this action ran, or None when the task ran from code baked into its image.
+
+        This is metadata only — where the bundle lives and which version it is. Use
+        `Action.download_code` or `Run.download_code` to fetch the source itself.
+        """
+        from flyte._internal.runtime.task_serde import extract_code_bundle
+
+        return extract_code_bundle(self.pb2.task)
 
     @property
     def metadata(self) -> run_definition_pb2.ActionMetadata:

--- a/src/flyte/remote/_code.py
+++ b/src/flyte/remote/_code.py
@@ -1,0 +1,132 @@
+"""
+Fetching the code bundle a remote run executed.
+
+When a task is launched from a local directory, the SDK packages the source into a
+`flyte.models.CodeBundle` (a tarball, or a cloudpickle for notebook/REPL sessions), uploads it,
+and records its location in the task spec. This module is the read path back: given an action,
+find that bundle and pull it down — the same source the console's "Code" tab shows.
+
+Two routes to the bytes, tried in this order:
+
+1. **The data proxy.** `CreateDownloadLink(ARTIFACT_TYPE_CODE_BUNDLE)` returns a pre-signed URL.
+   This is what the console uses, and it needs no object-store credentials on the client — only
+   the Flyte API key/session already in use. Backends that don't serve this artifact type
+   (OSS Flyte signs reports only) and pickled bundles (deliberately refused, they aren't source)
+   fail here and fall through.
+2. **Direct object-store read** of the URI recorded in the task spec, via `flyte.storage`. Works
+   wherever the caller has credentials for the bucket — inside a cluster, or locally when the
+   blob store is configured — and is the only route for a pkl bundle.
+
+If both fail the data-proxy error is raised, with the storage error chained onto it, so the
+message explains the route the caller most likely expected to work.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import httpx
+from flyteidl2.common import identifier_pb2
+from flyteidl2.dataproxy import dataproxy_service_pb2
+
+from flyte._initialize import ensure_client, get_client
+from flyte._logging import logger
+from flyte.models import CodeBundle
+
+# Code bundles are source archives — small — but "small" is a matter of copy_style, and the
+# default httpx timeout is too tight for a bundle that ships data files alongside the code.
+_DOWNLOAD_TIMEOUT = httpx.Timeout(connect=10.0, read=300.0, write=300.0, pool=10.0)
+
+
+def bundle_uri(bundle: CodeBundle) -> str:
+    """The remote location of the bundle's archive, tgz or pkl."""
+    uri = bundle.tgz or bundle.pkl
+    if not uri:
+        raise ValueError("Code bundle should be either tgz or pkl, found neither.")
+    return uri
+
+
+async def _download_via_data_proxy(
+    action_id: identifier_pb2.ActionIdentifier,
+    attempt: int,
+    target: pathlib.Path,
+) -> None:
+    """Sign a download link for the action's code bundle and stream it into target."""
+    ensure_client()
+    resp = await get_client().dataproxy_service.create_download_link(
+        dataproxy_service_pb2.CreateDownloadLinkRequest(
+            artifact_type=dataproxy_service_pb2.ARTIFACT_TYPE_CODE_BUNDLE,
+            action_attempt_id=identifier_pb2.ActionAttemptIdentifier(
+                action_id=action_id,
+                attempt=attempt,
+            ),
+        )
+    )
+    signed_urls = list(resp.pre_signed_urls.signed_url)
+    if not signed_urls:
+        raise RuntimeError("The data proxy returned no download link for the code bundle.")
+
+    async with httpx.AsyncClient(timeout=_DOWNLOAD_TIMEOUT, follow_redirects=True) as client:
+        async with client.stream("GET", signed_urls[0]) as response:
+            response.raise_for_status()
+            with target.open("wb") as f:
+                async for chunk in response.aiter_bytes():
+                    f.write(chunk)
+
+
+async def _download_via_storage(bundle: CodeBundle, target: pathlib.Path) -> None:
+    """Read the bundle straight out of the blob store recorded in the task spec."""
+    import flyte.storage as storage
+
+    await storage.get(bundle_uri(bundle), str(target))
+
+
+async def download_code_bundle(
+    bundle: CodeBundle,
+    dest: pathlib.Path,
+    *,
+    action_id: identifier_pb2.ActionIdentifier,
+    attempt: int,
+    extract: bool = True,
+) -> pathlib.Path:
+    """
+    Download `bundle` into `dest`, optionally extracting a tarball.
+
+    Args:
+        bundle: The bundle to fetch, as recorded in the action's task spec.
+        dest: Directory to download into. Created if it does not exist.
+        action_id: The action the bundle belongs to, used to sign the download link.
+        attempt: The attempt to sign the download link for.
+        extract: Unpack a tgz bundle into `dest` after downloading. Pkl bundles are never
+            unpacked — there is nothing to unpack.
+
+    Returns:
+        The directory the source was extracted into, or the path of the downloaded archive when
+        it was not extracted.
+    """
+    dest = pathlib.Path(dest)
+    dest.mkdir(parents=True, exist_ok=True)
+    if not dest.is_dir():
+        raise ValueError(f"Destination should be a directory, found {dest}")
+
+    uri = bundle_uri(bundle)
+    archive = dest / pathlib.PurePosixPath(uri).name
+
+    try:
+        await _download_via_data_proxy(action_id, attempt, archive)
+    except Exception as proxy_error:
+        logger.debug(f"Could not fetch code bundle via the data proxy ({proxy_error}), reading {uri} directly.")
+        try:
+            await _download_via_storage(bundle, archive)
+        except Exception as storage_error:
+            archive.unlink(missing_ok=True)
+            raise proxy_error from storage_error
+
+    if extract and bundle.tgz:
+        # The same extraction the worker performs when it inflates a bundle in-cluster.
+        from flyte._code_bundle.bundle import _extract_tar
+
+        await _extract_tar(archive, dest)
+        return dest
+
+    return archive

--- a/src/flyte/remote/_run.py
+++ b/src/flyte/remote/_run.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pathlib
 from dataclasses import dataclass, field
 from typing import Any, AsyncGenerator, AsyncIterator, Callable, Dict, Literal, Tuple
 
@@ -12,7 +13,7 @@ from flyteidl2.workflow import run_definition_pb2, run_service_pb2
 
 from flyte._initialize import ensure_client, get_client, get_init_config
 from flyte._logging import logger
-from flyte.models import ActionPhase
+from flyte.models import ActionPhase, CodeBundle
 from flyte.syncify import syncify
 
 from . import Action, ActionDetails, ActionInputs, ActionOutputs
@@ -303,6 +304,55 @@ class Run(ToJSONMixin):
             The report contents as an HTML string.
         """
         return await self.action.get_report.aio(attempt=attempt)
+
+    @syncify
+    async def code_bundle(self) -> CodeBundle | None:
+        """
+        The code bundle this run executed, or None when it ran from code baked into its image.
+
+        Metadata only — where the bundle lives, which version it is, and whether it is a tarball
+        or a pickle. Use `Run.download_code` to fetch the source itself.
+        """
+        details = await self.details.aio()
+        return details.action_details.code_bundle
+
+    @syncify
+    async def download_code(
+        self,
+        dest: str | pathlib.Path | None = None,
+        extract: bool = True,
+        attempt: int | None = None,
+    ) -> pathlib.Path:
+        """
+        Download the code this run executed — the source shown in the console's "Code" tab.
+
+        The code is whatever `flyte run` / `flyte deploy` packaged and uploaded for this run: a
+        tarball of the source tree, or a cloudpickle of the task when it was launched from a
+        notebook or REPL. Runs whose task ran from code baked into its image carry no bundle,
+        and raise.
+
+        ```python
+        run = flyte.remote.Run.get("my-run")
+        src = run.download_code()
+        print((src / "workflows" / "main.py").read_text())
+        ```
+
+        This fetches the bundle of the run's root action. A nested action can be packaged
+        differently (a task from another environment, deployed separately) — use
+        `Action.download_code` on that action to fetch its own code.
+
+        Args:
+            dest: Directory to download into, created if missing. Defaults to a directory named
+                after the run, under the current working directory.
+            extract: Unpack the tarball into `dest`. Set False to keep the archive as-is.
+                Pickled bundles are never unpacked.
+            attempt: Attempt to fetch the bundle for. Defaults to the latest attempt.
+
+        Returns:
+            The directory the source was extracted into, or the path of the downloaded archive
+            when `extract` is False or the bundle is a pickle.
+        """
+        return await self.action.download_code.aio(dest=dest, extract=extract, attempt=attempt)
 
     @syncify
     async def details(self) -> RunDetails:

--- a/tests/cli/test_get.py
+++ b/tests/cli/test_get.py
@@ -64,3 +64,66 @@ def test_get_secret_cluster_pool_rejects_domain(runner: CliRunner):
     assert "Illegal usage" in result.stderr
     assert "cluster_pool" in result.stderr
     assert "domain" in result.stderr
+
+
+@patch("flyte.cli._get.remote.Run.get")
+@patch.object(_main_module, "CLIConfig", return_value=Mock())
+def test_get_code_with_dest_downloads_and_extracts(mock_cli_config, mock_run_get, runner: CliRunner, tmp_path):
+    run = Mock()
+    run.download_code.return_value = tmp_path / "code"
+    mock_run_get.return_value = run
+
+    result = runner.invoke(main, ["get", "code", "my_run", "--dest", str(tmp_path / "code")])
+
+    assert result.exit_code == 0, result.stderr
+    mock_run_get.assert_called_once_with(name="my_run")
+    run.download_code.assert_called_once_with(dest=tmp_path / "code", extract=True, attempt=None)
+
+
+@patch("flyte.cli._get.remote.Action.get")
+@patch.object(_main_module, "CLIConfig", return_value=Mock())
+def test_get_code_for_an_action_keeps_the_archive(mock_cli_config, mock_action_get, runner: CliRunner, tmp_path):
+    action = Mock()
+    action.download_code.return_value = tmp_path / "code" / "fast123.tar.gz"
+    mock_action_get.return_value = action
+
+    result = runner.invoke(
+        main,
+        ["get", "code", "my_run", "my_action", "--dest", str(tmp_path / "code"), "--no-extract", "--attempt", "2"],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    mock_action_get.assert_called_once_with(run_name="my_run", name="my_action")
+    action.download_code.assert_called_once_with(dest=tmp_path / "code", extract=False, attempt=2)
+
+
+@patch("flyte.cli._get.remote.Run.get")
+@patch.object(_main_module, "CLIConfig", return_value=Mock())
+def test_get_code_without_dest_lists_the_bundle(mock_cli_config, mock_run_get, runner: CliRunner, tmp_path):
+    """With no --dest the bundle is fetched to a scratch dir, listed, and discarded."""
+    import tarfile
+
+    source = tmp_path / "main.py"
+    source.write_text("print('hi')\n")
+    archive = tmp_path / "fast123.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(source, arcname="workflows/main.py")
+
+    run = Mock()
+    run.download_code.return_value = archive
+    mock_run_get.return_value = run
+
+    result = runner.invoke(main, ["get", "code", "my_run"])
+
+    assert result.exit_code == 0, result.stderr
+    assert "workflows/main.py" in result.output
+    # Fetched without extracting, into a directory the command owns.
+    kwargs = run.download_code.call_args.kwargs
+    assert kwargs["extract"] is False
+    assert kwargs["dest"] != tmp_path
+
+
+def test_get_code_no_extract_requires_dest(runner: CliRunner):
+    result = runner.invoke(main, ["get", "code", "my_run", "--no-extract"])
+    assert result.exit_code != 0
+    assert "--no-extract" in result.stderr

--- a/tests/flyte/remote/test_download_code.py
+++ b/tests/flyte/remote/test_download_code.py
@@ -1,0 +1,317 @@
+"""Tests for Run.download_code / Action.download_code and the code bundle they resolve."""
+
+from __future__ import annotations
+
+import pathlib
+import tarfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from flyteidl2.common import identifier_pb2, phase_pb2
+from flyteidl2.core import tasks_pb2
+from flyteidl2.dataproxy import dataproxy_service_pb2
+from flyteidl2.workflow import run_definition_pb2
+from google.protobuf.struct_pb2 import Struct
+
+from flyte._internal.runtime.task_serde import extract_code_bundle
+from flyte.remote._action import Action, ActionDetails
+from flyte.remote._run import Run, RunDetails
+
+TGZ_URI = "s3://bucket/org/proj/fast123abc.tar.gz"
+PKL_URI = "s3://bucket/org/proj/code_bundle.pkl.gz"
+
+
+def _make_run(run_name: str = "run-1", action_name: str = "a0") -> Run:
+    run_id = identifier_pb2.RunIdentifier(name=run_name)
+    action_id = identifier_pb2.ActionIdentifier(run=run_id, name=action_name)
+    return Run(pb2=run_definition_pb2.Run(action=run_definition_pb2.Action(id=action_id)))
+
+
+def _make_action(run_name: str = "run-1", action_name: str = "n0-child") -> Action:
+    run_id = identifier_pb2.RunIdentifier(name=run_name)
+    action_id = identifier_pb2.ActionIdentifier(run=run_id, name=action_name)
+    return Action(pb2=run_definition_pb2.Action(id=action_id))
+
+
+def _details_with_container_args(*args: str, attempts: int = 1) -> ActionDetails:
+    pb2 = run_definition_pb2.ActionDetails()
+    pb2.status.phase = phase_pb2.ACTION_PHASE_SUCCEEDED
+    pb2.status.attempts = attempts
+    pb2.task.task_template.container.args.extend(args)
+    return ActionDetails(pb2=pb2)
+
+
+def _tgz_details(attempts: int = 1) -> ActionDetails:
+    return _details_with_container_args("--tgz", TGZ_URI, "--dest", ".", "--version", "123abc", attempts=attempts)
+
+
+def _signed_url_response(url: str = "https://signed/fast123abc.tar.gz"):
+    resp = dataproxy_service_pb2.CreateDownloadLinkResponse()
+    resp.pre_signed_urls.signed_url.append(url)
+    return resp
+
+
+def _make_tarball(tmp_path: pathlib.Path, *names: str) -> bytes:
+    """A real gzipped tarball, so extraction is exercised end to end."""
+    src = tmp_path / "src"
+    src.mkdir()
+    for name in names:
+        f = src / name
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(f"# {name}\n")
+    archive = tmp_path / "bundle.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        for name in names:
+            tar.add(src / name, arcname=name)
+    return archive.read_bytes()
+
+
+class _FakeStreamResponse:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    async def aiter_bytes(self):
+        yield self._payload
+
+
+def _patch_httpx(payload: bytes):
+    """Patch httpx.AsyncClient so stream() yields the given bytes without network."""
+    stream_ctx = MagicMock()
+    stream_ctx.__aenter__ = AsyncMock(return_value=_FakeStreamResponse(payload))
+    stream_ctx.__aexit__ = AsyncMock(return_value=False)
+    client = MagicMock()
+    client.stream = MagicMock(return_value=stream_ctx)
+    client_ctx = MagicMock()
+    client_ctx.__aenter__ = AsyncMock(return_value=client)
+    client_ctx.__aexit__ = AsyncMock(return_value=False)
+    return patch("flyte.remote._code.httpx.AsyncClient", return_value=client_ctx), client
+
+
+# --------------------------------------------------------------------------------------
+# bundle resolution
+# --------------------------------------------------------------------------------------
+
+
+def test_extract_code_bundle_from_container_args():
+    details = _tgz_details()
+    bundle = details.code_bundle
+    assert bundle is not None
+    assert bundle.tgz == TGZ_URI
+    assert bundle.pkl is None
+    assert bundle.computed_version == "123abc"
+    assert bundle.destination == "."
+
+
+def test_extract_code_bundle_from_k8s_pod_primary_container():
+    """A pod-template task keeps its args in the pod spec, not in template.container."""
+    pod_spec = Struct()
+    pod_spec.update(
+        {
+            "containers": [
+                {"name": "sidecar", "args": ["serve"]},
+                {"name": "primary", "args": ["--tgz", TGZ_URI, "--dest", ".", "--version", "v9"]},
+            ]
+        }
+    )
+    spec = run_definition_pb2.ActionDetails().task
+    spec.task_template.k8s_pod.CopyFrom(tasks_pb2.K8sPod(pod_spec=pod_spec, primary_container_name="primary"))
+
+    bundle = extract_code_bundle(spec)
+    assert bundle is not None
+    assert bundle.tgz == TGZ_URI
+    assert bundle.computed_version == "v9"
+
+
+def test_extract_code_bundle_falls_back_to_metadata_uri():
+    """An image-baked entrypoint with no --tgz arg still records the bundle in metadata."""
+    spec = run_definition_pb2.ActionDetails().task
+    spec.task_template.metadata.code_bundle_uri = TGZ_URI
+    bundle = extract_code_bundle(spec)
+    assert bundle is not None and bundle.tgz == TGZ_URI and bundle.pkl is None
+
+    spec2 = run_definition_pb2.ActionDetails().task
+    spec2.task_template.metadata.code_bundle_uri = PKL_URI
+    bundle2 = extract_code_bundle(spec2)
+    assert bundle2 is not None and bundle2.pkl == PKL_URI and bundle2.tgz is None
+
+
+def test_code_bundle_is_none_without_a_bundle():
+    pb2 = run_definition_pb2.ActionDetails()
+    pb2.task.task_template.container.args.extend(["a0", "--run-name", "run-1"])
+    assert ActionDetails(pb2=pb2).code_bundle is None
+
+
+@pytest.mark.asyncio
+async def test_run_code_bundle_reads_the_root_action():
+    run = _make_run()
+    # A terminal, already-cached RunDetails is served from the Run without hitting the API.
+    run._details = RunDetails(pb2=run_definition_pb2.RunDetails(action=_tgz_details().pb2))
+
+    bundle = await run.code_bundle.aio()
+
+    assert bundle is not None and bundle.tgz == TGZ_URI
+
+
+# --------------------------------------------------------------------------------------
+# download
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_download_code_extracts_tarball_from_signed_url(tmp_path):
+    run = _make_run()
+    payload = _make_tarball(tmp_path, "workflows/main.py", "README.md")
+    client = MagicMock()
+    create = AsyncMock(return_value=_signed_url_response())
+    client.dataproxy_service.create_download_link = create
+    httpx_patch, _ = _patch_httpx(payload)
+    dest = tmp_path / "out"
+
+    with (
+        patch("flyte.remote._code.ensure_client"),
+        patch("flyte.remote._code.get_client", return_value=client),
+        patch.object(run.action.__class__, "details", new=AsyncMock(return_value=_tgz_details(attempts=2))),
+        httpx_patch,
+    ):
+        path = await run.download_code.aio(dest=dest)
+
+    assert path == dest
+    assert (dest / "workflows" / "main.py").read_text() == "# workflows/main.py\n"
+    assert (dest / "README.md").exists()
+    # The archive is kept alongside the extracted source, as it is on the worker.
+    assert (dest / "fast123abc.tar.gz").exists()
+
+    sent = create.await_args[0][0]
+    assert sent.artifact_type == dataproxy_service_pb2.ARTIFACT_TYPE_CODE_BUNDLE
+    assert sent.action_attempt_id.action_id == run.action.action_id
+    assert sent.action_attempt_id.attempt == 2
+
+
+@pytest.mark.asyncio
+async def test_download_code_without_extract_keeps_the_archive(tmp_path):
+    run = _make_run()
+    payload = _make_tarball(tmp_path, "main.py")
+    client = MagicMock()
+    client.dataproxy_service.create_download_link = AsyncMock(return_value=_signed_url_response())
+    httpx_patch, _ = _patch_httpx(payload)
+    dest = tmp_path / "out"
+
+    with (
+        patch("flyte.remote._code.ensure_client"),
+        patch("flyte.remote._code.get_client", return_value=client),
+        patch.object(run.action.__class__, "details", new=AsyncMock(return_value=_tgz_details())),
+        httpx_patch,
+    ):
+        path = await run.download_code.aio(dest=dest, extract=False)
+
+    assert path == dest / "fast123abc.tar.gz"
+    assert path.read_bytes() == payload
+    assert not (dest / "main.py").exists()
+
+
+@pytest.mark.asyncio
+async def test_download_code_falls_back_to_object_store(tmp_path):
+    """Backends that don't sign code bundles (OSS Flyte) leave the blob store as the only route."""
+    run = _make_run()
+    payload = _make_tarball(tmp_path, "main.py")
+    client = MagicMock()
+    client.dataproxy_service.create_download_link = AsyncMock(side_effect=RuntimeError("unimplemented"))
+    dest = tmp_path / "out"
+
+    async def fake_get(uri: str, target: str):
+        assert uri == TGZ_URI
+        pathlib.Path(target).write_bytes(payload)
+
+    with (
+        patch("flyte.remote._code.ensure_client"),
+        patch("flyte.remote._code.get_client", return_value=client),
+        patch.object(run.action.__class__, "details", new=AsyncMock(return_value=_tgz_details())),
+        patch("flyte.storage.get", new=AsyncMock(side_effect=fake_get)),
+    ):
+        path = await run.download_code.aio(dest=dest)
+
+    assert path == dest
+    assert (dest / "main.py").read_text() == "# main.py\n"
+
+
+@pytest.mark.asyncio
+async def test_download_code_reports_the_data_proxy_error_when_both_routes_fail(tmp_path):
+    run = _make_run()
+    client = MagicMock()
+    client.dataproxy_service.create_download_link = AsyncMock(
+        side_effect=RuntimeError("code bundle is a pickled archive")
+    )
+
+    with (
+        patch("flyte.remote._code.ensure_client"),
+        patch("flyte.remote._code.get_client", return_value=client),
+        patch.object(run.action.__class__, "details", new=AsyncMock(return_value=_tgz_details())),
+        patch("flyte.storage.get", new=AsyncMock(side_effect=OSError("no credentials"))),
+    ):
+        with pytest.raises(RuntimeError, match="pickled archive") as exc:
+            await run.download_code.aio(dest=tmp_path / "out")
+
+    assert isinstance(exc.value.__cause__, OSError)
+    # A failed download leaves no half-written archive behind.
+    assert not (tmp_path / "out" / "fast123abc.tar.gz").exists()
+
+
+@pytest.mark.asyncio
+async def test_download_code_raises_when_the_task_has_no_bundle(tmp_path):
+    run = _make_run()
+    pb2 = run_definition_pb2.ActionDetails()
+    pb2.status.attempts = 1
+    details = ActionDetails(pb2=pb2)
+
+    with patch.object(run.action.__class__, "details", new=AsyncMock(return_value=details)):
+        with pytest.raises(RuntimeError, match="No code bundle is associated with action 'a0' in run 'run-1'"):
+            await run.download_code.aio(dest=tmp_path / "out")
+
+
+@pytest.mark.asyncio
+async def test_action_download_code_uses_its_own_action_id(tmp_path):
+    """A nested action can be packaged separately from the run's root action."""
+    action = _make_action(action_name="n0-child")
+    payload = _make_tarball(tmp_path, "child.py")
+    client = MagicMock()
+    create = AsyncMock(return_value=_signed_url_response())
+    client.dataproxy_service.create_download_link = create
+    httpx_patch, _ = _patch_httpx(payload)
+
+    with (
+        patch("flyte.remote._code.ensure_client"),
+        patch("flyte.remote._code.get_client", return_value=client),
+        patch.object(action.__class__, "details", new=AsyncMock(return_value=_tgz_details(attempts=3))),
+        httpx_patch,
+    ):
+        path = await action.download_code.aio(dest=tmp_path / "out", attempt=1)
+
+    assert (path / "child.py").exists()
+    sent = create.await_args[0][0]
+    assert sent.action_attempt_id.action_id == action.action_id
+    # An explicit attempt wins over the latest one.
+    assert sent.action_attempt_id.attempt == 1
+
+
+@pytest.mark.asyncio
+async def test_download_code_defaults_destination_to_the_run_name(tmp_path, monkeypatch):
+    run = _make_run(run_name="my-run")
+    payload = _make_tarball(tmp_path, "main.py")
+    monkeypatch.chdir(tmp_path)
+    client = MagicMock()
+    client.dataproxy_service.create_download_link = AsyncMock(return_value=_signed_url_response())
+    httpx_patch, _ = _patch_httpx(payload)
+
+    with (
+        patch("flyte.remote._code.ensure_client"),
+        patch("flyte.remote._code.get_client", return_value=client),
+        patch.object(run.action.__class__, "details", new=AsyncMock(return_value=_tgz_details())),
+        httpx_patch,
+    ):
+        path = await run.download_code.aio()
+
+    assert path == tmp_path / "my-run"
+    assert (path / "main.py").exists()


### PR DESCRIPTION
## Why

The console shows a run's source under its **Code** tab, but the SDK had no way to get at it. The pieces existed — `extract_code_bundle`, `download_bundle`, `flyte.extend.download_code_bundle` — but only as worker-side internals: no method on `remote.Run` or `remote.Action`, and no CLI command. The only SDK caller was the private `_get_code_bundle_for_run` helper used for hybrid-mode reruns.

## What

**SDK**
- `Run.download_code(dest=None, extract=True, attempt=None)` and `Action.download_code(...)` — download the bundle and unpack it, returning the directory the source landed in (or the archive path when `extract=False`). `dest` defaults to `./<run_name>`.
- `Run.code_bundle()` and `ActionDetails.code_bundle` — the `CodeBundle` metadata (tgz/pkl URI, version) without downloading anything.

```python
run = flyte.remote.Run.get("my-run")
src = run.download_code()
print((src / "workflows" / "main.py").read_text())
```

**CLI**

```bash
flyte get code my_run                          # list the bundle's files
flyte get code my_run --dest ./my_run_code     # unpack and keep it
flyte get code my_run my_action                # a specific action's own code
```

Also supports `--no-extract` and `--attempt`.

## How it gets the bytes

Primary route is the same pre-signed link the console uses — `CreateDownloadLink` with `ARTIFACT_TYPE_CODE_BUNDLE` — so **no object-store credentials are needed on the client**, only the API key already in use.

Two cases fail there and fall back to reading the bundle URI through `flyte.storage`:
- backends that sign reports only (OSS Flyte's dataproxy rejects any artifact type other than `ARTIFACT_TYPE_REPORT`),
- pkl bundles, which the cloud dataproxy deliberately refuses as "not source" — but which a Python caller can meaningfully fetch.

If both routes fail, the data-proxy error is raised with the storage error chained onto it, and no half-written archive is left behind.

## Bundle resolution

`extract_code_bundle` previously read only `task_template.container.args`. It now also checks the two other places a bundle is recorded, matching the order the backend itself uses (`dataproxy_cloud.go`'s `getCodeBundleURLFromTaskTemplate`):

1. container args (`--tgz` / `--pkl` / `--dest` / `--version`) — richest, gives destination and version
2. the primary container's args inside a **K8sPod** target — so pod-template tasks are covered
3. `task_template.metadata.code_bundle_uri` — location only

## Testing

- 16 new tests: 12 in `tests/flyte/remote/test_download_code.py` (bundle resolution across all three sources, signed-URL download + real tarball extraction, `--no-extract`, storage fallback, both-routes-fail error chaining, no-bundle error, per-action ids, default destination) and 4 in `tests/cli/test_get.py`.
- `make fmt`, `make mypy`, `make ty` pass.
- Full `tests/flyte tests/cli`: **98 failed / 4230 passed** on this branch vs **98 failed / 4214 passed** on `main` — identical failure set, +16 from this PR. The 98 pre-existing failures are a local proto/venv mismatch unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011D9VpQSthX7M2oHHRH3QKD