### PR TITLE
fix(deploy): make --dryrun work for projects containing app environments

### DIFF
--- a/src/flyte/app/_deploy.py
+++ b/src/flyte/app/_deploy.py
@@ -108,8 +108,11 @@ async def _deploy_app(
             app_idl.spec.container.image = serialization_context.image_cache.image_lookup[app.name]
 
         if dryrun:
-            # Dryrun intentionally short-circuits with the translated IDL proto.
-            return typing.cast("App", app_idl)
+            # Dryrun short-circuits before the server call. Wrap the translated IDL in the same
+            # App facade a real deploy returns -- casting the bare proto leaks it to callers like
+            # DeployedAppEnvironment.table_repr, which read App properties (.name, .revision,
+            # .endpoint, ...) the proto does not have and blow up with `AttributeError: name`.
+            return App(app_idl)
         ensure_client()
         resolved_image = app_idl.spec.container.image if app_idl.spec.HasField("container") else image_uri_for_log
         msg = f"Deploying app {app.name}, with image {resolved_image} version {serialization_context.version}"

--- a/src/flyte/cli/_deploy.py
+++ b/src/flyte/cli/_deploy.py
@@ -127,7 +127,7 @@ def _print_entity_rows(rows: List[Any], title: str, output_format: Any) -> None:
     A recursive deploy mixes environment kinds, and each kind describes itself with its
     own columns -- a task row is (type, name, version, triggers) while an app row is
     (type, name, revision, desired state, current state, public_url, console_url).
-    ``format`` takes its headers from the first row only, so rendering them together
+    `format` takes its headers from the first row only, so rendering them together
     files app values under task headers and tacks the overflow on as unlabeled columns.
     Group by column signature instead, so each kind gets its own headed table.
 

--- a/src/flyte/cli/_deploy.py
+++ b/src/flyte/cli/_deploy.py
@@ -2,7 +2,7 @@ import pathlib
 from dataclasses import dataclass, field, fields
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Dict, List, cast, get_args
+from typing import Any, Dict, List, Tuple, cast, get_args
 
 import rich_click as click
 
@@ -121,6 +121,41 @@ class DeployArguments:
         return [common.get_option_from_metadata(f.metadata) for f in fields(cls) if f.metadata]
 
 
+def _print_entity_rows(rows: List[Any], title: str, output_format: Any) -> None:
+    """Render deployed-entity rows, one table per distinct set of columns.
+
+    A recursive deploy mixes environment kinds, and each kind describes itself with its
+    own columns -- a task row is (type, name, version, triggers) while an app row is
+    (type, name, revision, desired state, current state, public_url, console_url).
+    ``format`` takes its headers from the first row only, so rendering them together
+    files app values under task headers and tacks the overflow on as unlabeled columns.
+    Group by column signature instead, so each kind gets its own headed table.
+
+    JSON output stays a single flat list: each row is serialized on its own keys, so it
+    is already correct, and splitting it would emit two separate documents.
+    """
+    if not rows:
+        return
+    if output_format in ("json", "json-raw"):
+        common.print_output(common.format(title, rows, output_format), output_format)
+        return
+
+    groups: Dict[Tuple[str, ...], List[Any]] = {}
+    for row in rows:
+        groups.setdefault(tuple(k for k, _ in row), []).append(row)
+
+    for group in groups.values():
+        common.print_output(common.format(_group_title(group, title), group, output_format), output_format)
+
+
+def _group_title(group: List[Any], fallback: str) -> str:
+    """Title a group by the entity type its rows carry, e.g. "task" -> "Tasks"."""
+    for key, value in group[0]:
+        if key.casefold() == "type" and value:
+            return f"{str(value).capitalize()}s"
+    return fallback
+
+
 class DeployEnvCommand(click.RichCommand):
     def __init__(self, env_name: str, env: Any, deploy_args: DeployArguments, *args, **kwargs):
         self.env_name = env_name
@@ -152,7 +187,7 @@ class DeployEnvCommand(click.RichCommand):
         common.print_output(
             common.format("Environments", deployment[0].env_repr(), obj.output_format), obj.output_format
         )
-        common.print_output(common.format("Entities", deployment[0].table_repr(), obj.output_format), obj.output_format)
+        _print_entity_rows(deployment[0].table_repr(), "Entities", obj.output_format)
 
 
 class DeployEnvRecursiveCommand(click.Command):
@@ -225,10 +260,7 @@ class DeployEnvRecursiveCommand(click.Command):
             common.format("Environments", [env for d in deployments for env in d.env_repr()], obj.output_format),
             obj.output_format,
         )
-        common.print_output(
-            common.format("Tasks", [task for d in deployments for task in d.table_repr()], obj.output_format),
-            obj.output_format,
-        )
+        _print_entity_rows([e for d in deployments for e in d.table_repr()], "Entities", obj.output_format)
 
 
 class EnvPerFileGroup(common.ObjectsPerFileGroup):

--- a/tests/flyte/app/test_app_deploy.py
+++ b/tests/flyte/app/test_app_deploy.py
@@ -1,9 +1,11 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
 from flyteidl2.app import app_definition_pb2
 
 from flyte.app import AppEnvironment
 from flyte.app._deploy import DeployedAppEnvironment
+from flyte.models import SerializationContext
 from flyte.remote import App
 
 
@@ -39,3 +41,31 @@ def test_deployed_app_environment_table_repr_uses_public_and_console_urls():
     assert row["console_url"] == (
         "[link=https://console.example.com/apps/test-app]https://console.example.com/apps/test-app[/link]"
     )
+
+
+@pytest.mark.asyncio
+async def test_deploy_app_dryrun_returns_app_facade(tmp_path):
+    # Dryrun used to return the bare app_definition_pb2.App proto cast to App. Every
+    # consumer reads App properties, so `flyte deploy --dryrun` over a project holding
+    # an app env died with `Error invoking command: name` when the deploy CLI rendered
+    # its entity table (AttributeError: name, raised by the proto).
+    from flyte.app._deploy import _deploy_app
+
+    app_env = AppEnvironment(name="test-app", image="auto")
+    ctx = SerializationContext(
+        org="test-org",
+        project="test-project",
+        domain="test-domain",
+        version="v1.0.0",
+        root_dir=tmp_path,
+    )
+
+    deployed = await _deploy_app(app_env, ctx, dryrun=True)
+
+    assert isinstance(deployed, App)
+    # The properties DeployedAppEnvironment.table_repr/summary_repr read must resolve.
+    assert deployed.name == "test-app"
+    assert deployed.revision == 0
+    assert deployed.endpoint == ""
+    assert deployed.desired_state == app_definition_pb2.Spec.DESIRED_STATE_ACTIVE
+    assert deployed.deployment_status == app_definition_pb2.Status.DEPLOYMENT_STATUS_UNSPECIFIED

--- a/tests/flyte/cli/test_deploy_entity_tables.py
+++ b/tests/flyte/cli/test_deploy_entity_tables.py
@@ -1,0 +1,76 @@
+"""Deploy renders one table per entity kind, not one table per deploy."""
+
+import json
+
+from flyte.cli._deploy import _print_entity_rows
+
+TASK_ROW = [("type", "task"), ("name", "env.t1"), ("version", "v1"), ("triggers", "")]
+APP_ROW = [
+    ("type", "App"),
+    ("name", "my-app"),
+    ("revision", "0"),
+    ("desired state", "DESIRED_STATE_ACTIVE"),
+    ("current state", "DEPLOYMENT_STATUS_UNSPECIFIED"),
+    ("public_url", ""),
+    ("console_url", ""),
+]
+
+
+def _tables(rows, output_format="table"):
+    printed = []
+    import flyte.cli._deploy as deploy_mod
+
+    original = deploy_mod.common.print_output
+    deploy_mod.common.print_output = lambda renderable, of: printed.append(renderable)
+    try:
+        _print_entity_rows(rows, "Entities", output_format)
+    finally:
+        deploy_mod.common.print_output = original
+    return printed
+
+
+def test_task_and_app_rows_get_separate_tables():
+    # A recursive deploy mixes kinds whose rows carry different columns. Rendered as one
+    # table, the app values file under the task headers (revision under "Version", desired
+    # state under "Triggers") and the overflow becomes unlabeled columns.
+    tables = _tables([TASK_ROW, APP_ROW])
+
+    assert len(tables) == 2
+    tasks, apps = tables
+    assert tasks.title == "Tasks"
+    assert [c.header for c in tasks.columns] == ["Type", "Name", "Version", "Triggers"]
+    assert tasks.row_count == 1
+
+    assert apps.title == "Apps"
+    assert [c.header for c in apps.columns] == [
+        "Type",
+        "Name",
+        "Revision",
+        "Desired state",
+        "Current state",
+        "Public_url",
+        "Console_url",
+    ]
+    assert apps.row_count == 1
+
+
+def test_homogeneous_rows_stay_in_one_table():
+    tables = _tables([TASK_ROW, TASK_ROW])
+
+    assert len(tables) == 1
+    assert tables[0].title == "Tasks"
+    assert tables[0].row_count == 2
+
+
+def test_no_rows_prints_nothing():
+    assert _tables([]) == []
+
+
+def test_json_raw_stays_a_single_flat_document():
+    # Splitting JSON per kind would emit two documents; each row already serializes
+    # on its own keys, so one flat list is correct.
+    out = _tables([TASK_ROW, APP_ROW], output_format="json-raw")
+
+    assert len(out) == 1
+    parsed = json.loads(out[0])
+    assert [row["type"] for row in parsed] == ["task", "App"]


### PR DESCRIPTION
## Problem

`flyte deploy --dryrun` over a project that contains an `AppEnvironment` fails with:

```
╭─ Error ──────────────────────────────────────╮
│ Error invoking command: name                 │
╰──────────────────────────────────────────────╯
```

Reported in Slack. The user wanted `--dryrun` as a quick smoke test that every task deploys without error — the role `pyflyte package` played in v1.

This is **not** fixed by #1573 (which only renames the `dryrun` kwarg to `dry_run` on the `flyte.deploy` Python API and never touches `src/flyte/app/_deploy.py`). The reporter confirmed the failure still reproduces on `main` after that landed.

## Root cause

`_deploy_app` short-circuits the dryrun with the translated `app_definition_pb2.App` proto, cast to `flyte.remote.App`:

```python
if dryrun:
    return typing.cast("App", app_idl)
```

The cast is a lie. `remote.App` is a facade whose `.name`, `.revision`, `.endpoint`, `.url`, `.desired_state` and `.deployment_status` are **properties** reading out of `pb2`; the proto itself has only `metadata`/`spec`/`status`. Every consumer — `DeployedAppEnvironment.table_repr`, `summary_repr` — reads those properties, so the first one the deploy CLI touches while rendering its entity table raises `AttributeError: name`.

`str(AttributeError("name"))` is the bare word `name`, which is how the opaque `Error invoking command: name` message is produced.

Only `--dryrun` is affected: the real path returns `await App.create.aio(app_idl)`, a properly wrapped `App`.

## Fix

Wrap the dryrun IDL in the real facade — `App` is a thin wrapper over exactly this proto, so every property resolves. `endpoint` and `revision` come back empty because nothing has been assigned yet, which is correct for a dryrun.

## Second bug, same output path

With the crash fixed, the rendered table was still wrong. A recursive deploy mixes environment kinds, and each kind describes itself with its own columns:

- task row: `(type, name, version, triggers)`
- app row: `(type, name, revision, desired state, current state, public_url, console_url)`

`_common.format` takes its headers from the first row only, so both were crammed into one table — app values filed under task headers (revision under "Version", desired state under "Triggers"), with the overflow tacked on as unlabeled columns. **This was wrong for real deploys too, not just dryruns.**

Rows are now grouped by column signature so each kind gets its own headed table ("Tasks", "Apps"). JSON output stays a single flat list: each row already serializes on its own keys, and splitting it would emit two documents.

Before (one table, mis-filed):

```
                                 Tasks
┌──────┬────────┬────────┬───────────┬──────────┬──┬─────────┐
│ Type │ Name   │ Version│ Triggers  │          │  │         │
╞══════╪════════╪════════╪═══════════╪══════════╪══╪═════════╡
│ task │ env.t1 │ v1     │           │          │  │         │
│ App  │ my-app │ 0      │ DESIRED_… │ DEPLOY…  │  │ https…  │
└──────┴────────┴────────┴───────────┴──────────┴──┴─────────┘
```

After (one table per kind, correct headers):

```
                    Tasks                          Apps
┌──────┬────────┬─────────┬──────────┐   ┌──────┬────────┬──────────┬───────────┬ ...
│ Type │ Name   │ Version │ Triggers │   │ Type │ Name   │ Revision │ Desired … │
╞══════╪════════╪═════════╪══════════╡   ╞══════╪════════╪══════════╪═══════════╡
│ task │ env.t1 │ v1      │          │   │ App  │ my-app │ 0        │ DESIRED_… │
└──────┴────────┴─────────┴──────────┘   └──────┴────────┴──────────┴───────────┴ ...
```

## Tests

- `test_deploy_app_dryrun_returns_app_facade` — asserts the dryrun return is an `App` and that every property `table_repr`/`summary_repr` reads resolves. Verified to fail on the unpatched code with `assert False`.
- `tests/flyte/cli/test_deploy_entity_tables.py` — covers heterogeneous rows splitting into per-kind tables, homogeneous rows staying in one, the empty case, and JSON staying a single flat document.

`tests/flyte/app`, `tests/flyte/cli`, `tests/flyte/test_deploy.py`: 328 passed. ruff and mypy clean on the touched files.

Verified end-to-end against a repro package holding one task env and one app env: `--dryrun --recursive` now exits 0, and the single-env and `--output-format json-raw` paths render correctly.

> Note: the pre-commit `mypy` hook fails on this branch, but it fails identically on an unmodified checkout — 9 pre-existing errors under `examples/` (torch, deltalake). Not introduced here.